### PR TITLE
Compatiblity with CFTime

### DIFF
--- a/pystac/utils.py
+++ b/pystac/utils.py
@@ -150,7 +150,7 @@ def datetime_to_str(dt):
     Returns:
         str: The ISO8601 formatted string representing the datetime.
     """
-    
+
     # workaround for CFTime datetimes
     if hasattr(dt, 'tzinfo') and dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)

--- a/pystac/utils.py
+++ b/pystac/utils.py
@@ -150,8 +150,10 @@ def datetime_to_str(dt):
     Returns:
         str: The ISO8601 formatted string representing the datetime.
     """
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
+    
+    if hasattr(dt, 'tzinfo'):
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
 
     timestamp = dt.isoformat()
     zulu = '+00:00'

--- a/pystac/utils.py
+++ b/pystac/utils.py
@@ -151,9 +151,9 @@ def datetime_to_str(dt):
         str: The ISO8601 formatted string representing the datetime.
     """
     
-    if hasattr(dt, 'tzinfo'):
-        if dt.tzinfo is None:
-            dt = dt.replace(tzinfo=timezone.utc)
+    # workaround for CFTime datetimes
+    if hasattr(dt, 'tzinfo') and dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
 
     timestamp = dt.isoformat()
     zulu = '+00:00'


### PR DESCRIPTION
I am trying to catalog climate model data stored in Zarr format on Google Cloud / AWS using STAC. My approach is to create a STAC collection for each Zarr dataset and link to the Zarr data using collection-level assets (see related discussion @ https://github.com/radiantearth/stac-spec/issues/781).

I have hit a tiny snag with datetimes. I need to populate `temporal_extent` for the collections. I get this by reading the dataset's time range. The times are encoded using the [CF Conventions for time coordinates](https://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#time-coordinate). In python, CF times are implemented by the [cftime](https://unidata.github.io/cftime/index.html) package. cftime provides a (mostly) duck-type compatible with datetime. However, cftime has no `.tzinfo` attribute.

This tiny change allows pystac to work with cftime datetimes.

I have not added a test because I didn't want to add cftime to the dependencies. One could possibly use a mock to test this feature. Or we could merge this tiny change with no test. I'll follow whatever path the devs recommend.

cc @charlesbluca