### PR TITLE
Update EO extension docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -88,6 +88,13 @@ Provider
    :members:
    :undoc-members:
 
+Summaries
+~~~~~~~~~
+
+.. autoclass:: pystac.Summaries
+   :members:
+   :undoc-members:
+
 Item Spec
 ---------
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -201,22 +201,33 @@ ExtensionIndex
 .. .. autoclass:: pystac.stac_object.ExtensionIndex
 ..    :members: __getitem__, __getattr__, enable, implements
 
-
-EO Extension
+Base Classes
 ------------
 
-These classes are representations of the `EO Extension Spec <https://github.com/radiantearth/stac-spec/tree/v1.0.0-beta.2/extensions/eo>`_.
+Abstract base classes that should be inherited to implement specific extensions.
 
-EOItemExt
-~~~~~~~~~
+SummariesExtension
+~~~~~~~~~~~~~~~~~~
 
-**TEMPORARILY REMOVED**
+.. autoclass:: pystac.extensions.base.SummariesExtension
+   :members:
 
-.. .. autoclass:: pystac.extensions.eo.EOItemExt
-..    :members:
-..    :undoc-members:
-..    :show-inheritance:
+PropertiesExtension
+~~~~~~~~~~~~~~~~~~~
 
+.. autoclass:: pystac.extensions.base.PropertiesExtension
+   :members:
+   :show-inheritance:
+
+ExtensionManagementMixin
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: pystac.extensions.base.ExtensionManagementMixin
+   :members:
+   :show-inheritance:
+
+Electro-Optical Extension
+-------------------------
 Band
 ~~~~
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -228,15 +228,47 @@ ExtensionManagementMixin
 
 Electro-Optical Extension
 -------------------------
+
+These classes are representations of the `EO Extension Spec <https://github.com/radiantearth/stac-spec/tree/v1.0.0-beta.2/extensions/eo>`_.
+
 Band
 ~~~~
 
-**TEMPORARILY REMOVED**
+.. autoclass:: pystac.extensions.eo.Band
+   :members:
+   :undoc-members:
 
-.. .. autoclass:: pystac.extensions.eo.Band
-..    :members:
-..    :undoc-members:
+EOExtension
+~~~~~~~~~~~
 
+.. autoclass:: pystac.extensions.eo.EOExtension
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+ItemEOExtension
+~~~~~~~~~~~~~~~
+
+.. autoclass:: pystac.extensions.eo.ItemEOExtension
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+AssetEOExtension
+~~~~~~~~~~~~~~~~
+
+.. autoclass:: pystac.extensions.eo.AssetEOExtension
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+SummariesEOExtension
+~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: pystac.extensions.eo.SummariesEOExtension
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 Label Extension
 ---------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -502,7 +502,7 @@ PySTAC includes a ``pystac.validation`` package for validating STAC objects, inc
 from PySTAC objects and directly from JSON.
 
 .. automodule:: pystac.validation
-   :members: validate, validate_dict, validate_all, set_validator, STACValidationError
+   :members: validate, validate_dict, validate_all, set_validator
 
 STACValidator
 ~~~~~~~~~~~~~

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -193,21 +193,6 @@ ExtensionTypeError
 Extensions
 ----------
 
-**TEMPORARILY REMOVED**
-.. .. autoclass:: pystac.extensions.Extensions
-..    :members:
-..    :undoc-members:
-
-ExtensionIndex
-~~~~~~~~~~~~~~
-
-**TEMPORARILY REMOVED**
-
-.. An ExtensionIndex is accessed through the :attr:`STACObject.ext <pystac.STACObject.ext>` property and is the primary way to access information and functionality around STAC extensions.
-
-.. .. autoclass:: pystac.stac_object.ExtensionIndex
-..    :members: __getitem__, __getattr__, enable, implements
-
 Base Classes
 ------------
 

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -309,87 +309,85 @@ The :class:`~pystac.validation.JsonSchemaSTACValidator` takes a :class:`~pystac.
 Extensions
 ==========
 
-Accessing Extension functionality
+From the documentation on `STAC Spec Extensions 
+<https://github.com/radiantearth/stac-spec/tree/master/extensions>`__:
+
+   Extensions to the core STAC specification provide additional JSON fields that can be
+   used to better describe the data. Most tend to be about describing a particular 
+   domain or type of data, but some imply functionality.
+
+This library makes an effort to support all extensions that are part of the
+`stac-extensions GitHub org
+<https://stac-extensions.github.io/#extensions-in-stac-extensions-organization>`__, and
+we are committed to supporting all STAC Extensions at the "Candidate" maturity level or
+above (see the `Extension Maturity
+<https://stac-extensions.github.io/#extension-maturity>`__ documentation for details).
+
+Accessing Extension Functionality
 ---------------------------------
 
-All STAC objects are accessed through ``Catalog``, ``Collection`` and ``Item``, and all extension functionality
-is accessed through the ``ext`` property on those objects. For instance, to access the band information
-from the ``eo`` extension for an item that implements the extension, you use:
+Extension functionality is encapsulated in classes that are specific to the STAC
+Extension (e.g. Electro-Optical, Projection, etc.) and STAC Object
+(:class:`~pystac.Collection`, :class:`pystac.Item`, or :class:`pystac.Asset`). All
+classes that extend these objects inherit from
+:class:`pystac.extensions.base.PropertiesExtension`, and you can use the
+``ext`` method on these classes to extend an object.
+
+For instance, to extend an item with the :stac-ext:`Electro-Optical Extension <eo>`
+you would use :meth:`EOExtension.ext <pystac.extensions.eo.EOExtension.ext>` as
+follows:
 
 .. code-block:: python
 
-   # All of the below are equivalent:
-   item.ext['eo'].bands
-   item.ext[pystac.Extensions.EO].bands
-   item.ext.eo.bands
+   import pystac
+   from pystac.extensions.eo import EOExtension
 
-Notice the ``eo`` property on ``ext`` - this utilizes the `__getattr__ <https://docs.python.org/3/reference/datamodel.html#object.__getattr__>`_ method to delegate the property name to the ``__getitem__`` method, so we can access any registered extension as if it were a property on ``ext``.
+   item = Item(...)  # See docs for creating an Item
+   eo_ext = EOExtension.ext(item)
 
-Extensions wrap the objects they extend. Extensions hold
-no values of their own, but instead use Python `properties <https://docs.python.org/3/library/functions.html#property>`_
-to directly modify the values of the objects they wrap.
-
-Any object that is returned by extension methods therefore also wrap components of the STAC objects.
-For instance, the ``LabelClasses`` holds a reference to the original ``Item``'s ``label:classes`` property, so that
-modifying the ``LabelClasses``
-properties through the setters will modify the item properties directly. For example:
+This extended instance now gives you access to the properties defined in that extension:
 
 .. code-block:: python
 
-    from pystac.extensions import label
+   eo_ext.bands
+   eo_ext.cloud_cover
 
-    label_classes = item.ext.label.label_classes
-    label_classes[0].classes.append("other_class")
-    assert "other_class" in item.properties['label:classes'][0]['classes']
+See the documentation for each extension implementation for details on the supported
+properties and other functionality.
 
-Because these objects wrap the object's dictionary, the __init__ methods need to take the
-``dict`` they wrap. Therefore to create a new object, use the class's `.create` method, for example:
+Instances of :class:`~pystac.extensions.base.PropertiesExtension` have a
+:attr:`~pystac.extensions.base.PropertiesExtension.properties` attribute that gives
+access to the properties of the extended object. There is also a
+:attr:`~pystac.extensions.base.PropertiesExtension.additional_read_properties`
+attribute that, if present, gives read access to properties of any objects that own the
+extended object. For instance, an extended :class:`pystac.Asset` instance would have
+read access to the properties of the :class:`pystac.Item` that owns it (if there is one).
 
-.. code-block:: python
-
-   item.ext.label.label_classes = [label.LabelClasses.create(['class1', 'class2'], name='label')]
-
-An `apply` method is available in extension wrappers and any objects that they return. This allows
-you to pass in property values pertaining to the extension. These will require arguments for properties
-required as part of the extension specification and have `None` default values for optional parameters:
-
-.. code-block:: python
-
-   eo_ext = item.ext.eo
-   eo_ext.apply(0.5, bands, cloud_cover=None) # Do not have to specify cloud_cover
-
-
-If you attempt to retrieve an extension wrapper for an extension that the object doesn't implement, PySTAC will
-throw a `pystac.extensions.ExtensionError`.
-
-Enabling an extension
----------------------
-
-You'll need to enable an extension on an object before using it. For example, if you are creating an Item and want to
-apply the label extension, you can do so in two ways.
-
-You can add the extension in the list of extensions when you create the Item:
+An ``apply`` method is available on extended objects. This allows you to pass in
+property values pertaining to the extension. Properties that are required by the
+extension will be required arguments to the ``apply`` method. Optional properties will
+have a default value of ``None``:
 
 .. code-block:: python
 
-   item = Item(id='Labels',
-               geometry=item.geometry,
-               bbox=item.bbox,
-               datetime=datetime.utcnow(),
-               properties={},
-               stac_extensions=[pystac.Extensions.LABEL])
+   # Do not have to specify cloud_cover
+   eo_ext.apply(0.5, bands, cloud_cover=None)
 
-or you can call ``ext.enable`` on an Item (which will work for any item, whether you created it or are modifying it):
 
-.. code-block:: python
+If you attempt to extend an object that is not supported by an extension, PySTAC will
+throw a :class:`pystac.ExtensionTypeError`.
 
-   item = Item(id='Labels',
-               geometry=item.geometry,
-               bbox=item.bbox,
-               datetime=datetime.utcnow(),
-               properties={})
+Extended Summaries
+------------------
 
-   item.ext.enable(pystac.Extensions.LABEL)
+Extension classes like :class:`~pystac.extensions.eo.EOExtension` may also provide a
+``summaries`` static method that can be used to extend the Collection summaries. This
+method returns a class inheriting from
+:class:`pystac.extensions.base.SummariesExtension` that provides tools for summarizing
+the properties defined by that extension. These classes also hold a reference to the
+Collection's :class:`pystac.Summaries` instance in the ``summaries`` attribute. 
+
+See :class:`pystac.extensions.eo.SummariesEOExtension` for an example implementation.
 
 Item Asset properties
 =====================

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -370,7 +370,7 @@ have a default value of ``None``:
 
 .. code-block:: python
 
-   # Do not have to specify cloud_cover
+   # Can also omit cloud_cover entirely...
    eo_ext.apply(0.5, bands, cloud_cover=None)
 
 

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -397,6 +397,30 @@ have a default value of ``None``:
 If you attempt to extend an object that is not supported by an extension, PySTAC will
 throw a :class:`pystac.ExtensionTypeError`.
 
+Adding an Extension
+-------------------
+
+You can add an extension to a STAC object that does not already implement that extension
+using the :meth:`ExtensionManagementMixin.add_to
+<pystac.extensions.base.ExtensionManagementMixin.add_to>` method. Any concrete
+extension implementations that extend existing STAC objects should inherit from the
+:class:`~pystac.extensions.base.ExtensionManagementMixin` class, and will therefore have
+this method available. The
+:meth:`~pystac.extensions.base.ExtensionManagementMixin.add_to` adds the correct schema
+URI to the :attr:`~pystac.STACObject.stac_extensions` list for the object being extended.
+
+.. code-block:: python
+
+   # Load a basic item without any extensions
+   item = Item.from_file("tests/data-files/item/sample-item.json")
+   print(item.stac_extensions)
+   # []
+
+   # Add the Electro-Optical extension
+   EOExtension.add_to(item)
+   print(item.stac_extensions)
+   # ['https://stac-extensions.github.io/eo/v1.0.0/schema.json']
+
 Extended Summaries
 ------------------
 

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -357,11 +357,31 @@ properties and other functionality.
 
 Instances of :class:`~pystac.extensions.base.PropertiesExtension` have a
 :attr:`~pystac.extensions.base.PropertiesExtension.properties` attribute that gives
-access to the properties of the extended object. There is also a
-:attr:`~pystac.extensions.base.PropertiesExtension.additional_read_properties`
-attribute that, if present, gives read access to properties of any objects that own the
+access to the properties of the extended object. *This attribute is a reference to the
+properties of the* :class:`~pystac.Item` *or* :class:`~pystac.Asset` *being extended and
+can therefore mutate those properties.* For instance:
+
+.. code-block:: python
+
+   item = Item.from_file("tests/data-files/eo/eo-landsat-example.json")
+   print(item.properties["eo:cloud_cover"])
+   # 78
+
+   eo_ext = EOExtension.ext(item)
+   print(eo_ext.cloud_cover)
+   # 78
+
+   eo_ext.cloud_cover = 45
+   print(item.properties["eo:cloud_cover"])
+   # 45
+
+There is also a :attr:`~pystac.extensions.base.PropertiesExtension.additional_read_properties`
+attribute that, if present, gives read-only access to properties of any objects that own the
 extended object. For instance, an extended :class:`pystac.Asset` instance would have
-read access to the properties of the :class:`pystac.Item` that owns it (if there is one).
+read access to the properties of the :class:`pystac.Item` that owns it (if there is
+one). If a property exists in both additional_read_properties and properties, the value
+in additional_read_properties will take precedence.
+
 
 An ``apply`` method is available on extended objects. This allows you to pass in
 property values pertaining to the extension. Properties that are required by the

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,7 +59,8 @@ extensions = [
 
 extlinks = {
     'tutorial': ('https://github.com/azavea/pystac/'
-                  'tree/{}/docs/tutorials/%s'.format(git_branch), 'tutorial')
+                  'tree/{}/docs/tutorials/%s'.format(git_branch), 'tutorial'),
+    'stac-ext': ('https://github.com/stac-extensions/%s', '%s extension')
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/pystac/extensions/base.py
+++ b/pystac/extensions/base.py
@@ -5,6 +5,16 @@ import pystac
 
 
 class SummariesExtension:
+    """Base class for extending the properties in :attr:`pystac.Collection.summaries` to include
+    properties defined by a STAC Extension.
+    
+    This class should generally not be instantiated directly. Instead, create an extension-specific
+    class that inherits from this class and instantiate that. See
+    :class:`~pystac.extensions.eo.SummariesEOExtension` for an example."""
+
+    summaries: pystac.Summaries
+    """The summaries for the :class:`~pystac.Collection` being extended."""
+
     def __init__(self, collection: pystac.Collection) -> None:
         self.summaries = collection.summaries
 
@@ -23,8 +33,20 @@ P = TypeVar("P")
 
 
 class PropertiesExtension(ABC):
+    """Abstract base class for extending the properties of an :class:`~pystac.Item` to include properties
+    defined by a STAC Extension.
+
+    This class should not be instantiated directly. Instead, create an extension-specific
+    class that inherits from this class and instantiate that. See
+    :class:`~pystac.extensions.eo.PropertiesEOExtension` for an example.
+    """
     properties: Dict[str, Any]
+    """Additional properties associated with this extension."""
+
     additional_read_properties: Optional[Iterable[Dict[str, Any]]] = None
+    """Additional read-only properties accessible from the extended object. These are used when
+    extending a :class:`~pystac.Asset` to give access to the properties of the owning
+    :class:`~pystac.Item`."""
 
     def _get_property(self, prop_name: str, typ: Type[P] = Type[Any]) -> Optional[P]:
         result: Optional[typ] = self.properties.get(prop_name)
@@ -50,13 +72,24 @@ S = TypeVar("S", bound=pystac.STACObject)
 
 
 class ExtensionManagementMixin(Generic[S], ABC):
+    """Abstract base class with tools for adding and removing extensions from STAC Objects. This
+    class is generic over the type of object being extended (e.g. :class:`~pystac.Item`).
+    
+    Concrete extension implementations should inherit from this class and either provide a concrete
+    type or a bounded type variable. 
+
+    See :class:`~pystac.extensions.eo.EOExtension` for an example implementation.
+    """
     @classmethod
     @abstractmethod
     def get_schema_uri(cls) -> str:
+        """Gets the schema URI associated with this extension."""
         pass
 
     @classmethod
     def add_to(cls, obj: S) -> None:
+        """Add the schema URI for this extension to the :attr:`pystac.STACObject.stac_extensions` list for
+        the given object."""
         if obj.stac_extensions is None:
             obj.stac_extensions = [cls.get_schema_uri()]
         else:
@@ -64,6 +97,8 @@ class ExtensionManagementMixin(Generic[S], ABC):
 
     @classmethod
     def remove_from(cls, obj: S) -> None:
+        """Remove the schema URI for this extension from the :attr:`pystac.STACObject.stac_extensions` list for
+        the given object."""
         if obj.stac_extensions is not None:
             obj.stac_extensions = [
                 uri for uri in obj.stac_extensions if uri != cls.get_schema_uri()
@@ -71,6 +106,8 @@ class ExtensionManagementMixin(Generic[S], ABC):
 
     @classmethod
     def has_extension(cls, obj: S) -> bool:
+        """Check if the given object implements this extension by checking
+        :attr:`pystac.STACObject.stac_extensions` for this extension's schema URI."""
         return (
             obj.stac_extensions is not None
             and cls.get_schema_uri() in obj.stac_extensions

--- a/pystac/extensions/base.py
+++ b/pystac/extensions/base.py
@@ -42,8 +42,8 @@ class PropertiesExtension(ABC):
     """
 
     properties: Dict[str, Any]
-    """The properties that this extension wraps. 
-    
+    """The properties that this extension wraps.
+
     The extension which implements PropertiesExtension can use ``_get_property`` and
     ``_set_property`` to get and set values on this instance. Note that _set_properties
     mutates the properties directly."""
@@ -51,9 +51,10 @@ class PropertiesExtension(ABC):
     additional_read_properties: Optional[Iterable[Dict[str, Any]]] = None
     """Additional read-only properties accessible from the extended object.
 
-    These are used when extending an :class:`~pystac.Asset` to give access to the properties of
-    the owning :class:`~pystac.Item`. If a property exists in both ``additional_read_properties`` and
-    ``properties``, the value in ``additional_read_properties`` will take precedence. 
+    These are used when extending an :class:`~pystac.Asset` to give access to the
+    properties of the owning :class:`~pystac.Item`. If a property exists in both
+    ``additional_read_properties`` and ``properties``, the value in
+    ``additional_read_properties`` will take precedence.
     """
 
     def _get_property(self, prop_name: str, typ: Type[P] = Type[Any]) -> Optional[P]:

--- a/pystac/extensions/base.py
+++ b/pystac/extensions/base.py
@@ -5,11 +5,11 @@ import pystac
 
 
 class SummariesExtension:
-    """Base class for extending the properties in :attr:`pystac.Collection.summaries` to include
-    properties defined by a STAC Extension.
-    
-    This class should generally not be instantiated directly. Instead, create an extension-specific
-    class that inherits from this class and instantiate that. See
+    """Base class for extending the properties in :attr:`pystac.Collection.summaries`
+    to include properties defined by a STAC Extension.
+
+    This class should generally not be instantiated directly. Instead, create an
+    extension-specific class that inherits from this class and instantiate that. See
     :class:`~pystac.extensions.eo.SummariesEOExtension` for an example."""
 
     summaries: pystac.Summaries
@@ -33,20 +33,21 @@ P = TypeVar("P")
 
 
 class PropertiesExtension(ABC):
-    """Abstract base class for extending the properties of an :class:`~pystac.Item` to include properties
-    defined by a STAC Extension.
+    """Abstract base class for extending the properties of an :class:`~pystac.Item`
+    to include properties defined by a STAC Extension.
 
-    This class should not be instantiated directly. Instead, create an extension-specific
-    class that inherits from this class and instantiate that. See
+    This class should not be instantiated directly. Instead, create an
+    extension-specific class that inherits from this class and instantiate that. See
     :class:`~pystac.extensions.eo.PropertiesEOExtension` for an example.
     """
+
     properties: Dict[str, Any]
     """Additional properties associated with this extension."""
 
     additional_read_properties: Optional[Iterable[Dict[str, Any]]] = None
-    """Additional read-only properties accessible from the extended object. These are used when
-    extending a :class:`~pystac.Asset` to give access to the properties of the owning
-    :class:`~pystac.Item`."""
+    """Additional read-only properties accessible from the extended object. These are
+    used when extending a :class:`~pystac.Asset` to give access to the properties of
+    the owning :class:`~pystac.Item`."""
 
     def _get_property(self, prop_name: str, typ: Type[P] = Type[Any]) -> Optional[P]:
         result: Optional[typ] = self.properties.get(prop_name)
@@ -72,14 +73,16 @@ S = TypeVar("S", bound=pystac.STACObject)
 
 
 class ExtensionManagementMixin(Generic[S], ABC):
-    """Abstract base class with tools for adding and removing extensions from STAC Objects. This
-    class is generic over the type of object being extended (e.g. :class:`~pystac.Item`).
-    
-    Concrete extension implementations should inherit from this class and either provide a concrete
-    type or a bounded type variable. 
+    """Abstract base class with tools for adding and removing extensions from STAC
+    Objects. This class is generic over the type of object being extended (e.g.
+    :class:`~pystac.Item`).
+
+    Concrete extension implementations should inherit from this class and either
+    provide a concrete type or a bounded type variable.
 
     See :class:`~pystac.extensions.eo.EOExtension` for an example implementation.
     """
+
     @classmethod
     @abstractmethod
     def get_schema_uri(cls) -> str:
@@ -88,8 +91,8 @@ class ExtensionManagementMixin(Generic[S], ABC):
 
     @classmethod
     def add_to(cls, obj: S) -> None:
-        """Add the schema URI for this extension to the :attr:`pystac.STACObject.stac_extensions` list for
-        the given object."""
+        """Add the schema URI for this extension to the
+        :attr:`pystac.STACObject.stac_extensions` list for the given object."""
         if obj.stac_extensions is None:
             obj.stac_extensions = [cls.get_schema_uri()]
         else:
@@ -97,8 +100,8 @@ class ExtensionManagementMixin(Generic[S], ABC):
 
     @classmethod
     def remove_from(cls, obj: S) -> None:
-        """Remove the schema URI for this extension from the :attr:`pystac.STACObject.stac_extensions` list for
-        the given object."""
+        """Remove the schema URI for this extension from the
+        :attr:`pystac.STACObject.stac_extensions` list for the given object."""
         if obj.stac_extensions is not None:
             obj.stac_extensions = [
                 uri for uri in obj.stac_extensions if uri != cls.get_schema_uri()

--- a/pystac/extensions/base.py
+++ b/pystac/extensions/base.py
@@ -42,12 +42,19 @@ class PropertiesExtension(ABC):
     """
 
     properties: Dict[str, Any]
-    """Additional properties associated with this extension."""
+    """The properties that this extension wraps. 
+    
+    The extension which implements PropertiesExtension can use ``_get_property`` and
+    ``_set_property`` to get and set values on this instance. Note that _set_properties
+    mutates the properties directly."""
 
     additional_read_properties: Optional[Iterable[Dict[str, Any]]] = None
-    """Additional read-only properties accessible from the extended object. These are
-    used when extending a :class:`~pystac.Asset` to give access to the properties of
-    the owning :class:`~pystac.Item`."""
+    """Additional read-only properties accessible from the extended object.
+
+    These are used when extending an :class:`~pystac.Asset` to give access to the properties of
+    the owning :class:`~pystac.Item`. If a property exists in both ``additional_read_properties`` and
+    ``properties``, the value in ``additional_read_properties`` will take precedence. 
+    """
 
     def _get_property(self, prop_name: str, typ: Type[P] = Type[Any]) -> Optional[P]:
         result: Optional[typ] = self.properties.get(prop_name)
@@ -73,7 +80,7 @@ S = TypeVar("S", bound=pystac.STACObject)
 
 
 class ExtensionManagementMixin(Generic[S], ABC):
-    """Abstract base class with tools for adding and removing extensions from STAC
+    """Abstract base class with methods for adding and removing extensions from STAC
     Objects. This class is generic over the type of object being extended (e.g.
     :class:`~pystac.Item`).
 

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -315,7 +315,12 @@ class EOExtension(
         """Extends the given STAC Object with properties from the :stac-ext:`Electro-Optical
         Extension <eo>`.
 
-        The type of the ``obj`` argument must match
+        This extension can be applied to instances of :class:`~pystac.Item` or
+        :class:`~pystac.Asset`.
+
+        Raises:
+
+            pystac.ExtensionTypeError : If an invalid object type is passed.
         """
         if isinstance(obj, pystac.Item):
             return cast(EOExtension[T], ItemEOExtension(obj))

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -40,7 +40,7 @@ CLOUD_COVER_PROP = "eo:cloud_cover"
 class Band:
     """Represents Band information attached to an Item that implements the eo extension.
 
-    Use Band.create to create a new Band.
+    Use :meth:`Band.create` to create a new Band.
     """
 
     def __init__(self, properties: Dict[str, Any]) -> None:
@@ -60,8 +60,8 @@ class Band:
         Args:
             name : The name of the band (e.g., "B01", "B02", "B1", "B5", "QA").
             common_name : The name commonly used to refer to the band to make it
-                easier to search for bands across instruments. See the `list of
-                accepted common names <https://github.com/radiantearth/stac-spec/tree/v0.8.1/extensions/eo#common-band-names>`_.
+                easier to search for bands across instruments. See the :stac-ext:`list
+                of accepted common names <eo#common-band-names>`.
             description : Description to fully explain the band.
             center_wavelength : The center wavelength of the band, in micrometers (μm).
             full_width_half_max : Full width at half maximum (FWHM). The width of the band,
@@ -88,8 +88,8 @@ class Band:
         Args:
             name : The name of the band (e.g., "B01", "B02", "B1", "B5", "QA").
             common_name : The name commonly used to refer to the band to make it easier
-                to search for bands across instruments. See the `list of accepted common names
-                <https://github.com/radiantearth/stac-spec/tree/v0.8.1/extensions/eo#common-band-names>`_.
+                to search for bands across instruments. See the :stac-ext:`list of
+                accepted common names <eo#common-band-names>`.
             description : Description to fully explain the band.
             center_wavelength : The center wavelength of the band, in micrometers (μm).
             full_width_half_max : Full width at half maximum (FWHM). The width of the band,
@@ -121,8 +121,8 @@ class Band:
     @property
     def common_name(self) -> Optional[str]:
         """Get or sets the name commonly used to refer to the band to make it easier
-            to search for bands across instruments. See the `list of accepted common names
-            <https://github.com/radiantearth/stac-spec/tree/v0.8.1/extensions/eo#common-band-names>`_.
+            to search for bands across instruments. See the :stac-ext:`list of accepted
+            common names <eo#common-band-names>`.
 
         Returns:
             Optional[str]
@@ -202,7 +202,8 @@ class Band:
         """Gets the band range for a common band name.
 
         Args:
-            common_name : The common band name. Must be one of the `list of accepted common names <https://github.com/radiantearth/stac-spec/tree/v0.8.1/extensions/eo#common-band-names>`_.
+            common_name : The common band name. Must be one of the :stac-ext:`list of
+                accepted common names <eo#common-band-names>`.
 
         Returns:
             Tuple[float, float] or None: The band range for this name as (min, max), or
@@ -234,7 +235,8 @@ class Band:
         """Returns a description of the band for one with a common name.
 
         Args:
-            common_name : The common band name. Must be one of the `list of accepted common names <https://github.com/radiantearth/stac-spec/tree/v0.8.1/extensions/eo#common-band-names>`_.
+            common_name : The common band name. Must be one of the :stac-ext:`list of
+                accepted common names <eo#common-band-names>`.
 
         Returns:
             str or None: If a recognized common name, returns a description including the

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -4,7 +4,18 @@ https://github.com/stac-extensions/eo
 """
 
 import re
-from typing import Any, Dict, Generic, Iterable, List, Optional, Set, Tuple, TypeVar, cast
+from typing import (
+    Any,
+    Dict,
+    Generic,
+    Iterable,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    TypeVar,
+    cast,
+)
 
 import pystac
 from pystac.collection import RangeSummary
@@ -238,33 +249,34 @@ class Band:
 class EOExtension(
     Generic[T], PropertiesExtension, ExtensionManagementMixin[pystac.Item]
 ):
-    """An abstract class that can be used to extend the properties of an :class:`~pystac.Item` 
-    with properties from the :stac-ext:`Electro-Optical Extension <eo>`. This class is generic 
-    over the type of STAC Object to be extended (e.g. :class:`~pystac.Item`, 
-    :class:`~pystac.Collection`).
+    """An abstract class that can be used to extend the properties of an
+    :class:`~pystac.Item` with properties from the :stac-ext:`Electro-Optical
+    Extension <eo>`. This class is generic over the type of STAC Object to be
+    extended (e.g. :class:`~pystac.Item`, :class:`~pystac.Collection`).
 
-    This class will generally not be used directly. Instead, use the concrete implementation
-    associated with the STAC Object you want to extend (e.g. :class:`~ItemEOExtension` to extend 
-    an :class:`~pystac.Item`).
+    This class will generally not be used directly. Instead, use the concrete
+    implementation associated with the STAC Object you want to extend (e.g.
+    :class:`~ItemEOExtension` to extend an :class:`~pystac.Item`).
     """
 
     def apply(self, bands: List[Band], cloud_cover: Optional[float] = None) -> None:
         """Applies label extension properties to the extended Item.
 
         Args:
-            bands : A list of available bands where each item is a :class:`~Band` object. 
-                If given, requires at least one band.
+            bands : A list of available bands where each item is a :class:`~Band`
+                object. If given, requires at least one band.
             cloud_cover : The estimate of cloud cover as a percentage
-                (0-100) of the entire scene. If not available the field should not be
-                provided.
+                (0-100) of the entire scene. If not available the field should not
+                be provided.
         """
         self.bands = bands
         self.cloud_cover = cloud_cover
 
     @property
     def bands(self) -> Optional[List[Band]]:
-        """Gets or sets a list of available bands where each item is a :class:`~Band` object
-        (or ``None`` if no bands have been set). If not available the field should not be provided.
+        """Gets or sets a list of available bands where each item is a :class:`~Band`
+        object (or ``None`` if no bands have been set). If not available the field
+        should not be provided.
         """
         return self._get_bands()
 
@@ -300,10 +312,10 @@ class EOExtension(
 
     @staticmethod
     def ext(obj: T) -> "EOExtension[T]":
-        """Extends the given STAC Object with properties from the :stac-ext:`Electro-Optical 
+        """Extends the given STAC Object with properties from the :stac-ext:`Electro-Optical
         Extension <eo>`.
 
-        The type of the ``obj`` argument must match 
+        The type of the ``obj`` argument must match
         """
         if isinstance(obj, pystac.Item):
             return cast(EOExtension[T], ItemEOExtension(obj))
@@ -321,12 +333,12 @@ class EOExtension(
 
 
 class ItemEOExtension(EOExtension[pystac.Item]):
-    """A concrete implementation of :class:`EOExtension` on an :class:`~pystac.Item` that extends
-    the properties of the Item to include properties defined in the :stac-ext:`Electro-Optical 
-    Extension <eo>`.
+    """A concrete implementation of :class:`EOExtension` on an :class:`~pystac.Item`
+    that extends the properties of the Item to include properties defined in the
+    :stac-ext:`Electro-Optical Extension <eo>`.
 
-    This class should generally not be instantiated directly. Instead, call :meth:`EOExtension.ext`
-    on an :class:`~pystac.Item` to extend it.
+    This class should generally not be instantiated directly. Instead, call
+    :meth:`EOExtension.ext` on an :class:`~pystac.Item` to extend it.
     """
 
     item: pystac.Item
@@ -334,7 +346,7 @@ class ItemEOExtension(EOExtension[pystac.Item]):
 
     properties: Dict[str, Any]
     """The :class:`~pystac.Item` properties, including extension properties."""
-    
+
     def __init__(self, item: pystac.Item):
         self.item = item
         self.properties = item.properties
@@ -365,12 +377,12 @@ class ItemEOExtension(EOExtension[pystac.Item]):
 
 
 class AssetEOExtension(EOExtension[pystac.Asset]):
-    """A concrete implementation of :class:`EOExtension` on an :class:`~pystac.Asset` that extends
-    the Asset fields to include properties defined in the :stac-ext:`Electro-Optical 
-    Extension <eo>`.
-    
-    This class should generally not be instantiated directly. Instead, call :meth:`EOExtension.ext`
-    on an :class:`~pystac.Asset` to extend it.
+    """A concrete implementation of :class:`EOExtension` on an :class:`~pystac.Asset`
+    that extends the Asset fields to include properties defined in the
+    :stac-ext:`Electro-Optical Extension <eo>`.
+
+    This class should generally not be instantiated directly. Instead, call
+    :meth:`EOExtension.ext` on an :class:`~pystac.Asset` to extend it.
     """
 
     asset_href: str
@@ -380,8 +392,8 @@ class AssetEOExtension(EOExtension[pystac.Asset]):
     """The :class:`~pystac.Asset` fields, including extension properties."""
 
     additional_read_properties: Optional[Iterable[Dict[str, Any]]] = None
-    """If present, this will be a list containing 1 dictionary representing the properties of the
-    owning :class:`~pystac.Item`."""
+    """If present, this will be a list containing 1 dictionary representing the
+    properties of the owning :class:`~pystac.Item`."""
 
     def __init__(self, asset: pystac.Asset):
         self.asset_href = asset.href
@@ -395,9 +407,10 @@ class AssetEOExtension(EOExtension[pystac.Asset]):
 
 class SummariesEOExtension(SummariesExtension):
     """A concrete implementation of :class:`~SummariesExtension` that extends
-    the ``summaries`` field of a :class:`~pystac.Collection` to include properties 
+    the ``summaries`` field of a :class:`~pystac.Collection` to include properties
     defined in the :stac-ext:`Electro-Optical Extension <eo>`.
     """
+
     @property
     def bands(self) -> Optional[List[Band]]:
         """Get or sets a list of :class:`~pystac.Band` objects that represent

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -259,7 +259,9 @@ class EOExtension(
     :class:`~ItemEOExtension` to extend an :class:`~pystac.Item`).
     """
 
-    def apply(self, bands: List[Band], cloud_cover: Optional[float] = None) -> None:
+    def apply(
+        self, bands: Optional[List[Band]] = None, cloud_cover: Optional[float] = None
+    ) -> None:
         """Applies label extension properties to the extended Item.
 
         Args:

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -26,13 +26,16 @@ class STACObject(ABC):
     has links e.g. (Catalogs, Collections, or Items). A STACObject has
     common functionality, can be converted to and from Python ``dicts`` representing
     JSON, and can be cloned or copied.
-
-    Attributes:
-        links : A list of :class:`~pystac.Link` objects representing
-            all links associated with this STACObject.
     """
 
     id: str
+    """The ID of the STAC Object."""
+
+    links: List[Link]
+    """A list of :class:`~pystac.Link` objects representing all links associated with this STAC Object."""
+    
+    stac_extensions: List[str]
+    """A list of schema URIs for STAC Extensions implemented by this STAC Object."""
 
     STAC_OBJECT_TYPE: STACObjectType
 

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -32,8 +32,9 @@ class STACObject(ABC):
     """The ID of the STAC Object."""
 
     links: List[Link]
-    """A list of :class:`~pystac.Link` objects representing all links associated with this STAC Object."""
-    
+    """A list of :class:`~pystac.Link` objects representing all links associated with
+    this STAC Object."""
+
     stac_extensions: List[str]
     """A list of schema URIs for STAC Extensions implemented by this STAC Object."""
 


### PR DESCRIPTION
**Related Issue(s):** #

#326 
#353 

**Description:**

* Adds docstrings for the extension base classes
* Updates docstrings for the new EO extension classes
* Updates the "Extensions" section of the "Concepts" docs to reflect the new extension structure
* Other fixes to the docs to make the above changes work

I plan on submitting 1-2 more PRs to address the remaining extension documentation work for #326, but I wanted to get feedback on this first since I'll likely use it as a template for the other extensions.

**PR Checklist:**

- [x] Code is formatted (run `scripts/format`)
- [x] Tests pass (run `scripts/test`)
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.