### PR TITLE
Enforce coverage percentage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,5 @@
+[report]
+fail_under = 89
+
 [run]
 source = pystac

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+source = pystac

--- a/scripts/test
+++ b/scripts/test
@@ -55,7 +55,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         echo
 
         # Test suite with coverage enabled
-        coverage run --source=pystac/ -m unittest discover tests/
+        coverage run -m unittest discover tests/
         coverage xml
     fi
 fi


### PR DESCRIPTION
**Related Issue(s):** https://github.com/stac-utils/pystac/issues/331


**Description:** Enforce the current level of code coverage, to make it easy to detect any substantial reduction and to bump it when coverage increases.


**PR Checklist:**

- [x] Code is formatted (run `scripts/format`)
- [x] Tests pass (run `scripts/test`)
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.