### PR TITLE
Don't fail on item.set_self_href(None) for items with relative asset hrefs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 
 - Fixed error when accessing the statistics attribute of the pointcloud extension when no statistics were defined ([#282](https://github.com/stac-utils/pystac/pull/282))
+- Fixed exception being thrown when calling set_self_href on items with assets that have relative hrefs ([#291](https://github.com/stac-utils/pystac/pull/291))
 
 ### Changed
 

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -127,7 +127,7 @@ class Item(STACObject):
         super().set_self_href(href)
         new_href = self.get_self_href()  # May have been made absolute.
 
-        if prev_href is not None:
+        if prev_href is not None and new_href is not None:
             # Make sure relative asset links remain valid.
             for asset in self.assets.values():
                 asset_href = asset.href

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -46,6 +46,16 @@ class ItemTest(unittest.TestCase):
             for asset in item.assets.values():
                 self.assertTrue(is_absolute_href(asset.href))
 
+    def test_set_self_href_none_ignores_relative_asset_hrefs(self):
+        cat = TestCases.test_case_2()
+        for item in cat.get_all_items():
+            for asset in item.assets.values():
+                if is_absolute_href(asset.href):
+                    asset.href = (f'./{os.path.basename(asset.href)}')
+            item.set_self_href(None)
+            for asset in item.assets.values():
+                self.assertFalse(is_absolute_href(asset.href))
+
     def test_asset_absolute_href(self):
         item_dict = self.get_example_item_dict()
         item = Item.from_dict(item_dict)

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -37,15 +37,14 @@ class ItemTest(unittest.TestCase):
         self.assertEqual(len(item.assets['thumbnail'].properties), 0)
 
     def test_set_self_href_doesnt_break_asset_hrefs(self):
-        cat = TestCases.test_case_6()
+        cat = TestCases.test_case_2()
         for item in cat.get_all_items():
             for asset in item.assets.values():
-                print(asset.href)
-                assert not is_absolute_href(asset.href)
+                if is_absolute_href(asset.href):
+                    asset.href = (f'./{os.path.basename(asset.href)}')
             item.set_self_href('http://example.com/item.json')
             for asset in item.assets.values():
                 self.assertTrue(is_absolute_href(asset.href))
-                self.assertTrue(os.path.exists(asset.href))
 
     def test_asset_absolute_href(self):
         item_dict = self.get_example_item_dict()


### PR DESCRIPTION
**Description:**
Currently if you call `set_self_href` on an Item with `None` as the parameter, if that item has assets with relative hrefs, the logic that attempts to ensure relative asset hrefs remain valid when switching the item href ends up throwing an error. This change makes it so that, if you are setting the item self href to None, any relative asset hrefs are left as is.

**PR Checklist:**

- [x] Code is formatted (run `scripts/format`)
- [x] Tests pass (run `scripts/test`)
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.