### PR TITLE
Remove duplicate `read_text` without orjson

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -39,3 +39,14 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
           fail_ci_if_error: false 
+  vanilla:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+      - name: Install without orjson
+        run: pip install '.[validation]'
+      - name: Run unittests
+        run: python -m unittest discover tests

--- a/.style.yapf
+++ b/.style.yapf
@@ -1,2 +1,0 @@
-[style]
-column_limit = 100

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Changed
 
+### Fixed
+
+- Reading json without orjson ([#348](https://github.com/stac-utils/pystac/pull/348))
+
 ### Remove
 
 ## [1.0.0-beta.1]

--- a/pystac/stac_io.py
+++ b/pystac/stac_io.py
@@ -23,7 +23,7 @@ import pystac.serialization
 
 # Use orjson if available
 try:
-    import orjson
+    import orjson  # type: ignore
 except ImportError:
     orjson = None
 
@@ -77,7 +77,7 @@ class StacIO(ABC):
         if orjson is not None:
             return orjson.loads(txt)
         else:
-            return json.loads(self.read_text(txt))
+            return json.loads(txt)
 
     def _json_dumps(
         self, json_dict: Dict[str, Any], source: Union[str, "Link_Type"]

--- a/scripts/format
+++ b/scripts/format
@@ -9,7 +9,7 @@ fi
 function usage() {
     echo -n \
         "Usage: $(basename "$0")
-Format code with yapf
+Format code with black
 "
 }
 

--- a/tests/test_stac_io.py
+++ b/tests/test_stac_io.py
@@ -1,6 +1,7 @@
 import unittest
 import warnings
 
+import pystac
 from pystac.stac_io import STAC_IO
 from tests.utils import TestCases
 
@@ -18,3 +19,8 @@ class StacIOTest(unittest.TestCase):
             # Verify some things
             self.assertEqual(len(w), 1)
             self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+
+    def test_read_text(self):
+        _ = pystac.read_file(
+            TestCases.get_path("data-files/collections/multi-extent.json")
+        )


### PR DESCRIPTION
**Related Issue(s):** None


**Description:** If orjson was not present, the `_json_loads` method on `StacIO` would try to read the text again, which would lead to the read text method being called with json (bad). This slipped through CI because one of the requirements-dev.txt dependencies installs orjson, so the non-orjson case wasn't being tested. This commit also includes a new build job to install+test without requirements-dev.txt to try and protect against regression.

Also includes a scripts comment fix to s/yapf/black, and a comment to make pylance ignore a missing orjson import. I didn't update the docs re the yapf->black switch b/c @lossyrob said that some other folks were working on the docs upgrades.


**PR Checklist:**

- [x] Code is formatted (run `scripts/format`)
- [x] Tests pass (run `scripts/test`)
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.