### PR TITLE
Add codespell to CI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,16 @@ To format code:
 
 Note that you may have to use `yapf3` explicitly depending on your environment.
 
-You can also run the `./scripts/test` script to check flake8 and yapf.
+To check for spelling mistakes in modified files:
+
+```
+> git diff --name-only | xargs codespell -I .codespellignore -f
+
+You can also run the `./scripts/test` script to check for linting, spelling, and run unit tests.
+
+### Continuous Integration
+
+CI will run the `scripts/test` script to check for code quality. If you have a Pull Request that fails CI, make sure to fix any linting, spelling or test issues reported by `scripts/test`.
 
 ### Documentation
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+codespell==1.17.1
 ipython==7.16.1
 jsonschema==3.2.0
 pylint==1.9.1

--- a/scripts/test
+++ b/scripts/test
@@ -23,6 +23,16 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         # Code formatting
         yapf -dpr pystac tests
 
+        # Code spelling
+        codespell -I .codespellignore -f \
+            pystac/*.py pystac/**/*.py \
+            tests/*.py tests/**/*.py \
+            docs/*.rst docs/**/*.rst \
+            docs/*.ipynb docs/**/*.ipynb \
+            scripts/* \
+            *.py \
+            *.md
+
         # Test suite with coverage enabled
         coverage run --source=pystac/ -m unittest discover tests/
         coverage xml


### PR DESCRIPTION
This PR adds running codespell to the scripts/test script, which is run by CI. This will fail PRs that have spelling mistakes. A currently empty ignore file is put into place in case codespell fails on any intentional spellings.

Fixes #200