### PR TITLE
Execute the validate method in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Fixed
 
+- Validation checks in a few tests ([#346](https://github.com/stac-utils/pystac/pull/346))
+
 ### Changed
 
 - API change: The extension API changed significantly. See ([#309](https://github.com/stac-utils/pystac/pull/309)) for more details.

--- a/tests/extensions/test_pointcloud.py
+++ b/tests/extensions/test_pointcloud.py
@@ -57,7 +57,7 @@ class PointcloudTest(unittest.TestCase):
         self.assertEqual(pc_count + 100, pc_item.properties["pc:count"])
 
         # Validate
-        pc_item.validate
+        pc_item.validate()
 
         # Cannot test validation errors until the pointcloud schema.json syntax is fixed
         # Ensure setting bad count fails validation
@@ -79,7 +79,7 @@ class PointcloudTest(unittest.TestCase):
         self.assertEqual("sonar", pc_item.properties["pc:type"])
 
         # Validate
-        pc_item.validate
+        pc_item.validate()
 
     def test_encoding(self):
         pc_item = pystac.Item.from_file(self.example_uri)
@@ -94,7 +94,7 @@ class PointcloudTest(unittest.TestCase):
         self.assertEqual("binary", pc_item.properties["pc:encoding"])
 
         # Validate
-        pc_item.validate
+        pc_item.validate()
 
     def test_schemas(self):
         pc_item = pystac.Item.from_file(self.example_uri)
@@ -112,7 +112,7 @@ class PointcloudTest(unittest.TestCase):
         )
 
         # Validate
-        pc_item.validate
+        pc_item.validate()
 
     def test_statistics(self):
         pc_item = pystac.Item.from_file(self.example_uri)
@@ -158,7 +158,7 @@ class PointcloudTest(unittest.TestCase):
         PointcloudExtension.ext(pc_item).density = density
         self.assertEqual(density, pc_item.properties["pc:density"])
         # Validate
-        pc_item.validate
+        pc_item.validate()
 
     def test_pointcloud_schema(self):
         props: Dict[str, Any] = {

--- a/tests/extensions/test_projection.py
+++ b/tests/extensions/test_projection.py
@@ -140,7 +140,7 @@ class ProjectionTest(unittest.TestCase):
         self.assertEqual(ProjectionExtension.ext(asset_no_prop).epsg, 8888)
 
         # Validate
-        proj_item.validate
+        proj_item.validate()
 
     def test_wkt2(self):
         proj_item = pystac.Item.from_file(self.example_uri)


### PR DESCRIPTION
**Related Issue(s):** #339


**Description:** There were a few instances in the test suite where we wanted to validate an item, but the method wasn't actually called.


**PR Checklist:**

- [x] Code is formatted (run `scripts/format`)
- [x] Tests pass (run `scripts/test`)
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.