### PR TITLE
Remove unnecessary deepcopies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Fix handling of optional properties when using apply on view extension ([#259](https://github.com/stac-utils/pystac/pull/259))
 - Fixed issue with setting None into projection extension fields that are not required breaking validation ([#269](https://github.com/stac-utils/pystac/pull/269))
+- Remove unnecessary `deepcopy` calls in `to_dict` methods to avoid costly overhead ([#273](https://github.com/stac-utils/pystac/pull/273))
+
 
 ### Changed
 

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -381,7 +381,7 @@ class Catalog(STACObject):
         if self.title is not None:
             d['title'] = self.title
 
-        return deepcopy(d)
+        return d
 
     def clone(self):
         clone = Catalog(id=self.id,

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -107,7 +107,7 @@ class Collection(Catalog):
         if self.summaries is not None:
             d['summaries'] = self.summaries
 
-        return deepcopy(d)
+        return d
 
     def clone(self):
         clone = Collection(id=self.id,
@@ -213,7 +213,7 @@ class Extent:
         """
         d = {'spatial': self.spatial.to_dict(), 'temporal': self.temporal.to_dict()}
 
-        return deepcopy(d)
+        return d
 
     def clone(self):
         """Clones this object.
@@ -315,7 +315,7 @@ class SpatialExtent:
             dict: A serializion of the SpatialExtent that can be written out as JSON.
         """
         d = {'bbox': self.bboxes}
-        return deepcopy(d)
+        return d
 
     def clone(self):
         """Clones this object.
@@ -418,7 +418,7 @@ class TemporalExtent:
             encoded_intervals.append([start, end])
 
         d = {'interval': encoded_intervals}
-        return deepcopy(d)
+        return d
 
     def clone(self):
         """Clones this object.
@@ -505,7 +505,7 @@ class Provider:
         if self.url is not None:
             d['url'] = self.url
 
-        return deepcopy(d)
+        return d
 
     @staticmethod
     def from_dict(d):

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -297,7 +297,7 @@ class Item(STACObject):
         for key in self.extra_fields:
             d[key] = self.extra_fields[key]
 
-        return deepcopy(d)
+        return d
 
     def clone(self):
         clone = Item(id=self.id,
@@ -475,7 +475,7 @@ class Asset:
         if self.roles is not None:
             d['roles'] = self.roles
 
-        return deepcopy(d)
+        return d
 
     def clone(self):
         """Clones this asset.

--- a/pystac/link.py
+++ b/pystac/link.py
@@ -1,4 +1,4 @@
-from copy import (copy, deepcopy)
+from copy import copy
 from enum import Enum
 
 from pystac import STACError
@@ -211,7 +211,7 @@ class Link:
             for k, v in self.properties.items():
                 d[k] = v
 
-        return deepcopy(d)
+        return d
 
     def clone(self):
         """Clones this link.


### PR DESCRIPTION
Calls to `deepcopy` are fairly expensive when working with large number of STACs. In `to_dict` methods, a dictionary `d` is instantiated only to have `deepcopy` applied to it for the `return` value. This seems to be unnecessary.

Here's `snakeviz` output of some `cProfile` timings.
Before:
![image](https://user-images.githubusercontent.com/1977405/110704485-a067f600-81ba-11eb-8407-f0b2134ea5a9.png)

After:
![image](https://user-images.githubusercontent.com/1977405/110704509-a8c03100-81ba-11eb-87eb-b0266823070b.png)

It should be noted that the after includes also the use of `orjson` to optimize ser/de operations. This optimization can be left out of `pystac` because it requires an external dependency and because it can easily be plugged in through a `STAC_IO` subclass