### PR TITLE
Make asset HREFs relative or absolute based on CatalogType during save

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -101,7 +101,7 @@ Catalog Types
 
 The STAC `best practices document <https://github.com/radiantearth/stac-spec/blob/v1.0.0-beta.2/best-practices.md>`_ lays out different catalog types, and how their links should be formatted. A brief description is below, but check out the document for the official take on these types:
 
-Note that the catalog types do not dictate the asset HREF formats, only link formats. Asset HREFs in any catalog type can be relative or absolute; see the section on :ref:`rel vs abs asset` below.
+The catalog types will also dictate the asset HREF formats. Asset HREFs in any catalog type can be relative or absolute may be absolute depending on their location; see the section on :ref:`rel vs abs asset` below.
 
 
 Self-Contained Catalogs

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -608,8 +608,10 @@ class Catalog(STACObject):
         # Ensure relative vs absolute
         if catalog_type == CatalogType.ABSOLUTE_PUBLISHED:
             self.make_all_links_absolute()
+            self.make_all_asset_hrefs_absolute()
         elif catalog_type in (CatalogType.SELF_CONTAINED, CatalogType.RELATIVE_PUBLISHED):
             self.make_all_links_relative()
+            self.make_all_asset_hrefs_relative()
         else:
             raise ValueError(f'catalog_type is not a CatalogType: "{catalog_type}"')
 

--- a/pystac/validation/stac_validator.py
+++ b/pystac/validation/stac_validator.py
@@ -34,7 +34,11 @@ class STACValidator(ABC):
         pass
 
     @abstractmethod
-    def validate_extension(self, stac_dict, stac_object_type, stac_version, extension_id,
+    def validate_extension(self,
+                           stac_dict,
+                           stac_object_type,
+                           stac_version,
+                           extension_id,
                            href=None):
         """Validate an extension stac object.
 
@@ -173,7 +177,11 @@ class JsonSchemaSTACValidator(STACValidator):
                                           stac_dict.get('id'))
             raise STACValidationError(msg, source=e) from e
 
-    def validate_extension(self, stac_dict, stac_object_type, stac_version, extension_id,
+    def validate_extension(self,
+                           stac_dict,
+                           stac_object_type,
+                           stac_version,
+                           extension_id,
                            href=None):
         """Validate an extension stac object.
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,6 @@ sphinx-autobuild==0.7.1
 sphinxcontrib-fulltoc==1.2.0
 sphinxcontrib-napoleon==0.7
 flake8==3.8.*
-yapf==0.28.*
+yapf==0.30.*
 nbsphinx==0.7.1
 coverage==5.2.*

--- a/scripts/format
+++ b/scripts/format
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+if [[ -n "${CI}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+        "Usage: $(basename "$0")
+Format code with yapf
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+        yapf -ipr pystac tests
+    fi
+fi

--- a/tests/test_writing.py
+++ b/tests/test_writing.py
@@ -44,6 +44,7 @@ class STACWritingTest(unittest.TestCase):
                         self.assertEqual(asset.href, rel_href)
                     else:
                         self.assertTrue(is_valid)
+
         def validate_item_link_type(href, link_type, should_include_self):
             item_dict = STAC_IO.read_json(href)
             item = STACObject.from_file(href)

--- a/tests/test_writing.py
+++ b/tests/test_writing.py
@@ -3,7 +3,7 @@ from tempfile import TemporaryDirectory
 
 from pystac import (STAC_IO, STACObject, Collection, CatalogType, LinkType)
 from pystac.serialization import (STACObjectType)
-from pystac.utils import make_absolute_href
+from pystac.utils import is_absolute_href, make_absolute_href, make_relative_href
 from pystac.validation import validate_dict
 
 from tests.utils import TestCases
@@ -31,12 +31,27 @@ class STACWritingTest(unittest.TestCase):
         return validate_dict(d, object_type)
 
     def validate_link_types(self, root_href, catalog_type):
+        def validate_asset_href_type(item, item_href, link_type):
+            for asset in item.assets.values():
+                if link_type == LinkType.ABSOLUTE:
+                    self.assertTrue(is_absolute_href(asset.href))
+                else:
+                    is_valid = not is_absolute_href(asset.href)
+                    if not is_valid:
+                        # If the item href and asset href don't share
+                        # the same root, the asset href must be absolute
+                        rel_href = make_relative_href(asset.href, item_href)
+                        self.assertEqual(asset.href, rel_href)
+                    else:
+                        self.assertTrue(is_valid)
         def validate_item_link_type(href, link_type, should_include_self):
             item_dict = STAC_IO.read_json(href)
             item = STACObject.from_file(href)
             for link in item.get_links():
                 if not link.rel == 'self':
                     self.assertEqual(link.link_type, link_type)
+
+            validate_asset_href_type(item, href, link_type)
 
             rels = set([link['rel'] for link in item_dict['links']])
             self.assertEqual('self' in rels, should_include_self)


### PR DESCRIPTION
Previously only link href types (absolute vs relative) were modified as part of the `Catalog.save` process based on the catalog types: for ABSOLUTE_PUBLISHED, all link hrefs were made absolute, etc. The asset HREFs were not modified, which was counter to the expected result outlined in stac-utils/stactools#31.

This change causes asset HREFs to also be changed to absolute or relative based on the catalog type. Note that if the asset HREF cannot be made relative, e.g. the asset HREF points to an HTTP location and the item is being stored locally, then the HREF is left unchanged.

Also upgrade yapf to 0.30.* and add a `scripts/format` script to run code formatting.