### PR TITLE
Fix normalizing hrefs for RELATIVE_UNPUBLISHED catalogs

### DIFF
--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -286,6 +286,17 @@ class CatalogTest(unittest.TestCase):
         abspath = os.path.abspath('./relativepath')
         self.assertTrue(catalog.get_self_href().startswith(abspath))
 
+    def test_normalize_hrefs_dont_make_items_absolute(self):
+        catalog = TestCases.test_case_1()
+        catalog.catalog_type = CatalogType.RELATIVE_PUBLISHED
+        catalog.normalize_hrefs('./relativepath')
+        abspath = os.path.abspath('./relativepath')
+        self.assertTrue(catalog.get_self_href().startswith(abspath))
+        for (_, _, items) in catalog.walk():
+            for item in items:
+                for link in item.links:
+                    self.assertFalse(os.path.isabs(link.get_href()), link.get_href())
+
     def test_normalize_href_works_with_label_source_links(self):
         catalog = TestCases.test_case_1()
         catalog.normalize_hrefs('http://example.com')


### PR DESCRIPTION
**Related Issue(s):** None

**Description:** Per https://pystac.readthedocs.io/en/latest/api.html#pystac.CatalogType.RELATIVE_PUBLISHED,
`RELATIVE_PUBLISHED` catalogs should only have one absolute link, the
`self` link on the root catalog. The commit here is a failing test showing that items have absolute hierarchical paths after normalizing hrefs on a `RELATIVE_UNPUBLISHED` catalog. Before fixing in this PR, I want to make sure this is unexpected behavior and it's not just me mis-understanding what's going on.

**PR Checklist:**

- [x] Code is formatted (run `scripts/format`)
- [ ] Tests pass (run `scripts/test`)
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.