### PR TITLE
Handle setting new versions correctly in version extension.

### DIFF
--- a/pystac/extensions/version.py
+++ b/pystac/extensions/version.py
@@ -110,7 +110,9 @@ class VersionItemExt(base.ItemExtension):
 
     @latest.setter
     def latest(self, source_item: pystac.Item) -> None:
-        self.item.add_link(pystac.Link(LATEST, source_item, MEDIA_TYPE))
+        self.item.clear_links(LATEST)
+        if source_item:
+            self.item.add_link(pystac.Link(LATEST, source_item, MEDIA_TYPE))
 
     @property
     def predecessor(self) -> Optional[pystac.Item]:
@@ -123,7 +125,9 @@ class VersionItemExt(base.ItemExtension):
 
     @predecessor.setter
     def predecessor(self, source_item: pystac.Item) -> None:
-        self.item.add_link(pystac.Link(PREDECESSOR, source_item, MEDIA_TYPE))
+        self.item.clear_links(PREDECESSOR)
+        if source_item:
+            self.item.add_link(pystac.Link(PREDECESSOR, source_item, MEDIA_TYPE))
 
     @property
     def successor(self) -> Optional[pystac.Item]:
@@ -136,7 +140,9 @@ class VersionItemExt(base.ItemExtension):
 
     @successor.setter
     def successor(self, source_item: pystac.Item) -> None:
-        self.item.add_link(pystac.Link(SUCCESSOR, source_item, MEDIA_TYPE))
+        self.item.clear_links(SUCCESSOR)
+        if source_item:
+            self.item.add_link(pystac.Link(SUCCESSOR, source_item, MEDIA_TYPE))
 
     @classmethod
     def from_item(cls, an_item: pystac.Item):
@@ -205,7 +211,9 @@ class VersionCollectionExt(base.CollectionExtension):
 
     @latest.setter
     def latest(self, source_collection) -> None:
-        self.collection.add_link(pystac.Link(LATEST, source_collection, MEDIA_TYPE))
+        self.collection.clear_links(LATEST)
+        if source_collection:
+            self.collection.add_link(pystac.Link(LATEST, source_collection, MEDIA_TYPE))
 
     @property
     def predecessor(self) -> Optional[pystac.Collection]:
@@ -218,7 +226,9 @@ class VersionCollectionExt(base.CollectionExtension):
 
     @predecessor.setter
     def predecessor(self, source_collection) -> None:
-        self.collection.add_link(pystac.Link(PREDECESSOR, source_collection, MEDIA_TYPE))
+        self.collection.clear_links(PREDECESSOR)
+        if source_collection:
+            self.collection.add_link(pystac.Link(PREDECESSOR, source_collection, MEDIA_TYPE))
 
     @property
     def successor(self) -> Optional[pystac.Collection]:
@@ -231,7 +241,9 @@ class VersionCollectionExt(base.CollectionExtension):
 
     @successor.setter
     def successor(self, source_collection) -> None:
-        self.collection.add_link(pystac.Link(SUCCESSOR, source_collection, MEDIA_TYPE))
+        self.collection.clear_links(SUCCESSOR)
+        if source_collection:
+            self.collection.add_link(pystac.Link(SUCCESSOR, source_collection, MEDIA_TYPE))
 
     @classmethod
     def from_collection(cls, a_collection: pystac.Collection):

--- a/tests/extensions/test_version.py
+++ b/tests/extensions/test_version.py
@@ -140,6 +140,59 @@ class VersionItemExtTest(unittest.TestCase):
         self.assertIs(successor, item1_copy)
         self.assertIs(latest, item1_copy)
 
+    def test_setting_none_clears_link(self):
+        deprecated = False
+        latest = make_item(2013)
+        predecessor = make_item(2010)
+        successor = make_item(2012)
+        self.item.ext.version.apply(self.version, deprecated, latest, predecessor, successor)
+
+        self.item.ext.version.latest = None
+        links = self.item.get_links(version.LATEST)
+        self.assertEqual(0, len(links))
+        self.assertIsNone(self.item.ext.version.latest)
+
+        self.item.ext.version.predecessor = None
+        links = self.item.get_links(version.PREDECESSOR)
+        self.assertEqual(0, len(links))
+        self.assertIsNone(self.item.ext.version.predecessor)
+
+        self.item.ext.version.successor = None
+        links = self.item.get_links(version.SUCCESSOR)
+        self.assertEqual(0, len(links))
+        self.assertIsNone(self.item.ext.version.successor)
+
+    def test_multiple_link_setting(self):
+        deprecated = False
+        latest1 = make_item(2013)
+        predecessor1 = make_item(2010)
+        successor1 = make_item(2012)
+        self.item.ext.version.apply(self.version, deprecated, latest1, predecessor1, successor1)
+
+        year = 2015
+        latest2 = make_item(year)
+        expected_href = URL_TEMPLATE % year
+        self.item.ext.version.latest = latest2
+        links = self.item.get_links(version.LATEST)
+        self.assertEqual(1, len(links))
+        self.assertEqual(expected_href, links[0].get_href())
+
+        year = 2009
+        predecessor2 = make_item(year)
+        expected_href = URL_TEMPLATE % year
+        self.item.ext.version.predecessor = predecessor2
+        links = self.item.get_links(version.PREDECESSOR)
+        self.assertEqual(1, len(links))
+        self.assertEqual(expected_href, links[0].get_href())
+
+        year = 2014
+        successor2 = make_item(year)
+        expected_href = URL_TEMPLATE % year
+        self.item.ext.version.successor = successor2
+        links = self.item.get_links(version.SUCCESSOR)
+        self.assertEqual(1, len(links))
+        self.assertEqual(expected_href, links[0].get_href())
+
 
 def make_collection(year: int) -> pystac.Collection:
     asset_id = f'my/collection/of/things/{year}'
@@ -272,6 +325,60 @@ class VersionCollectionExtTest(unittest.TestCase):
         self.assertIs(predecessor, col2_copy)
         self.assertIs(successor, col1_copy)
         self.assertIs(latest, col1_copy)
+
+    def test_setting_none_clears_link(self):
+        deprecated = False
+        latest = make_collection(2013)
+        predecessor = make_collection(2010)
+        successor = make_collection(2012)
+        self.collection.ext.version.apply(self.version, deprecated, latest, predecessor, successor)
+
+        self.collection.ext.version.latest = None
+        links = self.collection.get_links(version.LATEST)
+        self.assertEqual(0, len(links))
+        self.assertIsNone(self.collection.ext.version.latest)
+
+        self.collection.ext.version.predecessor = None
+        links = self.collection.get_links(version.PREDECESSOR)
+        self.assertEqual(0, len(links))
+        self.assertIsNone(self.collection.ext.version.predecessor)
+
+        self.collection.ext.version.successor = None
+        links = self.collection.get_links(version.SUCCESSOR)
+        self.assertEqual(0, len(links))
+        self.assertIsNone(self.collection.ext.version.successor)
+
+    def test_multiple_link_setting(self):
+        deprecated = False
+        latest1 = make_collection(2013)
+        predecessor1 = make_collection(2010)
+        successor1 = make_collection(2012)
+        self.collection.ext.version.apply(self.version, deprecated, latest1, predecessor1,
+                                          successor1)
+
+        year = 2015
+        latest2 = make_collection(year)
+        expected_href = URL_TEMPLATE % year
+        self.collection.ext.version.latest = latest2
+        links = self.collection.get_links(version.LATEST)
+        self.assertEqual(1, len(links))
+        self.assertEqual(expected_href, links[0].get_href())
+
+        year = 2009
+        predecessor2 = make_collection(year)
+        expected_href = URL_TEMPLATE % year
+        self.collection.ext.version.predecessor = predecessor2
+        links = self.collection.get_links(version.PREDECESSOR)
+        self.assertEqual(1, len(links))
+        self.assertEqual(expected_href, links[0].get_href())
+
+        year = 2014
+        successor2 = make_collection(year)
+        expected_href = URL_TEMPLATE % year
+        self.collection.ext.version.successor = successor2
+        links = self.collection.get_links(version.SUCCESSOR)
+        self.assertEqual(1, len(links))
+        self.assertEqual(expected_href, links[0].get_href())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Prior to this change, setting the 'latest', 'successor', or 'predecessor' would add links, but not clear any old links if there were already versions set. This ensures that the links are cleared before setting any new version of the object.

It also ensures that setting a version to 'None' will clear the links, allowing users to remove a version from an item or collection.

Fixes #210