### PR TITLE
In Item.make_asset_hrefs_relative, leave relative hrefs alone.

### DIFF
--- a/pystac/item.py
+++ b/pystac/item.py
@@ -186,11 +186,17 @@ class Item(STACObject):
         Returns:
             Item: self
         """
-        self_href = self.get_self_href()
-        if self_href is None:
-            raise STACError('Cannot make asset HREFs relative if no self_href is set.')
+
+        self_href = None
         for asset in self.assets.values():
-            asset.href = make_relative_href(asset.href, self_href)
+            href = asset.href
+            if is_absolute_href(href):
+                if self_href is None:
+                    self_href = self.get_self_href()
+                    if self_href is None:
+                        raise STACError('Cannot make asset HREFs relative '
+                                        'if no self_href is set.')
+                asset.href = make_relative_href(asset.href, self_href)
         return self
 
     def make_asset_hrefs_absolute(self):

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -556,6 +556,20 @@ class CatalogTest(unittest.TestCase):
         href = item.assets['cf73ec1a-d790-4b59-b077-e101738571ed'].href
         self.assertTrue(is_absolute_href(href))
 
+    def test_make_all_asset_hrefs_relative(self):
+        cat = TestCases.test_case_2()
+        item = cat.get_item('cf73ec1a-d790-4b59-b077-e101738571ed', recursive=True)
+        asset = item.assets['cf73ec1a-d790-4b59-b077-e101738571ed']
+        original_href = asset.href
+        cat.make_all_asset_hrefs_absolute()
+
+        assert is_absolute_href(asset.href)
+
+        cat.make_all_asset_hrefs_relative()
+
+        self.assertFalse(is_absolute_href(asset.href))
+        self.assertEqual(asset.href, original_href)
+
     def test_make_all_links_relative_or_absolute(self):
         def check_all_relative(cat):
             for root, catalogs, items in cat.walk():

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -177,6 +177,16 @@ class ItemTest(unittest.TestCase):
         clone_asset = list(clone.assets.values())[0]
         self.assertIs(clone_asset.owner, clone)
 
+    def test_make_asset_href_relative_is_noop_on_relative_hrefs(self):
+        cat = TestCases.test_case_2()
+        item = next(cat.get_all_items())
+        asset = list(item.assets.values())[0]
+        assert not is_absolute_href(asset.href)
+        original_href = asset.get_absolute_href()
+
+        item.make_asset_hrefs_relative()
+        self.assertEqual(asset.get_absolute_href(), original_href)
+
 
 class CommonMetadataTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This fixes a bug where make_asset_hrefs_relative was modifying already relative paths, which set the HREFs to invalid locations.