### PR TITLE
#163 enable coverage capture

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -31,3 +31,11 @@ jobs:
 
       - name: Execute linters and test suites
         run: ./scripts/cibuild
+
+
+      - name: Upload All coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.xml
+          fail_ci_if_error: false 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ sphinxcontrib-napoleon==0.7
 flake8==3.8.*
 yapf==0.28.*
 nbsphinx==0.4.3
+coverage==5.2.*

--- a/scripts/test
+++ b/scripts/test
@@ -23,7 +23,8 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         # Code formatting
         yapf -dpr pystac tests
 
-        # Test suite
-        python -m unittest discover tests/
+        # Test suite with coverage enabled
+        coverage run --source=pystac/ -m unittest discover tests/
+        coverage xml
     fi
 fi


### PR DESCRIPTION
Small PR to help future tracking of gains by unittests using Coverage analysis and visualization in codecov.

A codecov token needs to be added to the Repo secrets. Pipeline step is set to continue on failure to push. I wrote this mostly to assist in contributing unittests for #155 .

Signed-off-by: Tisham Dhar <tisham.dhar@ga.gov.au>