### PR TITLE
Refactor caching to utilize HREFs and parent IDs

### DIFF
--- a/pystac/cache.py
+++ b/pystac/cache.py
@@ -1,6 +1,32 @@
 from collections import ChainMap
 from copy import copy
 
+import pystac
+
+
+def get_cache_key(stac_object):
+    """Produce a cache key for the given STAC object.
+
+    If a self href is set, use that as the cache key.
+    If not, use a key that combines this object's ID with
+    it's parents' IDs.
+
+    Returns:
+        Tuple[str, bool]: A tuple with the cache key as the first
+            element and a boolean that is true if the cache key is
+            the object's HREF as the second element.
+    """
+    href = stac_object.get_self_href()
+    if href is not None:
+        return (href, True)
+    else:
+        ids = []
+        obj = stac_object
+        while obj is not None:
+            ids.append(obj.id)
+            obj = obj.get_parent()
+        return ('/'.join(ids), False)
+
 
 class ResolvedObjectCache:
     """This class tracks resolved objects tied to root catalogs.
@@ -19,72 +45,84 @@ class ResolvedObjectCache:
     them with their copies.
 
     Args:
-        ids_to_objects (Dict[str, STACObject]): Existing cache of STACObject IDs mapped
-        to the cached STACObject.
-        ids_to_hrefs (Dict[str, str]): Cache of STACObject IDs to their HREFs.
-        hrefs_to_ids
+        id_keys_to_objects (Dict[str, STACObject]): Existing cache of
+            a key made up of the STACObject and it's parents IDs mapped
+            to the cached STACObject.
+        hrefs_to_objects (Dict[str, STACObject]): STAC Object HREFs matched to
+            their cached object.
+        ids_to_collections (Dict[str, Collection]): Map of collection IDs to collections.
     """
-    def __init__(self, ids_to_objects=None, ids_to_hrefs=None, hrefs_to_ids=None):
-        self.ids_to_objects = ids_to_objects or {}
-        self.ids_to_hrefs = ids_to_hrefs or {}
-        self.hrefs_to_ids = hrefs_to_ids or {}
+    def __init__(self, id_keys_to_objects=None, hrefs_to_objects=None, ids_to_collections=None):
+        self.id_keys_to_objects = id_keys_to_objects or {}
+        self.hrefs_to_objects = hrefs_to_objects or {}
+        self.ids_to_collections = ids_to_collections or {}
 
         self._collection_cache = None
-
-    def _cache_href(self, obj):
-        href = obj.get_self_href()
-        if href is not None:
-            self.ids_to_hrefs[obj.id] = href
-            self.hrefs_to_ids[href] = obj.id
 
     def get_or_cache(self, obj):
         """Gets the STACObject that is the cached version of the given STACObject; or, if
         none exists, sets the cached object to the given object.
 
         Args:
-            obj (STACObject): The given object who's ID will be checked against the cache.
+            obj (STACObject): The given object who's cache key will be checked
+                against the cache.
 
         Returns:
-            STACObject: Either the cached object that has the same ID as the given
+            STACObject: Either the cached object that has the same cache key as the given
             object, or the given object.
         """
-        if obj.id in self.ids_to_objects:
-            return self.ids_to_objects[obj.id]
+        key, is_href = get_cache_key(obj)
+        if is_href:
+            if key in self.hrefs_to_objects:
+                return self.hrefs_to_objects[key]
+            else:
+                self.cache(obj)
+                return obj
         else:
-            self.ids_to_objects[obj.id] = obj
-            self._cache_href(obj)
-            return obj
+            if key in self.id_keys_to_objects:
+                return self.id_keys_to_objects[key]
+            else:
+                self.cache(obj)
+                return obj
 
     def get(self, obj):
-        """Get the cached object that has the same ID as the given object.
+        """Get the cached object that has the same cache key as the given object.
 
         Args:
-            obj (STACObject): The given object who's ID will be checked against the cache.
+            obj (STACObject): The given object who's cache key will be checked against the cache.
 
         Returns:
-            STACObject or None: Either the cached object that has the same ID as the given
+            STACObject or None: Either the cached object that has the same cache key as the given
             object, or None
         """
-        return self.get_by_id(obj.id)
-
-    def get_by_id(self, obj_id):
-        """Get the cached object that has the given ID.
-
-        Args:
-            obj_id (str): The ID to be checked against the cache.
-
-        Returns:
-            STACObject or None: Either the cached object that has the given ID, or None
-        """
-
-        return self.ids_to_objects.get(obj_id)
+        key, is_href = get_cache_key(obj)
+        if is_href:
+            return self.get_by_href(key)
+        else:
+            return self.id_keys_to_objects.get(key)
 
     def get_by_href(self, href):
-        obj_id = self.hrefs_to_ids.get(href)
-        if obj_id is not None:
-            return self.get_by_id(obj_id)
-        else:
-            return None
+        """Gets the cached object at href.
+
+        Args:
+            href (str): The href to use as the key for the cached object.
+
+        Returns:
+            STACObject or None: Returns the STACObject if cached, otherwise None.
+        """
+        return self.hrefs_to_objects.get(href)
+
+    def get_collection_by_id(self, id):
+        """Retrieved a cached Collection by its ID.
+
+        Args:
+            id (str): The ID of the collection.
+
+        Returns:
+            Collection or None: Returns the collection if there is one cached
+                with the given ID, otehrwise None.
+        """
+        return self.ids_to_collections.get(id)
 
     def cache(self, obj):
         """Set the given object into the cache.
@@ -92,43 +130,38 @@ class ResolvedObjectCache:
         Args:
             obj (STACObject): The object to cache
         """
-        self.ids_to_objects[obj.id] = obj
-        self._cache_href(obj)
+        key, is_href = get_cache_key(obj)
+        if is_href:
+            self.hrefs_to_objects[key] = obj
+        else:
+            self.id_keys_to_objects[key] = obj
+
+        if obj.STAC_OBJECT_TYPE == pystac.STACObjectType.COLLECTION:
+            self.ids_to_collections[obj.id] = obj
 
     def remove(self, obj):
-        """Removes any cached object that matches the given object's id.
+        """Removes any cached object that matches the given object's cache key.
 
         Args:
             obj (STACObject): The object to remove
         """
-        self.remove_by_id(obj.id)
+        key, is_href = get_cache_key(obj)
 
-    def remove_by_id(self, obj_id):
-        """Removes any cached object that matches the given ID.
+        if is_href:
+            self.hrefs_to_objects.pop(key, None)
+        else:
+            self.id_keys_to_objects.pop(key, None)
 
-        Args:
-            obj_id (str): The object ID to remove
-        """
-        self.ids_to_objects.pop(obj_id, None)
-        href = self.ids_to_hrefs.pop(obj_id, None)
-        if href is not None:
-            self.hrefs_to_ids.pop(href, None)
-
-    def clone(self):
-        """Clone this ResolvedObjectCache
-
-        Returns:
-            ResolvedObjectCache: A clone of this cache, which contains a shallow
-            copy of the ID to STACObject cache.
-        """
-        return ResolvedObjectCache(copy(self.ids_to_objects), copy(self.ids_to_hrefs),
-                                   copy(self.hrefs_to_ids))
+        if obj.STAC_OBJECT_TYPE == pystac.STACObjectType.COLLECTION:
+            self.id_keys_to_objects.pop(obj.id, None)
 
     def __contains__(self, obj):
-        return self.contains_id(obj.id)
+        key, is_href = get_cache_key(obj)
+        return key in self.hrefs_to_objects if is_href else key in self.id_keys_to_objects
 
-    def contains_id(self, obj_id):
-        return obj_id in self.ids_to_objects
+    def contains_collection_id(self, collection_id):
+        """Returns True if there is a collection with given collection ID is cached."""
+        return collection_id in self.ids_to_collections
 
     def as_collection_cache(self):
         if self._collection_cache is None:
@@ -140,7 +173,7 @@ class ResolvedObjectCache:
         """Merges two ResolvedObjectCache.
 
         The merged cache will give preference to the first argument; that is, if there
-        are cached IDs that exist in both the first and second cache, the object cached
+        are cached keys that exist in both the first and second cache, the object cached
         in the first will be cached in the resulting merged ResolvedObjectCache.
 
         Args:
@@ -151,10 +184,14 @@ class ResolvedObjectCache:
         Returns:
             ResolvedObjectCache: The resulting merged cache.
         """
-        merged = ResolvedObjectCache(
-            ids_to_objects=dict(ChainMap(copy(first.ids_to_objects), copy(second.ids_to_objects))),
-            ids_to_hrefs=dict(ChainMap(copy(first.ids_to_hrefs), copy(second.ids_to_hrefs))),
-            hrefs_to_ids=dict(ChainMap(copy(first.hrefs_to_ids), copy(second.hrefs_to_ids))))
+        merged = ResolvedObjectCache(id_keys_to_objects=dict(
+            ChainMap(copy(first.id_keys_to_objects), copy(second.id_keys_to_objects))),
+                                     hrefs_to_objects=dict(
+                                         ChainMap(copy(first.hrefs_to_objects),
+                                                  copy(second.hrefs_to_objects))),
+                                     ids_to_collections=dict(
+                                         ChainMap(copy(first.ids_to_collections),
+                                                  copy(second.ids_to_collections))))
 
         merged._collection_cache = ResolvedObjectCollectionCache.merge(
             merged, first._collection_cache, second._collection_cache)
@@ -196,7 +233,7 @@ class ResolvedObjectCollectionCache(CollectionCache):
         self.resolved_object_cache = resolved_object_cache
 
     def get_by_id(self, collection_id):
-        result = self.resolved_object_cache.get_by_id(collection_id)
+        result = self.resolved_object_cache.get_collection_by_id(collection_id)
         if result is None:
             return super().get_by_id(collection_id)
         else:
@@ -210,7 +247,7 @@ class ResolvedObjectCollectionCache(CollectionCache):
             return result
 
     def contains_id(self, collection_id):
-        return (self.resolved_object_cache.contains_id(collection_id)
+        return (self.resolved_object_cache.contains_collection_id(collection_id)
                 or super().contains_id(collection_id))
 
     def cache(self, collection, href=None):

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -180,6 +180,16 @@ class LinkMixin:
                 link.make_absolute()
         return self
 
+    def get_root_link(self):
+        """Get the :class:`~pystac.Link` representing
+        the root for this object.
+
+        Returns:
+            :class:`~pystac.Link` or None: The root link for this object,
+            or ``None`` if no root link is set.
+        """
+        return self.get_single_link('root')
+
     def get_self_href(self):
         """Gets the absolute HREF that is represented by the ``rel == 'self'``
         :class:`~pystac.Link`.
@@ -206,12 +216,22 @@ class LinkMixin:
         :class:`~pystac.Link`.
 
         Args:
-            str: The absolute HREF of this object. If the given HREF
+            href (str): The absolute HREF of this object. If the given HREF
                 is not absolute, it will be transformed to an absolute
-                HREF based on the current working directory.
+                HREF based on the current working directory. If this is None
+                the call will clear the self HREF link.
         """
+        root_link = self.get_root_link()
+        if root_link is not None and root_link.is_resolved():
+            root_link.target._resolved_objects.remove(self)
+
         self.remove_links('self')
-        self.add_link(Link.self_href(href))
+        if href is not None:
+            self.add_link(Link.self_href(href))
+
+        if root_link is not None and root_link.is_resolved():
+            root_link.target._resolved_objects.cache(self)
+
         return self
 
 
@@ -258,16 +278,6 @@ class STACObject(LinkMixin, ABC):
             return root_link.target
         else:
             return None
-
-    def get_root_link(self):
-        """Get the :class:`~pystac.Link` representing
-        the root for this object.
-
-        Returns:
-            :class:`~pystac.Link` or None: The root link for this object,
-            or ``None`` if no root link is set.
-        """
-        return self.get_single_link('root')
 
     def set_root(self, root, link_type=None):
         """Sets the root :class:`~pystac.Catalog` or :class:`~pystac.Collection`

--- a/tests/data-files/invalid/shared-id/catalog.json
+++ b/tests/data-files/invalid/shared-id/catalog.json
@@ -1,0 +1,17 @@
+{
+    "id": "test",
+    "stac_version": "1.0.0-beta.2",
+    "description": "test desc",
+    "links": [
+        {
+            "rel": "root",
+            "href": "./catalog.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "child",
+            "href": "./test/collection.json",
+            "type": "application/json"
+        }
+    ]
+}

--- a/tests/data-files/invalid/shared-id/test/collection.json
+++ b/tests/data-files/invalid/shared-id/test/collection.json
@@ -1,0 +1,43 @@
+{
+    "id": "test",
+    "stac_version": "1.0.0-beta.2",
+    "description": "test desc",
+    "links": [
+        {
+            "rel": "root",
+            "href": "../catalog.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "item",
+            "href": "./test-item-1/test-item-1.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "parent",
+            "href": "../catalog.json",
+            "type": "application/json"
+        }
+    ],
+    "extent": {
+        "spatial": {
+            "bbox": [
+                [
+                    -2.5048828125,
+                    3.8916575492899987,
+                    -1.9610595703125,
+                    3.8916575492899987
+                ]
+            ]
+        },
+        "temporal": {
+            "interval": [
+                [
+                    "2020-03-14T16:32:00Z",
+                    null
+                ]
+            ]
+        }
+    },
+    "license": "proprietary"
+}

--- a/tests/data-files/invalid/shared-id/test/test-item-1/test-item-1.json
+++ b/tests/data-files/invalid/shared-id/test/test-item-1/test-item-1.json
@@ -1,0 +1,60 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0-beta.2",
+    "id": "test-item-1",
+    "properties": {
+        "datetime": "2020-03-14T16:32:00Z"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -2.5048828125,
+                    3.8916575492899987
+                ],
+                [
+                    -1.9610595703125,
+                    3.8916575492899987
+                ],
+                [
+                    -1.9610595703125,
+                    4.275202171119132
+                ],
+                [
+                    -2.5048828125,
+                    4.275202171119132
+                ],
+                [
+                    -2.5048828125,
+                    3.8916575492899987
+                ]
+            ]
+        ]
+    },
+    "links": [
+        {
+            "rel": "root",
+            "href": "../../catalog.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "collection",
+            "href": "../collection.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "parent",
+            "href": "../collection.json",
+            "type": "application/json"
+        }
+    ],
+    "assets": {},
+    "bbox": [
+        -2.5048828125,
+        3.8916575492899987,
+        -1.9610595703125,
+        3.8916575492899987
+    ],
+    "collection": "test"
+}

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,72 @@
+import unittest
+
+import pystac
+from pystac.cache import (ResolvedObjectCache, ResolvedObjectCollectionCache)
+from tests.utils import TestCases
+
+
+def create_catalog(suffix, include_href=True):
+    return pystac.Catalog(
+        id='test {}'.format(suffix),
+        description='test desc {}'.format(suffix),
+        href=('http://example.com/catalog_{}.json'.format(suffix) if include_href else None))
+
+
+class ResolvedObjectCacheTest(unittest.TestCase):
+    def tests_get_or_cache_returns_previously_cached_href(self):
+        cache = ResolvedObjectCache()
+        cat = create_catalog(1)
+        cache_result_1 = cache.get_or_cache(cat)
+        self.assertIs(cache_result_1, cat)
+
+        identical_cat = create_catalog(1)
+        cache_result_2 = cache.get_or_cache(identical_cat)
+        self.assertIs(cache_result_2, cat)
+
+    def test_get_or_cache_returns_previously_cached_id(self):
+        cache = ResolvedObjectCache()
+        cat = create_catalog(1, include_href=False)
+        cache_result_1 = cache.get_or_cache(cat)
+        self.assertIs(cache_result_1, cat)
+
+        identical_cat = create_catalog(1, include_href=False)
+        cache_result_2 = cache.get_or_cache(identical_cat)
+        self.assertIs(cache_result_2, cat)
+
+
+class ResolvedObjectCollectionCacheTest(unittest.TestCase):
+    def test_merge(self):
+        cat1 = create_catalog(1, include_href=False)
+        cat2 = create_catalog(2)
+        cat3 = create_catalog(3, include_href=False)
+        cat4 = create_catalog(4)
+
+        identical_cat1 = create_catalog(1, include_href=False)
+        identical_cat2 = create_catalog(2)
+
+        cached_ids_1 = {cat1.id: cat1}
+        cached_hrefs_1 = {cat2.get_self_href(): cat2}
+        cached_ids_2 = {cat3.id: cat3, cat1.id: identical_cat1}
+        cached_hrefs_2 = {cat4.get_self_href(): cat4, cat2.get_self_href(): identical_cat2}
+        cache1 = ResolvedObjectCollectionCache(ResolvedObjectCache(),
+                                               cached_ids=cached_ids_1,
+                                               cached_hrefs=cached_hrefs_1)
+        cache2 = ResolvedObjectCollectionCache(ResolvedObjectCache(),
+                                               cached_ids=cached_ids_2,
+                                               cached_hrefs=cached_hrefs_2)
+
+        merged = ResolvedObjectCollectionCache.merge(ResolvedObjectCache(), cache1, cache2)
+
+        self.assertEqual(set(merged.cached_ids.keys()), set([cat.id for cat in [cat1, cat3]]))
+        self.assertIs(merged.get_by_id(cat1.id), cat1)
+        self.assertEqual(set(merged.cached_hrefs.keys()),
+                         set([cat.get_self_href() for cat in [cat2, cat4]]))
+        self.assertIs(merged.get_by_href(cat2.get_self_href()), cat2)
+
+    def test_cache(self):
+        cache = ResolvedObjectCache().as_collection_cache()
+        collection = TestCases.test_case_8()
+        collection_json = collection.to_dict()
+        cache.cache(collection_json, collection.get_self_href())
+
+        self.assertEqual(cache.get_by_id(collection.id)['id'], collection.id)

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -560,6 +560,13 @@ class CatalogTest(unittest.TestCase):
         cat = TestCases.test_case_8()
         cat.fully_resolve()
 
+    def test_handles_children_with_same_id(self):
+        # This catalog has the root and child collection share an ID.
+        cat = pystac.read_file(TestCases.get_path('data-files/invalid/shared-id/catalog.json'))
+        items = list(cat.get_all_items())
+
+        self.assertEqual(len(items), 1)
+
 
 class FullCopyTest(unittest.TestCase):
     def check_link(self, link, tag):


### PR DESCRIPTION
This PR refactors the caching strategy used by the resolved object cache to be based on an object's self HREF if available, and if not, to use a combination of the object's and its parents' IDs.

Before this change PySTAC required IDs to be unique within a catalog. This proved to be too restrictive and produced unexpected results in several situations.

Fixes #160 
Fixes #92 