### PR TITLE
stac_validator.py: Fix formatting in _get_error_message()

### DIFF
--- a/pystac/validation/stac_validator.py
+++ b/pystac/validation/stac_validator.py
@@ -135,7 +135,7 @@ class JsonSchemaSTACValidator(STACValidator):
             s += 'with ID {} '.format(stac_id)
         s += 'against schema at {}'.format(schema_uri)
         if extension_id is not None:
-            s += "for STAC extension '{}'".format(extension_id)
+            s += " for STAC extension '{}'".format(extension_id)
 
         return s
 


### PR DESCRIPTION
Example: `jsonfor`

```
Validation failed for COLLECTION with ID [SNIP]
scientific/json-schema/schema.jsonfor STAC extension 'scientific'
```