### PR TITLE
Fix #186 and related issues

### DIFF
--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -88,12 +88,13 @@ class Catalog(STACObject):
             self.extra_fields = extra_fields
 
         self._resolved_objects = ResolvedObjectCache()
-        self._resolved_objects.cache(self)
 
         self.add_link(Link.root(self))
 
         if href is not None:
             self.set_self_href(href)
+
+        self._resolved_objects.cache(self)
 
     def __repr__(self):
         return '<Catalog id={}>'.format(self.id)
@@ -637,18 +638,15 @@ class Catalog(STACObject):
                       description=description,
                       title=title,
                       stac_extensions=stac_extensions,
-                      extra_fields=d)
+                      extra_fields=d,
+                      href=href)
 
-        has_self_link = False
         for link in links:
-            has_self_link |= link['rel'] == 'self'
             if link['rel'] == 'root':
                 # Remove the link that's generated in Catalog's constructor.
                 cat.remove_links('root')
 
-            cat.add_link(Link.from_dict(link))
-
-        if not has_self_link and href is not None:
-            cat.add_link(Link.self_href(href))
+            if link['rel'] != 'self' or href is None:
+                cat.add_link(Link.from_dict(link))
 
         return cat

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -82,30 +82,6 @@ class Collection(Catalog):
         self.properties = properties
         self.summaries = summaries
 
-    def set_self_href(self, href):
-        """Sets the absolute HREF that is represented by the ``rel == 'self'``
-        :class:`~pystac.Link`.
-
-        Args:
-            str: The absolute HREF of this object. If the given HREF
-                is not absolute, it will be transformed to an absolute
-                HREF based on the current working directory.
-
-        Note:
-            Overridden for collections so that the root's ResolutionObjectCache can properly
-            update the HREF cache.
-        """
-        root_link = self.get_root_link()
-        if root_link is not None and root_link.is_resolved():
-            root_link.target._resolved_objects.remove(self)
-
-        super().set_self_href(href)
-
-        if root_link is not None and root_link.is_resolved():
-            root_link.target._resolved_objects.cache(self)
-
-        return self
-
     def __repr__(self):
         return '<Collection id={}>'.format(self.id)
 

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -187,19 +187,16 @@ class Collection(Catalog):
                                 keywords=keywords,
                                 providers=providers,
                                 properties=properties,
-                                summaries=summaries)
+                                summaries=summaries,
+                                href=href)
 
-        has_self_link = False
         for link in links:
-            has_self_link |= link['rel'] == 'self'
             if link['rel'] == 'root':
                 # Remove the link that's generated in Catalog's constructor.
                 collection.remove_links('root')
 
-            collection.add_link(Link.from_dict(link))
-
-        if not has_self_link and href is not None:
-            collection.add_link(Link.self_href(href))
+            if link['rel'] != 'self' or href is None:
+                collection.add_link(Link.from_dict(link))
 
         return collection
 

--- a/pystac/serialization/common_properties.py
+++ b/pystac/serialization/common_properties.py
@@ -39,6 +39,8 @@ def merge_common_properties(item_dict, collection_cache=None, json_href=None):
         if type(stac_extensions) is list:
             if 'commons' not in stac_extensions:
                 return False
+        else:
+            return False
 
     # Try the cache if we have a collection ID.
     if 'collection' in item_dict:

--- a/pystac/serialization/common_properties.py
+++ b/pystac/serialization/common_properties.py
@@ -73,10 +73,13 @@ def merge_common_properties(item_dict, collection_cache=None, json_href=None):
         if isinstance(collection, Collection):
             collection_id = collection.id
             collection_props = collection.properties
-        else:
+        elif type(collection) is dict:
             collection_id = collection['id']
             if 'properties' in collection:
                 collection_props = collection['properties']
+        else:
+            raise ValueError('{} is expected to be a Collection or '
+                             'dict but is neither.'.format(collection))
 
         if collection_props is not None:
             for k in collection_props:

--- a/tests/data-files/examples/example-info.csv
+++ b/tests/data-files/examples/example-info.csv
@@ -134,3 +134,4 @@
 "sentinel-0.6.0/sentinel-2-l1c/9/V/catalog.json","CATALOG","0.6.0","",""
 "sentinel-0.6.0/sentinel-2-l1c/9/catalog.json","CATALOG","0.6.0","",""
 "sentinel-0.6.0/sentinel-2-l1c/catalog.json","COLLECTION","0.6.0","",""
+"hand-0.9.0/collection.json","COLLECTION","0.9.0","",""

--- a/tests/data-files/examples/example-info.csv
+++ b/tests/data-files/examples/example-info.csv
@@ -135,3 +135,4 @@
 "sentinel-0.6.0/sentinel-2-l1c/9/catalog.json","CATALOG","0.6.0","",""
 "sentinel-0.6.0/sentinel-2-l1c/catalog.json","COLLECTION","0.6.0","",""
 "hand-0.9.0/collection.json","COLLECTION","0.9.0","",""
+"hand-0.8.1/collection.json","COLLECTION","0.8.1","",""

--- a/tests/data-files/examples/hand-0.8.1/010100/010100.json
+++ b/tests/data-files/examples/hand-0.8.1/010100/010100.json
@@ -1,0 +1,66 @@
+{
+    "type": "Feature",
+    "stac_version": "0.8.1",
+    "id": "010100",
+    "properties": {
+        "datetime": "2020-06-01T00:00:00Z"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -69.840087890625,
+              45.92822950933618
+            ],
+            [
+              -67.2802734375,
+              45.92822950933618
+            ],
+            [
+              -67.2802734375,
+              47.52461999690651
+            ],
+            [
+              -69.840087890625,
+              47.52461999690651
+            ],
+            [
+              -69.840087890625,
+              45.92822950933618
+            ]
+          ]
+        ]
+    },
+    "bbox": [
+        -70.4171738459305,
+        45.73847961442135,
+        -66.60498877163946,
+        48.09932887950686
+    ],
+    "links": [
+        {
+            "rel": "collection",
+            "href": "../collection.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "root",
+            "href": "../collection.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "parent",
+            "href": "../collection.json",
+            "type": "application/json"
+        }
+    ],
+    "assets": {
+        "hand": {
+            "href": "s3://hand-data/010100/010100hand.tif",
+            "type": "image/tiff; application=geotiff",
+            "description": "HAND raster, buffer removed, final result"
+        }
+    },
+    "collection": "hand_021"
+}

--- a/tests/data-files/examples/hand-0.8.1/collection.json
+++ b/tests/data-files/examples/hand-0.8.1/collection.json
@@ -1,0 +1,37 @@
+{
+    "id": "hand_021",
+    "stac_version": "0.8.1",
+    "description": "The continental flood inundation mapping (CFIM) framework is a high-performance computing (HPC)-based computational framework for the Height Above Nearest Drainage (HAND)-based inundation mapping methodology...",
+    "links": [
+        {
+            "rel": "root",
+            "href": "./collection.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "item",
+            "href": "./010100/010100.json",
+            "type": "application/json"
+        }
+    ],
+    "title": "HAND and the Hydraulic Property Table version 0.2.1",
+    "extent": {
+        "spatial": {
+            "bbox": [[
+                -124.90220439990048,
+                48.57285024335522,
+                -123.0335319132177,
+                52.88065372625198
+            ]]
+        },
+        "temporal": {
+            "interval": [
+                [
+                    "2020-06-01T00:00:00Z",
+                    null
+                ]
+            ]
+        }
+    },
+    "license": "CC-BY-4.0"
+}

--- a/tests/data-files/examples/hand-0.9.0/010100/010100.json
+++ b/tests/data-files/examples/hand-0.9.0/010100/010100.json
@@ -1,0 +1,66 @@
+{
+    "type": "Feature",
+    "stac_version": "0.9.0",
+    "id": "010100",
+    "properties": {
+        "datetime": "2020-06-01T00:00:00Z"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [
+              -69.840087890625,
+              45.92822950933618
+            ],
+            [
+              -67.2802734375,
+              45.92822950933618
+            ],
+            [
+              -67.2802734375,
+              47.52461999690651
+            ],
+            [
+              -69.840087890625,
+              47.52461999690651
+            ],
+            [
+              -69.840087890625,
+              45.92822950933618
+            ]
+          ]
+        ]
+    },
+    "bbox": [
+        -70.4171738459305,
+        45.73847961442135,
+        -66.60498877163946,
+        48.09932887950686
+    ],
+    "links": [
+        {
+            "rel": "collection",
+            "href": "../collection.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "root",
+            "href": "../collection.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "parent",
+            "href": "../collection.json",
+            "type": "application/json"
+        }
+    ],
+    "assets": {
+        "hand": {
+            "href": "s3://hand-data/010100/010100hand.tif",
+            "type": "image/tiff; application=geotiff",
+            "description": "HAND raster, buffer removed, final result"
+        }
+    },
+    "collection": "hand_021"
+}

--- a/tests/data-files/examples/hand-0.9.0/collection.json
+++ b/tests/data-files/examples/hand-0.9.0/collection.json
@@ -1,0 +1,37 @@
+{
+    "id": "hand_021",
+    "stac_version": "0.9.0",
+    "description": "The continental flood inundation mapping (CFIM) framework is a high-performance computing (HPC)-based computational framework for the Height Above Nearest Drainage (HAND)-based inundation mapping methodology...",
+    "links": [
+        {
+            "rel": "root",
+            "href": "./collection.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "item",
+            "href": "./010100/010100.json",
+            "type": "application/json"
+        }
+    ],
+    "title": "HAND and the Hydraulic Property Table version 0.2.1",
+    "extent": {
+        "spatial": {
+            "bbox": [[
+                -124.90220439990048,
+                48.57285024335522,
+                -123.0335319132177,
+                52.88065372625198
+            ]]
+        },
+        "temporal": {
+            "interval": [
+                [
+                    "2020-06-01T00:00:00Z",
+                    null
+                ]
+            ]
+        }
+    },
+    "license": "CC-BY-4.0"
+}

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -567,6 +567,14 @@ class CatalogTest(unittest.TestCase):
 
         self.assertEqual(len(items), 1)
 
+    def test_catalog_with_href_caches_by_href(self):
+        cat = TestCases.test_case_1()
+        cache = cat._resolved_objects
+
+        # Since all of our STAC objects have HREFs, everything should be
+        # cached only by HREF
+        self.assertEqual(len(cache.id_keys_to_objects), 0)
+
 
 class FullCopyTest(unittest.TestCase):
     def check_link(self, link, tag):

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -191,6 +191,12 @@ class CollectionTest(unittest.TestCase):
 
         self.assertEqual(collection.get_self_href(), test_href)
 
+    def test_reading_0_8_1_collection_as_catalog_throws_correct_exception(self):
+        cat = pystac.Catalog.from_file(
+            TestCases.get_path('data-files/examples/hand-0.8.1/collection.json'))
+        with self.assertRaises(ValueError):
+            list(cat.get_all_items())
+
 
 class ExtentTest(unittest.TestCase):
     def test_spatial_allows_single_bbox(self):

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -197,6 +197,15 @@ class CollectionTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             list(cat.get_all_items())
 
+    def test_collection_with_href_caches_by_href(self):
+        collection = pystac.read_file(
+            TestCases.get_path('data-files/examples/hand-0.8.1/collection.json'))
+        cache = collection._resolved_objects
+
+        # Since all of our STAC objects have HREFs, everything should be
+        # cached only by HREF
+        self.assertEqual(len(cache.id_keys_to_objects), 0)
+
 
 class ExtentTest(unittest.TestCase):
     def test_spatial_allows_single_bbox(self):

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -136,6 +136,15 @@ class ItemTest(unittest.TestCase):
         with self.assertRaises(KeyError):
             item_dict['bbox']
 
+    def test_0_9_item_with_no_extensions_does_not_read_collection_data(self):
+        item_json = pystac.STAC_IO.read_json(
+            TestCases.get_path('data-files/examples/hand-0.9.0/010100/010100.json'))
+        assert item_json.get('stac_extensions') is None
+        assert item_json.get('stac_version') == '0.9.0'
+
+        did_merge = pystac.serialization.common_properties.merge_common_properties(item_json)
+        self.assertFalse(did_merge)
+
 
 class CommonMetadataTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This PR fixes issues uncovered while investigating #186.

- The merge_common_properties logic was executing in the case of a 0.9.0 item that did not have the 'commons' extension implemented. This was due to a bug in the logic that didn't account for the case where `stac_extensions` was not declared in the Item.
- When the merge_common_properties logic does execute, if the collection that is referenced by the item produces a cached value that is not a Collection (for example if a collection was read in as a Catalog as described in #186), throw a more clear error than was previously being thrown.

The two other changes below relate to the caching changes made in #214:
- The logic in Catalog and Collection `from_dict` was causing root objects to be cached twice - once with it's ID key and once when the HREF was set on the object. This changes the logic to ensure that if an object is read in with an HREF, it's cached only by its HREF. 
- `set_self_href` on Collection was promoted to be the implementation for all STACObjects. This method on Collection should have been deleted in #214, but is done so here.

Fixes #186