### PR TITLE
Ensure correct url format from local files

### DIFF
--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -1,5 +1,6 @@
 from abc import (ABC, abstractmethod)
 from enum import Enum
+from urllib.request import pathname2url
 
 import pystac
 from pystac import STACError
@@ -521,6 +522,7 @@ class STACObject(LinkMixin, ABC):
         """
         if not is_absolute_href(href):
             href = make_absolute_href(href)
+        href = f"file:{pathname2url(href)}"
         d = STAC_IO.read_json(href)
 
         if cls == STACObject:


### PR DESCRIPTION
Not sure if others are having the same problem or I am missing something, but without this fix all tests fail in Windows.

The reason for it is in here:

https://github.com/stac-utils/pystac/blob/develop/pystac/stac_io.py#L19

The urlopen function does not understand a windows path such as `c:\folder\file.ext`, and raises an exception.