### PR TITLE
Fix docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -178,10 +178,10 @@ STACError
 
 .. autoclass:: pystac.STACError
 
-ExtensionError
-~~~~~~~~~~~~~~
+ExtensionTypeError
+~~~~~~~~~~~~~~~~~~
 
-.. autoclass:: pystac.extensions.ExtensionError
+.. autoclass:: pystac.ExtensionTypeError
 
 Extensions
 ----------

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -12,5 +12,8 @@ sphinxcontrib-fulltoc==1.2.0
 nbsphinx==0.7.1
 coverage==5.2.*
 
+# https://github.com/pydata/xarray/issues/5299#issuecomment-840730954
+jinja2<3.0
+
 # optional dependencies
 orjson==3.5.2


### PR DESCRIPTION
**Related Issue(s):** #


**Description:**

A recent update to `jinja2` doesn't jive with `nbsphinx` and was causing the docs build to fail. This pins to `jinja2<3.0` per [this issue](https://github.com/pydata/xarray/issues/5299). If/when this gets fixed we can relax this requirement again.

Also fixes a reference to `pystac.extensions.ExtensionError` that is no longer valid in the API docs. 

*We need to do a much bigger overhaul of the docs in order to bring them up to speed with the current state of the code, but this at least gets them to build successfully.*

**PR Checklist:**

- [x] Code is formatted (run `scripts/format`)
- [x] Tests pass (run `scripts/test`)
- [ ] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
    **Didn't seem necessary, but let me know if anyone disagrees.**