### PR TITLE
Set cloned asset owner during item clone.

### DIFF
--- a/pystac/item.py
+++ b/pystac/item.py
@@ -304,7 +304,8 @@ class Item(STACObject):
         for link in self.links:
             clone.add_link(link.clone())
 
-        clone.assets = dict([(k, a.clone()) for (k, a) in self.assets.items()])
+        for k, asset in self.assets.items():
+            clone.add_asset(k, asset.clone())
 
         return clone
 

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -167,6 +167,16 @@ class ItemTest(unittest.TestCase):
         did_merge = pystac.serialization.common_properties.merge_common_properties(item_json)
         self.assertFalse(did_merge)
 
+    def test_clone_sets_asset_owner(self):
+        cat = TestCases.test_case_2()
+        item = next(cat.get_all_items())
+        original_asset = list(item.assets.values())[0]
+        assert original_asset.owner is item
+
+        clone = item.clone()
+        clone_asset = list(clone.assets.values())[0]
+        self.assertIs(clone_asset.owner, clone)
+
 
 class CommonMetadataTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This fixes a bug where a clone of item ended up with assets that did not have the owner set.