### PR TITLE
Test small parts on identify.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ stdout*
 /integration*
 .idea/
 docs/_build/
+coverage.xml
 
 # Sphinx documentation
 docs/_build/

--- a/tests/data-files/get_examples.py
+++ b/tests/data-files/get_examples.py
@@ -76,6 +76,8 @@ if __name__ == '__main__':
                             print('Creating example at {}'.format(target_path))
 
                             info = identify_stac_object(js)
+                            # Explicitly cover __repr__ functions in tests
+                            str_info = str(info)
 
                             # Handle the case where there are collection links that
                             # don't exist.


### PR DESCRIPTION
Closes #170 
- Tests String representations
- Tests version comparison
- Adds coverage.xml to .gitignore to avoid cluttering up local git during tests

Signed-off-by: Tisham Dhar <tisham.dhar@ga.gov.au>