### PR TITLE
[WIP] Add staticmethod for canonical links

### DIFF
--- a/pystac/link.py
+++ b/pystac/link.py
@@ -14,7 +14,7 @@ HIERARCHICAL_LINKS = ["root", "child", "parent", "collection", "item", "items"]
 
 
 class Link:
-    """A link is connects a :class:`~pystac.STACObject` to another entity.
+    """A link connects a :class:`~pystac.STACObject` to another entity.
 
     The target of a link can be either another STACObject, or
     an HREF. When serialized, links always refer to the HREF of the target.
@@ -325,3 +325,13 @@ class Link:
     def item(item: "Item_Type", title: Optional[str] = None) -> "Link":
         """Creates a link to an Item."""
         return Link("item", item, title=title, media_type="application/json")
+
+    @staticmethod
+    def canonical(
+        item_or_collection: Union["Item_Type", "Collection_Type"],
+        title: Optional[str] = None,
+    ) -> "Link":
+        """Creates a canonical link to an Item or Collection."""
+        return Link(
+            "canonical", item_or_collection, title=title, media_type="application/json"
+        )

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -82,6 +82,19 @@ class LinkTest(unittest.TestCase):
 
 
 class StaticLinkTest(unittest.TestCase):
+    def setUp(self):
+        self.item = pystac.Item(
+            id="test-item",
+            geometry=None,
+            bbox=None,
+            datetime=TEST_DATETIME,
+            properties={},
+        )
+
+        self.collection = pystac.Collection(
+            "collection id", "desc", extent=ARBITRARY_EXTENT
+        )
+
     def test_from_dict_round_trip(self):
         test_cases = [
             {"rel": "", "href": ""},  # Not valid, but works.
@@ -101,13 +114,21 @@ class StaticLinkTest(unittest.TestCase):
                 pystac.Link.from_dict(d)
 
     def test_collection(self):
-        c = pystac.Collection("collection id", "desc", extent=ARBITRARY_EXTENT)
-        link = pystac.Link.collection(c)
+        link = pystac.Link.collection(self.collection)
         expected = {"rel": "collection", "href": None, "type": "application/json"}
         self.assertEqual(expected, link.to_dict())
 
     def test_child(self):
-        c = pystac.Collection("collection id", "desc", extent=ARBITRARY_EXTENT)
-        link = pystac.Link.child(c)
+        link = pystac.Link.child(self.collection)
         expected = {"rel": "child", "href": None, "type": "application/json"}
+        self.assertEqual(expected, link.to_dict())
+
+    def test_canonical_item(self):
+        link = pystac.Link.canonical(self.item)
+        expected = {"rel": "canonical", "href": None, "type": "application/json"}
+        self.assertEqual(expected, link.to_dict())
+
+    def test_canonical_collection(self):
+        link = pystac.Link.canonical(self.collection)
+        expected = {"rel": "canonical", "href": None, "type": "application/json"}
         self.assertEqual(expected, link.to_dict())


### PR DESCRIPTION
**Related Issue(s):** #

#328 

**Description:**

* Adds `Link.canonical` static method for creating links with a "canonical" rel type

    Since the "via" links can refer to arbitrary non-STAC records I didn't add an equivalent static method for those.

**PR Checklist:**

- [x] Code is formatted (run `scripts/format`)
- [x] Tests pass (run `scripts/test`)
- [ ] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.