### PR TITLE
Set catalog_type on Catalog and Collection during clone

### DIFF
--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -384,7 +384,8 @@ class Catalog(STACObject):
                         description=self.description,
                         title=self.title,
                         stac_extensions=self.stac_extensions,
-                        extra_fields=deepcopy(self.extra_fields))
+                        extra_fields=deepcopy(self.extra_fields),
+                        catalog_type=self.catalog_type)
         clone._resolved_objects.cache(clone)
 
         for link in self.links:

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -24,6 +24,8 @@ class Collection(Catalog):
         stac_extensions (List[str]): Optional list of extensions the Collection implements.
         href (str or None): Optional HREF for this collection, which be set as the collection's
             self link's HREF.
+        catalog_type (str or None): Optional catalog type for this catalog. Must
+            be one of the values in :class`~pystac.CatalogType`.
         license (str):  Collection's license(s) as a `SPDX License identifier
             <https://spdx.org/licenses/>`_, `various`, or `proprietary`. If collection includes
             data with multiple different licenses, use `various` and add a link for each.
@@ -114,6 +116,7 @@ class Collection(Catalog):
                            title=self.title,
                            stac_extensions=self.stac_extensions,
                            extra_fields=self.extra_fields,
+                           catalog_type=self.catalog_type,
                            license=self.license,
                            keywords=self.keywords,
                            providers=self.providers,

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -256,6 +256,12 @@ class CatalogTest(unittest.TestCase):
             cat2 = pystac.read_file(href)
             self.assertEqual(cat2.catalog_type, CatalogType.SELF_CONTAINED)
 
+    def test_clone_uses_previous_catalog_type(self):
+        catalog = TestCases.test_case_1()
+        assert catalog.catalog_type == CatalogType.SELF_CONTAINED
+        clone = catalog.clone()
+        self.assertEqual(clone.catalog_type, CatalogType.SELF_CONTAINED)
+
     def test_save_throws_if_no_catalog_type(self):
         catalog = TestCases.test_case_3()
         assert catalog.catalog_type is None

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -104,6 +104,12 @@ class CollectionTest(unittest.TestCase):
             collection2 = pystac.read_file(href)
             self.assertEqual(collection2.catalog_type, CatalogType.SELF_CONTAINED)
 
+    def test_clone_uses_previous_catalog_type(self):
+        catalog = TestCases.test_case_8()
+        assert catalog.catalog_type == CatalogType.SELF_CONTAINED
+        clone = catalog.clone()
+        self.assertEqual(clone.catalog_type, CatalogType.SELF_CONTAINED)
+
     def test_multiple_extents(self):
         cat1 = TestCases.test_case_1()
         col1 = cat1.get_child('country-1').get_child('area-1-1')


### PR DESCRIPTION
Before this change, a cloned catalog or collection would not carry forward the catalog_type. This commit fixes this issue.