### PR TITLE
Allow for unnormalized path prefixes like /vsitar/

### DIFF
--- a/pystac/utils.py
+++ b/pystac/utils.py
@@ -108,6 +108,13 @@ def make_absolute_href(source_href, start_href=None, start_is_dir=False):
             else:
                 start_dir = _pathlib.dirname(parsed_start.path)
             abs_path = _pathlib.abspath(_join(is_path, start_dir, parsed_source.path))
+
+            # Account for the normalization of abspath for
+            # things like /vsitar// prefixes by replacing the
+            # original start_dir text when abspath modifies the start_dir.
+            if not start_dir == _pathlib.abspath(start_dir):
+                abs_path = abs_path.replace(_pathlib.abspath(start_dir), start_dir)
+
             if parsed_start.scheme != '':
                 if not is_path:
                     abs_path = abs_path.replace('\\', '/')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -79,6 +79,13 @@ class UtilsTest(unittest.TestCase):
             actual = make_absolute_href(source_href, start_href)
             self.assertEqual(actual, expected)
 
+    def test_make_absolute_href_on_vsitar(self):
+        rel_path = 'some/item.json'
+        cat_path = '/vsitar//tmp/catalog.tar/catalog.json'
+        expected = '/vsitar//tmp/catalog.tar/some/item.json'
+
+        self.assertEqual(expected, make_absolute_href(rel_path, cat_path))
+
     def test_make_absolute_href_windows(self):
         utils._pathlib = ntpath
         try:


### PR DESCRIPTION
The logic in make_absolute_href uses os.path.abspath, which normalizes paths. This lets us translate joined paths like /home/user/../catalog.json into proper paths. However, normalizing the path will also modify the root path being joined to in ways that may not be desirable. Specifically in the case of a /vsitar/ prefix, the double slashes that are required for proper GDAL reading are removed by normalization. This commit modifies the logic in make_absolute_href to detect when the original start path is modified by a call to abspath, and if so replaces the modified version with the original version.

Fixes #180