### PR TITLE
Split default IO down into to/from href methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- Split `DefaultStacIO`'s reading and writing into two methods to allow subclasses to use the default link resolution behavior ([#354](https://github.com/stac-utils/pystac/pull/354))
+
 ### Fixed
 
 - Reading json without orjson ([#348](https://github.com/stac-utils/pystac/pull/348))

--- a/pystac/stac_io.py
+++ b/pystac/stac_io.py
@@ -176,7 +176,9 @@ class DefaultStacIO(StacIO):
             href = source.get_absolute_href()
             if href is None:
                 raise IOError(f"Could not get an absolute HREF from link {source}")
+        return self.read_text_from_href(href, *args, **kwargs)
 
+    def read_text_from_href(self, href: str, *args: Any, **kwargs: Any) -> str:
         parsed = urlparse(href)
         if parsed.scheme != "":
             try:
@@ -197,7 +199,11 @@ class DefaultStacIO(StacIO):
             href = dest.get_absolute_href()
             if href is None:
                 raise IOError(f"Could not get an absolute HREF from link {dest}")
+        return self.write_text_to_href(href, txt, *args, **kwargs)
 
+    def write_text_to_href(
+        self, href: str, txt: str, *args: Any, **kwargs: Any
+    ) -> None:
         dirname = os.path.dirname(href)
         if dirname != "" and not os.path.isdir(dirname):
             os.makedirs(dirname)


### PR DESCRIPTION
**Related Issue(s):** https://github.com/stac-utils/stactools/pull/113


**Description:** This allows subclasses of `DefaultStacIO` to not have to re-impelment link resolution if they don't want to. I would like this for, e.g., [this fsspec io](https://github.com/stac-utils/stactools/pull/113/files#diff-3d671a54c5fbbcedc1f768fb8e61ee8c36d16f46f8e9c69798a32b966a4bdcc4R25-R49), where right now I'm just copying the link resolution code from pystac.


**PR Checklist:**

- [x] Code is formatted (run `scripts/format`)
- [x] Tests pass (run `scripts/test`)
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.