### PR TITLE
Remove link type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,19 @@
 
 ### Added
 
+- HIERARCHICAL_LINKS array constant of all the types of hierarchical links (self is not included)
+
 ### Fixed
 
 - Fixed error when accessing the statistics attribute of the pointcloud extension when no statistics were defined ([#282](https://github.com/stac-utils/pystac/pull/282))
 
 ### Changed
 
+- Link behavior - link URLs can be either relative or absolute. Hierarchical (e.g., parent, child) links are made relative or absolute based on the value of the root catalog's `catalog_type` field
+
 ### Removed
+
+- Removed LinkType class and the `link_type` field from links
 
 ## [v0.5.5]
 

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -155,14 +155,17 @@ Relative vs Absolute Link HREFs
 
 Absolute links point to their file locations in a fully described way. Relative links
 are relative to the linking object's file location. For example, if a catalog at
-``/some/location/catalog.json`` has a link to an item that has an HREF set to ``item-id/item-id.json``, then that link should resolve to the absolute path ``/some/location/item-id/item-id.json``.
+``/some/location/catalog.json`` has a link to an item that has an HREF set to ``item-id/item-id.json``,
+then that link should resolve to the absolute path ``/some/location/item-id/item-id.json``.
 
-The implementation of :class:`~pystac.Link` in PySTAC allows for the link to be marked as
-``link_type=LinkType.ABSOLUTE`` or ``link_type=LinkType.RELATIVE``. This means that,
-even if the stored HREF of the link is absolute, if the link is marked as relative, serializing
-the link will produce a relative link, based on the self link of the parent object.
+Links are set as absolute or relative HREFs at save time, as determine by the root catalog's catalog_type
+:attribute:`~pystac.Catalog.catalog_type`. This means that, even if the stored HREF of the link is absolute,
+if the root ``catalog_type=CatalogType.RELATIVE_PUBLISHED`` or ``catalog_type=CatalogType.SELF_CONTAINED``
+and subsequent serializing of the any links in the catalog will produce a relative link,
+based on the self link of the parent object.
 
-You can make all the links of a catalog relative or absolute using the :func:`Catalog.make_all_links_relative <pystac.Catalog.make_all_links_relative>` and :func:`Catalog.make_all_links_absolute <pystac.Catalog.make_all_links_absolute>` methods.
+You can make all the links of a catalog relative or absolute by setting the :func:`Catalog.catalog_type` field
+then resaving the entire catalog.
 
 .. _rel vs abs asset:
 

--- a/docs/tutorials/adding-new-and-custom-extensions.ipynb
+++ b/docs/tutorials/adding-new-and-custom-extensions.ipynb
@@ -181,7 +181,7 @@
    "source": [
     "The `from_item` class method simply returns a new instance of the item extension given an item.\n",
     "\n",
-    "The `_object_links` class method returns the `rel` string for any links that point to STAC objects like Catalogs, Collections or Items. PySTAC needs to know which links point to STAC objects because it needs to consider them when fully resolving a STAC into in-memory objects. In a lot of cases, extensions don't add new links to STAC objects, so this is normally an empty list; however, if the extension does do this (like the `source` link in the [Label Extension](https://github.com/radiantearth/stac-spec/tree/v1.0.0-beta.2/extensions/label#links-source-imagery)), make sure to return the correct value (like the LabelItemExt is doing [here](https://github.com/azavea/pystac/blob/v0.5.0/pystac/extensions/label.py#L291-L293))."
+    "The `_object_links` class method returns the `rel` string for any links that point to STAC objects like Catalogs, Collections or Items. PySTAC needs to know which links point to STAC objects because it needs to consider them when fully resolving a STAC into in-memory objects. It also will use this information when deciding on whether to use absolute or relative HREFs for the links, based on the root catalog type. In a lot of cases, extensions don't add new links to STAC objects, so this is normally an empty list; however, if the extension does do this (like the `source` link in the [Label Extension](https://github.com/radiantearth/stac-spec/tree/v1.0.0-beta.2/extensions/label#links-source-imagery)), make sure to return the correct value (like the LabelItemExt is doing [here](https://github.com/azavea/pystac/blob/v0.5.0/pystac/extensions/label.py#L291-L293))."
    ]
   },
   {

--- a/pystac/__init__.py
+++ b/pystac/__init__.py
@@ -18,7 +18,7 @@ from pystac.stac_io import STAC_IO
 from pystac.extensions import Extensions
 from pystac.stac_object import (STACObject, STACObjectType)
 from pystac.media_type import MediaType
-from pystac.link import Link
+from pystac.link import (Link, HIERARCHICAL_LINKS)
 from pystac.catalog import (Catalog, CatalogType)
 from pystac.collection import (Collection, Extent, SpatialExtent, TemporalExtent, Provider)
 from pystac.item import (Item, Asset, CommonMetadata)

--- a/pystac/__init__.py
+++ b/pystac/__init__.py
@@ -18,7 +18,7 @@ from pystac.stac_io import STAC_IO
 from pystac.extensions import Extensions
 from pystac.stac_object import (STACObject, STACObjectType)
 from pystac.media_type import MediaType
-from pystac.link import (Link, LinkType)
+from pystac.link import Link
 from pystac.catalog import (Catalog, CatalogType)
 from pystac.collection import (Collection, Extent, SpatialExtent, TemporalExtent, Provider)
 from pystac.item import (Item, Asset, CommonMetadata)

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -599,7 +599,7 @@ class Catalog(STACObject):
         include_self_link = False
         # include a self link if this is the root catalog or if ABSOLUTE_PUBLISHED catalog
         if ((self.get_self_href() == self.get_root_link().get_absolute_href()
-                and root.catalog_type != CatalogType.SELF_CONTAINED)
+             and root.catalog_type != CatalogType.SELF_CONTAINED)
                 or root.catalog_type == CatalogType.ABSOLUTE_PUBLISHED):
             include_self_link = True
 

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -492,7 +492,7 @@ class Catalog(STACObject):
             setter_funcs.append(fn)
 
             return setter_funcs
-        
+
         # Collect functions that will actually mutate the objects.
         # Delay mutation as setting hrefs while walking the catalog
         # can result in bad links.
@@ -598,11 +598,11 @@ class Catalog(STACObject):
 
         include_self_link = False
         # include a self link if this is the root catalog or if ABSOLUTE_PUBLISHED catalog
-        if ((self.get_self_href() == self.get_root_link().get_absolute_href() 
-            and root.catalog_type != CatalogType.SELF_CONTAINED) or
-            root.catalog_type == CatalogType.ABSOLUTE_PUBLISHED):
+        if ((self.get_self_href() == self.get_root_link().get_absolute_href()
+                and root.catalog_type != CatalogType.SELF_CONTAINED)
+                or root.catalog_type == CatalogType.ABSOLUTE_PUBLISHED):
             include_self_link = True
-        
+
         self.save_object(include_self_link=include_self_link)
 
         self.catalog_type = catalog_type

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -148,6 +148,9 @@ class Catalog(STACObject):
             root._resolved_objects = ResolvedObjectCache.merge(root._resolved_objects,
                                                                self._resolved_objects)
 
+    def is_relative(self):
+        return self.catalog_type in [CatalogType.RELATIVE_PUBLISHED, CatalogType.SELF_CONTAINED]
+
     def add_child(self, child, title=None):
         """Adds a link to a child :class:`~pystac.Catalog` or :class:`~pystac.Collection`.
         This method will set the child's parent to this object, and its root to

--- a/pystac/extensions/base.py
+++ b/pystac/extensions/base.py
@@ -7,7 +7,7 @@ from pystac.extensions import ExtensionError
 
 
 class ExtendedObject:
-    """ExtendedObject maps STACObject classes (Catalog, Collecition and Item) to
+    """ExtendedObject maps STACObject classes (Catalog, Collection and Item) to
     extension classes (classes that implement one of CatalogExtension, CollectionExtesion,
     or ItemCollection). When an extension is registered with PySTAC it uses the registered
     list of ExtendedObject to determine how to handle extending objects, e.g. when item.ext.label

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -4,7 +4,7 @@ import dateutil.parser
 
 import pystac
 from pystac import (STACError, STACObjectType)
-from pystac.link import Link, LinkType
+from pystac.link import Link
 from pystac.stac_object import STACObject
 from pystac.utils import (is_absolute_href, make_absolute_href, make_relative_href, datetime_to_str,
                           str_to_datetime)
@@ -221,7 +221,7 @@ class Item(STACObject):
 
         return self
 
-    def set_collection(self, collection, link_type=None):
+    def set_collection(self, collection):
         """Set the collection of this item.
 
         This method will replace any existing Collection link and attribute for
@@ -230,22 +230,14 @@ class Item(STACObject):
         Args:
             collection (Collection or None): The collection to set as this
                 item's collection. If None, will clear the collection.
-            link_type (str): the link type to use for the collection link.
-                One of :class:`~pystac.LinkType`.
 
         Returns:
             Item: self
         """
-        if not link_type:
-            prev = self.get_single_link('collection')
-            if prev is not None:
-                link_type = prev.link_type
-            else:
-                link_type = LinkType.ABSOLUTE
         self.remove_links('collection')
         self.collection_id = None
         if collection is not None:
-            self.add_link(Link.collection(collection, link_type=link_type))
+            self.add_link(Link.collection(collection))
             self.collection_id = collection.id
 
         return self

--- a/pystac/link.py
+++ b/pystac/link.py
@@ -6,15 +6,6 @@ from pystac.stac_io import STAC_IO
 from pystac.utils import (make_absolute_href, make_relative_href, is_absolute_href)
 
 
-class LinkType(str, Enum):
-    """Enumerates link types; used to determine if a link is absolute or relative."""
-    def __str__(self):
-        return str(self.value)
-
-    ABSOLUTE = 'ABSOLUTE'
-    RELATIVE = 'RELATIVE'
-
-
 class Link:
     """A link is connects a :class:`~pystac.STACObject` to another entity.
 
@@ -40,8 +31,6 @@ class Link:
         properties (dict): Optional, additional properties for this link. This is used by
             extensions as a way to serialize and deserialize properties on link
             object JSON.
-        link_type (str): The link type, either relative or absolute. Use one of
-            :class:`~pystac.LinkType`.
 
     Attributes:
         rel (str): The relation of the link (e.g. 'child', 'item')
@@ -54,8 +43,6 @@ class Link:
         properties (dict or None): Optional, additional properties for this link.
             This is used by extensions as a way to serialize and deserialize properties
             on link object JSON.
-        link_type (str): The link type, either relative or absolute. Use one of
-            :class:`~pystac.LinkType`.
         owner (STACObject or None): The owner of this link. The link will use
             its owner's root catalog :class:`~pystac.resolved_object_cache.ResolvedObjectCache`
             to resolve objects, and will create absolute HREFs from relative HREFs against
@@ -66,14 +53,12 @@ class Link:
                  target,
                  media_type=None,
                  title=None,
-                 properties=None,
-                 link_type=LinkType.ABSOLUTE):
+                 properties=None):
         self.rel = rel
         self.target = target  # An object or an href
         self.media_type = media_type
         self.title = title
         self.properties = properties
-        self.link_type = link_type
         self.owner = None
 
     def set_owner(self, owner):
@@ -85,23 +70,14 @@ class Link:
         self.owner = owner
         return self
 
-    def make_absolute(self):
-        """Sets the link type of this link to absolute"""
-        self.link_type = LinkType.ABSOLUTE
-        return self
-
-    def make_relative(self):
-        """Sets the link type of this link to relative"""
-        self.link_type = LinkType.RELATIVE
-        return self
-
     def get_href(self):
         """Gets the HREF for this link.
 
         Returns:
-            str: Returns this link's HREF. If the link type is LinkType.RELATIVE,
-            and there is an owner of the link, then the HREF returned will be
-            relative. In all other cases, this method will return an absolute HREF.
+            str: Returns this link's HREF. If there is an owner of the link and 
+            the root catalog (if there is one) is of type RELATIVE_PUBLISHED,
+            then the HREF returned will be relative. 
+            In all other cases, this method will return an absolute HREF.
         """
         href = None
         if self.rel in ['root', 'child', 'parent', 'item'] and self.owner is not None:
@@ -174,14 +150,14 @@ class Link:
                 obj.set_self_href(target_href)
                 if root is not None:
                     obj = root._resolved_objects.get_or_cache(obj)
-                    obj.set_root(root, link_type=self.link_type)
+                    obj.set_root(root)
         else:
             obj = self.target
 
         self.target = obj
 
         if self.owner and self.rel in ['child', 'item']:
-            self.target.set_parent(self.owner, link_type=self.link_type)
+            self.target.set_parent(self.owner)
 
         return self
 
@@ -229,8 +205,7 @@ class Link:
         return Link(rel=self.rel,
                     target=self.target,
                     media_type=self.media_type,
-                    title=self.title,
-                    link_type=self.link_type)
+                    title=self.title)
 
     @staticmethod
     def from_dict(d):
@@ -252,44 +227,38 @@ class Link:
         if any(d):
             properties = d
 
-        if rel == 'self' or is_absolute_href(href):
-            link_type = LinkType.ABSOLUTE
-        else:
-            link_type = LinkType.RELATIVE
-
         return Link(rel=rel,
                     target=href,
                     media_type=media_type,
                     title=title,
-                    properties=properties,
-                    link_type=link_type)
+                    properties=properties)
 
     @staticmethod
-    def root(c, link_type=LinkType.ABSOLUTE):
+    def root(c):
         """Creates a link to a root Catalog or Collection."""
-        return Link('root', c, media_type='application/json', link_type=link_type)
+        return Link('root', c, media_type='application/json')
 
     @staticmethod
-    def parent(c, link_type=LinkType.ABSOLUTE):
+    def parent(c):
         """Creates a link to a parent Catalog or Collection."""
-        return Link('parent', c, media_type='application/json', link_type=link_type)
+        return Link('parent', c, media_type='application/json')
 
     @staticmethod
-    def collection(c, link_type=LinkType.ABSOLUTE):
+    def collection(c):
         """Creates a link to an item's Collection."""
-        return Link('collection', c, media_type='application/json', link_type=link_type)
+        return Link('collection', c, media_type='application/json')
 
     @staticmethod
     def self_href(href):
         """Creates a self link to a file's location."""
-        return Link('self', href, media_type='application/json', link_type=LinkType.ABSOLUTE)
+        return Link('self', href, media_type='application/json')
 
     @staticmethod
-    def child(c, title=None, link_type=LinkType.ABSOLUTE):
+    def child(c, title=None):
         """Creates a link to a child Catalog or Collection."""
-        return Link('child', c, title=title, media_type='application/json', link_type=link_type)
+        return Link('child', c, title=title, media_type='application/json')
 
     @staticmethod
-    def item(item, title=None, link_type=LinkType.ABSOLUTE):
+    def item(item, title=None):
         """Creates a link to an Item."""
-        return Link('item', item, title=title, media_type='application/json', link_type=link_type)
+        return Link('item', item, title=title, media_type='application/json')

--- a/pystac/link.py
+++ b/pystac/link.py
@@ -1,5 +1,6 @@
 from copy import copy
 
+import pystac
 from pystac import STACError
 from pystac.stac_io import STAC_IO
 from pystac.utils import (make_absolute_href, make_relative_href, is_absolute_href)
@@ -81,12 +82,14 @@ class Link:
         else:
             href = self.target
 
-        # if a hierarchical link with an owner and root, and relative catalog
-        if self.rel in HIERARCHICAL_LINKS and self.owner is not None:
-            root = self.owner.get_root()
-            if root is not None and root.catalog_type in ['RELATIVE_PUBLISHED', 'SELF_CONTAINED']:
-                if href and is_absolute_href(href):
-                    href = make_relative_href(href, self.owner.get_self_href())
+        if href and self.owner is not None:
+            rel_links = HIERARCHICAL_LINKS + pystac.STAC_EXTENSIONS.get_extended_object_links(self.owner)
+            # if a hierarchical link with an owner and root, and relative catalog
+            if self.rel in rel_links:
+                root = self.owner.get_root()
+                if root is not None and root.catalog_type in ['RELATIVE_PUBLISHED', 'SELF_CONTAINED']:
+                    if href and is_absolute_href(href):
+                        href = make_relative_href(href, self.owner.get_self_href())
 
         return href
 

--- a/pystac/link.py
+++ b/pystac/link.py
@@ -1,5 +1,4 @@
 from copy import (copy, deepcopy)
-from enum import Enum
 
 from pystac import STACError
 from pystac.stac_io import STAC_IO
@@ -77,9 +76,9 @@ class Link:
         """Gets the HREF for this link.
 
         Returns:
-            str: Returns this link's HREF. If there is an owner of the link and 
+            str: Returns this link's HREF. If there is an owner of the link and
             the root catalog (if there is one) is of type RELATIVE_PUBLISHED,
-            then the HREF returned will be relative. 
+            then the HREF returned will be relative.
             In all other cases, this method will return an absolute HREF.
         """
         href = None

--- a/pystac/link.py
+++ b/pystac/link.py
@@ -4,7 +4,6 @@ from pystac import STACError
 from pystac.stac_io import STAC_IO
 from pystac.utils import (make_absolute_href, make_relative_href, is_absolute_href)
 
-
 HIERARCHICAL_LINKS = ['root', 'child', 'parent', 'collection', 'item', 'items']
 
 
@@ -50,12 +49,7 @@ class Link:
             to resolve objects, and will create absolute HREFs from relative HREFs against
             the owner's self HREF.
     """
-    def __init__(self,
-                 rel,
-                 target,
-                 media_type=None,
-                 title=None,
-                 properties=None):
+    def __init__(self, rel, target, media_type=None, title=None, properties=None):
         self.rel = rel
         self.target = target  # An object or an href
         self.media_type = media_type
@@ -204,10 +198,7 @@ class Link:
             Link: The cloned link.
         """
 
-        return Link(rel=self.rel,
-                    target=self.target,
-                    media_type=self.media_type,
-                    title=self.title)
+        return Link(rel=self.rel, target=self.target, media_type=self.media_type, title=self.title)
 
     @staticmethod
     def from_dict(d):
@@ -229,11 +220,7 @@ class Link:
         if any(d):
             properties = d
 
-        return Link(rel=rel,
-                    target=href,
-                    media_type=media_type,
-                    title=title,
-                    properties=properties)
+        return Link(rel=rel, target=href, media_type=media_type, title=title, properties=properties)
 
     @staticmethod
     def root(c):

--- a/pystac/link.py
+++ b/pystac/link.py
@@ -6,6 +6,9 @@ from pystac.stac_io import STAC_IO
 from pystac.utils import (make_absolute_href, make_relative_href, is_absolute_href)
 
 
+HIERARCHICAL_LINKS = ['root', 'child', 'parent', 'collection', 'item', 'items']
+
+
 class Link:
     """A link is connects a :class:`~pystac.STACObject` to another entity.
 
@@ -80,11 +83,11 @@ class Link:
             In all other cases, this method will return an absolute HREF.
         """
         href = None
-        if self.rel in ['root', 'child', 'parent', 'item'] and self.owner is not None:
+        if self.rel in HIERARCHICAL_LINKS and self.owner is not None:
             # get root
             root = self.owner.get_root()
             if root is not None:
-                if root.catalog_type == 'RELATIVE_PUBLISHED':
+                if root.catalog_type in ['RELATIVE_PUBLISHED', 'SELF_CONTAINED']:
                     if self.is_resolved():
                         href = self.target.get_self_href()
                     else:

--- a/pystac/link.py
+++ b/pystac/link.py
@@ -75,20 +75,19 @@ class Link:
             then the HREF returned will be relative.
             In all other cases, this method will return an absolute HREF.
         """
-        href = None
+        # get the self href
+        if self.is_resolved():
+            href = self.target.get_self_href()
+        else:
+            href = self.target        
+
+        # if a hierarchical link with an owner and root, and relative catalog
         if self.rel in HIERARCHICAL_LINKS and self.owner is not None:
-            # get root
             root = self.owner.get_root()
-            if root is not None:
-                if root.catalog_type in ['RELATIVE_PUBLISHED', 'SELF_CONTAINED']:
-                    if self.is_resolved():
-                        href = self.target.get_self_href()
-                    else:
-                        href = self.target
-                    if href and is_absolute_href(href):
-                        href = make_relative_href(href, self.owner.get_self_href())
-        if href is None:
-            href = self.get_absolute_href()
+            if root is not None and root.catalog_type in ['RELATIVE_PUBLISHED', 'SELF_CONTAINED']:
+                if href and is_absolute_href(href):
+                    href = make_relative_href(href, self.owner.get_self_href())
+
         return href
 
     def get_absolute_href(self):

--- a/pystac/link.py
+++ b/pystac/link.py
@@ -82,14 +82,13 @@ class Link:
         else:
             href = self.target
 
-        if href and self.owner is not None:
-            rel_links = HIERARCHICAL_LINKS + pystac.STAC_EXTENSIONS.get_extended_object_links(self.owner)
+        if href and is_absolute_href(href) and self.owner and self.owner.get_root():
+            root = self.owner.get_root()
+            rel_links = HIERARCHICAL_LINKS + \
+                pystac.STAC_EXTENSIONS.get_extended_object_links(self.owner)
             # if a hierarchical link with an owner and root, and relative catalog
-            if self.rel in rel_links:
-                root = self.owner.get_root()
-                if root is not None and root.catalog_type in ['RELATIVE_PUBLISHED', 'SELF_CONTAINED']:
-                    if href and is_absolute_href(href):
-                        href = make_relative_href(href, self.owner.get_self_href())
+            if root.is_relative() and self.rel in rel_links:
+                href = make_relative_href(href, self.owner.get_self_href())
 
         return href
 

--- a/pystac/link.py
+++ b/pystac/link.py
@@ -79,7 +79,7 @@ class Link:
         if self.is_resolved():
             href = self.target.get_self_href()
         else:
-            href = self.target        
+            href = self.target
 
         # if a hierarchical link with an owner and root, and relative catalog
         if self.rel in HIERARCHICAL_LINKS and self.owner is not None:

--- a/pystac/link.py
+++ b/pystac/link.py
@@ -103,17 +103,20 @@ class Link:
             and there is an owner of the link, then the HREF returned will be
             relative. In all other cases, this method will return an absolute HREF.
         """
-        if self.link_type == LinkType.RELATIVE:
-            if self.is_resolved():
-                href = self.target.get_self_href()
-            else:
-                href = self.target
-
-            if href and is_absolute_href(href) and self.owner is not None:
-                href = make_relative_href(href, self.owner.get_self_href())
-        else:
+        href = None
+        if self.rel in ['root', 'child', 'parent', 'item'] and self.owner is not None:
+            # get root
+            root = self.owner.get_root()
+            if root is not None:
+                if root.catalog_type == 'RELATIVE_PUBLISHED':
+                    if self.is_resolved():
+                        href = self.target.get_self_href()
+                    else:
+                        href = self.target
+                    if href and is_absolute_href(href):
+                        href = make_relative_href(href, self.owner.get_self_href())
+        if href is None:
             href = self.get_absolute_href()
-
         return href
 
     def get_absolute_href(self):

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -165,25 +165,6 @@ class LinkMixin:
             self.links = []
         return self
 
-    def make_links_relative(self):
-        """Sets each link associated with this object to be relative.
-        This does not include the self link, as those must always be absolute.
-        See :func:`Link.make_relative <pystac.Link.make_relative>` for more information.
-        """
-        for link in self.links:
-            if link.rel != 'self':
-                link.make_relative()
-        return self
-
-    def make_links_absolute(self):
-        """Sets each link associated with this object to be absolute.
-        See :func:`Link.make_absolute <pystac.Link.make_absolute>` for more information.
-        """
-        for link in self.links:
-            if link.rel != 'self':
-                link.make_absolute()
-        return self
-
     def get_root_link(self):
         """Get the :class:`~pystac.Link` representing
         the root for this object.

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -442,7 +442,7 @@ class STACObject(LinkMixin, ABC):
 
     @abstractmethod
     def _object_links(self):
-        """Inhereted classes return a list of link 'rel' types that represent
+        """Inherited classes return a list of link 'rel' types that represent
         STACObjects linked to by this object (not including root, parent or self).
         This can include optional relations (which may not be present).
         """

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -3,7 +3,7 @@ from enum import Enum
 
 import pystac
 from pystac import STACError
-from pystac.link import (Link, LinkType)
+from pystac.link import Link
 from pystac.stac_io import STAC_IO
 from pystac.utils import (is_absolute_href, make_absolute_href)
 from pystac.extensions import ExtensionError
@@ -283,14 +283,13 @@ class STACObject(LinkMixin, ABC):
         else:
             return None
 
-    def set_root(self, root, link_type=None):
+    def set_root(self, root):
         """Sets the root :class:`~pystac.Catalog` or :class:`~pystac.Collection`
         for this object.
 
         Args:
             root (Catalog, Collection or None): The root
                 object to set. Passing in None will clear the root.
-            link_type (str): The link type (see :class:`~pystac.LinkType`)
         """
         root_link_index = next(iter([i for i, link in enumerate(self.links) if link.rel == 'root']),
                                None)
@@ -301,16 +300,10 @@ class STACObject(LinkMixin, ABC):
             if root_link.is_resolved():
                 root_link.target._resolved_objects.remove(self)
 
-            if link_type is None:
-                link_type = root_link.link_type
-
-        if link_type is None:
-            link_type = LinkType.ABSOLUTE
-
         if root is None:
             self.remove_links('root')
         else:
-            new_root_link = Link.root(root, link_type=link_type)
+            new_root_link = Link.root(root)
             if root_link_index is not None:
                 self.links[root_link_index] = new_root_link
                 new_root_link.set_owner(self)
@@ -336,25 +329,18 @@ class STACObject(LinkMixin, ABC):
         else:
             return None
 
-    def set_parent(self, parent, link_type=None):
+    def set_parent(self, parent):
         """Sets the parent :class:`~pystac.Catalog` or :class:`~pystac.Collection`
         for this object.
 
         Args:
             parent (Catalog, Collection or None): The parent
                 object to set. Passing in None will clear the parent.
-            link_type (str): The link type (see :class:`~pystac.LinkType`)
         """
-        if not link_type:
-            prev = self.get_single_link('parent')
-            if prev is not None:
-                link_type = prev.link_type
-            else:
-                link_type = LinkType.ABSOLUTE
 
         self.remove_links('parent')
         if parent is not None:
-            self.add_link(Link.parent(parent, link_type=link_type))
+            self.add_link(Link.parent(parent))
         return self
 
     def get_stac_objects(self, rel):
@@ -537,7 +523,7 @@ class STACObject(LinkMixin, ABC):
         if root_link is not None:
             if not root_link.is_resolved():
                 if root_link.get_absolute_href() == href:
-                    o.set_root(o, link_type=root_link.link_type)
+                    o.set_root(o)
         return o
 
     @classmethod

--- a/tests/data-files/collections/multi-extent.json
+++ b/tests/data-files/collections/multi-extent.json
@@ -13,11 +13,6 @@
       "type": "application/json"
     },
     {
-      "rel": "root",
-      "href": "../../catalog.json",
-      "type": "application/json"
-    },
-    {
       "rel": "parent",
       "href": "../catalog.json",
       "type": "application/json"

--- a/tests/data-files/eo/eo-landsat-example.json
+++ b/tests/data-files/eo/eo-landsat-example.json
@@ -227,18 +227,5 @@
             "title": "HTML index page"
         }
     },
-    "links": [
-        {
-            "rel": "self",
-            "href": "https://odu9mlf7d6.execute-api.us-east-1.amazonaws.com/stage/search?id=LC08_L1TP_107018_20181001_20181001_01_RT"
-        },
-        {
-            "rel": "parent",
-            "href": "https://odu9mlf7d6.execute-api.us-east-1.amazonaws.com/stage/stac/collections/landsat-8-l1"
-        },
-        {
-            "rel": "root",
-            "href": "https://odu9mlf7d6.execute-api.us-east-1.amazonaws.com/stage/stac"
-        }
-    ]
+    "links": []
 }

--- a/tests/data-files/eo/sample-bands-in-item-properties.json
+++ b/tests/data-files/eo/sample-bands-in-item-properties.json
@@ -66,7 +66,6 @@
   "collection": "CS3",
   "links": [
     {"rel": "self", "href": "http://cool-sat.com/catalog/CS3-20160503_132130_04/CS3-20160503_132130_04.json"},
-    {"rel": "root", "href": "http://cool-sat.com/catalog/catalog.json"},
     {"rel": "parent", "href": "http://cool-sat.com/catalog/CS3-20160503_132130_04/catalog.json"},
     {"rel": "collection", "href": "http://cool-sat.com/catalog/CS3-20160503_132130_04/catalog.json"},
     {"rel": "alternate", "type": "text/html", "href": "http://cool-sat.com/catalog/CS3-20160503_132130_04/CS3-20160503_132130_04.html"}

--- a/tests/data-files/file/file-example.json
+++ b/tests/data-files/file/file-example.json
@@ -81,20 +81,5 @@
       "file:nodata": []
     }
   },
-  "links": [
-    {
-      "rel": "self",
-      "href": "https://example.com/collections/sentinel-1/items/S1A_EW_GRDM_1SSH_20181103T235855_20181103T235955_024430_02AD5D_5616"
-    },
-    {
-      "rel": "parent",
-      "href": "https://example.com/collections/sentinel-1",
-      "file:checksum": "11146d97123fd2c02dec9a1b6d3b13136dbe600cf966"
-    },
-    {
-      "rel": "root",
-      "href": "https://example.com/collections",
-      "file:checksum": "1114fa4b9d69fdddc7c1be7bed9440621400b383b43f"
-    }
-  ]
+  "links": []
 }

--- a/tests/data-files/label/label-example-1.json
+++ b/tests/data-files/label/label-example-1.json
@@ -95,7 +95,7 @@
   "links": [
     {
       "rel": "source",
-      "href": "http://example.com/area-1-1-imagery/area-1-1-imagery.json",
+      "href": "../area-1-1-imagery/area-1-1-imagery.json",
       "type": "application/json"
     }
   ],

--- a/tests/data-files/label/label-example-1.json
+++ b/tests/data-files/label/label-example-1.json
@@ -95,17 +95,7 @@
   "links": [
     {
       "rel": "source",
-      "href": "../area-1-1-imagery/area-1-1-imagery.json",
-      "type": "application/json"
-    },
-    {
-      "rel": "root",
-      "href": "../../../catalog.json",
-      "type": "application/json"
-    },
-    {
-      "rel": "parent",
-      "href": "../collection.json",
+      "href": "http://example.com/area-1-1-imagery/area-1-1-imagery.json",
       "type": "application/json"
     }
   ],

--- a/tests/data-files/label/label-example-2.json
+++ b/tests/data-files/label/label-example-2.json
@@ -88,17 +88,7 @@
   "links": [
     {
       "rel": "source",
-      "href": "../area-1-1-imagery/area-1-1-imagery.json",
-      "type": "application/json"
-    },
-    {
-      "rel": "root",
-      "href": "../../../catalog.json",
-      "type": "application/json"
-    },
-    {
-      "rel": "parent",
-      "href": "../collection.json",
+      "href": "http://example.com/area-1-1-imagery/area-1-1-imagery.json",
       "type": "application/json"
     }
   ],

--- a/tests/data-files/label/label-example-2.json
+++ b/tests/data-files/label/label-example-2.json
@@ -88,7 +88,7 @@
   "links": [
     {
       "rel": "source",
-      "href": "http://example.com/area-1-1-imagery/area-1-1-imagery.json",
+      "href": "../area-1-1-imagery/area-1-1-imagery.json",
       "type": "application/json"
     }
   ],

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from collections import defaultdict
 
 import pystac
-from pystac import (Catalog, Collection, CatalogType, LinkType, Item, Asset, MediaType, Extensions)
+from pystac import (Catalog, Collection, CatalogType, Item, Asset, MediaType, Extensions)
 from pystac.extensions.label import LabelClasses
 from pystac.validation import STACValidationError
 from pystac.utils import is_absolute_href

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -6,7 +6,8 @@ from datetime import datetime
 from collections import defaultdict
 
 import pystac
-from pystac import (Catalog, Collection, CatalogType, Item, Asset, MediaType, Extensions, HIERARCHICAL_LINKS)
+from pystac import (Catalog, Collection, CatalogType,
+                    Item, Asset, MediaType, Extensions, HIERARCHICAL_LINKS)
 from pystac.extensions.label import LabelClasses
 from pystac.validation import STACValidationError
 from pystac.utils import is_absolute_href
@@ -656,8 +657,6 @@ class CatalogTest(unittest.TestCase):
                 for item in items:
                     for link in item.links:
                         if link.rel in HIERARCHICAL_LINKS:
-                            if is_absolute_href(link.get_href()):
-                                import pdb; pdb.set_trace()
                             self.assertFalse(is_absolute_href(link.get_href()))
 
         def check_all_absolute(cat):

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from collections import defaultdict
 
 import pystac
-from pystac import (Catalog, Collection, CatalogType, Item, Asset, MediaType, Extensions)
+from pystac import (Catalog, Collection, CatalogType, Item, Asset, MediaType, Extensions, HIERARCHICAL_LINKS)
 from pystac.extensions.label import LabelClasses
 from pystac.validation import STACValidationError
 from pystac.utils import is_absolute_href
@@ -261,14 +261,6 @@ class CatalogTest(unittest.TestCase):
         assert catalog.catalog_type == CatalogType.SELF_CONTAINED
         clone = catalog.clone()
         self.assertEqual(clone.catalog_type, CatalogType.SELF_CONTAINED)
-
-    def test_save_throws_if_no_catalog_type(self):
-        catalog = TestCases.test_case_3()
-        assert catalog.catalog_type is None
-        with TemporaryDirectory() as tmp_dir:
-            catalog.normalize_hrefs(tmp_dir)
-            with self.assertRaises(ValueError):
-                catalog.save()
 
     def test_normalize_hrefs_sets_all_hrefs(self):
         catalog = TestCases.test_case_1()
@@ -659,23 +651,21 @@ class CatalogTest(unittest.TestCase):
         def check_all_relative(cat):
             for root, catalogs, items in cat.walk():
                 for link in root.links:
-                    if link.rel != 'self':
-                        self.assertTrue(link.link_type == LinkType.RELATIVE)
+                    if link.rel in HIERARCHICAL_LINKS:
                         self.assertFalse(is_absolute_href(link.get_href()))
                 for item in items:
                     for link in item.links:
-                        if link.rel != 'self':
-                            self.assertTrue(link.link_type == LinkType.RELATIVE)
+                        if link.rel in HIERARCHICAL_LINKS:
+                            if is_absolute_href(link.get_href()):
+                                import pdb; pdb.set_trace()
                             self.assertFalse(is_absolute_href(link.get_href()))
 
         def check_all_absolute(cat):
             for root, catalogs, items in cat.walk():
                 for link in root.links:
-                    self.assertTrue(link.link_type == LinkType.ABSOLUTE)
                     self.assertTrue(is_absolute_href(link.get_href()))
                 for item in items:
                     for link in item.links:
-                        self.assertTrue(link.link_type == LinkType.ABSOLUTE)
                         self.assertTrue(is_absolute_href(link.get_href()))
 
         test_cases = TestCases.all_test_catalogs()
@@ -684,9 +674,9 @@ class CatalogTest(unittest.TestCase):
             with TemporaryDirectory() as tmp_dir:
                 c2 = catalog.full_copy()
                 c2.normalize_hrefs(tmp_dir)
-                c2.make_all_links_relative()
+                c2.catalog_type = CatalogType.RELATIVE_PUBLISHED
                 check_all_relative(c2)
-                c2.make_all_links_absolute()
+                c2.catalog_type = CatalogType.ABSOLUTE_PUBLISHED
                 check_all_absolute(c2)
 
     def test_full_copy_and_normalize_works_with_created_stac(self):

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -6,8 +6,8 @@ from datetime import datetime
 from collections import defaultdict
 
 import pystac
-from pystac import (Catalog, Collection, CatalogType,
-                    Item, Asset, MediaType, Extensions, HIERARCHICAL_LINKS)
+from pystac import (Catalog, Collection, CatalogType, Item, Asset, MediaType, Extensions,
+                    HIERARCHICAL_LINKS)
 from pystac.extensions.label import LabelClasses
 from pystac.validation import STACValidationError
 from pystac.utils import is_absolute_href

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -49,18 +49,6 @@ class LinkTest(unittest.TestCase):
         link.set_owner(None)
         self.assertIsNone(link.owner)
 
-        self.assertEqual(pystac.LinkType.ABSOLUTE, link.link_type)
-
-        link.make_absolute()
-        self.assertEqual(pystac.LinkType.ABSOLUTE, link.link_type)
-        self.assertEqual(target, link.get_href())
-        self.assertEqual(target, link.get_absolute_href())
-
-        link.make_relative()
-        self.assertEqual(pystac.LinkType.RELATIVE, link.link_type)
-        self.assertEqual(target, link.get_href())
-        self.assertEqual(target, link.get_absolute_href())
-
         link.set_owner(self.item)
         self.assertEqual(self.item, link.owner)
 
@@ -72,8 +60,7 @@ class LinkTest(unittest.TestCase):
                            target,
                            mime_type,
                            'a title',
-                           properties={'a': 'b'},
-                           link_type=pystac.LinkType.RELATIVE)
+                           properties={'a': 'b'})
         expected_dict = {
             'rel': rel,
             'href': target,
@@ -83,14 +70,11 @@ class LinkTest(unittest.TestCase):
         }
         self.assertEqual(expected_dict, link.to_dict())
 
-        self.assertEqual(pystac.LinkType.RELATIVE, link.link_type)
-
     def test_link_does_not_fail_if_href_is_none(self):
         """Test to ensure get_href does not fail when the href is None."""
         catalog = pystac.Catalog(id='test', description='test desc')
         catalog.add_item(self.item)
         catalog.set_self_href('/some/href')
-        catalog.make_all_links_relative()
 
         link = catalog.get_single_link('item')
         self.assertIsNone(link.get_href())
@@ -133,50 +117,9 @@ class StaticLinkTest(unittest.TestCase):
             d2 = pystac.Link.from_dict(d).to_dict()
             self.assertEqual(d, d2)
 
-    def test_from_dict_link_type(self):
-        test_cases = [
-            ({
-                'rel': '',
-                'href': 'https://a'
-            }, pystac.LinkType.ABSOLUTE),
-            ({
-                'rel': '',
-                'href': '/a'
-            }, pystac.LinkType.ABSOLUTE),
-            ({
-                'rel': '',
-                'href': 'a'
-            }, pystac.LinkType.RELATIVE),
-            ({
-                'rel': '',
-                'href': './a'
-            }, pystac.LinkType.RELATIVE),
-            # 'self' is a special case.
-            ({
-                'rel': 'self',
-                'href': 'does not matter'
-            }, pystac.LinkType.ABSOLUTE),
-        ]
-        for case in test_cases:
-            item = pystac.Link.from_dict(case[0])
-            self.assertEqual(case[1], item.link_type)
-
     def test_from_dict_failures(self):
         for d in [{}, {'href': 't'}, {'rel': 'r'}]:
             with self.assertRaises(KeyError):
-                pystac.Link.from_dict(d)
-
-        for d in [
-            {
-                'rel': '',
-                'href': 1
-            },
-            {
-                'rel': '',
-                'href': None
-            },
-        ]:
-            with self.assertRaises(AttributeError):
                 pystac.Link.from_dict(d)
 
     def test_collection(self):

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -56,11 +56,7 @@ class LinkTest(unittest.TestCase):
         rel = 'my rel'
         target = '../elsewhere'
         mime_type = 'example/stac_thing'
-        link = pystac.Link(rel,
-                           target,
-                           mime_type,
-                           'a title',
-                           properties={'a': 'b'})
+        link = pystac.Link(rel, target, mime_type, 'a title', properties={'a': 'b'})
         expected_dict = {
             'rel': rel,
             'href': target,

--- a/tests/test_writing.py
+++ b/tests/test_writing.py
@@ -1,7 +1,7 @@
 import unittest
 from tempfile import TemporaryDirectory
 
-from pystac import (STAC_IO, STACObject, Collection, CatalogType)
+from pystac import (STAC_IO, STACObject, Collection, CatalogType, HIERARCHICAL_LINKS)
 from pystac.serialization import (STACObjectType)
 from pystac.utils import is_absolute_href, make_absolute_href, make_relative_href
 from pystac.validation import validate_dict
@@ -30,12 +30,11 @@ class STACWritingTest(unittest.TestCase):
         d = STAC_IO.read_json(path)
         return validate_dict(d, object_type)
 
-    def validate_link_types(self, root_href, catalog_type):
+    def validate_link_types(self, root_href, catalog_type):           
+
         def validate_asset_href_type(item, item_href, link_type):
             for asset in item.assets.values():
-                if link_type == LinkType.ABSOLUTE:
-                    self.assertTrue(is_absolute_href(asset.href))
-                else:
+                if not is_absolute_href(asset.href):
                     is_valid = not is_absolute_href(asset.href)
                     if not is_valid:
                         # If the item href and asset href don't share
@@ -50,7 +49,10 @@ class STACWritingTest(unittest.TestCase):
             item = STACObject.from_file(href)
             for link in item.get_links():
                 if not link.rel == 'self':
-                    self.assertEqual(link.link_type, link_type)
+                    if link_type == 'RELATIVE' and link.rel in HIERARCHICAL_LINKS:
+                        self.assertFalse(is_absolute_href(link.get_href()))
+                    else:
+                        self.assertTrue(is_absolute_href(link.get_href()))
 
             validate_asset_href_type(item, href, link_type)
 
@@ -60,9 +62,6 @@ class STACWritingTest(unittest.TestCase):
         def validate_catalog_link_type(href, link_type, should_include_self):
             cat_dict = STAC_IO.read_json(href)
             cat = STACObject.from_file(href)
-            for link in cat.get_links():
-                if not link.rel == 'self':
-                    self.assertEqual(link.link_type, link_type)
 
             rels = set([link['rel'] for link in cat_dict['links']])
             self.assertEqual('self' in rels, should_include_self)
@@ -77,9 +76,9 @@ class STACWritingTest(unittest.TestCase):
                 validate_item_link_type(item_href, link_type,
                                         catalog_type == CatalogType.ABSOLUTE_PUBLISHED)
 
-        link_type = LinkType.RELATIVE
+        link_type = 'RELATIVE'
         if catalog_type == CatalogType.ABSOLUTE_PUBLISHED:
-            link_type = LinkType.ABSOLUTE
+            link_type = 'ABSOLUTE'
 
         root_should_include_href = catalog_type in [
             CatalogType.ABSOLUTE_PUBLISHED, CatalogType.RELATIVE_PUBLISHED
@@ -110,9 +109,11 @@ class STACWritingTest(unittest.TestCase):
     def test_testcases(self):
         for catalog in TestCases.all_test_catalogs():
             catalog = catalog.full_copy()
-            for catalog_type in [
-                    CatalogType.ABSOLUTE_PUBLISHED, CatalogType.RELATIVE_PUBLISHED,
-                    CatalogType.SELF_CONTAINED
-            ]:
+            ctypes = [
+                      CatalogType.ABSOLUTE_PUBLISHED,
+                      CatalogType.RELATIVE_PUBLISHED,
+                      CatalogType.SELF_CONTAINED
+                    ]
+            for catalog_type in ctypes:
                 with self.subTest(title='Catalog {} [{}]'.format(catalog.id, catalog_type)):
                     self.do_test(catalog, catalog_type)

--- a/tests/test_writing.py
+++ b/tests/test_writing.py
@@ -30,7 +30,7 @@ class STACWritingTest(unittest.TestCase):
         d = STAC_IO.read_json(path)
         return validate_dict(d, object_type)
 
-    def validate_link_types(self, root_href, catalog_type):           
+    def validate_link_types(self, root_href, catalog_type):
 
         def validate_asset_href_type(item, item_href, link_type):
             for asset in item.assets.values():

--- a/tests/test_writing.py
+++ b/tests/test_writing.py
@@ -1,7 +1,7 @@
 import unittest
 from tempfile import TemporaryDirectory
 
-from pystac import (STAC_IO, STACObject, Collection, CatalogType, LinkType)
+from pystac import (STAC_IO, STACObject, Collection, CatalogType)
 from pystac.serialization import (STACObjectType)
 from pystac.utils import is_absolute_href, make_absolute_href, make_relative_href
 from pystac.validation import validate_dict

--- a/tests/test_writing.py
+++ b/tests/test_writing.py
@@ -1,6 +1,7 @@
 import unittest
 from tempfile import TemporaryDirectory
 
+import pystac
 from pystac import (STAC_IO, STACObject, Collection, CatalogType, HIERARCHICAL_LINKS)
 from pystac.serialization import (STACObjectType)
 from pystac.utils import is_absolute_href, make_absolute_href, make_relative_href
@@ -46,9 +47,10 @@ class STACWritingTest(unittest.TestCase):
         def validate_item_link_type(href, link_type, should_include_self):
             item_dict = STAC_IO.read_json(href)
             item = STACObject.from_file(href)
+            rel_links = HIERARCHICAL_LINKS + pystac.STAC_EXTENSIONS.get_extended_object_links(item)
             for link in item.get_links():
                 if not link.rel == 'self':
-                    if link_type == 'RELATIVE' and link.rel in HIERARCHICAL_LINKS:
+                    if link_type == 'RELATIVE' and link.rel in rel_links:
                         self.assertFalse(is_absolute_href(link.get_href()))
                     else:
                         self.assertTrue(is_absolute_href(link.get_href()))

--- a/tests/test_writing.py
+++ b/tests/test_writing.py
@@ -31,7 +31,6 @@ class STACWritingTest(unittest.TestCase):
         return validate_dict(d, object_type)
 
     def validate_link_types(self, root_href, catalog_type):
-
         def validate_asset_href_type(item, item_href, link_type):
             for asset in item.assets.values():
                 if not is_absolute_href(asset.href):
@@ -110,10 +109,9 @@ class STACWritingTest(unittest.TestCase):
         for catalog in TestCases.all_test_catalogs():
             catalog = catalog.full_copy()
             ctypes = [
-                      CatalogType.ABSOLUTE_PUBLISHED,
-                      CatalogType.RELATIVE_PUBLISHED,
-                      CatalogType.SELF_CONTAINED
-                    ]
+                CatalogType.ABSOLUTE_PUBLISHED, CatalogType.RELATIVE_PUBLISHED,
+                CatalogType.SELF_CONTAINED
+            ]
             for catalog_type in ctypes:
                 with self.subTest(title='Catalog {} [{}]'.format(catalog.id, catalog_type)):
                     self.do_test(catalog, catalog_type)


### PR DESCRIPTION
**Related Issue(s):** #
#286 , also resolves #285

**Description:**
This PR removes the link_type field and the LinkType class, along with the need to loop through all links to set them as RELATIVE or ABSOLUTE.
Instead, when a link href is requested it returns an absolute link unless all the following are true:

- The link is a hierarchical link ('root', 'child', 'parent', 'item')
- The link has an owner (i.e., it is part of a STAC object and not a standalong Link instance)
- The owner has a root catalog
- The root catalog.catalog_type is CatalogType.RELATIVE_PUBLISHED

When all are true the link relative to the owner is returned.

There are some additional implications and related changes:
- Catalog.catalog_type is now always defined, never None. It defaults to ABSOLUTE_PUBLISHED
- A user can just set `Catalog.catalog_type = Catalog.Type.X`...subsequent saves will generate relative links for all saved objects
- Specifying CatalogType to `normalize_and_save` and `save` is no longer needed, in fact it should be deprecated.  It's been left in for backward compatibility. The catalog_type of the root should be favored.
- An implication/assumption is that unless you are working with a stand-alone Item or Collection, there will always be a root catalog. 
- Fixed #286 so that now you can seamlessly save any node in a tree which will save it from that point down

I've not yet updated tests, instead I'm putting this WIP PR up for discussion since it's a big internal change.  Afterward I can update tests


**PR Checklist:**

- [x] Code is formatted (run `scripts/format`)
- [ ] Tests pass (run `scripts/test`)
- [ ] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.