### PR TITLE
Add more pointcloud extension tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 - Split `DefaultStacIO`'s reading and writing into two methods to allow subclasses to use the default link resolution behavior ([#354](https://github.com/stac-utils/pystac/pull/354))
+- Increased test coverage for the pointcloud extension ([#352](https://github.com/stac-utils/pystac/pull/352))
 
 ### Fixed
 


### PR DESCRIPTION
**Related Issue(s):** #248 


**Description:** Increase coverage for pointcloud extension tests. Doesn't go 100% b/c I don't like testing `__repr__` and there's some property getter paths that don't seem worth exploring because they seem like they're already protected in one of the superclasses.


**PR Checklist:**

- [x] Code is formatted (run `scripts/format`)
- [x] Tests pass (run `scripts/test`)
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.