### PR TITLE
handle optional arguments in View Extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [unreleased]
+
+### Fixed
+
+- Fix handling of optional properties when using apply on view extension ([#259](https://github.com/stac-utils/pystac/pull/259))
+
 ## [v0.5.4]
 
 ### Added

--- a/pystac/extensions/view.py
+++ b/pystac/extensions/view.py
@@ -28,11 +28,11 @@ class ViewItemExt(ItemExtension):
         self.item = item
 
     def apply(self,
-              off_nadir=None,
-              incidence_angle=None,
-              azimuth=None,
-              sun_azimuth=None,
-              sun_elevation=None):
+              off_nadir: Optional[float] = None,
+              incidence_angle: Optional[float] = None,
+              azimuth: Optional[float] = None,
+              sun_azimuth: Optional[float] = None,
+              sun_elevation: Optional[float] = None):
         """Applies View Geometry extension properties to the extended Item.
 
         Args:
@@ -49,11 +49,21 @@ class ViewItemExt(ItemExtension):
             sun_elevation (float): Sun elevation angle. The angle from the tangent of the scene
                 center point to the sun. Measured from the horizon in degrees (0-90).
         """
-        self.off_nadir = off_nadir
-        self.incidence_angle = incidence_angle
-        self.azimuth = azimuth
-        self.sun_azimuth = sun_azimuth
-        self.sun_elevation = sun_elevation
+        if (off_nadir is None and incidence_angle is None and azimuth is None
+                and sun_azimuth is None and sun_elevation is None):
+            raise pystac.STACError(
+                'Must provide at least one of: off_nadir, incidence_angle, azimuth, sun_azimuth, sun_elevation'  # noqa: E501
+            )
+        if off_nadir:
+            self.off_nadir = off_nadir
+        if incidence_angle:
+            self.incidence_angle = incidence_angle
+        if azimuth:
+            self.azimuth = azimuth
+        if sun_azimuth:
+            self.sun_azimuth = sun_azimuth
+        if sun_elevation:
+            self.sun_elevation = sun_elevation
 
     @property
     def off_nadir(self):

--- a/pystac/extensions/view.py
+++ b/pystac/extensions/view.py
@@ -1,7 +1,6 @@
 from pystac import Extensions
 from pystac.item import Item
 from pystac.extensions.base import (ItemExtension, ExtensionDefinition, ExtendedObject)
-from typing import Optional
 
 
 class ViewItemExt(ItemExtension):

--- a/pystac/extensions/view.py
+++ b/pystac/extensions/view.py
@@ -1,6 +1,7 @@
 from pystac import Extensions
 from pystac.item import Item
 from pystac.extensions.base import (ItemExtension, ExtensionDefinition, ExtendedObject)
+from typing import Optional
 
 
 class ViewItemExt(ItemExtension):

--- a/pystac/extensions/view.py
+++ b/pystac/extensions/view.py
@@ -1,3 +1,4 @@
+import pystac
 from pystac import Extensions
 from pystac.item import Item
 from pystac.extensions.base import (ItemExtension, ExtensionDefinition, ExtendedObject)

--- a/tests/extensions/test_view.py
+++ b/tests/extensions/test_view.py
@@ -29,6 +29,29 @@ class ViewTest(unittest.TestCase):
                             sun_azimuth=2.0,
                             sun_elevation=1.0)
 
+    def test_apply_one(self):
+        item = next(TestCases.test_case_2().get_all_items())
+        with self.assertRaises(ExtensionError):
+            item.ext.view
+
+        item.ext.enable(Extensions.VIEW)
+        item.ext.view.apply(off_nadir=1.0)
+
+    @unittest.expectedFailure
+    def test_apply_none(self):
+        item = next(TestCases.test_case_2().get_all_items())
+        with self.assertRaises(ExtensionError):
+            item.ext.view
+
+        item.ext.enable(Extensions.VIEW)
+        item.ext.view.apply(
+            off_nadir=None,
+            incidence_angle=None,
+            azimuth=None,
+            sun_azimuth=None,
+            sun_elevation=None,
+        )
+
     def test_validate_view(self):
         item = pystac.read_file(self.example_uri)
         item.validate()

--- a/tests/extensions/test_view.py
+++ b/tests/extensions/test_view.py
@@ -29,29 +29,6 @@ class ViewTest(unittest.TestCase):
                             sun_azimuth=2.0,
                             sun_elevation=1.0)
 
-    def test_apply_one(self):
-        item = next(TestCases.test_case_2().get_all_items())
-        with self.assertRaises(ExtensionError):
-            item.ext.view
-
-        item.ext.enable(Extensions.VIEW)
-        item.ext.view.apply(off_nadir=1.0)
-
-    @unittest.expectedFailure
-    def test_apply_none(self):
-        item = next(TestCases.test_case_2().get_all_items())
-        with self.assertRaises(ExtensionError):
-            item.ext.view
-
-        item.ext.enable(Extensions.VIEW)
-        item.ext.view.apply(
-            off_nadir=None,
-            incidence_angle=None,
-            azimuth=None,
-            sun_azimuth=None,
-            sun_elevation=None,
-        )
-
     def test_validate_view(self):
         item = pystac.read_file(self.example_uri)
         item.validate()


### PR DESCRIPTION
Resolves https://github.com/stac-utils/pystac/issues/258, in which parameters that were not passed to the `.apply()` method in the view extension would result in validation issues. 

Updated:
- Only sets property is passed is not None
- Raise error if all parameters are None
- Added tests for added functionality 