### PR TITLE
Set catalog_type when reading a Collection.

### DIFF
--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import dateutil.parser
 from dateutil import tz
 from copy import (copy, deepcopy)
-from pystac import (STACError, STACObjectType)
+from pystac import (STACError, STACObjectType, CatalogType)
 from pystac.catalog import Catalog
 from pystac.link import Link
 from pystac.utils import datetime_to_str
@@ -66,13 +66,14 @@ class Collection(Catalog):
                  stac_extensions=None,
                  href=None,
                  extra_fields=None,
+                 catalog_type=None,
                  license='proprietary',
                  keywords=None,
                  providers=None,
                  properties=None,
                  summaries=None):
         super(Collection, self).__init__(id, description, title, stac_extensions, extra_fields,
-                                         href)
+                                         href, catalog_type)
         self.extent = extent
         self.license = license
 
@@ -136,6 +137,8 @@ class Collection(Catalog):
 
     @classmethod
     def from_dict(cls, d, href=None, root=None):
+        catalog_type = CatalogType.determine_type(d)
+
         d = deepcopy(d)
         id = d.pop('id')
         description = d.pop('description')
@@ -164,7 +167,8 @@ class Collection(Catalog):
                                 providers=providers,
                                 properties=properties,
                                 summaries=summaries,
-                                href=href)
+                                href=href,
+                                catalog_type=catalog_type)
 
         for link in links:
             if link['rel'] == 'root':

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -92,6 +92,18 @@ class CollectionTest(unittest.TestCase):
 
         self.assertTrue(item.ext.implements('eo'))
 
+    def test_save_uses_previous_catalog_type(self):
+        collection = TestCases.test_case_8()
+        assert collection.STAC_OBJECT_TYPE == pystac.STACObjectType.COLLECTION
+        self.assertEqual(collection.catalog_type, CatalogType.SELF_CONTAINED)
+        with TemporaryDirectory() as tmp_dir:
+            collection.normalize_hrefs(tmp_dir)
+            href = collection.get_self_href()
+            collection.save()
+
+            collection2 = pystac.read_file(href)
+            self.assertEqual(collection2.catalog_type, CatalogType.SELF_CONTAINED)
+
     def test_multiple_extents(self):
         cat1 = TestCases.test_case_1()
         col1 = cat1.get_child('country-1').get_child('area-1-1')


### PR DESCRIPTION
As a follow-up to #224, set the catalog_type in Collection.to_dict
similar to how it is set in Catalog.to_dict.