### PR TITLE
Don't error when pointcloud statistics are missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixed
 
+- Fixed error when accessing the statistics attribute of the pointcloud extension when no statistics were defined ([#282](https://github.com/stac-utils/pystac/pull/282))
+
 ### Changed
 
 ### Removed
@@ -20,8 +22,6 @@
 
 - Fix handling of optional properties when using apply on view extension ([#259](https://github.com/stac-utils/pystac/pull/259))
 - Fixed issue with setting None into projection extension fields that are not required breaking validation ([#269](https://github.com/stac-utils/pystac/pull/269))
-- Remove unnecessary `deepcopy` calls in `to_dict` methods to avoid costly overhead ([#273](https://github.com/stac-utils/pystac/pull/273))
-
 
 ### Changed
 

--- a/pystac/extensions/pointcloud.py
+++ b/pystac/extensions/pointcloud.py
@@ -262,7 +262,10 @@ class PointcloudItemExt(ItemExtension):
         """
         if asset is None or 'pc:statistics' not in asset.properties:
             stats = self.item.properties.get('pc:statistics')
-            return [PointcloudStatistic(s) for s in stats]
+            if stats:
+                return [PointcloudStatistic(s) for s in stats]
+            else:
+                return None
         else:
             return [PointcloudStatistic.create(s) for s in asset.properties.get('pc:statistics')]
 

--- a/tests/data-files/pointcloud/example-laz-no-statistics.json
+++ b/tests/data-files/pointcloud/example-laz-no-statistics.json
@@ -1,0 +1,140 @@
+{
+    "stac_version": "1.0.0-beta.2",
+    "stac_extensions": [
+        "pointcloud"
+    ],
+    "assets": {},
+    "bbox": [
+        -123.0755422,
+        44.04971882,
+        123.791472,
+        -123.0619599,
+        44.06278031,
+        187.531248
+    ],
+    "geometry": {
+        "coordinates": [
+            [
+                [
+                    -123.07498674,
+                    44.04971882
+                ],
+                [
+                    -123.07554223,
+                    44.06248623
+                ],
+                [
+                    -123.0625126,
+                    44.06278031
+                ],
+                [
+                    -123.06195992,
+                    44.05001283
+                ],
+                [
+                    -123.07498674,
+                    44.04971882
+                ]
+            ]
+        ],
+        "type": "Polygon"
+    },
+    "id": "autzen-full.laz",
+    "links": [
+        {
+            "href": "/Users/hobu/dev/git/pdal/test/data/autzen/autzen-full.laz",
+            "rel": "self"
+        }
+    ],
+    "properties": {
+        "datetime": "2013-07-17T00:00:00Z",
+        "pc:count": 10653336,
+        "pc:density": 0,
+        "pc:encoding": "LASzip",
+        "pc:schemas": [
+            {
+                "name": "X",
+                "size": 8,
+                "type": "floating"
+            },
+            {
+                "name": "Y",
+                "size": 8,
+                "type": "floating"
+            },
+            {
+                "name": "Z",
+                "size": 8,
+                "type": "floating"
+            },
+            {
+                "name": "Intensity",
+                "size": 2,
+                "type": "unsigned"
+            },
+            {
+                "name": "ReturnNumber",
+                "size": 1,
+                "type": "unsigned"
+            },
+            {
+                "name": "NumberOfReturns",
+                "size": 1,
+                "type": "unsigned"
+            },
+            {
+                "name": "ScanDirectionFlag",
+                "size": 1,
+                "type": "unsigned"
+            },
+            {
+                "name": "EdgeOfFlightLine",
+                "size": 1,
+                "type": "unsigned"
+            },
+            {
+                "name": "Classification",
+                "size": 1,
+                "type": "unsigned"
+            },
+            {
+                "name": "ScanAngleRank",
+                "size": 4,
+                "type": "floating"
+            },
+            {
+                "name": "UserData",
+                "size": 1,
+                "type": "unsigned"
+            },
+            {
+                "name": "PointSourceId",
+                "size": 2,
+                "type": "unsigned"
+            },
+            {
+                "name": "GpsTime",
+                "size": 8,
+                "type": "floating"
+            },
+            {
+                "name": "Red",
+                "size": 2,
+                "type": "unsigned"
+            },
+            {
+                "name": "Green",
+                "size": 2,
+                "type": "unsigned"
+            },
+            {
+                "name": "Blue",
+                "size": 2,
+                "type": "unsigned"
+            }
+        ],
+        "pc:type": "lidar",
+        "title": "USGS 3DEP LiDAR"
+    },
+    "type": "Feature"
+}

--- a/tests/extensions/test_pointcloud.py
+++ b/tests/extensions/test_pointcloud.py
@@ -13,6 +13,8 @@ class PointcloudTest(unittest.TestCase):
     def setUp(self):
         self.maxDiff = None
         self.example_uri = TestCases.get_path('data-files/pointcloud/example-laz.json')
+        self.example_uri_no_statistics = TestCases.get_path(
+            'data-files/pointcloud/example-laz-no-statistics.json')
 
     def test_to_from_dict(self):
         with open(self.example_uri) as f:
@@ -184,3 +186,7 @@ class PointcloudTest(unittest.TestCase):
                 val = props[k] + 1
             setattr(stat, k, val)
             self.assertEqual(getattr(stat, k), val)
+
+    def test_statistics_accessor_when_no_stats(self):
+        pc_item = pystac.read_file(self.example_uri_no_statistics)
+        self.assertEqual(pc_item.ext.pointcloud.statistics, None)


### PR DESCRIPTION
**Related Issue(s):**
stac-utils/stactools#44


**Description:**
The `statistics` attribute of the pointcloud extension is optional, but `PointcloudItemExt.get_statistics` was erroring if the pointcloud was missing stats. This fixes the issue to return `None` if there are no statistics defined.

**PR Checklist:**

- [x] Code is formatted (run `scripts/format`)
- [x] Tests pass (run `scripts/test`)
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.