### PR TITLE
Modify Item set_self_href to ensure asset HREFs do not break.

### DIFF
--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -7,7 +7,7 @@ from pystac.stac_object import STACObject
 from pystac.layout import (BestPracticesLayoutStrategy, LayoutTemplate)
 from pystac.link import (Link, LinkType)
 from pystac.cache import ResolvedObjectCache
-from pystac.utils import (is_absolute_href, make_absolute_href, make_relative_href)
+from pystac.utils import (is_absolute_href, make_absolute_href)
 
 
 class CatalogType:
@@ -481,21 +481,10 @@ class Catalog(STACObject):
         def process_item(item, _root_href):
             item.resolve_links()
 
-            old_self_href = item.get_self_href()
             new_self_href = strategy.get_href(item, _root_href)
 
             def fn():
                 item.set_self_href(new_self_href)
-
-                # Make sure relative asset links remain valid.
-                # This will only work if there is a self href set.
-                for asset in item.assets.values():
-                    asset_href = asset.href
-                    if not is_absolute_href(asset_href):
-                        if old_self_href is not None:
-                            abs_href = make_absolute_href(asset_href, old_self_href)
-                            new_relative_href = make_relative_href(abs_href, new_self_href)
-                            asset.href = new_relative_href
 
             return fn
 

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -8,7 +8,7 @@ import pystac
 from pystac import Asset, Item, Provider
 from pystac.validation import validate_dict
 from pystac.item import CommonMetadata
-from pystac.utils import str_to_datetime
+from pystac.utils import (str_to_datetime, is_absolute_href)
 from pystac.serialization.identify import STACObjectType
 from tests.utils import (TestCases, test_to_from_dict)
 
@@ -35,6 +35,17 @@ class ItemTest(unittest.TestCase):
         self.assertEqual(item.assets['analytic'].properties['product'],
                          'http://cool-sat.com/catalog/products/analytic.json')
         self.assertEqual(len(item.assets['thumbnail'].properties), 0)
+
+    def test_set_self_href_doesnt_break_asset_hrefs(self):
+        cat = TestCases.test_case_6()
+        for item in cat.get_all_items():
+            for asset in item.assets.values():
+                print(asset.href)
+                assert not is_absolute_href(asset.href)
+            item.set_self_href('http://example.com/item.json')
+            for asset in item.assets.values():
+                self.assertTrue(is_absolute_href(asset.href))
+                self.assertTrue(os.path.exists(asset.href))
 
     def test_asset_absolute_href(self):
         item_dict = self.get_example_item_dict()


### PR DESCRIPTION
Previous to this change, using set_self_href on Item could cause assets with relative HREFs to lose a pointer to the actual asset files. This was not true in the case of using normalize_hrefs on a catalog containing the item, but calling set_self_href directly on the item could cause this problem to occur. This change moves the logic to ensure relative asset HREFs do not break when changing the Item's HREF into an overridden version of set_self_href on Item.