### PR TITLE
Ensure resolve object cache is set before set_self_href is called

### DIFF
--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -87,13 +87,13 @@ class Catalog(STACObject):
         else:
             self.extra_fields = extra_fields
 
+        self._resolved_objects = ResolvedObjectCache()
+        self._resolved_objects.cache(self)
+
         self.add_link(Link.root(self))
 
         if href is not None:
             self.set_self_href(href)
-
-        self._resolved_objects = ResolvedObjectCache()
-        self._resolved_objects.cache(self)
 
     def __repr__(self):
         return '<Catalog id={}>'.format(self.id)

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -177,6 +177,20 @@ class CollectionTest(unittest.TestCase):
             [[item2.common_metadata.start_datetime, base_extent.temporal.intervals[0][1]]],
             collection.extent.temporal.intervals)
 
+    def test_supplying_href_in_init_does_not_fail(self):
+        test_href = "http://example.com/collection.json"
+        spatial_extent = SpatialExtent(bboxes=[RANDOM_BBOX])
+        temporal_extent = TemporalExtent(intervals=[[TEST_DATETIME, None]])
+
+        collection_extent = Extent(spatial=spatial_extent, temporal=temporal_extent)
+        collection = Collection(id='test',
+                                description='test desc',
+                                extent=collection_extent,
+                                properties={},
+                                href=test_href)
+
+        self.assertEqual(collection.get_self_href(), test_href)
+
 
 class ExtentTest(unittest.TestCase):
     def test_spatial_allows_single_bbox(self):


### PR DESCRIPTION
This commit modifies the order of the logic in the Catalog.__init__ method to ensure the resolved object cache is established before a set_self_href call is made, which occurs if a non-None href is supplied. The logic of the Collection's set_self_href method requires the resolution cache be created on the object, which this change ensures.

Fixes #182