### PR TITLE
added type property for catalogs and collections

### DIFF
--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -366,6 +366,7 @@ class Catalog(STACObject):
             links = filter(lambda l: l.rel != 'self', links)
 
         d = {
+            'type': self.STAC_OBJECT_TYPE.value.title(),
             'id': self.id,
             'stac_version': pystac.get_stac_version(),
             'description': self.description,

--- a/pystac/serialization/identify.py
+++ b/pystac/serialization/identify.py
@@ -264,18 +264,25 @@ def identify_stac_object_type(json_dict):
     """
     object_type = None
 
-    # Identify pre-1.0 ITEMCOLLECTION (since removed)
-    if 'type' in json_dict and 'assets' not in json_dict:
-        if 'stac_version' in json_dict and json_dict['stac_version'].startswith('0'):
-            if json_dict['type'] == 'FeatureCollection':
-                object_type = STACObjectType.ITEMCOLLECTION
+    if 'type' in json_dict:  # Try to identify using 'type' property
+        for t in STACObjectType:
+            if json_dict['type'].lower() == t.value.lower():
+                object_type = t
+                break
 
-    if 'extent' in json_dict:
-        object_type = STACObjectType.COLLECTION
-    elif 'assets' in json_dict:
-        object_type = STACObjectType.ITEM
-    else:
-        object_type = STACObjectType.CATALOG
+    if object_type is None:  # Use old-approach based on other properties
+        # Identify pre-1.0 ITEMCOLLECTION (since removed)
+        if 'type' in json_dict and 'assets' not in json_dict:
+            if 'stac_version' in json_dict and json_dict['stac_version'].startswith('0'):
+                if json_dict['type'] == 'FeatureCollection':
+                    object_type = STACObjectType.ITEMCOLLECTION
+
+        if 'extent' in json_dict:
+            object_type = STACObjectType.COLLECTION
+        elif 'assets' in json_dict:
+            object_type = STACObjectType.ITEM
+        else:
+            object_type = STACObjectType.CATALOG
 
     return object_type
 


### PR DESCRIPTION
**Related Issue(s):** #
 https://github.com/radiantearth/stac-spec/pull/971

**Description:**
Adds tpe property for catalogs and collections

**PR Checklist:**

- [x] Code is formatted (run `scripts/format`)
- [x] Tests pass (run `scripts/test`)
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.