### PR TITLE
Fix bug that caused get_children to miss some links.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## [v0.5.2]
 
-### Added 
- 
-- `update_extent_from_items` method to Collection for updating Extent objects within a collection based on the contained items. ([#168](https://github.com/stac-utils/pystac/pull/168)) 
+### Added
+
+- `update_extent_from_items` method to Collection for updating Extent objects within a collection based on the contained items. ([#168](https://github.com/stac-utils/pystac/pull/168))
+
+### Fixed
+
+- Fix bug that caused get_children to miss some links. ([#172](https://github.com/stac-utils/pystac/pull/172))
 
 ## [v0.5.1]
 

--- a/tests/data-files/catalogs/cbers-partial/CBERS4AWFI/collection.json
+++ b/tests/data-files/catalogs/cbers-partial/CBERS4AWFI/collection.json
@@ -1,0 +1,119 @@
+{
+    "id": "CBERS4AWFI",
+    "stac_version": "1.0.0-beta.2",
+    "description": "CBERS4 AWFI camera catalog",
+    "links": [
+        {
+            "rel": "root",
+            "href": "../catalog.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "parent",
+            "href": "../catalog.json",
+            "type": "application/json"
+        }
+    ],
+    "stac_extensions": [
+        "eo",
+        "item-assets"
+    ],
+    "providers": [
+        {
+            "name": "Instituto Nacional de Pesquisas Espaciais, INPE",
+            "roles": [
+                "producer"
+            ],
+            "url": "http://www.cbers.inpe.br"
+        },
+        {
+            "name": "AMS Kepler",
+            "description": "Convert INPE's original TIFF to COG and copy to Amazon Web Services",
+            "roles": [
+                "processor"
+            ],
+            "url": "https://github.com/fredliporace/cbers-on-aws"
+        },
+        {
+            "name": "Amazon Web Services",
+            "roles": [
+                "host"
+            ],
+            "url": "https://registry.opendata.aws/cbers/"
+        }
+    ],
+    "properties": {
+        "gsd": 64.0,
+        "platform": "CBERS-4",
+        "instruments": [
+            "AWFI"
+        ]
+    },
+    "item_assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "type": "image/jpeg"
+        },
+        "metadata": {
+            "title": "INPE original metadata",
+            "type": "text/xml"
+        },
+        "B13": {
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "eo:bands": [
+                {
+                    "name": "B13",
+                    "common_name": "blue"
+                }
+            ]
+        },
+        "B14": {
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "eo:bands": [
+                {
+                    "name": "B14",
+                    "common_name": "green"
+                }
+            ]
+        },
+        "B15": {
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "eo:bands": [
+                {
+                    "name": "B15",
+                    "common_name": "red"
+                }
+            ]
+        },
+        "B16": {
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "eo:bands": [
+                {
+                    "name": "B16",
+                    "common_name": "nir"
+                }
+            ]
+        }
+    },
+    "extent": {
+        "spatial": {
+            "bbox": [
+                [
+                    -180.0,
+                    -83.0,
+                    180.0,
+                    83.0
+                ]
+            ]
+        },
+        "temporal": {
+            "interval": [
+                [
+                    "2014-12-08T00:00:00Z",
+                    null
+                ]
+            ]
+        }
+    },
+    "license": "CC-BY-SA-3.0"
+}

--- a/tests/data-files/catalogs/cbers-partial/CBERS4MUX/collection.json
+++ b/tests/data-files/catalogs/cbers-partial/CBERS4MUX/collection.json
@@ -1,0 +1,119 @@
+{
+    "id": "CBERS4MUX",
+    "stac_version": "1.0.0-beta.2",
+    "description": "CBERS4 MUX camera catalog",
+    "links": [
+        {
+            "rel": "root",
+            "href": "../catalog.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "parent",
+            "href": "../catalog.json",
+            "type": "application/json"
+        }
+    ],
+    "stac_extensions": [
+        "eo",
+        "item-assets"
+    ],
+    "providers": [
+        {
+            "name": "Instituto Nacional de Pesquisas Espaciais, INPE",
+            "roles": [
+                "producer"
+            ],
+            "url": "http://www.cbers.inpe.br"
+        },
+        {
+            "name": "AMS Kepler",
+            "description": "Convert INPE's original TIFF to COG and copy to Amazon Web Services",
+            "roles": [
+                "processor"
+            ],
+            "url": "https://github.com/fredliporace/cbers-on-aws"
+        },
+        {
+            "name": "Amazon Web Services",
+            "roles": [
+                "host"
+            ],
+            "url": "https://registry.opendata.aws/cbers/"
+        }
+    ],
+    "properties": {
+        "gsd": 20.0,
+        "platform": "CBERS-4",
+        "instruments": [
+            "MUX"
+        ]
+    },
+    "item_assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "type": "image/jpeg"
+        },
+        "metadata": {
+            "title": "INPE original metadata",
+            "type": "text/xml"
+        },
+        "B5": {
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "eo:bands": [
+                {
+                    "name": "B5",
+                    "common_name": "blue"
+                }
+            ]
+        },
+        "B6": {
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "eo:bands": [
+                {
+                    "name": "B6",
+                    "common_name": "green"
+                }
+            ]
+        },
+        "B7": {
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "eo:bands": [
+                {
+                    "name": "B7",
+                    "common_name": "red"
+                }
+            ]
+        },
+        "B8": {
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "eo:bands": [
+                {
+                    "name": "B8",
+                    "common_name": "nir"
+                }
+            ]
+        }
+    },
+    "extent": {
+        "spatial": {
+            "bbox": [
+                [
+                    -180.0,
+                    -83.0,
+                    180.0,
+                    83.0
+                ]
+            ]
+        },
+        "temporal": {
+            "interval": [
+                [
+                    "2014-12-08T00:00:00Z",
+                    null
+                ]
+            ]
+        }
+    },
+    "license": "CC-BY-SA-3.0"
+}

--- a/tests/data-files/catalogs/cbers-partial/CBERS4PAN10M/collection.json
+++ b/tests/data-files/catalogs/cbers-partial/CBERS4PAN10M/collection.json
@@ -1,0 +1,110 @@
+{
+    "id": "CBERS4PAN10M",
+    "stac_version": "1.0.0-beta.2",
+    "description": "CBERS4 PAN10M camera catalog",
+    "links": [
+        {
+            "rel": "root",
+            "href": "../catalog.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "parent",
+            "href": "../catalog.json",
+            "type": "application/json"
+        }
+    ],
+    "stac_extensions": [
+        "eo",
+        "item-assets"
+    ],
+    "providers": [
+        {
+            "name": "Instituto Nacional de Pesquisas Espaciais, INPE",
+            "roles": [
+                "producer"
+            ],
+            "url": "http://www.cbers.inpe.br"
+        },
+        {
+            "name": "AMS Kepler",
+            "description": "Convert INPE's original TIFF to COG and copy to Amazon Web Services",
+            "roles": [
+                "processor"
+            ],
+            "url": "https://github.com/fredliporace/cbers-on-aws"
+        },
+        {
+            "name": "Amazon Web Services",
+            "roles": [
+                "host"
+            ],
+            "url": "https://registry.opendata.aws/cbers/"
+        }
+    ],
+    "properties": {
+        "gsd": 10.0,
+        "platform": "CBERS-4",
+        "instruments": [
+            "PAN10M"
+        ]
+    },
+    "item_assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "type": "image/jpeg"
+        },
+        "metadata": {
+            "title": "INPE original metadata",
+            "type": "text/xml"
+        },
+        "B2": {
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "eo:bands": [
+                {
+                    "name": "B2",
+                    "common_name": "green"
+                }
+            ]
+        },
+        "B3": {
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "eo:bands": [
+                {
+                    "name": "B3",
+                    "common_name": "red"
+                }
+            ]
+        },
+        "B4": {
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "eo:bands": [
+                {
+                    "name": "B4",
+                    "common_name": "nir"
+                }
+            ]
+        }
+    },
+    "extent": {
+        "spatial": {
+            "bbox": [
+                [
+                    -180.0,
+                    -83.0,
+                    180.0,
+                    83.0
+                ]
+            ]
+        },
+        "temporal": {
+            "interval": [
+                [
+                    "2014-12-08T00:00:00Z",
+                    null
+                ]
+            ]
+        }
+    },
+    "license": "CC-BY-SA-3.0"
+}

--- a/tests/data-files/catalogs/cbers-partial/CBERS4PAN5M/collection.json
+++ b/tests/data-files/catalogs/cbers-partial/CBERS4PAN5M/collection.json
@@ -1,0 +1,92 @@
+{
+    "id": "CBERS4PAN5M",
+    "stac_version": "1.0.0-beta.2",
+    "description": "CBERS4 PAN5M camera catalog",
+    "links": [
+        {
+            "rel": "root",
+            "href": "../catalog.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "parent",
+            "href": "../catalog.json",
+            "type": "application/json"
+        }
+    ],
+    "stac_extensions": [
+        "eo",
+        "item-assets"
+    ],
+    "providers": [
+        {
+            "name": "Instituto Nacional de Pesquisas Espaciais, INPE",
+            "roles": [
+                "producer"
+            ],
+            "url": "http://www.cbers.inpe.br"
+        },
+        {
+            "name": "AMS Kepler",
+            "description": "Convert INPE's original TIFF to COG and copy to Amazon Web Services",
+            "roles": [
+                "processor"
+            ],
+            "url": "https://github.com/fredliporace/cbers-on-aws"
+        },
+        {
+            "name": "Amazon Web Services",
+            "roles": [
+                "host"
+            ],
+            "url": "https://registry.opendata.aws/cbers/"
+        }
+    ],
+    "properties": {
+        "gsd": 5.0,
+        "platform": "CBERS-4",
+        "instruments": [
+            "PAN5M"
+        ]
+    },
+    "item_assets": {
+        "thumbnail": {
+            "title": "Thumbnail",
+            "type": "image/jpeg"
+        },
+        "metadata": {
+            "title": "INPE original metadata",
+            "type": "text/xml"
+        },
+        "B1": {
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "eo:bands": [
+                {
+                    "name": "B1",
+                    "common_name": "pan"
+                }
+            ]
+        }
+    },
+    "extent": {
+        "spatial": {
+            "bbox": [
+                [
+                    -180.0,
+                    -83.0,
+                    180.0,
+                    83.0
+                ]
+            ]
+        },
+        "temporal": {
+            "interval": [
+                [
+                    "2014-12-08T00:00:00Z",
+                    null
+                ]
+            ]
+        }
+    },
+    "license": "CC-BY-SA-3.0"
+}

--- a/tests/data-files/catalogs/cbers-partial/catalog.json
+++ b/tests/data-files/catalogs/cbers-partial/catalog.json
@@ -1,0 +1,28 @@
+{
+    "id": "CBERS4",
+    "stac_version": "1.0.0-beta.2",
+    "description": "Catalogs of CBERS-4 mission's imagery on AWS",
+    "links": [
+        {
+            "rel": "root",
+            "href": "https://cbers-stac-1-0.s3.amazonaws.com/catalog.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "child",
+            "href": "./CBERS4MUX/collection.json"
+        },
+        {
+            "rel": "child",
+            "href": "./CBERS4AWFI/collection.json"
+        },
+        {
+            "rel": "child",
+            "href": "./CBERS4PAN10M/collection.json"
+        },
+        {
+            "rel": "child",
+            "href": "./CBERS4PAN5M/collection.json"
+        }
+    ]
+}

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -392,7 +392,6 @@ class CatalogTest(unittest.TestCase):
             for root, catalogs, items in cat.walk():
                 for link in root.links:
                     if link.rel != 'self':
-                        # print(l.rel)
                         self.assertTrue(link.link_type == LinkType.RELATIVE)
                         self.assertFalse(is_absolute_href(link.get_href()))
                 for item in items:
@@ -529,6 +528,10 @@ class CatalogTest(unittest.TestCase):
             for item in cat2.get_all_items():
                 # Iterate again over the items. This would fail in #88
                 pass
+
+    def test_get_children_cbers(self):
+        cat = TestCases.test_case_6()
+        self.assertEqual(len(list(cat.get_children())), 4)
 
 
 class FullCopyTest(unittest.TestCase):

--- a/tests/utils/test_cases.py
+++ b/tests/utils/test_cases.py
@@ -158,3 +158,9 @@ class TestCases:
     def test_case_5():
         """Based on a subset of https://cbers.stac.cloud/"""
         return Catalog.from_file(TestCases.get_path('data-files/catalogs/test-case-5/catalog.json'))
+
+    @staticmethod
+    def test_case_6():
+        """Based on a subset of CBERS, contains a root and 4 empty children"""
+        return Catalog.from_file(
+            TestCases.get_path('data-files/catalogs/cbers-partial/catalog.json'))


### PR DESCRIPTION
There was a bug that was causing some children to get missed in the `get_children` call of the cbers catalog. This appeared based on the root link being resolved and the logic reordering the links during resolution. 

Thanks @matthewhanson and @digitaltopo for catching this.