### PR TITLE
Fix spacenet tutorial, allow for single bbox argument to SpatialExtent, and other fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ To format code:
 > yapf -ipr pystac tests
 ```
 
+Note that you may have to use `yapf3` explicitly depending on your environment.
+
 You can also run the `./scripts/test` script to check flake8 and yapf.
 
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -81,15 +81,13 @@ PySTAC uses [flake8](http://flake8.pycqa.org/en/latest/) and [yapf](https://gith
 To run the flake8 style checks:
 
 ```
-> flake8 pystac
-> flake8 tests
+> flake8 pystac tests
 ```
 
 To format code:
 
 ```
-> yapf -ipr pystac
-> yapf -ipr tests
+> yapf -ipr pystac tests
 ```
 
 You can also run the `./scripts/test` script to check flake8 and yapf.

--- a/docs/tutorials/pystac-spacenet-tutorial.ipynb
+++ b/docs/tutorials/pystac-spacenet-tutorial.ipynb
@@ -68,7 +68,7 @@
     "from botocore.errorfactory import ClientError\n",
     "import pystac\n",
     "from pystac.extensions import label\n",
-    "from shapely.geometry import GeometryCollection, Polygon, box, shape"
+    "from shapely.geometry import GeometryCollection, Polygon, box, shape, mapping"
    ]
   },
   {
@@ -217,7 +217,7 @@
     "    params['id'] = basename(uri).split('.')[0]\n",
     "    with rasterio.open(uri) as src:\n",
     "        params['bbox'] = list(src.bounds)\n",
-    "        params['geometry'] = box(*params['bbox']).__geo_interface__\n",
+    "        params['geometry'] = mapping(box(*params['bbox']))\n",
     "    params['datetime'] = capture_date\n",
     "    params['properties'] = {}\n",
     "    i = pystac.Item(**params)\n",
@@ -240,7 +240,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bounds = GeometryCollection([shape(s.geometry) for s in spacenet.get_all_items()]).bounds\n",
+    "bounds = [list(GeometryCollection([shape(s.geometry) for s in spacenet.get_all_items()]).bounds)]\n",
     "vegas.extent.spatial = pystac.SpatialExtent(bounds)"
    ]
   },
@@ -248,16 +248,45 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Currently, this STAC only exists in memory. We need to set all of the paths based on the root directory  we want to save off that catalog too, and then save a \"self contained\" catalog, which will have all links be relative and contain no 'self' links. We can do this all in one shot with the `normalize_and_save` method:"
+    "Currently, this STAC only exists in memory. We need to set all of the paths based on the root directory  we want to save off that catalog too, and then save a \"self contained\" catalog, which will have all links be relative and contain no 'self' links. We can do this by using the `normalize` method to set the HREFs of all of our STAC objects. We'll then validate the catalog, and then save:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 12,
    "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Catalog id=spacenet>"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "spacenet.normalize_hrefs('spacenet-stac')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
    "outputs": [],
    "source": [
-    "spacenet.normalize_and_save('spacenet-stac', catalog_type=pystac.CatalogType.SELF_CONTAINED)"
+    "spacenet.validate_all()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spacenet.save(catalog_type=pystac.CatalogType.SELF_CONTAINED)"
    ]
   },
   {
@@ -285,7 +314,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -298,7 +327,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -314,7 +343,7 @@
     "        label_item = pystac.Item(\n",
     "            id='{}-labels'.format(item.id),\n",
     "            bbox=item.bbox,\n",
-    "            geometry=box(*item.bbox).__geo_interface__,\n",
+    "            geometry=mapping(box(*item.bbox)),\n",
     "            datetime=item.datetime,\n",
     "            properties={},\n",
     "            stac_extensions=[pystac.Extensions.LABEL]\n",
@@ -323,7 +352,12 @@
     "        label_item.ext.label.apply(\n",
     "            label_description='Building labels for scene {}'.format(item.id),\n",
     "            label_type=label.LabelType.VECTOR,\n",
-    "            label_properties=['partialBuilding']\n",
+    "            label_properties=['partialBuilding'],\n",
+    "            \n",
+    "            # Label classes is marked as required in 1.0.0-beta.2, so make it up.\n",
+    "            # Once this PR is released, this can be removed:\n",
+    "            # https://github.com/radiantearth/stac-spec/pull/905\n",
+    "            label_classes=[label.LabelClasses.create(classes=['building'], name='partialBuilding')]\n",
     "        )\n",
     "        \n",
     "        label_item.ext.label.add_geojson_labels(href=label_uri)\n",
@@ -347,7 +381,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -356,7 +390,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -383,7 +417,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -428,12 +462,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Catalog id=spacenet>"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "spacenet_cog.normalize_hrefs('spacenet-cog-stac')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
-    "spacenet_cog.normalize_and_save('spacenet-cog-stac', \n",
-    "                                catalog_type=pystac.CatalogType.SELF_CONTAINED)"
+    "spacenet_cog.validate_all()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spacenet_cog.save(catalog_type=pystac.CatalogType.SELF_CONTAINED)"
    ]
   },
   {

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -1,3 +1,4 @@
+import collections.abc
 from datetime import datetime
 import dateutil.parser
 from dateutil import tz
@@ -305,6 +306,12 @@ class SpatialExtent:
             2D Collection with only one bbox would be [[xmin, ymin, xmax, ymax]]
     """
     def __init__(self, bboxes):
+        # A common mistake is to pass in a single bbox instead of a list of bboxes.
+        # Account for this by transforming the input in that case.
+        if isinstance(bboxes, collections.abc.Sequence):
+            if not isinstance(bboxes[0], collections.abc.Sequence):
+                bboxes = [bboxes]
+
         self.bboxes = bboxes
 
     def to_dict(self):
@@ -388,6 +395,13 @@ class TemporalExtent:
         Datetimes are required to be in UTC.
     """
     def __init__(self, intervals):
+        # A common mistake is to pass in a single interval instead of a
+        # list of intervals. Account for this by transforming the input
+        # in that case.
+        if isinstance(intervals, collections.abc.Sequence):
+            if not isinstance(intervals[0], collections.abc.Sequence):
+                intervals = [intervals]
+
         for i in intervals:
             if i[0] is None and i[1] is None:
                 raise STACError('TemporalExtent interval must have either '

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -1,4 +1,4 @@
-import collections.abc
+from collections import abc
 from datetime import datetime
 import dateutil.parser
 from dateutil import tz
@@ -308,8 +308,8 @@ class SpatialExtent:
     def __init__(self, bboxes):
         # A common mistake is to pass in a single bbox instead of a list of bboxes.
         # Account for this by transforming the input in that case.
-        if isinstance(bboxes, collections.abc.Sequence):
-            if not isinstance(bboxes[0], collections.abc.Sequence):
+        if isinstance(bboxes, abc.Sequence):
+            if not isinstance(bboxes[0], abc.Sequence):
                 bboxes = [bboxes]
 
         self.bboxes = bboxes
@@ -398,8 +398,8 @@ class TemporalExtent:
         # A common mistake is to pass in a single interval instead of a
         # list of intervals. Account for this by transforming the input
         # in that case.
-        if isinstance(intervals, collections.abc.Sequence):
-            if not isinstance(intervals[0], collections.abc.Sequence):
+        if isinstance(intervals, abc.Sequence):
+            if not isinstance(intervals[0], abc.Sequence):
                 intervals = [intervals]
 
         for i in intervals:

--- a/pystac/link.py
+++ b/pystac/link.py
@@ -105,7 +105,7 @@ class Link:
             else:
                 href = self.target
 
-            if is_absolute_href(href) and self.owner is not None:
+            if href and is_absolute_href(href) and self.owner is not None:
                 href = make_relative_href(href, self.owner.get_self_href())
         else:
             href = self.get_absolute_href()

--- a/pystac/validation/stac_validator.py
+++ b/pystac/validation/stac_validator.py
@@ -67,12 +67,17 @@ class STACValidator(ABC):
                STACValidator implementation.
         """
         results = []
-        core_result = self.validate_core(stac_dict, stac_object_type, stac_version, href)
+
+        # Pass the dict through JSON serialization and parsing, otherwise
+        # some valid properties can be marked as invalid (e.g. tuples in
+        # coordinate sequences for geometries).
+        json_dict = json.loads(json.dumps(stac_dict))
+        core_result = self.validate_core(json_dict, stac_object_type, stac_version, href)
         if core_result is not None:
             results.append(core_result)
 
         for extension_id in extensions:
-            ext_result = self.validate_extension(stac_dict, stac_object_type, stac_version,
+            ext_result = self.validate_extension(json_dict, stac_object_type, stac_version,
                                                  extension_id, href)
             if ext_result is not None:
                 results.append(ext_result)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+ipython==7.16.1
 jsonschema==3.2.0
 pylint==1.9.1
 Sphinx==1.8.0
@@ -6,5 +7,5 @@ sphinxcontrib-fulltoc==1.2.0
 sphinxcontrib-napoleon==0.7
 flake8==3.8.*
 yapf==0.28.*
-nbsphinx==0.4.3
+nbsphinx==0.7.1
 coverage==5.2.*

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -12,6 +12,8 @@ from pystac.extensions.eo import Band
 from pystac.utils import datetime_to_str
 from tests.utils import (TestCases, RANDOM_GEOM, RANDOM_BBOX)
 
+TEST_DATETIME = datetime(2020, 3, 14, 16, 32)
+
 
 class CollectionTest(unittest.TestCase):
     def test_spatial_extent_from_coordinates(self):
@@ -27,14 +29,14 @@ class CollectionTest(unittest.TestCase):
         item1 = Item(id='test-item-1',
                      geometry=RANDOM_GEOM,
                      bbox=RANDOM_BBOX,
-                     datetime=datetime.utcnow(),
+                     datetime=TEST_DATETIME,
                      properties={'key': 'one'},
                      stac_extensions=['eo', 'commons'])
 
         item2 = Item(id='test-item-2',
                      geometry=RANDOM_GEOM,
                      bbox=RANDOM_BBOX,
-                     datetime=datetime.utcnow(),
+                     datetime=TEST_DATETIME,
                      properties={'key': 'two'},
                      stac_extensions=['eo', 'commons'])
 
@@ -142,7 +144,7 @@ class CollectionTest(unittest.TestCase):
         item1 = Item(id='test-item-1',
                      geometry=RANDOM_GEOM,
                      bbox=[-180, -90, 180, 90],
-                     datetime=datetime.utcnow(),
+                     datetime=TEST_DATETIME,
                      properties={'key': 'one'},
                      stac_extensions=['eo', 'commons'])
 
@@ -178,18 +180,17 @@ class CollectionTest(unittest.TestCase):
 
 class ExtentTest(unittest.TestCase):
     def test_spatial_allows_single_bbox(self):
-        temporal_extent = TemporalExtent(intervals=[[datetime.utcnow(), None]])
+        temporal_extent = TemporalExtent(intervals=[[TEST_DATETIME, None]])
 
         # Pass in a single BBOX
         spatial_extent = SpatialExtent(bboxes=RANDOM_BBOX)
 
         collection_extent = Extent(spatial=spatial_extent, temporal=temporal_extent)
 
-        collection = Collection(id='test',
-                                description='test',
-                                extent=collection_extent,
-                                license='CC-BY-SA-4.0')
-        collection.set_self_href('/usr/collection.json')
+        collection = Collection(id='test', description='test desc', extent=collection_extent)
+
+        # HREF required by validation
+        collection.set_self_href('https://example.com/collection.json')
 
         collection.validate()
 
@@ -197,14 +198,13 @@ class ExtentTest(unittest.TestCase):
         spatial_extent = SpatialExtent(bboxes=[RANDOM_BBOX])
 
         # Pass in a single interval
-        temporal_extent = TemporalExtent(intervals=[datetime.utcnow(), None])
+        temporal_extent = TemporalExtent(intervals=[TEST_DATETIME, None])
 
         collection_extent = Extent(spatial=spatial_extent, temporal=temporal_extent)
 
-        collection = Collection(id='test',
-                                description='test',
-                                extent=collection_extent,
-                                license='CC-BY-SA-4.0')
-        collection.set_self_href('/usr/collection.json')
+        collection = Collection(id='test', description='test desc', extent=collection_extent)
+
+        # HREF required by validation
+        collection.set_self_href('https://example.com/collection.json')
 
         collection.validate()

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -1,0 +1,24 @@
+from datetime import datetime
+import unittest
+
+import pystac
+from tests.utils import (RANDOM_BBOX, RANDOM_GEOM)
+
+
+class LinkTest(unittest.TestCase):
+    def test_link_doest_fail_if_href_is_none(self):
+        """Tests to cover a bug that was uncovered where a non-None HREF
+        was supposed"""
+        catalog = pystac.Catalog(id='test', description='test')
+        item = pystac.Item(id='test-item',
+                           geometry=RANDOM_GEOM,
+                           bbox=RANDOM_BBOX,
+                           datetime=datetime.utcnow(),
+                           properties={'key': 'one'})
+        catalog.add_item(item)
+        catalog.set_self_href('/some/href')
+        catalog.make_all_links_relative()
+
+        for link in catalog.links:
+            if link.rel == 'item':
+                self.assertIsNone(link.get_href())

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -4,21 +4,21 @@ import unittest
 import pystac
 from tests.utils import (RANDOM_BBOX, RANDOM_GEOM)
 
+TEST_DATETIME = datetime(2020, 3, 14, 16, 32)
+
 
 class LinkTest(unittest.TestCase):
-    def test_link_doest_fail_if_href_is_none(self):
-        """Tests to cover a bug that was uncovered where a non-None HREF
-        was supposed"""
-        catalog = pystac.Catalog(id='test', description='test')
+    def test_link_does_not_fail_if_href_is_none(self):
+        """Test to ensure get_href does not fail when the href is None"""
+        catalog = pystac.Catalog(id='test', description='test desc')
         item = pystac.Item(id='test-item',
                            geometry=RANDOM_GEOM,
                            bbox=RANDOM_BBOX,
                            datetime=datetime.utcnow(),
-                           properties={'key': 'one'})
+                           properties={})
         catalog.add_item(item)
         catalog.set_self_href('/some/href')
         catalog.make_all_links_relative()
 
-        for link in catalog.links:
-            if link.rel == 'item':
-                self.assertIsNone(link.get_href())
+        link = catalog.get_single_link('item')
+        self.assertIsNone(link.get_href())

--- a/tests/validation/test_validate.py
+++ b/tests/validation/test_validate.py
@@ -1,6 +1,7 @@
+from datetime import datetime
+import json
 import os
 import shutil
-import json
 import unittest
 from tempfile import TemporaryDirectory
 
@@ -108,3 +109,25 @@ class ValidateTest(unittest.TestCase):
 
             with self.assertRaises(STACValidationError):
                 pystac.validation.validate_all(stac_dict, new_cat_href)
+
+    def test_validates_geojson_with_tuple_coordinates(self):
+        """This unit tests guards against a bug where if a geometry
+        dict has tuples instead of lists for the coordinate sequence,
+        which can be produced by shapely, then the geometry still passses
+        validation.
+        """
+        geom = {
+            'type':
+            'Polygon',
+            'coordinates': (((-115.3057626, 36.1265426997), (-115.3057626, 36.1282976997),
+                             (-115.3075176, 36.1282976997), (-115.3075176, 36.1265426997),
+                             (-115.3057626, 36.1265426997)), )
+        }
+
+        item = pystac.Item(id='test-item',
+                           geometry=geom,
+                           bbox=[-115.308, 36.126, -115.305, 36.129],
+                           datetime=datetime.utcnow(),
+                           properties={'key': 'one'})
+
+        self.assertIsNone(item.validate())

--- a/tests/validation/test_validate.py
+++ b/tests/validation/test_validate.py
@@ -119,15 +119,15 @@ class ValidateTest(unittest.TestCase):
         geom = {
             'type':
             'Polygon',
-            'coordinates': (((-115.3057626, 36.1265426997), (-115.3057626, 36.1282976997),
-                             (-115.3075176, 36.1282976997), (-115.3075176, 36.1265426997),
-                             (-115.3057626, 36.1265426997)), )
+            # Last , is required to ensure tuple creation.
+            'coordinates': (((-115.305, 36.126), (-115.305, 36.128), (-115.307, 36.128),
+                             (-115.307, 36.126), (-115.305, 36.126)), )
         }
 
         item = pystac.Item(id='test-item',
                            geometry=geom,
                            bbox=[-115.308, 36.126, -115.305, 36.129],
                            datetime=datetime.utcnow(),
-                           properties={'key': 'one'})
+                           properties={})
 
         self.assertIsNone(item.validate())


### PR DESCRIPTION
This PR adds a few fixes and enhancements based on solving the issues raised in #197 and #198.

- Fixes the spacenet tutorial to pass in a list of bboxes to the spatial extent, rather than a single bbox.
- Changes that tutorial to validate each of the catalogs it produces.
- Fix an issue raised by the validation of the label items, where the `label_classes` property is required. This requirement is dropped in a yet-unreleased version of the schemas, so a note was added to remove after 1.0.0-beta.2's successor is released.
- Fixed an issue with `Link.get_href()`, which was throwing a bad exception if a relative link had None for it's target href.
- Allowed users to pass in a single bbox to `SpatialExtent` and interval to `TemporalExtent` to guard against the common mistake mentioned in #198 
- Fixed an issue that caused geometry GeoJSON produced by shapely to fail PySTAC's validation. The reason for this was because the validation happened on the unmodified dict produced by a `to_dict` call. This can produce geometries that have their coordinates encoded with tuples instead of lists. The GeoJSON schema requires these to be lists, so the validation failed with a very cryptic message (a byproduct of using `oneOf` in JSON schemas - if the object doesn't match `oneOf` the schemas listed for a real validation failure, it instead complains about how it doesn't validate correctly against the first entry). The workaround here is to transform the dicts being passed in for validation to and from JSON serialization - if you JSON serialize a property whose value is a tuple, that will be transformed into a list for the JSON-ification. This solves the issue with shapely's `mapping` output, but also will solve for any case where a JSON serialization of an object would actually pass JSON schema validation, but the direct dict encoding may not.
- Fixes the failing readthedocs by upgrading nbsphinx. This upgrade produces a lot of warnings about rendering notebook output, which was fixed by including `ipython` in the dev dependencies.

Fixes #197 
Fixes #198 