### PR TITLE
Removed type information from docstrings

### DIFF
--- a/pystac/__init__.py
+++ b/pystac/__init__.py
@@ -79,7 +79,7 @@ def read_file(href: str) -> STACObject:
     This is a convenience method for :meth:`STACObject.from_file <pystac.STACObject.from_file>`
 
     Args:
-        href (str): The HREF to read the object from.
+        href : The HREF to read the object from.
 
     Returns:
         The specific STACObject implementation class that is represented
@@ -104,10 +104,10 @@ def write_file(
     Convenience method for :meth:`STACObject.from_file <pystac.STACObject.from_file>`
 
     Args:
-        obj (STACObject): The STACObject to save.
-        include_self_link (bool): If this is true, include the 'self' link with this object.
+        obj : The STACObject to save.
+        include_self_link : If this is true, include the 'self' link with this object.
             Otherwise, leave out the self link.
-        dest_href (str): Optional HREF to save the file to. If None, the object will be saved
+        dest_href : Optional HREF to save the file to. If None, the object will be saved
             to the object's self href.
     """
     obj.save_object(include_self_link=include_self_link, dest_href=dest_href)
@@ -128,10 +128,10 @@ def read_dict(
     This is a convenience method for :meth:`pystac.serialization.stac_object_from_dict`
 
     Args:
-        d (dict): The dict to parse.
-        href (str): Optional href that is the file location of the object being
+        d : The dict to parse.
+        href : Optional href that is the file location of the object being
             parsed.
-        root (Catalog or Collection): Optional root of the catalog for this object.
+        root : Optional root of the catalog for this object.
             If provided, the root's resolved object cache can be used to search for
             previously resolved instances of the STAC object.
         stac_io: Optional StacIO instance to use for reading. If None, the

--- a/pystac/asset.py
+++ b/pystac/asset.py
@@ -14,30 +14,30 @@ class Asset:
     can be downloaded or streamed.
 
     Args:
-        href (str): Link to the asset object. Relative and absolute links are both
+        href : Link to the asset object. Relative and absolute links are both
             allowed.
-        title (str): Optional displayed title for clients and users.
-        description (str): A description of the Asset providing additional details,
+        title : Optional displayed title for clients and users.
+        description : A description of the Asset providing additional details,
             such as how it was processed or created. CommonMark 0.29 syntax MAY be used
             for rich text representation.
-        media_type (str): Optional description of the media type. Registered Media Types
+        media_type : Optional description of the media type. Registered Media Types
             are preferred. See :class:`~pystac.MediaType` for common media types.
-        roles ([str]): Optional, Semantic roles (i.e. thumbnail, overview,
+        roles : Optional, Semantic roles (i.e. thumbnail, overview,
             data, metadata) of the asset.
-        properties (dict): Optional, additional properties for this asset. This is used
+        properties : Optional, additional properties for this asset. This is used
             by extensions as a way to serialize and deserialize properties on asset
             object JSON.
 
     Attributes:
-        href (str): Link to the asset object. Relative and absolute links are both
+        href : Link to the asset object. Relative and absolute links are both
             allowed.
-        title (str): Optional displayed title for clients and users.
-        description (str): A description of the Asset providing additional details,
+        title : Optional displayed title for clients and users.
+        description : A description of the Asset providing additional details,
             such as how it was processed or created. CommonMark 0.29 syntax MAY be
             used for rich text representation.
-        media_type (str): Optional description of the media type. Registered Media Types
+        media_type : Optional description of the media type. Registered Media Types
             are preferred. See :class:`~pystac.MediaType` for common media types.
-        properties (dict): Optional, additional properties for this asset. This is used
+        properties : Optional, additional properties for this asset. This is used
             by extensions as a way to serialize and deserialize properties on asset
             object JSON.
         owner: The Item or Collection this asset belongs to, or None if it has no owner.

--- a/pystac/cache.py
+++ b/pystac/cache.py
@@ -50,12 +50,12 @@ class ResolvedObjectCache:
     them with their copies.
 
     Args:
-        id_keys_to_objects (Dict[str, STACObject]): Existing cache of
+        id_keys_to_objects : Existing cache of
             a key made up of the STACObject and it's parents IDs mapped
             to the cached STACObject.
-        hrefs_to_objects (Dict[str, STACObject]): STAC Object HREFs matched to
+        hrefs_to_objects : STAC Object HREFs matched to
             their cached object.
-        ids_to_collections (Dict[str, Collection]): Map of collection IDs
+        ids_to_collections : Map of collection IDs
             to collections.
     """
 
@@ -76,7 +76,7 @@ class ResolvedObjectCache:
         none exists, sets the cached object to the given object.
 
         Args:
-            obj (STACObject): The given object who's cache key will be checked
+            obj : The given object who's cache key will be checked
                 against the cache.
 
         Returns:
@@ -101,7 +101,7 @@ class ResolvedObjectCache:
         """Get the cached object that has the same cache key as the given object.
 
         Args:
-            obj (STACObject): The given object who's cache key will be checked against
+            obj : The given object who's cache key will be checked against
                 the cache.
 
         Returns:
@@ -118,7 +118,7 @@ class ResolvedObjectCache:
         """Gets the cached object at href.
 
         Args:
-            href (str): The href to use as the key for the cached object.
+            href : The href to use as the key for the cached object.
 
         Returns:
             STACObject or None: Returns the STACObject if cached, otherwise None.
@@ -129,7 +129,7 @@ class ResolvedObjectCache:
         """Retrieved a cached Collection by its ID.
 
         Args:
-            id (str): The ID of the collection.
+            id : The ID of the collection.
 
         Returns:
             Collection or None: Returns the collection if there is one cached
@@ -141,7 +141,7 @@ class ResolvedObjectCache:
         """Set the given object into the cache.
 
         Args:
-            obj (STACObject): The object to cache
+            obj : The object to cache
         """
         key, is_href = get_cache_key(obj)
         if is_href:
@@ -156,7 +156,7 @@ class ResolvedObjectCache:
         """Removes any cached object that matches the given object's cache key.
 
         Args:
-            obj (STACObject): The object to remove
+            obj : The object to remove
         """
         key, is_href = get_cache_key(obj)
 
@@ -194,9 +194,9 @@ class ResolvedObjectCache:
         in the first will be cached in the resulting merged ResolvedObjectCache.
 
         Args:
-            first (ResolvedObjectCache): The first cache to merge. This cache will be
+            first : The first cache to merge. This cache will be
                 the preferred cache for objects in the case of ID conflicts.
-            second (ResolvedObjectCache): The second cache to merge.
+            second : The second cache to merge.
 
         Returns:
             ResolvedObjectCache: The resulting merged cache.

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -68,7 +68,7 @@ class CatalogType(str, Enum):
         Only applies to Catalogs or Collections
 
         Args:
-            stac_json (dict): The STAC JSON dict to determine the catalog type
+            stac_json : The STAC JSON dict to determine the catalog type
 
         Returns:
             Optional[CatalogType]: The catalog type of the catalog or collection.
@@ -102,28 +102,28 @@ class Catalog(STACObject):
     as well as :class:`~pystac.Item` s.
 
     Args:
-        id (str): Identifier for the catalog. Must be unique within the STAC.
-        description (str): Detailed multi-line description to fully explain the catalog.
+        id : Identifier for the catalog. Must be unique within the STAC.
+        description : Detailed multi-line description to fully explain the catalog.
             `CommonMark 0.28 syntax <http://commonmark.org/>`_ MAY be used for rich text
             representation.
-        title (str or None): Optional short descriptive one-line title for the catalog.
-        stac_extensions (List[str]): Optional list of extensions the Catalog implements.
-        href (str or None): Optional HREF for this catalog, which be set as the
+        title : Optional short descriptive one-line title for the catalog.
+        stac_extensions : Optional list of extensions the Catalog implements.
+        href : Optional HREF for this catalog, which be set as the
             catalog's self link's HREF.
-        catalog_type (str or None): Optional catalog type for this catalog. Must
+        catalog_type : Optional catalog type for this catalog. Must
             be one of the values in :class`~pystac.CatalogType`.
 
     Attributes:
-        id (str): Identifier for the catalog.
-        description (str): Detailed multi-line description to fully explain the catalog.
-        title (str or None): Optional short descriptive one-line title for the catalog.
-        stac_extensions (List[str] or None): Optional list of extensions the Catalog
+        id : Identifier for the catalog.
+        description : Detailed multi-line description to fully explain the catalog.
+        title : Optional short descriptive one-line title for the catalog.
+        stac_extensions : Optional list of extensions the Catalog
             implements.
-        extra_fields (dict or None): Extra fields that are part of the top-level JSON
+        extra_fields : Extra fields that are part of the top-level JSON
             properties of the Catalog.
-        links (List[Link]): A list of :class:`~pystac.Link` objects representing
+        links : A list of :class:`~pystac.Link` objects representing
             all links associated with this Catalog.
-        catalog_type (str): The catalog type. Defaults to ABSOLUTE_PUBLISHED
+        catalog_type : The catalog type. Defaults to ABSOLUTE_PUBLISHED
     """
 
     STAC_OBJECT_TYPE = pystac.STACObjectType.CATALOG
@@ -197,9 +197,9 @@ class Catalog(STACObject):
         this Catalog's root.
 
         Args:
-            child (Catalog or Collection): The child to add.
-            title (str): Optional title to give to the :class:`~pystac.Link`
-            strategy (HrefLayoutStrategy): The layout strategy to use for setting the
+            child : The child to add.
+            title : Optional title to give to the :class:`~pystac.Link`
+            strategy : The layout strategy to use for setting the
                 self href of the child.
         """
 
@@ -229,7 +229,7 @@ class Catalog(STACObject):
         this Catalog's root.
 
         Args:
-            children (Iterable[Catalog or Collection]): The children to add.
+            children : The children to add.
         """
         for child in children:
             self.add_child(child)
@@ -245,8 +245,8 @@ class Catalog(STACObject):
         this Catalog's root.
 
         Args:
-            item (Item): The item to add.
-            title (str): Optional title to give to the :class:`~pystac.Link`
+            item : The item to add.
+            title : Optional title to give to the :class:`~pystac.Link`
         """
 
         # Prevent typo confusion
@@ -273,7 +273,7 @@ class Catalog(STACObject):
         this Catalog's root.
 
         Args:
-            items (Iterable[Item]): The items to add.
+            items : The items to add.
         """
         for item in items:
             self.add_item(item)
@@ -284,8 +284,8 @@ class Catalog(STACObject):
         """Gets the child of this catalog with the given ID, if it exists.
 
         Args:
-            id (str): The ID of the child to find.
-            recursive (bool): If True, search this catalog and all children for the
+            id : The ID of the child to find.
+            recursive : If True, search this catalog and all children for the
                 item; otherwise, only search the children of this catalog. Defaults
                 to False.
 
@@ -336,7 +336,7 @@ class Catalog(STACObject):
         """Removes an child from this catalog.
 
         Args:
-            child_id (str): The ID of the child to remove.
+            child_id : The ID of the child to remove.
         """
         new_links: List[pystac.Link] = []
         root = self.get_root()
@@ -357,8 +357,8 @@ class Catalog(STACObject):
         """Returns an item with a given ID.
 
         Args:
-            id (str): The ID of the item to find.
-            recursive (bool): If True, search this catalog and all children for the
+            id : The ID of the item to find.
+            recursive : If True, search this catalog and all children for the
                 item; otherwise, only search the items of this catalog. Defaults
                 to False.
 
@@ -400,7 +400,7 @@ class Catalog(STACObject):
         """Removes an item from this catalog.
 
         Args:
-            item_id (str): The ID of the item to remove.
+            item_id : The ID of the item to remove.
         """
         new_links: List[pystac.Link] = []
         root = self.get_root()
@@ -515,13 +515,13 @@ class Catalog(STACObject):
         in sequence.
 
         Args:
-            root_href (str): The absolute HREF that all links will be normalized
+            root_href : The absolute HREF that all links will be normalized
                 against.
-            catalog_type (str): The catalog type that dictates the structure of
+            catalog_type : The catalog type that dictates the structure of
                 the catalog to save. Use a member of :class:`~pystac.CatalogType`.
                 Defaults to the root catalog.catalog_type or the current catalog
                 catalog_type if there is no root catalog.
-            strategy (HrefLayoutStrategy): The layout strategy to use in setting the
+            strategy : The layout strategy to use in setting the
                 HREFS for this catalog. Defaults to
                 :class:`~pystac.layout.BestPracticesLayoutStrategy`
         """
@@ -538,8 +538,8 @@ class Catalog(STACObject):
         This method mutates the entire catalog tree.
 
         Args:
-            root_href (str): The absolute HREF that all links will be normalized against.
-            strategy (HrefLayoutStrategy): The layout strategy to use in setting the HREFS
+            root_href : The absolute HREF that all links will be normalized against.
+            strategy : The layout strategy to use in setting the HREFS
                 for this catalog. Defaults to :class:`~pystac.layout.BestPracticesLayoutStrategy`
 
         See:
@@ -611,12 +611,12 @@ class Catalog(STACObject):
         and organize the items based on template values.
 
         Args:
-            template (str):   A template string that
+            template :   A template string that
                 can be consumed by a :class:`~pystac.layout.LayoutTemplate`
-            defaults (dict):  Default values for the template variables
+            defaults :  Default values for the template variables
                 that will be used if the property cannot be found on
                 the item.
-            parent_ids (List[str]): Optional list of the parent catalogs'
+            parent_ids : Optional list of the parent catalogs'
                 identifiers. If the bottom-most subcatalogs already match the
                 template, no subcatalog is added.
 
@@ -683,7 +683,7 @@ class Catalog(STACObject):
         self link HREF.
 
         Args:
-            catalog_type (str): The catalog type that dictates the structure of
+            catalog_type : The catalog type that dictates the structure of
                 the catalog to save. Use a member of :class:`~pystac.CatalogType`.
                 If not supplied, the catalog_type of this catalog will be used.
                 If that attribute is not set, an exception will be raised.
@@ -783,7 +783,7 @@ class Catalog(STACObject):
         item_mapper function.
 
         Args:
-            item_mapper (Callable):   A function that takes in an item, and returns
+            item_mapper :   A function that takes in an item, and returns
                 either an item or list of items. The item that is passed into the
                 item_mapper is a copy, so the method can mutate it safely.
 
@@ -829,7 +829,7 @@ class Catalog(STACObject):
         through the asset_mapper function.
 
         Args:
-            asset_mapper (Callable): A function that takes in an key and an Asset, and
+            asset_mapper : A function that takes in an key and an Asset, and
                 returns either an Asset, a (key, Asset), or a dictionary of Assets with
                 unique keys. The Asset that is passed into the item_mapper is a copy,
                 so the method can mutate it safely.

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -36,13 +36,13 @@ class SpatialExtent:
     """Describes the spatial extent of a Collection.
 
     Args:
-        bboxes (List[List[float]]): A list of bboxes that represent the spatial
+        bboxes : A list of bboxes that represent the spatial
             extent of the collection. Each bbox can be 2D or 3D. The length of the bbox
             array must be 2*n where n is the number of dimensions. For example, a
             2D Collection with only one bbox would be [[xmin, ymin, xmax, ymax]]
 
     Attributes:
-        bboxes (List[List[float]]): A list of bboxes that represent the spatial
+        bboxes : A list of bboxes that represent the spatial
             extent of the collection. Each bbox can be 2D or 3D. The length of the bbox
             array must be 2*n where n is the number of dimensions. For example, a
             2D Collection with only one bbox would be [[xmin, ymin, xmax, ymax]]
@@ -90,7 +90,7 @@ class SpatialExtent:
         in the coordinate set.
 
         Args:
-            coordinates (List[float]): Coordinates to derive the bbox from.
+            coordinates : Coordinates to derive the bbox from.
 
         Returns:
             SpatialExtent: A SpatialExtent with a single bbox that covers the
@@ -135,14 +135,14 @@ class TemporalExtent:
     """Describes the temporal extent of a Collection.
 
     Args:
-        intervals (List[List[datetime]]):  A list of two datetimes wrapped in a list,
+        intervals :  A list of two datetimes wrapped in a list,
         representing the temporal extent of a Collection. Open date ranges are supported
         by setting either the start (the first element of the interval) or the end (the
         second element of the interval) to None.
 
 
     Attributes:
-        intervals (List[List[datetime]]):  A list of two datetimes wrapped in a list,
+        intervals :  A list of two datetimes wrapped in a list,
         representing the temporal extent of a Collection. Open date ranges are
         represented by either the start (the first element of the interval) or the
         end (the second element of the interval) being None.
@@ -229,12 +229,12 @@ class Extent:
     """Describes the spatiotemporal extents of a Collection.
 
     Args:
-        spatial (SpatialExtent): Potential spatial extent covered by the collection.
-        temporal (TemporalExtent): Potential temporal extent covered by the collection.
+        spatial : Potential spatial extent covered by the collection.
+        temporal : Potential temporal extent covered by the collection.
 
     Attributes:
-        spatial (SpatialExtent): Potential spatial extent covered by the collection.
-        temporal (TemporalExtent): Potential temporal extent covered by the collection.
+        spatial : Potential spatial extent covered by the collection.
+        temporal : Potential temporal extent covered by the collection.
     """
 
     def __init__(self, spatial: SpatialExtent, temporal: TemporalExtent):
@@ -291,7 +291,7 @@ class Extent:
         """Create an Extent based on the datetimes and bboxes of a list of items.
 
         Args:
-            items (List[Item]): A list of items to derive the extent from.
+            items : A list of items to derive the extent from.
 
         Returns:
             Extent: An Extent that spatially and temporally covers all of the
@@ -359,23 +359,23 @@ class Provider:
     the final storage provider hosting the data.
 
     Args:
-        name (str): The name of the organization or the individual.
-        description (str): Optional multi-line description to add further provider
+        name : The name of the organization or the individual.
+        description : Optional multi-line description to add further provider
             information such as processing details for processors and producers,
             hosting details for hosts or basic contact information.
-        roles (List[str]): Optional roles of the provider. Any of
+        roles : Optional roles of the provider. Any of
             licensor, producer, processor or host.
-        url (str): Optional homepage on which the provider describes the dataset
+        url : Optional homepage on which the provider describes the dataset
             and publishes contact information.
 
     Attributes:
-        name (str): The name of the organization or the individual.
-        description (str): Optional multi-line description to add further provider
+        name : The name of the organization or the individual.
+        description : Optional multi-line description to add further provider
             information such as processing details for processors and producers,
             hosting details for hosts or basic contact information.
-        roles (List[str]): Optional roles of the provider. Any of
+        roles : Optional roles of the provider. Any of
             licensor, producer, processor or host.
-        url (str): Optional homepage on which the provider describes the dataset
+        url : Optional homepage on which the provider describes the dataset
             and publishes contact information.
     """
 
@@ -506,52 +506,52 @@ class Collection(Catalog):
     enable discovery.
 
     Args:
-        id (str): Identifier for the collection. Must be unique within the STAC.
-        description (str): Detailed multi-line description to fully explain the
+        id : Identifier for the collection. Must be unique within the STAC.
+        description : Detailed multi-line description to fully explain the
             collection. `CommonMark 0.28 syntax <http://commonmark.org/>`_ MAY
             be used for rich text representation.
-        extent (Extent): Spatial and temporal extents that describe the bounds of
+        extent : Spatial and temporal extents that describe the bounds of
             all items contained within this Collection.
-        title (str or None): Optional short descriptive one-line title for the
+        title : Optional short descriptive one-line title for the
             collection.
-        stac_extensions (List[str]): Optional list of extensions the Collection
+        stac_extensions : Optional list of extensions the Collection
             implements.
-        href (str or None): Optional HREF for this collection, which be set as the
+        href : Optional HREF for this collection, which be set as the
             collection's self link's HREF.
-        catalog_type (str or None): Optional catalog type for this catalog. Must
+        catalog_type : Optional catalog type for this catalog. Must
             be one of the values in :class`~pystac.CatalogType`.
-        license (str):  Collection's license(s) as a
+        license :  Collection's license(s) as a
             `SPDX License identifier <https://spdx.org/licenses/>`_,
             `various`, or `proprietary`. If collection includes
             data with multiple different licenses, use `various` and add a link for
             each. Defaults to 'proprietary'.
-        keywords (List[str]): Optional list of keywords describing the collection.
-        providers (List[Provider]): Optional list of providers of this Collection.
-        summaries (dict): An optional map of property summaries,
+        keywords : Optional list of keywords describing the collection.
+        providers : Optional list of providers of this Collection.
+        summaries : An optional map of property summaries,
             either a set of values or statistics such as a range.
-        extra_fields (dict or None): Extra fields that are part of the top-level
+        extra_fields : Extra fields that are part of the top-level
             JSON properties of the Collection.
 
     Attributes:
-        id (str): Identifier for the collection.
-        description (str): Detailed multi-line description to fully explain the
+        id : Identifier for the collection.
+        description : Detailed multi-line description to fully explain the
             collection.
-        extent (Extent): Spatial and temporal extents that describe the bounds of
+        extent : Spatial and temporal extents that describe the bounds of
             all items contained within this Collection.
-        title (str or None): Optional short descriptive one-line title for the
+        title : Optional short descriptive one-line title for the
             collection.
-        stac_extensions (List[str]): Optional list of extensions the Collection
+        stac_extensions : Optional list of extensions the Collection
             implements.
-        keywords (List[str] or None): Optional list of keywords describing the
+        keywords : Optional list of keywords describing the
             collection.
-        providers (List[Provider] or None): Optional list of providers of this
+        providers : Optional list of providers of this
             Collection.
-        assets (Optional[Dict[str, Asset]]): Optional map of Assets
-        summaries (dict or None): An optional map of property summaries,
+        assets : Optional map of Assets
+        summaries : An optional map of property summaries,
             either a set of values or statistics such as a range.
-        links (List[Link]): A list of :class:`~pystac.Link` objects representing
+        links : A list of :class:`~pystac.Link` objects representing
             all links associated with this Collection.
-        extra_fields (dict or None): Extra fields that are part of the top-level
+        extra_fields : Extra fields that are part of the top-level
             JSON properties of the Catalog.
     """
 
@@ -731,8 +731,8 @@ class Collection(Catalog):
         """Adds an Asset to this item.
 
         Args:
-            key (str): The unique key of this asset.
-            asset (Asset): The Asset to add.
+            key : The unique key of this asset.
+            asset : The Asset to add.
         """
         asset.set_owner(self)
         self.assets[key] = asset

--- a/pystac/errors.py
+++ b/pystac/errors.py
@@ -60,7 +60,7 @@ class STACValidationError(Exception):
     is invalid.
 
     Args:
-        source (object): Source of the exception. Type will be determined by the
+        source : Source of the exception. Type will be determined by the
             validation implementation. For the default JsonSchemaValidator this will a
             the ``jsonschema.ValidationError``.
     """

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -47,13 +47,13 @@ class Band:
         Sets the properties for this Band.
 
         Args:
-            name (str): The name of the band (e.g., "B01", "B02", "B1", "B5", "QA").
-            common_name (str): The name commonly used to refer to the band to make it
+            name : The name of the band (e.g., "B01", "B02", "B1", "B5", "QA").
+            common_name : The name commonly used to refer to the band to make it
                 easier to search for bands across instruments. See the `list of
                 accepted common names <https://github.com/radiantearth/stac-spec/tree/v0.8.1/extensions/eo#common-band-names>`_.
-            description (str): Description to fully explain the band.
-            center_wavelength (float): The center wavelength of the band, in micrometers (μm).
-            full_width_half_max (float): Full width at half maximum (FWHM). The width of the band,
+            description : Description to fully explain the band.
+            center_wavelength : The center wavelength of the band, in micrometers (μm).
+            full_width_half_max : Full width at half maximum (FWHM). The width of the band,
                 as measured at half the maximum transmission, in micrometers (μm).
         """  # noqa
         self.name = name
@@ -75,13 +75,13 @@ class Band:
         Creates a new band.
 
         Args:
-            name (str): The name of the band (e.g., "B01", "B02", "B1", "B5", "QA").
-            common_name (str): The name commonly used to refer to the band to make it easier
+            name : The name of the band (e.g., "B01", "B02", "B1", "B5", "QA").
+            common_name : The name commonly used to refer to the band to make it easier
                 to search for bands across instruments. See the `list of accepted common names
                 <https://github.com/radiantearth/stac-spec/tree/v0.8.1/extensions/eo#common-band-names>`_.
-            description (str): Description to fully explain the band.
-            center_wavelength (float): The center wavelength of the band, in micrometers (μm).
-            full_width_half_max (float): Full width at half maximum (FWHM). The width of the band,
+            description : Description to fully explain the band.
+            center_wavelength : The center wavelength of the band, in micrometers (μm).
+            full_width_half_max : Full width at half maximum (FWHM). The width of the band,
                 as measured at half the maximum transmission, in micrometers (μm).
         """  # noqa
         b = cls({})
@@ -191,7 +191,7 @@ class Band:
         """Gets the band range for a common band name.
 
         Args:
-            common_name (str): The common band name. Must be one of the `list of accepted common names <https://github.com/radiantearth/stac-spec/tree/v0.8.1/extensions/eo#common-band-names>`_.
+            common_name : The common band name. Must be one of the `list of accepted common names <https://github.com/radiantearth/stac-spec/tree/v0.8.1/extensions/eo#common-band-names>`_.
 
         Returns:
             Tuple[float, float] or None: The band range for this name as (min, max), or
@@ -223,7 +223,7 @@ class Band:
         """Returns a description of the band for one with a common name.
 
         Args:
-            common_name (str): The common band name. Must be one of the `list of accepted common names <https://github.com/radiantearth/stac-spec/tree/v0.8.1/extensions/eo#common-band-names>`_.
+            common_name : The common band name. Must be one of the `list of accepted common names <https://github.com/radiantearth/stac-spec/tree/v0.8.1/extensions/eo#common-band-names>`_.
 
         Returns:
             str or None: If a recognized common name, returns a description including the
@@ -242,10 +242,10 @@ class EOExtension(
     represents a snapshot of the earth for a single date and time.
 
     Args:
-        item (Item): The item to be extended.
+        item : The item to be extended.
 
     Attributes:
-        item (Item): The Item that is being extended.
+        item : The Item that is being extended.
 
     Note:
         Using EOItemExt to directly wrap an item will add the 'eo' extension ID to
@@ -256,9 +256,9 @@ class EOExtension(
         """Applies label extension properties to the extended Item.
 
         Args:
-            bands (List[Band]): a list of :class:`~pystac.Band` objects that represent
+            bands : a list of :class:`~pystac.Band` objects that represent
                 the available bands.
-            cloud_cover (float or None): The estimate of cloud cover as a percentage
+            cloud_cover : The estimate of cloud cover as a percentage
                 (0-100) of the entire scene. If not available the field should not be
                 provided.
         """

--- a/pystac/extensions/file.py
+++ b/pystac/extensions/file.py
@@ -59,10 +59,10 @@ class FileExtension(
     adds file related details such as checksum, data type and size for assets.
 
     Args:
-        item (Item): The item to be extended.
+        item : The item to be extended.
 
     Attributes:
-        item (Item): The Item that is being extended.
+        item : The Item that is being extended.
 
     Note:
         Using FileItemExt to directly wrap an item will add the 'file' extension ID to
@@ -79,10 +79,10 @@ class FileExtension(
         """Applies file extension properties to the extended Item.
 
         Args:
-            data_type (FileDataType): The data type of the file.
-            size (int or None): size of the file in bytes.
-            nodata (List[Object] or None): Value(s) for no-data.
-            checksum (str or None): Multihash for the corresponding file,
+            data_type : The data type of the file.
+            size : size of the file in bytes.
+            nodata : Value(s) for no-data.
+            checksum : Multihash for the corresponding file,
                 encoded as hexadecimal (base 16) string with lowercase letters.
         """
         self.data_type = data_type

--- a/pystac/extensions/label.py
+++ b/pystac/extensions/label.py
@@ -45,9 +45,9 @@ class LabelClasses:
         """Sets the properties for this LabelClasses.
 
         Args:
-            classes (List[str] or List[int] or List[float]): The different possible
+            classes : The different possible
                 class values.
-            name (str): The property key within the asset's each Feature corresponding
+            name : The property key within the asset's each Feature corresponding
                 to class labels. If labels are raster-formatted, do not supply;
                 required otherwise.
         """
@@ -63,9 +63,9 @@ class LabelClasses:
         """Creates a new LabelClasses.
 
         Args:
-            classes (List[str] or List[int] or List[float]): The different possible
+            classes : The different possible
                 class values.
-            name (str): The property key within the asset's each Feature corresponding
+            name : The property key within the asset's each Feature corresponding
                 to class labels. If labels are raster-formatted, do not supply;
                 required otherwise.
 
@@ -140,8 +140,8 @@ class LabelCount:
         """Sets the properties for this LabelCount.
 
         Args:
-            name (str): One of the different possible classes within the property.
-            count (int): The number of occurrences of the class.
+            name : One of the different possible classes within the property.
+            count : The number of occurrences of the class.
         """
         self.name = name
         self.count = count
@@ -151,8 +151,8 @@ class LabelCount:
         """Creates a LabelCount.
 
         Args:
-            name (str): One of the different possible classes within the property.
-            count (int): The number of occurrences of the class.
+            name : One of the different possible classes within the property.
+            count : The number of occurrences of the class.
         """
         x = cls({})
         x.apply(name, count)
@@ -216,8 +216,8 @@ class LabelStatistics:
         """Sets the property values for this instance.
 
         Args:
-            name (str): The name of the statistic being reported.
-            value (float): The value of the statistic
+            name : The name of the statistic being reported.
+            value : The value of the statistic
         """
         self.name = name
         self.value = value
@@ -227,8 +227,8 @@ class LabelStatistics:
         """Sets the property values for this instance.
 
         Args:
-            name (str): The name of the statistic being reported.
-            value (float): The value of the statistic
+            name : The name of the statistic being reported.
+            value : The value of the statistic
         """
         x = cls({})
         x.apply(name, value)
@@ -302,7 +302,7 @@ class LabelOverview:
         at least one is required.
 
         Args:
-            property_key (str): The property key within the asset corresponding to
+            property_key : The property key within the asset corresponding to
                 class labels that these counts or statistics are referencing. If the
                 label data is raster data, this should be None.
             counts: Optional list of LabelCounts containing counts
@@ -327,7 +327,7 @@ class LabelOverview:
         at least one is required.
 
         Args:
-            property_key (str): The property key within the asset corresponding to
+            property_key : The property key within the asset corresponding to
                 class labels.
             counts: Optional list of LabelCounts containing counts for
                 categorical data.
@@ -406,7 +406,7 @@ class LabelOverview:
         Creates a new LabelOverview.
 
         Args:
-            other (LabelOverview): The other LabelOverview to merge.
+            other : The other LabelOverview to merge.
 
         Returns:
             LabelOverview: A new LabelOverview with the counts merged. This will
@@ -450,10 +450,10 @@ class LabelExtension(ExtensionManagementMixin[pystac.Item]):
     labels and label metadata and should be part of a Collection.
 
     Args:
-        item (Item): The item to be extended.
+        item : The item to be extended.
 
     Attributes:
-        item (Item): The Item that is being extended.
+        item : The Item that is being extended.
 
     See:
         `Item fields in the label extension spec <https://github.com/radiantearth/stac-spec/tree/v0.8.1/extensions/label#item-fields>`_
@@ -480,22 +480,22 @@ class LabelExtension(ExtensionManagementMixin[pystac.Item]):
         """Applies label extension properties to the extended Item.
 
         Args:
-            label_description (str): A description of the label, how it was created,
+            label_description : A description of the label, how it was created,
                 and what it is recommended for
-            label_type (str): An ENUM of either vector label type or raster label type. Use
+            label_type : An ENUM of either vector label type or raster label type. Use
                 one of :class:`~pystac.LabelType`.
-            label_properties (list or None): These are the names of the property field(s) in each
+            label_properties : These are the names of the property field(s) in each
                 Feature of the label asset's FeatureCollection that contains the classes
                 (keywords from label:classes if the property defines classes).
                 If labels are rasters, this should be None.
-            label_classes (List[LabelClass]): Optional, but required if using categorical data.
+            label_classes : Optional, but required if using categorical data.
                 A list of LabelClasses defining the list of possible class names for each
                 label:properties. (e.g., tree, building, car, hippo)
-            label_tasks (List[str]): Recommended to be a subset of 'regression', 'classification',
+            label_tasks : Recommended to be a subset of 'regression', 'classification',
                 'detection', or 'segmentation', but may be an arbitrary value.
             label_methods: Recommended to be a subset of 'automated' or 'manual',
                 but may be an arbitrary value.
-            label_overviews (List[LabelOverview]): Optional list of LabelOverview classes
+            label_overviews : Optional list of LabelOverview classes
                 that store counts (for classification-type data) or summary statistics (for
                 continuous numerical/regression data).
         """  # noqa E501
@@ -681,9 +681,9 @@ class LabelExtension(ExtensionManagementMixin[pystac.Item]):
         """Adds a link to a source item.
 
         Args:
-            source_item (Item): Source imagery that the LabelItem applies to.
-            title (str): Optional title for the link.
-            assets (List[str]): Optional list of assets that determine what
+            source_item : Source imagery that the LabelItem applies to.
+            title : Optional title for the link.
+            assets : Optional list of assets that determine what
                 assets in the source item this label item data applies to.
         """
         properties = None
@@ -718,13 +718,13 @@ class LabelExtension(ExtensionManagementMixin[pystac.Item]):
         """Adds a label asset to this LabelItem.
 
         Args:
-            href (str): Link to the asset object. Relative and absolute links are both
+            href : Link to the asset object. Relative and absolute links are both
                 allowed.
-            title (str): Optional displayed title for clients and users.
-            media_type (str): Optional description of the media type. Registered Media
+            title : Optional displayed title for clients and users.
+            media_type : Optional description of the media type. Registered Media
                 Types are preferred. See :class:`~pystac.MediaType` for common
                 media types.
-            properties (dict): Optional, additional properties for this asset. This is
+            properties : Optional, additional properties for this asset. This is
                 used by extensions as a way to serialize and deserialize properties on
                 asset object JSON.
         """
@@ -745,10 +745,10 @@ class LabelExtension(ExtensionManagementMixin[pystac.Item]):
         """Adds a GeoJSON label asset to this LabelItem.
 
         Args:
-            href (str): Link to the asset object. Relative and absolute links are both
+            href : Link to the asset object. Relative and absolute links are both
                 allowed.
-            title (str): Optional displayed title for clients and users.
-            properties (dict): Optional, additional properties for this asset. This is
+            title : Optional displayed title for clients and users.
+            properties : Optional, additional properties for this asset. This is
                 used by extensions as a way to serialize and deserialize properties on
                 asset object JSON.
         """

--- a/pystac/extensions/pointcloud.py
+++ b/pystac/extensions/pointcloud.py
@@ -39,9 +39,9 @@ class PointcloudSchema:
         """Sets the properties for this PointCloudSchema.
 
         Args:
-           name (str): The name of dimension.
-           size (int): The size of the dimension in bytes. Whole bytes are supported.
-           type (str): Dimension type. Valid values are `floating`, `unsigned`, and
+           name : The name of dimension.
+           size : The size of the dimension in bytes. Whole bytes are supported.
+           type : Dimension type. Valid values are `floating`, `unsigned`, and
            `signed`
         """
         self.properties["name"] = name
@@ -53,9 +53,9 @@ class PointcloudSchema:
         """Creates a new PointCloudSchema.
 
         Args:
-           name (str): The name of dimension.
-           size (int): The size of the dimension in bytes. Whole bytes are supported.
-           type (str): Dimension type. Valid values are `floating`, `unsigned`, and
+           name : The name of dimension.
+           size : The size of the dimension in bytes. Whole bytes are supported.
+           type : Dimension type. Valid values are `floating`, `unsigned`, and
            `signed`
 
         Returns:
@@ -161,14 +161,14 @@ class PointcloudStatistic:
         """Sets the properties for this PointcloudStatistic.
 
         Args:
-            name (str): REQUIRED. The name of the channel.
-            position (int): Position of the channel in the schema.
-            average (float): The average of the channel.
-            count (int): The number of elements in the channel.
-            maximum (float): The maximum value of the channel.
-            minimum (float): The minimum value of the channel.
-            stddev (float): The standard deviation of the channel.
-            variance (float): The variance of the channel.
+            name : REQUIRED. The name of the channel.
+            position : Position of the channel in the schema.
+            average : The average of the channel.
+            count : The number of elements in the channel.
+            maximum : The maximum value of the channel.
+            minimum : The minimum value of the channel.
+            stddev : The standard deviation of the channel.
+            variance : The variance of the channel.
         """
         self.properties["name"] = name
         self.properties["position"] = position
@@ -194,14 +194,14 @@ class PointcloudStatistic:
         """Creates a new PointcloudStatistic class.
 
         Args:
-            name (str): REQUIRED. The name of the channel.
-            position (int): Position of the channel in the schema.
+            name : REQUIRED. The name of the channel.
+            position : Position of the channel in the schema.
             average (float) The average of the channel.
-            count (int): The number of elements in the channel.
-            maximum (float): The maximum value of the channel.
-            minimum (float): The minimum value of the channel.
-            stddev (float): The standard deviation of the channel.
-            variance (float): The variance of the channel.
+            count : The number of elements in the channel.
+            maximum : The maximum value of the channel.
+            minimum : The minimum value of the channel.
+            stddev : The standard deviation of the channel.
+            variance : The variance of the channel.
 
         Returns:
             LabelClasses
@@ -372,10 +372,10 @@ class PointcloudExtension(
     The Pointclout extension adds pointcloud information to STAC Items.
 
     Args:
-        item (Item): The item to be extended.
+        item : The item to be extended.
 
     Attributes:
-        item (Item): The Item that is being extended.
+        item : The Item that is being extended.
 
     """
 
@@ -392,18 +392,18 @@ class PointcloudExtension(
         """Applies Pointcloud extension properties to the extended Item.
 
         Args:
-            count (int): REQUIRED. The number of points in the cloud.
-            type (str): REQUIRED. Phenomenology type for the point cloud. Possible valid
+            count : REQUIRED. The number of points in the cloud.
+            type : REQUIRED. Phenomenology type for the point cloud. Possible valid
                 values might include lidar, eopc, radar, sonar, or otherThe type of file
                 or data format of the cloud.
-            encoding (str): REQUIRED. Content encoding or format of the data.
-            schemas (List[PointcloudSchema]): REQUIRED. A sequential array of items
+            encoding : REQUIRED. Content encoding or format of the data.
+            schemas : REQUIRED. A sequential array of items
             that define the
                 dimensions and their types.
-            density (float or None): Number of points per square unit area.
-            statistics (List[int] or None): A sequential array of items mapping to
+            density : Number of points per square unit area.
+            statistics : A sequential array of items mapping to
                 pc:schemas defines per-channel statistics.
-            epsg (str): An EPSG code for the projected coordinates of the pointcloud.
+            epsg : An EPSG code for the projected coordinates of the pointcloud.
         """
         self.count = count
         self.type = type

--- a/pystac/extensions/projection.py
+++ b/pystac/extensions/projection.py
@@ -33,10 +33,10 @@ class ProjectionExtension(
     The Projection extension adds projection information to STAC Items.
 
     Args:
-        item (Item): The item to be extended.
+        item : The item to be extended.
 
     Attributes:
-        item (Item): The Item that is being extended.
+        item : The Item that is being extended.
 
     Note:
         Using ProjectionItemExt to directly wrap an item will add the 'proj' extension
@@ -60,23 +60,23 @@ class ProjectionExtension(
         """Applies Projection extension properties to the extended Item.
 
         Args:
-            epsg (int or None): REQUIRED. EPSG code of the datasource.
-            wkt2 (str or None): WKT2 string representing the Coordinate Reference
+            epsg : REQUIRED. EPSG code of the datasource.
+            wkt2 : WKT2 string representing the Coordinate Reference
                 System (CRS) that the ``geometry`` and ``bbox`` fields represent
-            projjson (dict or None): PROJJSON dict representing the
+            projjson : PROJJSON dict representing the
                 Coordinate Reference System (CRS) that the ``geometry`` and ``bbox``
                 fields represent
-            geometry (dict or None): GeoJSON Polygon dict that defines the footprint of
+            geometry : GeoJSON Polygon dict that defines the footprint of
                 this Item.
-            bbox (List[float] or None): Bounding box of the Item in the asset CRS in
+            bbox : Bounding box of the Item in the asset CRS in
                 2 or 3 dimensions.
-            centroid (dict or None): A dict with members 'lat' and 'lon' that defines
+            centroid : A dict with members 'lat' and 'lon' that defines
                 coordinates representing the centroid of the item in the asset data CRS.
                 Coordinates are defined in latitude and longitude, even if the data
                 coordinate system may not use lat/long.
-            shape (List[int] or None): Number of pixels in Y and X directions for the
+            shape : Number of pixels in Y and X directions for the
                 default grid.
-            transform (List[float] or None): The affine transformation coefficients for
+            transform : The affine transformation coefficients for
                 the default grid
         """
         self.epsg = epsg

--- a/pystac/extensions/sar.py
+++ b/pystac/extensions/sar.py
@@ -64,10 +64,10 @@ class SarExtension(
     """SarItemExt extends Item to add sar properties to a STAC Item.
 
     Args:
-        item (Item): The item to be extended.
+        item : The item to be extended.
 
     Attributes:
-        item (Item): The item that is being extended.
+        item : The item that is being extended.
 
     Note:
         Using SarItemExt to directly wrap an item will add the 'sar'
@@ -93,36 +93,36 @@ class SarExtension(
         """Applies sar extension properties to the extended Item.
 
         Args:
-            instrument_mode (str): The name of the sensor acquisition mode that is
+            instrument_mode : The name of the sensor acquisition mode that is
                 commonly used. This should be the short name, if available. For example,
                 WV for "Wave mode."
-            frequency_band (FrequencyBand): The common name for the frequency band to
+            frequency_band : The common name for the frequency band to
                 make it easier to search for bands across instruments. See section
                 "Common Frequency Band Names" for a list of accepted names.
-            polarizations (List[Polarization]): Any combination of polarizations.
-            product_type (str): The product type, for example SSC, MGD, or SGC.
-            center_frequency (float): Optional center frequency of the instrument in
+            polarizations : Any combination of polarizations.
+            product_type : The product type, for example SSC, MGD, or SGC.
+            center_frequency : Optional center frequency of the instrument in
                 gigahertz (GHz).
-            resolution_range (float): Optional range resolution, which is the maximum
+            resolution_range : Optional range resolution, which is the maximum
                 ability to distinguish two adjacent targets perpendicular to the flight
                 path, in meters (m).
-            resolution_azimuth (float): Optional azimuth resolution, which is the
+            resolution_azimuth : Optional azimuth resolution, which is the
                 maximum ability to distinguish two adjacent targets parallel to the
                 flight path, in meters (m).
-            pixel_spacing_range (float): Optional range pixel spacing, which is the
+            pixel_spacing_range : Optional range pixel spacing, which is the
                 distance between adjacent pixels perpendicular to the flight path,
                 in meters (m). Strongly RECOMMENDED to be specified for
                 products of type GRD.
-            pixel_spacing_azimuth (float): Optional azimuth pixel spacing, which is the
+            pixel_spacing_azimuth : Optional azimuth pixel spacing, which is the
                 distance between adjacent pixels parallel to the flight path, in
                 meters (m). Strongly RECOMMENDED to be specified for products of
                 type GRD.
-            looks_range (int): Optional number of groups of signal samples (looks)
+            looks_range : Optional number of groups of signal samples (looks)
                 perpendicular to the flight path.
-            looks_azimuth (int): Optional number of groups of signal samples (looks)
+            looks_azimuth : Optional number of groups of signal samples (looks)
                 parallel to the flight path.
-            looks_equivalent_number (float): Optional equivalent number of looks (ENL).
-            observation_direction (ObservationDirection): Optional Antenna pointing
+            looks_equivalent_number : Optional equivalent number of looks (ENL).
+            observation_direction : Optional Antenna pointing
                 direction relative to the flight trajectory of the satellite.
         """
         self.instrument_mode = instrument_mode

--- a/pystac/extensions/sat.py
+++ b/pystac/extensions/sat.py
@@ -34,10 +34,10 @@ class SatExtension(
     """SatItemExt extends Item to add sat properties to a STAC Item.
 
     Args:
-        item (Item): The item to be extended.
+        item : The item to be extended.
 
     Attributes:
-        item (Item): The item that is being extended.
+        item : The item that is being extended.
 
     Note:
         Using SatItemExt to directly wrap an item will add the 'sat'
@@ -55,10 +55,10 @@ class SatExtension(
         for the sat extension to properties to be valid.
 
         Args:
-            orbit_state (OrbitState): Optional state of the orbit. Either ascending or
+            orbit_state : Optional state of the orbit. Either ascending or
                 descending for polar orbiting satellites, or geostationary for
                 geosynchronous satellites.
-            relative_orbit (int): Optional non-negative integer of the orbit number at
+            relative_orbit : Optional non-negative integer of the orbit number at
                 the time of acquisition.
         """
 

--- a/pystac/extensions/scientific.py
+++ b/pystac/extensions/scientific.py
@@ -95,9 +95,9 @@ class ScientificExtension(
         """Applies scientific extension properties to the extended Item.
 
         Args:
-            doi (str): Optional DOI string for the item.  Must not be a DOI link.
-            citation (str): Optional human-readable reference.
-            publications (List[Publication]): Optional list of relevant publications
+            doi : Optional DOI string for the item.  Must not be a DOI link.
+            citation : Optional human-readable reference.
+            publications : Optional list of relevant publications
                 referencing and describing the data.
         """
         self.doi = doi
@@ -164,7 +164,7 @@ class ScientificExtension(
         """Removes publications from the item.
 
         Args:
-            publication (Publication): The specific publication to remove of None to
+            publication : The specific publication to remove of None to
             remove all.
         """
         if PUBLICATIONS not in self.properties:

--- a/pystac/extensions/timestamps.py
+++ b/pystac/extensions/timestamps.py
@@ -39,11 +39,11 @@ class TimestampsExtension(
         """Applies timestamps extension properties to the extended Item.
 
         Args:
-            published (datetime or None): Date and time the corresponding data
+            published : Date and time the corresponding data
                 was published the first time.
-            expires (datetime or None): Date and time the corresponding data
+            expires : Date and time the corresponding data
                 expires (is not valid any longer).
-            unpublished (datetime or None): Date and time the corresponding data
+            unpublished : Date and time the corresponding data
                 was unpublished.
         """
         self.published = published

--- a/pystac/extensions/version.py
+++ b/pystac/extensions/version.py
@@ -40,10 +40,10 @@ class VersionExtension(
     along with links to the latest, predecessor, and successor Items.
 
     Args:
-        item (Item): The item to be extended.
+        item : The item to be extended.
 
     Attributes:
-        item (Item): The item that is being extended.
+        item : The item that is being extended.
 
     Note:
         Using VersionItemExt to directly wrap an item will add the 'version'
@@ -66,13 +66,13 @@ class VersionExtension(
         """Applies version extension properties to the extended Item.
 
         Args:
-            version (str): The version string for the item.
-            deprecated (bool): Optional flag set to True if an Item is
+            version : The version string for the item.
+            deprecated : Optional flag set to True if an Item is
                 deprecated with the potential to be removed.  Defaults to false
                 if not present.
-            latest (Item): Item with the latest (e.g., current) version.
-            predecessor (Item): Item with the previous version.
-            successor (Item): Item with the next most recent version.
+            latest : Item with the latest (e.g., current) version.
+            predecessor : Item with the previous version.
+            successor : Item with the next most recent version.
         """
         self.version = version
         if deprecated is not None:

--- a/pystac/extensions/view.py
+++ b/pystac/extensions/view.py
@@ -33,10 +33,10 @@ class ViewExtension(
     extensions that describe the actual data, such as the eo, sat or sar extensions.
 
     Args:
-        item (Item): The item to be extended.
+        item : The item to be extended.
 
     Attributes:
-        item (Item): The Item that is being extended.
+        item : The Item that is being extended.
 
     Note:
         Using ViewItemExt to directly wrap an item will add the 'view' extension ID to
@@ -54,19 +54,19 @@ class ViewExtension(
         """Applies View Geometry extension properties to the extended Item.
 
         Args:
-            off_nadir (float): The angle from the sensor between nadir (straight down)
+            off_nadir : The angle from the sensor between nadir (straight down)
                 and the scene center. Measured in degrees (0-90).
-            incidence_angle (float): The incidence angle is the angle between the
+            incidence_angle : The incidence angle is the angle between the
                 vertical (normal) to the intercepting surface and the line of sight
                 back to the satellite at the scene center. Measured in degrees (0-90).
-            azimuth (float): Viewing azimuth angle. The angle measured from the
+            azimuth : Viewing azimuth angle. The angle measured from the
                 sub-satellite point (point on the ground below the platform) between
                 the scene center and true north. Measured clockwise from north in
                 degrees (0-360).
-            sun_azimuth (float): Sun azimuth angle. From the scene center point on the
+            sun_azimuth : Sun azimuth angle. From the scene center point on the
                 ground, this is the angle between truth north and the sun. Measured
                 clockwise in degrees (0-360).
-            sun_elevation (float): Sun elevation angle. The angle from the tangent of
+            sun_elevation : Sun elevation angle. The angle from the tangent of
                 the scene center point to the sun. Measured from the horizon in
                 degrees (0-90).
         """

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -26,7 +26,7 @@ class CommonMetadata:
     this item and are optional
 
     Args:
-        properties (dict): Dictionary of attributes that is the Item's properties
+        properties : Dictionary of attributes that is the Item's properties
     """
 
     def __init__(self, properties: Dict[str, Any]):
@@ -590,48 +590,48 @@ class Item(STACObject):
     satellite imagery, derived data, DEM's, etc.
 
     Args:
-        id (str): Provider identifier. Must be unique within the STAC.
-        geometry (dict): Defines the full footprint of the asset represented by this
+        id : Provider identifier. Must be unique within the STAC.
+        geometry : Defines the full footprint of the asset represented by this
             item, formatted according to
             `RFC 7946, section 3.1 (GeoJSON) <https://tools.ietf.org/html/rfc7946>`_.
-        bbox (List[float] or None):  Bounding Box of the asset represented by this item
+        bbox :  Bounding Box of the asset represented by this item
             using either 2D or 3D geometries. The length of the array must be 2*n
             where n is the number of dimensions. Could also be None in the case of a
             null geometry.
-        datetime (datetime or None): Datetime associated with this item. If None,
+        datetime : Datetime associated with this item. If None,
             a start_datetime and end_datetime must be supplied in the properties.
-        properties (dict): A dictionary of additional metadata for the item.
-        stac_extensions (List[str]): Optional list of extensions the Item implements.
-        href (str or None): Optional HREF for this item, which be set as the item's
+        properties : A dictionary of additional metadata for the item.
+        stac_extensions : Optional list of extensions the Item implements.
+        href : Optional HREF for this item, which be set as the item's
             self link's HREF.
-        collection (Collection or str): The Collection or Collection ID that this item
+        collection : The Collection or Collection ID that this item
             belongs to.
-        extra_fields (dict or None): Extra fields that are part of the top-level JSON
+        extra_fields : Extra fields that are part of the top-level JSON
             properties of the Item.
 
     Attributes:
-        id (str): Provider identifier. Unique within the STAC.
-        geometry (dict): Defines the full footprint of the asset represented by this
+        id : Provider identifier. Unique within the STAC.
+        geometry : Defines the full footprint of the asset represented by this
             item, formatted according to
             `RFC 7946, section 3.1 (GeoJSON) <https://tools.ietf.org/html/rfc7946>`_.
-        bbox (List[float] or None):  Bounding Box of the asset represented by this item
+        bbox :  Bounding Box of the asset represented by this item
             using either 2D or 3D geometries. The length of the array is 2*n where n
             is the number of dimensions. Could also be None in the case of a null
             geometry.
-        datetime (datetime or None): Datetime associated with this item. If None,
+        datetime : Datetime associated with this item. If None,
             the start_datetime and end_datetime in the common_metadata
             will supply the datetime range of the Item.
-        properties (dict): A dictionary of additional metadata for the item.
-        stac_extensions (List[str] or None): Optional list of extensions the Item
+        properties : A dictionary of additional metadata for the item.
+        stac_extensions : Optional list of extensions the Item
             implements.
-        collection (Collection or None): Collection that this item is a part of.
-        links (List[Link]): A list of :class:`~pystac.Link` objects representing
+        collection : Collection that this item is a part of.
+        links : A list of :class:`~pystac.Link` objects representing
             all links associated with this STACObject.
-        assets (Dict[str, Asset]): Dictionary of asset objects that can be downloaded,
+        assets : Dictionary of asset objects that can be downloaded,
             each with a unique key.
-        collection_id (str or None): The Collection ID that this item belongs to, if
+        collection_id : The Collection ID that this item belongs to, if
             any.
-        extra_fields (dict or None): Extra fields that are part of the top-level JSON
+        extra_fields : Extra fields that are part of the top-level JSON
             properties of the Item.
     """
 
@@ -700,7 +700,7 @@ class Item(STACObject):
         as the old location.
 
         Args:
-            href (str): The absolute HREF of this object. If the given HREF
+            href : The absolute HREF of this object. If the given HREF
                 is not absolute, it will be transformed to an absolute
                 HREF based on the current working directory. If this is None
                 the call will clear the self HREF link.
@@ -759,8 +759,8 @@ class Item(STACObject):
         """Adds an Asset to this item.
 
         Args:
-            key (str): The unique key of this asset.
-            asset (Asset): The Asset to add.
+            key : The unique key of this asset.
+            asset : The Asset to add.
         """
         asset.set_owner(self)
         self.assets[key] = asset
@@ -817,7 +817,7 @@ class Item(STACObject):
         this item.
 
         Args:
-            collection (Collection or None): The collection to set as this
+            collection : The collection to set as this
                 item's collection. If None, will clear the collection.
 
         Returns:

--- a/pystac/layout.py
+++ b/pystac/layout.py
@@ -66,8 +66,8 @@ class LayoutTemplate:
         template = LayoutTemplate("${collection}/${common_metadata.license}")
 
     Args:
-        template (str): The template string to use.
-        defaults (dict): A dictionary of template vars to values. These values
+        template : The template string to use.
+        defaults : A dictionary of template vars to values. These values
             will be used in case a value cannot be derived from a stac object.
     """
 
@@ -184,7 +184,7 @@ class LayoutTemplate:
         value is used; if there is no default then this will raise an error.
 
         Args:
-            stac_object (STACObject): The STACObject to derive template
+            stac_object : The STACObject to derive template
                 variable values from.
 
         Returns:
@@ -207,7 +207,7 @@ class LayoutTemplate:
         the template string for this template.
 
         Args:
-            stac_object (STACObject): The STACObject to derive template
+            stac_object : The STACObject to derive template
                 variable values from.
 
         Returns:
@@ -265,18 +265,18 @@ class CustomLayoutStrategy(HrefLayoutStrategy):
     stac object paths.
 
     Args:
-        catalog_func (Callable[Catalog, str, bool] -> str): A function that takes
+        catalog_func : A function that takes
             an catalog, a parent directory, and a flag specifying whether
             or not this catalog is the root. If it is the root, its usually
             best to not create a subdirectory and put the Catalog file directly
             in the parent directory. Must return the string path.
-        collection_func (Callable[Catalog, str, bool] -> str): A function that
+        collection_func : A function that
             is used for collections in the same manner at ``catalog_func``. This
             takes the same parameters.
-        item_func  (Callable[Catalog, str] -> str): A function that takes
+        item_func  : A function that takes
             an item and a parent directory and returns the path to be used
             for the item.
-        fallback_strategy (HrefLayoutStrategy): The fallback strategy to
+        fallback_strategy : The fallback strategy to
             use if a function is not provided for a stac object type. Defaults to
             :class:`~pystac.layout.BestPracticesLayoutStrategy`
     """
@@ -332,16 +332,16 @@ class TemplateLayoutStrategy(HrefLayoutStrategy):
     object.
 
     Args:
-        catalog_template (str): The template string to use for catalog paths.
+        catalog_template : The template string to use for catalog paths.
             Must be a valid template string that can be used by
             :class:`~pystac.layout.LayoutTemplate`
-        collection_template (str): The template string to use for collection paths.
+        collection_template : The template string to use for collection paths.
             Must be a valid template string that can be used by
             :class:`~pystac.layout.LayoutTemplate`
-        item_template (str): The template string to use for item paths.
+        item_template : The template string to use for item paths.
             Must be a valid template string that can be used by
             :class:`~pystac.layout.LayoutTemplate`
-        fallback_strategy (HrefLayoutStrategy): The fallback strategy to
+        fallback_strategy : The fallback strategy to
             use if a template is not provided. Defaults to
             :class:`~pystac.layout.BestPracticesLayoutStrategy`
     """

--- a/pystac/link.py
+++ b/pystac/link.py
@@ -28,30 +28,30 @@ class Link:
     ideally the lazy deserialization of STACObjects is transparent to clients of PySTAC.
 
     Args:
-        rel (str): The relation of the link (e.g. 'child', 'item')
-        target (str or STACObject): The target of the link. If the link is
+        rel : The relation of the link (e.g. 'child', 'item')
+        target : The target of the link. If the link is
             unresolved, or the link is to something that is not a STACObject,
             the target is an HREF. If resolved, the target is a STACObject.
-        media_type (str): Optional description of the media type. Registered Media Types
+        media_type : Optional description of the media type. Registered Media Types
             are preferred. See :class:`~pystac.MediaType` for common media types.
-        title (str): Optional title for this link.
-        properties (dict): Optional, additional properties for this link. This is used
+        title : Optional title for this link.
+        properties : Optional, additional properties for this link. This is used
             by extensions as a way to serialize and deserialize properties on link
             object JSON.
 
     Attributes:
-        rel (str): The relation of the link (e.g. 'child', 'item')
-        target (str or STACObject): The target of the link. If the link is
+        rel : The relation of the link (e.g. 'child', 'item')
+        target : The target of the link. If the link is
             unresolved, or the link is to something that is not a STACObject,
             the target is an HREF. If resolved, the target is a STACObject.
-        media_type (str or None): Optional description of the media type.
+        media_type : Optional description of the media type.
             Registered Media Types are preferred. See
             :class:`~pystac.MediaType` for common media types.
-        title (str or None): Optional title for this link.
-        properties (dict or None): Optional, additional properties for this link.
+        title : Optional title for this link.
+        properties : Optional, additional properties for this link.
             This is used by extensions as a way to serialize and deserialize properties
             on link object JSON.
-        owner (STACObject or None): The owner of this link. The link will use
+        owner : The owner of this link. The link will use
             its owner's root catalog
             :class:`~pystac.resolved_object_cache.ResolvedObjectCache` to resolve
             objects, and will create absolute HREFs from relative HREFs against
@@ -161,7 +161,7 @@ class Link:
         already resolved.
 
         Args:
-            root (Catalog or Collection): Optional root of the catalog for this link.
+            root : Optional root of the catalog for this link.
                 If provided, the root's resolved object cache is used to search for
                 previously resolved instances of the STAC object.
         """
@@ -273,7 +273,7 @@ class Link:
         """Deserializes a Link from a dict.
 
         Args:
-            d (dict): The dict that represents the Link in JSON
+            d : The dict that represents the Link in JSON
 
         Returns:
             Link: Link instance constructed from the dict.

--- a/pystac/serialization/__init__.py
+++ b/pystac/serialization/__init__.py
@@ -21,10 +21,10 @@ def stac_object_from_dict(
     """Determines how to deserialize a dictionary into a STAC object.
 
     Args:
-        d (dict): The dict to parse.
-        href (str): Optional href that is the file location of the object being
+        d : The dict to parse.
+        href : Optional href that is the file location of the object being
             parsed.
-        root (Catalog or Collection): Optional root of the catalog for this object.
+        root : Optional root of the catalog for this object.
             If provided, the root's resolved object cache can be used to search for
             previously resolved instances of the STAC object.
 

--- a/pystac/serialization/common_properties.py
+++ b/pystac/serialization/common_properties.py
@@ -16,9 +16,9 @@ def merge_common_properties(
     Note: This is only applicable to reading old STAC versions (pre 1.0.0-beta.1).
 
     Args:
-        item_dict (dict): JSON dict of the Item which properties should be merged
+        item_dict : JSON dict of the Item which properties should be merged
             into.
-        collection_cache (CollectionCache): Optional CollectionCache
+        collection_cache : Optional CollectionCache
             that will be used to read and write cached collections.
         json_href: The HREF of the file that this JSON comes from. Used
             to resolve relative paths.

--- a/pystac/serialization/identify.py
+++ b/pystac/serialization/identify.py
@@ -141,11 +141,11 @@ class STACJSONDescription:
     """Describes the STAC object information for a STAC object represented in JSON
 
     Attributes:
-        object_type (str): Describes the STAC object type. One of
+        object_type : Describes the STAC object type. One of
             :class:`~pystac.STACObjectType`.
-        version_range (STACVersionRange): The STAC version range that describes what
+        version_range : The STAC version range that describes what
             has been identified as potential valid versions of the stac object.
-        extensions (List[str]): List of extension schema URIs for extensions this
+        extensions : List of extension schema URIs for extensions this
             object implements
     """
 
@@ -302,7 +302,7 @@ def identify_stac_object_type(json_dict: Dict[str, Any]) -> "STACObjectType_Type
     """Determines the STACObjectType of the provided JSON dict.
 
     Args:
-        json_dict (dict): The dict of STAC JSON to identify.
+        json_dict : The dict of STAC JSON to identify.
 
     Returns:
         STACObjectType: The object type represented by the JSON.
@@ -338,7 +338,7 @@ def identify_stac_object(json_dict: Dict[str, Any]) -> STACJSONDescription:
     """Determines the STACJSONDescription of the provided JSON dict.
 
     Args:
-        json_dict (dict): The dict of STAC JSON to identify.
+        json_dict : The dict of STAC JSON to identify.
 
     Returns:
         STACJSONDescription: The description of the STAC object serialized in the

--- a/pystac/serialization/migrate.py
+++ b/pystac/serialization/migrate.py
@@ -171,8 +171,8 @@ def migrate_to_latest(
     """Migrates the STAC JSON to the latest version
 
     Args:
-        json_dict (dict): The dict of STAC JSON to identify.
-        info (STACJSONDescription): The info from
+        json_dict : The dict of STAC JSON to identify.
+        info : The info from
             :func:`~pystac.serialization.identify.identify_stac_object` that describes
             the STAC object contained in the JSON dict.
 

--- a/pystac/stac_io.py
+++ b/pystac/stac_io.py
@@ -49,7 +49,7 @@ class StacIO(ABC):
         e.g. the "post" information in a pagination link from a STAC API search.
 
         Args:
-            source (str or pystac.Link): The source to read from.
+            source : The source to read from.
 
         Returns:
             str: The text contained in the file at the location specified by the uri.
@@ -68,8 +68,8 @@ class StacIO(ABC):
         link body.
 
         Args:
-            dest (str or pystac.Link): The destination to write to.
-            txt (str): The text to write.
+            dest : The destination to write to.
+            txt : The text to write.
         """
         raise NotImplementedError("write_text not implemented")
 
@@ -107,7 +107,7 @@ class StacIO(ABC):
         str vs Link as a parameter.
 
         Args:
-            source (str or Link): The source from which to read.
+            source : The source from which to read.
 
         Returns:
             dict: A dict representation of the JSON contained in the file at the
@@ -125,8 +125,8 @@ class StacIO(ABC):
         str vs Link as a parameter.
 
         Args:
-            source (str or pystac.Link): The source from which to read.
-            root (Catalog or Collection): Optional root of the catalog for this object.
+            source : The source from which to read.
+            root : Optional root of the catalog for this object.
                 If provided, the root's resolved object cache can be used to search for
                 previously resolved instances of the STAC object.
 
@@ -147,8 +147,8 @@ class StacIO(ABC):
         str vs Link as a parameter.
 
         Args:
-            dest (str or pystac.Link): The destination file to write the text to.
-            json_dict (dict): The JSON dict to write.
+            dest : The destination file to write the text to.
+            json_dict : The JSON dict to write.
         """
         txt = self._json_dumps(json_dict, dest)
         self.write_text(dest, txt)
@@ -295,7 +295,7 @@ class STAC_IO:
         """Read text from the given URI.
 
         Args:
-            uri (str): The URI from which to read text.
+            uri : The URI from which to read text.
 
         Returns:
             str: The text contained in the file at the location specified by the uri.
@@ -313,8 +313,8 @@ class STAC_IO:
         """Write the given text to a file at the given URI.
 
         Args:
-            uri (str): The URI of the file to write the text to.
-            txt (str): The text to write.
+            uri : The URI of the file to write the text to.
+            txt : The text to write.
 
         Note:
             This method uses the :func:`STAC_IO.write_text_method
@@ -329,7 +329,7 @@ class STAC_IO:
         """Read a dict from the given URI.
 
         Args:
-            uri (str): The URI from which to read.
+            uri : The URI from which to read.
 
         Returns:
             dict: A dict representation of the JSON contained in the file at the
@@ -350,8 +350,8 @@ class STAC_IO:
         """Read a STACObject from a JSON file at the given URI.
 
         Args:
-            uri (str): The URI from which to read.
-            root (Catalog or Collection): Optional root of the catalog for this object.
+            uri : The URI from which to read.
+            root : Optional root of the catalog for this object.
                 If provided, the root's resolved object cache can be used to search for
                 previously resolved instances of the STAC object.
 
@@ -373,8 +373,8 @@ class STAC_IO:
         """Write a dict to the given URI as JSON.
 
         Args:
-            uri (str): The URI of the file to write the text to.
-            json_dict (dict): The JSON dict to write.
+            uri : The URI of the file to write the text to.
+            json_dict : The JSON dict to write.
 
         Note:
             This method uses the :func:`STAC_IO.write_text_method

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -28,7 +28,7 @@ class STACObject(ABC):
     JSON, and can be cloned or copied.
 
     Attributes:
-        links (List[Link]): A list of :class:`~pystac.Link` objects representing
+        links : A list of :class:`~pystac.Link` objects representing
             all links associated with this STACObject.
     """
 
@@ -58,7 +58,7 @@ class STACObject(ABC):
         """Add a link to this object's set of links.
 
         Args:
-             link (Link): The link to add.
+             link : The link to add.
         """
         link.set_owner(cast(STACObject, self))
         self.links.append(link)
@@ -67,7 +67,7 @@ class STACObject(ABC):
         """Add links to this object's set of links.
 
         Args:
-             links (List[Link]): The links to add.
+             links : The links to add.
         """
 
         for link in links:
@@ -77,7 +77,7 @@ class STACObject(ABC):
         """Remove links to this object's set of links that match the given ``rel``.
 
         Args:
-             rel (str): The :class:`~pystac.Link` ``rel`` to match on.
+             rel : The :class:`~pystac.Link` ``rel`` to match on.
         """
 
         self.links = [link for link in self.links if link.rel != rel]
@@ -86,7 +86,7 @@ class STACObject(ABC):
         """Get single link that match the given ``rel``.
 
         Args:
-             rel (str): The :class:`~pystac.Link` ``rel`` to match on.
+             rel : The :class:`~pystac.Link` ``rel`` to match on.
         """
 
         return next((link for link in self.links if link.rel == rel), None)
@@ -95,7 +95,7 @@ class STACObject(ABC):
         """Gets the :class:`~pystac.Link` instances associated with this object.
 
         Args:
-            rel (str or None): If set, filter links such that only those
+            rel : If set, filter links such that only those
                 matching this relationship are returned.
 
         Returns:
@@ -111,7 +111,7 @@ class STACObject(ABC):
         """Clears all :class:`~pystac.Link` instances associated with this object.
 
         Args:
-            rel (str or None): If set, only clear links that match this relationship.
+            rel : If set, only clear links that match this relationship.
         """
         if rel is not None:
             self.links = [link for link in self.links if link.rel != rel]
@@ -168,7 +168,7 @@ class STACObject(ABC):
         :class:`~pystac.Link`.
 
         Args:
-            href (str): The absolute HREF of this object. If the given HREF
+            href : The absolute HREF of this object. If the given HREF
                 is not absolute, it will be transformed to an absolute
                 HREF based on the current working directory. If this is None
                 the call will clear the self HREF link.
@@ -212,7 +212,7 @@ class STACObject(ABC):
         for this object.
 
         Args:
-            root (Catalog, Collection or None): The root
+            root : The root
                 object to set. Passing in None will clear the root.
         """
         root_link_index = next(
@@ -257,7 +257,7 @@ class STACObject(ABC):
         for this object.
 
         Args:
-            parent (Catalog, Collection or None): The parent
+            parent : The parent
                 object to set. Passing in None will clear the parent.
         """
 
@@ -270,7 +270,7 @@ class STACObject(ABC):
         by links with their ``rel`` property matching the passed in argument.
 
         Args:
-            rel (str): The relation to match each :class:`~pystac.Link`'s
+            rel : The relation to match each :class:`~pystac.Link`'s
                 ``rel`` property against.
 
         Returns:
@@ -293,9 +293,9 @@ class STACObject(ABC):
         """Saves this STAC Object to it's 'self' HREF.
 
         Args:
-            include_self_link (bool): If this is true, include the 'self' link with
+            include_self_link : If this is true, include the 'self' link with
                 this object. Otherwise, leave out the self link.
-            dest_href (str): Optional HREF to save the file to. If None, the object
+            dest_href : Optional HREF to save the file to. If None, the object
                 will be saved to the object's self href.
             stac_io: Optional instance of StacIO to use. If not provided, will use the
                 instance set on the object's root if available, otherwise will use the
@@ -340,9 +340,9 @@ class STACObject(ABC):
         this object.
 
         Args:
-            root (STACObject): Optional root to set as the root of the copied object,
+            root : Optional root to set as the root of the copied object,
                 and any other copies that are contained by this object.
-            parent (STACObject): Optional parent to set as the parent of the copy
+            parent : Optional parent to set as the parent of the copy
                 of this object.
 
         Returns:
@@ -412,7 +412,7 @@ class STACObject(ABC):
         """Generate a dictionary representing the JSON of this serialized object.
 
         Args:
-            include_self_link (bool): If True, the dict will contain a self link
+            include_self_link : If True, the dict will contain a self link
                 to this object. If False, the self link will be omitted.
 
             dict: A serialization of the object that can be written out as JSON.
@@ -440,7 +440,7 @@ class STACObject(ABC):
         """Reads a STACObject implementation from a file.
 
         Args:
-            href (str): The HREF to read the object from.
+            href : The HREF to read the object from.
             stac_io: Optional instance of StacIO to use. If not provided, will use the
                 default instance.
 
@@ -480,10 +480,10 @@ class STACObject(ABC):
         """Parses this STACObject from the passed in dictionary.
 
         Args:
-            d (dict): The dict to parse.
-            href (str): Optional href that is the file location of the object being
+            d : The dict to parse.
+            href : Optional href that is the file location of the object being
                 parsed.
-            root (Catalog or Collection): Optional root of the catalog for this object.
+            root : Optional root of the catalog for this object.
                 If provided, the root's resolved object cache can be used to search for
                 previously resolved instances of the STAC object.
             migrate: Use True if this dict represents JSON from an older STAC object,

--- a/pystac/utils.py
+++ b/pystac/utils.py
@@ -49,10 +49,10 @@ def make_relative_href(
     """Makes a given HREF relative to the given starting HREF.
 
     Args:
-        source_href (str): The HREF to make relative.
-        start_href (str): The HREF that the resulting HREF will be relative with
+        source_href : The HREF to make relative.
+        start_href : The HREF that the resulting HREF will be relative with
             respect to.
-        start_is_dir (str): If True, the start_href is treated as a directory.
+        start_is_dir : If True, the start_href is treated as a directory.
             Otherwise, the start_href is considered to be a file HREF.
             Defaults to False.
 
@@ -90,11 +90,11 @@ def make_absolute_href(
     """Makes a given HREF absolute based on the given starting HREF.
 
     Args:
-        source_href (str): The HREF to make absolute.
-        start_href (str): The HREF that will be used as the basis for which to resolve
+        source_href : The HREF to make absolute.
+        start_href : The HREF that will be used as the basis for which to resolve
             relative paths, if source_href is a relative path. Defaults to the
             current working directory.
-        start_is_dir (str): If True, the start_href is treated as a directory.
+        start_is_dir : If True, the start_href is treated as a directory.
             Otherwise, the start_href is considered to be a file HREF.
             Defaults to False.
 
@@ -142,7 +142,7 @@ def is_absolute_href(href: str) -> bool:
     """Determines if an HREF is absolute or not.
 
     Args:
-        href (str): The HREF to consider.
+        href : The HREF to consider.
 
     Returns:
         bool: True if the given HREF is absolute, False if it is relative.
@@ -155,7 +155,7 @@ def datetime_to_str(dt: datetime) -> str:
     """Convert a python datetime to an ISO8601 string
 
     Args:
-        dt (datetime): The datetime to convert.
+        dt : The datetime to convert.
 
     Returns:
         str: The ISO8601 formatted string representing the datetime.
@@ -179,7 +179,7 @@ def geometry_to_bbox(geometry: Dict[str, Any]) -> List[float]:
     """Extract the bounding box from a geojson geometry
 
     Args:
-        geometry (dict): GeoJSON geometry dict
+        geometry : GeoJSON geometry dict
 
     Returns:
         list: Bounding box of geojson geometry, formatted according to:

--- a/pystac/validation/__init__.py
+++ b/pystac/validation/__init__.py
@@ -19,7 +19,7 @@ def validate(stac_object: "STACObject_Type") -> List[Any]:
     """Validates a :class:`~pystac.STACObject`.
 
     Args:
-        stac_object (STACObject): The stac object to validate.
+        stac_object : The stac object to validate.
 
     Returns:
         List[Object]: List of return values from the validation calls for the
@@ -52,15 +52,15 @@ def validate_dict(
     :class:`~pystac.validation.JsonSchemaSTACValidator` by default.
 
     Args:
-        stac_dict (dict): Dictionary that is the STAC json of the object.
-        stac_object_type (str): The stac object type of the object encoded in stac_dict.
+        stac_dict : Dictionary that is the STAC json of the object.
+        stac_object_type : The stac object type of the object encoded in stac_dict.
             One of :class:`~pystac.STACObjectType`. If not supplied, this will use
             PySTAC's identification logic to identify the object type.
-        stac_version (str): The version of STAC to validate the object against. If not supplied,
+        stac_version : The version of STAC to validate the object against. If not supplied,
             this will use PySTAC's identification logic to identify the stac version
-        extensions (List[str]): Extension IDs for this stac object. If not supplied,
+        extensions : Extension IDs for this stac object. If not supplied,
             PySTAC's identification logic to identify the extensions.
-        href (str): Optional HREF of the STAC object being validated.
+        href : Optional HREF of the STAC object being validated.
 
     Returns:
         List[Object]: List of return values from the validation calls for the
@@ -113,8 +113,8 @@ def validate_all(
 
     Args:
 
-        stac_dict (dict): Dictionary that is the STAC json of the object.
-        href (str): HREF of the STAC object being validated. Used for error
+        stac_dict : Dictionary that is the STAC json of the object.
+        href : HREF of the STAC object being validated. Used for error
             reporting and resolving relative links.
         stac_io: Optional StacIO instance to use for reading hrefs. If None,
             the StacIO.default() instance is used.
@@ -184,7 +184,7 @@ def set_validator(validator: STACValidator) -> None:
     """Sets the STACValidator to use in PySTAC.
 
     Args:
-        validator (STACValidator): The STACValidator implementation to use for
+        validator : The STACValidator implementation to use for
             validation.
     """
     RegisteredValidator.set_validator(validator)

--- a/pystac/validation/schema_uri_map.py
+++ b/pystac/validation/schema_uri_map.py
@@ -21,9 +21,9 @@ class SchemaUriMap(ABC):
         """Get the schema URI for the given object type and stac version.
 
         Args:
-            object_type (STACObjectType): STAC object type. One of
+            object_type : STAC object type. One of
                 :class:`~pystac.STACObjectType`
-            stac_version (str): The STAC version of the schema to return.
+            stac_version : The STAC version of the schema to return.
 
         Returns:
             str: The URI of the schema, or None if not found.

--- a/pystac/validation/stac_validator.py
+++ b/pystac/validation/stac_validator.py
@@ -38,11 +38,11 @@ class STACValidator(ABC):
         Return value can be None or specific to the implementation.
 
         Args:
-            stac_dict (dict): Dictionary that is the STAC json of the object.
-            stac_object_type (str): The stac object type of the object encoded
+            stac_dict : Dictionary that is the STAC json of the object.
+            stac_object_type : The stac object type of the object encoded
                 in stac_dict. One of :class:`~pystac.STACObjectType`.
-            stac_version (str): The version of STAC to validate the object against.
-            href (str): Optional HREF of the STAC object being validated.
+            stac_version : The version of STAC to validate the object against.
+            href : Optional HREF of the STAC object being validated.
         """
         pass
 
@@ -60,12 +60,12 @@ class STACValidator(ABC):
         Return value can be None or specific to the implementation.
 
         Args:
-            stac_dict (dict): Dictionary that is the STAC json of the object.
-            stac_object_type (str): The stac object type of the object encoded in
+            stac_dict : Dictionary that is the STAC json of the object.
+            stac_object_type : The stac object type of the object encoded in
                 stac_dict. One of :class:`~pystac.STACObjectType`.
-            stac_version (str): The version of STAC to validate the object against.
-            extension_id (str): The extension ID of the extension to validate against.
-            href (str): Optional HREF of the STAC object being validated.
+            stac_version : The version of STAC to validate the object against.
+            extension_id : The extension ID of the extension to validate against.
+            href : Optional HREF of the STAC object being validated.
         """
         pass
 
@@ -80,12 +80,12 @@ class STACValidator(ABC):
         """Validate a STAC object JSON.
 
         Args:
-            stac_dict (dict): Dictionary that is the STAC json of the object.
-            stac_object_type (str): The stac object type of the object encoded in
+            stac_dict : Dictionary that is the STAC json of the object.
+            stac_object_type : The stac object type of the object encoded in
                 stac_dict. One of :class:`~pystac.STACObjectType`.
-            stac_version (str): The version of STAC to validate the object against.
-            extensions (List[str]): Extension IDs for this stac object.
-            href (str): Optional href of the STAC object being validated.
+            stac_version : The version of STAC to validate the object against.
+            extensions : Extension IDs for this stac object.
+            href : Optional href of the STAC object being validated.
 
         Returns:
             List[Any]: List of return values from the validation calls for the
@@ -122,7 +122,7 @@ class JsonSchemaSTACValidator(STACValidator):
     objects and extensions.
 
     Args:
-        schema_uri_map (SchemaUriMap): The SchemaUriMap that defines where
+        schema_uri_map : The SchemaUriMap that defines where
             the validator will retrieve the JSON schemas for validation.
             Defaults to an instance of
             :class:`~pystac.validation.schema_uri_map.DefaultSchemaUriMap`
@@ -195,11 +195,11 @@ class JsonSchemaSTACValidator(STACValidator):
         Return value can be None or specific to the implementation.
 
         Args:
-            stac_dict (dict): Dictionary that is the STAC json of the object.
-            stac_object_type (str): The stac object type of the object encoded in
+            stac_dict : Dictionary that is the STAC json of the object.
+            stac_object_type : The stac object type of the object encoded in
                 stac_dict. One of :class:`~pystac.STACObjectType`.
-            stac_version (str): The version of STAC to validate the object against.
-            href (str): Optional HREF of the STAC object being validated.
+            stac_version : The version of STAC to validate the object against.
+            href : Optional HREF of the STAC object being validated.
 
         Returns:
            str: URI for the JSON schema that was validated against, or None if
@@ -234,12 +234,12 @@ class JsonSchemaSTACValidator(STACValidator):
         Return value can be None or specific to the implementation.
 
         Args:
-            stac_dict (dict): Dictionary that is the STAC json of the object.
-            stac_object_type (str): The stac object type of the object encoded in
+            stac_dict : Dictionary that is the STAC json of the object.
+            stac_object_type : The stac object type of the object encoded in
                 stac_dict. One of :class:`~pystac.STACObjectType`.
-            stac_version (str): The version of STAC to validate the object against.
-            extension_id (str): The extension ID to validate against.
-            href (str): Optional HREF of the STAC object being validated.
+            stac_version : The version of STAC to validate the object against.
+            extension_id : The extension ID to validate against.
+            href : Optional HREF of the STAC object being validated.
 
         Returns:
            str: URI for the JSON schema that was validated against, or None if

--- a/pystac/version.py
+++ b/pystac/version.py
@@ -57,7 +57,7 @@ def set_stac_version(stac_version: Optional[str]) -> None:
     the version.
 
     Args:
-        stac_version (str): The STAC version to use instead of the latest STAC version
+        stac_version : The STAC version to use instead of the latest STAC version
             that PySTAC supports (described in STACVersion.DEFAULT_STAC_VERSION).
             If None, clear to use the default for this version of PySTAC.
 


### PR DESCRIPTION


**Related Issue(s):** #

fixes #323

**Description:**


**PR Checklist:**

- [ ] Code is formatted (run `scripts/format`)
- [ ] Tests pass (run `scripts/test`)
- [ ] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.