### PR TITLE
Add solar_illumination field in eo extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- solar_illumination field in eo extension ([#356](https://github.com/stac-utils/pystac/issues/356))
+
 ### Changed
 
 ### Fixed

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -185,7 +185,7 @@ class Band:
 
     @property
     def solar_illumination(self) -> Optional[float]:
-        """Get or sets the The solar illumination of the band,
+        """Get or sets the solar illumination of the band,
             as measured at half the maximum transmission, in W/m2/micrometers.
 
         Returns:

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -42,6 +42,7 @@ class Band:
         description: Optional[str] = None,
         center_wavelength: Optional[float] = None,
         full_width_half_max: Optional[float] = None,
+        solar_illumination: Optional[float] = None,
     ) -> None:
         """
         Sets the properties for this Band.
@@ -55,12 +56,15 @@ class Band:
             center_wavelength : The center wavelength of the band, in micrometers (μm).
             full_width_half_max : Full width at half maximum (FWHM). The width of the band,
                 as measured at half the maximum transmission, in micrometers (μm).
+            solar_illumination: The solar illumination of the band, 
+                as measured at half the maximum transmission, in W/m2/micrometers.
         """  # noqa
         self.name = name
         self.common_name = common_name
         self.description = description
         self.center_wavelength = center_wavelength
         self.full_width_half_max = full_width_half_max
+        self.solar_illumination = solar_illumination
 
     @classmethod
     def create(
@@ -70,6 +74,7 @@ class Band:
         description: Optional[str] = None,
         center_wavelength: Optional[float] = None,
         full_width_half_max: Optional[float] = None,
+        solar_illumination: Optional[float] = None,
     ) -> "Band":
         """
         Creates a new band.
@@ -83,6 +88,8 @@ class Band:
             center_wavelength : The center wavelength of the band, in micrometers (μm).
             full_width_half_max : Full width at half maximum (FWHM). The width of the band,
                 as measured at half the maximum transmission, in micrometers (μm).
+            solar_illumination: The solar illumination of the band, 
+                as measured at half the maximum transmission, in W/m2/micrometers.
         """  # noqa
         b = cls({})
         b.apply(
@@ -91,6 +98,7 @@ class Band:
             description=description,
             center_wavelength=center_wavelength,
             full_width_half_max=full_width_half_max,
+            solar_illumination=solar_illumination,
         )
         return b
 
@@ -174,6 +182,23 @@ class Band:
             self.properties["full_width_half_max"] = v
         else:
             self.properties.pop("full_width_half_max", None)
+
+    @property
+    def solar_illumination(self) -> Optional[float]:
+        """Get or sets the The solar illumination of the band,
+            as measured at half the maximum transmission, in W/m2/micrometers.
+
+        Returns:
+            [float]
+        """
+        return self.properties.get("solar_illumination")
+
+    @solar_illumination.setter
+    def solar_illumination(self, v: Optional[float]) -> None:
+        if v is not None:
+            self.properties["solar_illumination"] = v
+        else:
+            self.properties.pop("solar_illumination", None)
 
     def __repr__(self) -> str:
         return "<Band name={}>".format(self.name)

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -56,7 +56,7 @@ class Band:
             center_wavelength : The center wavelength of the band, in micrometers (μm).
             full_width_half_max : Full width at half maximum (FWHM). The width of the band,
                 as measured at half the maximum transmission, in micrometers (μm).
-            solar_illumination: The solar illumination of the band, 
+            solar_illumination: The solar illumination of the band,
                 as measured at half the maximum transmission, in W/m2/micrometers.
         """  # noqa
         self.name = name
@@ -88,7 +88,7 @@ class Band:
             center_wavelength : The center wavelength of the band, in micrometers (μm).
             full_width_half_max : Full width at half maximum (FWHM). The width of the band,
                 as measured at half the maximum transmission, in micrometers (μm).
-            solar_illumination: The solar illumination of the band, 
+            solar_illumination: The solar illumination of the band,
                 as measured at half the maximum transmission, in W/m2/micrometers.
         """  # noqa
         b = cls({})

--- a/tests/data-files/eo/eo-landsat-example.json
+++ b/tests/data-files/eo/eo-landsat-example.json
@@ -65,7 +65,8 @@
           "name": "B1",
           "common_name": "coastal",
           "center_wavelength": 0.44,
-          "full_width_half_max": 0.02
+          "full_width_half_max": 0.02,
+          "solar_illumination": 2000
         }
       ]
     },

--- a/tests/extensions/test_eo.py
+++ b/tests/extensions/test_eo.py
@@ -89,12 +89,21 @@ class EOTest(unittest.TestCase):
 
         # Check adding a new asset
         new_bands = [
-            Band.create(name="red", description=Band.band_description("red"),
-                        solar_illumination=1900),
-            Band.create(name="green", description=Band.band_description("green"),
-                        solar_illumination=1950),
-            Band.create(name="blue", description=Band.band_description("blue"),
-                        solar_illumination=2000),
+            Band.create(
+                name="red",
+                description=Band.band_description("red"),
+                solar_illumination=1900,
+            ),
+            Band.create(
+                name="green",
+                description=Band.band_description("green"),
+                solar_illumination=1950,
+            ),
+            Band.create(
+                name="blue",
+                description=Band.band_description("blue"),
+                solar_illumination=2000,
+            ),
         ]
         asset = pystac.Asset(href="some/path.tif", media_type=pystac.MediaType.GEOTIFF)
         EOExtension.ext(asset).bands = new_bands

--- a/tests/extensions/test_eo.py
+++ b/tests/extensions/test_eo.py
@@ -66,6 +66,7 @@ class EOTest(unittest.TestCase):
         assert asset_bands is not None
         self.assertEqual(len(asset_bands), 1)
         self.assertEqual(asset_bands[0].name, "B1")
+        self.assertEqual(asset_bands[0].solar_illumination, 2000)
 
         index_asset = item.assets["index"]
         asset_bands = EOExtension.ext(index_asset).bands
@@ -88,9 +89,9 @@ class EOTest(unittest.TestCase):
 
         # Check adding a new asset
         new_bands = [
-            Band.create(name="red", description=Band.band_description("red")),
-            Band.create(name="green", description=Band.band_description("green")),
-            Band.create(name="blue", description=Band.band_description("blue")),
+            Band.create(name="red", description=Band.band_description("red"), solar_illumination=1900),
+            Band.create(name="green", description=Band.band_description("green"), solar_illumination=1950),
+            Band.create(name="blue", description=Band.band_description("blue"), solar_illumination=2000),
         ]
         asset = pystac.Asset(href="some/path.tif", media_type=pystac.MediaType.GEOTIFF)
         EOExtension.ext(asset).bands = new_bands

--- a/tests/extensions/test_eo.py
+++ b/tests/extensions/test_eo.py
@@ -89,9 +89,12 @@ class EOTest(unittest.TestCase):
 
         # Check adding a new asset
         new_bands = [
-            Band.create(name="red", description=Band.band_description("red"), solar_illumination=1900),
-            Band.create(name="green", description=Band.band_description("green"), solar_illumination=1950),
-            Band.create(name="blue", description=Band.band_description("blue"), solar_illumination=2000),
+            Band.create(name="red", description=Band.band_description("red"),
+                        solar_illumination=1900),
+            Band.create(name="green", description=Band.band_description("green"),
+                        solar_illumination=1950),
+            Band.create(name="blue", description=Band.band_description("blue"),
+                        solar_illumination=2000),
         ]
         asset = pystac.Asset(href="some/path.tif", media_type=pystac.MediaType.GEOTIFF)
         EOExtension.ext(asset).bands = new_bands


### PR DESCRIPTION
**Related Issue(s):** #356


**Description:**

added solar_illumination field accessor in `eo` extension

**PR Checklist:**

- [X] Code is formatted (run `scripts/format`)
- [X] Tests pass (run `scripts/test`)
- [X] This PR maintains or improves overall codebase code coverage.
- [X] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.