### PR TITLE
Get eo bands defined in assets only

### DIFF
--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -55,7 +55,8 @@ class EOItemExt(ItemExtension):
         """Gets an Item or an Asset bands.
 
         If an Asset is supplied and the bands property exists on the Asset,
-        returns the Asset's value. Otherwise returns the Item's value
+        returns the Asset's value. Otherwise returns the Item's value or 
+        all the asset's eo bands
 
         Returns:
             List[Band]
@@ -64,6 +65,13 @@ class EOItemExt(ItemExtension):
             bands = asset.properties.get('eo:bands')
         else:
             bands = self.item.properties.get('eo:bands')
+
+        # get assets with eo:bands even if not in item
+        if bands is None:
+            bands = []
+            for (value) in self.item.get_assets().items():
+                if 'eo:bands' in value.properties:
+                    bands.extend(value.properties.get('eo:bands'))
 
         if bands is not None:
             bands = [Band(b) for b in bands]

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -69,7 +69,7 @@ class EOItemExt(ItemExtension):
         # get assets with eo:bands even if not in item
         if bands is None:
             bands = []
-            for (value) in self.item.get_assets().items():
+            for (key, value) in self.item.get_assets().items():
                 if 'eo:bands' in value.properties:
                     bands.extend(value.properties.get('eo:bands'))
 

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -67,7 +67,7 @@ class EOItemExt(ItemExtension):
             bands = self.item.properties.get('eo:bands')
 
         # get assets with eo:bands even if not in item
-        if bands is None:
+        if asset is None and bands is None:
             bands = []
             for (key, value) in self.item.get_assets().items():
                 if 'eo:bands' in value.properties:

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -55,7 +55,7 @@ class EOItemExt(ItemExtension):
         """Gets an Item or an Asset bands.
 
         If an Asset is supplied and the bands property exists on the Asset,
-        returns the Asset's value. Otherwise returns the Item's value or 
+        returns the Asset's value. Otherwise returns the Item's value or
         all the asset's eo bands
 
         Returns:

--- a/tests/extensions/test_eo.py
+++ b/tests/extensions/test_eo.py
@@ -61,7 +61,7 @@ class EOTest(unittest.TestCase):
         asset_bands = eo_item.ext.eo.get_bands(index_asset)
         self.assertIs(None, asset_bands)
 
-        ## No asset specified
+        # No asset specified
         asset_bands = eo_item.ext.eo.get_bands()
         self.assertIsNot(None, asset_bands)
 

--- a/tests/extensions/test_eo.py
+++ b/tests/extensions/test_eo.py
@@ -61,6 +61,10 @@ class EOTest(unittest.TestCase):
         asset_bands = eo_item.ext.eo.get_bands(index_asset)
         self.assertIs(None, asset_bands)
 
+        ## No asset specified
+        asset_bands = eo_item.ext.eo.get_bands()
+        self.assertIsNot(None, asset_bands)
+
         # Set
         b2_asset = eo_item.assets['B2']
         self.assertEqual(eo_item.ext.eo.get_bands(b2_asset)[0].name, "B2")


### PR DESCRIPTION
**Context**
As defined in the [EO extension](https://github.com/radiantearth/stac-spec/tree/master/extensions/eo) specification, the `eo:bands` properties are allowed in assets without being declared at the item level

**Issue**

The `get_bands` method in `EOItemExt` does not return bands defined in asset level if no `asset` parameter in specified.

**Proposed Solution**

The `get_bands` method in `EOItemExt` return aggregated list of bands defined in asset level if no `asset` parameter in specified.

**PR Checklist:**

- [X] This PR is made against the dev branch (all proposed changes except releases should be against dev, not master).
- [X] This PR has **no** breaking changes.
