### PR TITLE
Fix spec links and shorten line lengths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 ### Fixed
 
+- Links to STAC Spec point to latest supported version ([#368](https://github.com/stac-utils/pystac/pull/368))
+- Links to STAC Extension pages point to repos in `stac-extensions` GitHub org ([#368](https://github.com/stac-utils/pystac/pull/368))
+
 ### Removed
 
 ## [1.0.0-beta.2]

--- a/doc8.ini
+++ b/doc8.ini
@@ -1,0 +1,4 @@
+[doc8]
+
+ignore-path=docs/_build,docs/tutorials
+max-line-length=88

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2,7 +2,8 @@ API Reference
 =============
 
 This API reference is auto-generated for the Python docstrings,
-and organized by the section of the `STAC Spec <https://github.com/radiantearth/stac-spec/tree/v1.0.0-beta.2>`_ they relate to, if related to a specific spec item.
+and organized by the section of the :stac-spec:`STAC Spec <>` they relate to, if related
+to a specific spec item.
 
 pystac
 ------
@@ -13,7 +14,11 @@ pystac
 STACObject
 ----------
 
-STACObject is the base class for :class:`Catalog <pystac.Catalog>`, :class:`Collection <pystac.Collection>` and :class:`Item <pystac.Item>`, and contains a variety of useful methods for dealing with links, copying objects, accessing extensions, and reading and writing files. You shouldn't use STACObject directly, but instead access this functionality through the implementing classes.
+STACObject is the base class for :class:`Catalog <pystac.Catalog>`, :class:`Collection
+<pystac.Collection>` and :class:`Item <pystac.Item>`, and contains a variety of useful
+methods for dealing with links, copying objects, accessing extensions, and reading and
+writing files. You shouldn't use STACObject directly, but instead access this
+functionality through the implementing classes.
 
 .. autoclass:: pystac.STACObject
    :members:
@@ -28,7 +33,7 @@ STACObject is the base class for :class:`Catalog <pystac.Catalog>`, :class:`Coll
 Catalog Spec
 ------------
 
-These classes are representations of the `Catalog Spec <https://github.com/radiantearth/stac-spec/tree/v1.0.0-beta.2/catalog-spec>`_.
+These classes are representations of the :stac-spec:`Catalog Spec <catalog-spec>`.
 
 Catalog
 ~~~~~~~
@@ -50,7 +55,7 @@ CatalogType
 Collection Spec
 ---------------
 
-These classes are representations of the `Collection Spec <https://github.com/radiantearth/stac-spec/tree/v1.0.0-beta.2/collection-spec>`_.
+These classes are representations of the :stac-spec:`Collection Spec <collection-spec>`.
 
 Collection
 ~~~~~~~~~~
@@ -98,7 +103,7 @@ Summaries
 Item Spec
 ---------
 
-These classes are representations of the `Item Spec <https://github.com/radiantearth/stac-spec/tree/v1.0.0-beta.2/item-spec>`_.
+These classes are representations of the :stac-spec:`Item Spec <item-spec>`.
 
 Item
 ~~~~
@@ -154,7 +159,8 @@ IO
 STAC_IO
 ~~~~~~~
 
-STAC_IO is the utility mechanism that PySTAC uses for reading and writing. Users of PySTAC can hook into PySTAC by overriding members to utilize their own IO methods.
+STAC_IO is the utility mechanism that PySTAC uses for reading and writing. Users of
+PySTAC can hook into PySTAC by overriding members to utilize their own IO methods.
 
 .. autoclass:: pystac.stac_io.STAC_IO
    :members:
@@ -228,7 +234,7 @@ ExtensionManagementMixin
 Electro-Optical Extension
 -------------------------
 
-These classes are representations of the `EO Extension Spec <https://github.com/radiantearth/stac-spec/tree/v1.0.0-beta.2/extensions/eo>`_.
+These classes are representations of the :stac-ext:`EO Extension Spec <eo>`.
 
 Band
 ~~~~
@@ -272,7 +278,7 @@ SummariesEOExtension
 Label Extension
 ---------------
 
-These classes are representations of the `Label Extension Spec <https://github.com/radiantearth/stac-spec/tree/v1.0.0-beta.2/extensions/label>`_.
+These classes are representations of the :stac-ext:`Label Extension Spec <label>`.
 
 LabelItemExt
 ~~~~~~~~~~~~
@@ -329,7 +335,7 @@ LabelStatistics
 Pointcloud Extension
 --------------------
 
-Implements the `Point Cloud Extension <https://github.com/radiantearth/stac-spec/tree/v1.0.0-beta.2/extensions/pointcloud>`_.
+Implements the :stac-ext:`Point Cloud Extension <pointcloud>`.
 
 PointcloudItemExt
 ~~~~~~~~~~~~~~~~~
@@ -359,7 +365,7 @@ ProjectionItemExt
 Timestamps Extension
 --------------------
 
-Implements the `Timestamps Extension <https://github.com/radiantearth/stac-spec/tree/v1.0.0-beta.2/extensions/timestamps>`_.
+Implements the :stac-ext:`Timestamps Extension <timestamps>`.
 
 TimestampsItemExt
 ~~~~~~~~~~~~~~~~~
@@ -374,7 +380,7 @@ TimestampsItemExt
 SAR Extension
 -------------
 
-Implements the `SAR Extension <https://github.com/radiantearth/stac-spec/tree/v1.0.0-beta.2/extensions/sar>`_.
+Implements the :stac-ext:`SAR Extension <sar>`.
 
 SarItemExt
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -389,7 +395,7 @@ SarItemExt
 SAT Extension
 -------------
 
-Implements the `SAT Extension <https://github.com/radiantearth/stac-spec/tree/v1.0.0-beta.2/extensions/sat>`_.
+Implements the :stac-ext:`SAT Extension <sat>`.
 
 SatItemExt
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -404,7 +410,8 @@ SatItemExt
 Single File STAC Extension
 --------------------------
 
-These classes are representations of the `Single File STAC Extension <https://github.com/radiantearth/stac-spec/tree/v1.0.0-beta.2/extensions/single-file-stac>`_.
+These classes are representations of the :stac-ext:`Single File STAC Extension
+<single-file-stac>`.
 
 **TEMPORARILY REMOVED**
 
@@ -423,7 +430,7 @@ SingleFileSTACCatalogExt
 Version Extension
 -----------------
 
-Implements the `Version Extension <https://github.com/radiantearth/stac-spec/tree/v1.0.0-beta.2/extensions/version>`_.
+Implements the :stac-ext:`Version Extension <version>`.
 
 VersionRelType
 ~~~~~~~~~~~~~~
@@ -431,7 +438,7 @@ VersionRelType
 .. autoclass:: pystac.extensions.version.VersionRelType
    :members:
    :show-inheritance:
-   
+
 VersionCollectionExt
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -455,7 +462,7 @@ VersionItemExt
 View Geometry Extension
 -----------------------
 
-Implements the `View Geometry Extension <https://github.com/radiantearth/stac-spec/tree/v1.0.0-beta.2/extensions/view>`_.
+Implements the :stac-ext:`View Geometry Extension <view>`.
 
 ViewItemExt
 ~~~~~~~~~~~
@@ -529,10 +536,10 @@ STACValidator
 SchemaUriMap
 ~~~~~~~~~~~~
 
-A ``SchemaMapUri`` defines methods for mapping STAC versions, object types and extension ids to
-schema URIs. A default implementation is included that uses known locations; however users
-can provide their own schema URI maps in a :class:`~pystac.validation.JsonSchemaSTACValidator`
-to modify the URIs used.
+A ``SchemaMapUri`` defines methods for mapping STAC versions, object types and extension
+ids to schema URIs. A default implementation is included that uses known locations;
+however users can provide their own schema URI maps in a
+:class:`~pystac.validation.JsonSchemaSTACValidator` to modify the URIs used.
 
 .. .. autoclass:: pystac.validation.SchemaUriMap
 ..    :members:

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -1,13 +1,15 @@
 Concepts
 ########
 
-This page will give an overview of some important concepts to understand when working with PySTAC. If you want to check code examples, see the :ref:`tutorials`.
+This page will give an overview of some important concepts to understand when working
+with PySTAC. If you want to check code examples, see the :ref:`tutorials`.
 
 Reading STACs
 =============
 
-PySTAC can read STAC data from JSON. Generally users read in the root catalog, and then use the python objects to crawl through the data. Once you read in the root of the STAC, you can
-work with the STAC in memory.
+PySTAC can read STAC data from JSON. Generally users read in the root catalog, and then
+use the python objects to crawl through the data. Once you read in the root of the STAC,
+you can work with the STAC in memory.
 
 .. code-block:: python
 
@@ -18,15 +20,20 @@ work with the STAC in memory.
    for root, catalogs, items in catalog.walk():
        # Do interesting things with the STAC data.
 
-To see how to hook into PySTAC for reading from alternate URIs such as cloud object storage,
-see :ref:`using stac_io`.
+To see how to hook into PySTAC for reading from alternate URIs such as cloud object
+storage, see :ref:`using stac_io`.
 
 Writing STACs
 =============
 
-While working with STACs in-memory don't require setting file paths, in order to save a STAC,
-you'll need to give each STAC object a ``self`` link that describes the location of where
-it should be saved to. Luckily, PySTAC makes it easy to create a STAC catalog with a `canonical layout <https://github.com/radiantearth/stac-spec/blob/v1.0.0-beta.2/best-practices.md#catalog-layout>`_ and with the links that follow the `best practices <https://github.com/radiantearth/stac-spec/blob/v1.0.0-beta.2/best-practices.md#use-of-links>`_. You simply call ``normalize_hrefs`` with the root directory of where the STAC will be saved, and then call ``save`` with the type of catalog (described in the :ref:`catalog types` section) that matches your use case.
+While working with STACs in-memory don't require setting file paths, in order to save a
+STAC, you'll need to give each STAC object a ``self`` link that describes the location
+of where it should be saved to. Luckily, PySTAC makes it easy to create a STAC catalog
+with a :stac-spec:`canonical layout <best-practices.md#catalog-layout>` and with the
+links that follow the :stac-spec:`best practices <best-practices.md#use-of-links>`. You
+simply call ``normalize_hrefs`` with the root directory of where the STAC will be saved,
+and then call ``save`` with the type of catalog (described in the :ref:`catalog types`
+section) that matches your use case.
 
 .. code-block:: python
 
@@ -50,7 +57,8 @@ Catalog, Collection and Items, all based off of the root URI that is passed in:
     catalog.normalize_hrefs('/some/location')
     catalog.save(catalog_type=CatalogType.SELF_CONTAINED)
 
-This will lay out the HREFs of the STAC according to the `best practices document <https://github.com/radiantearth/stac-spec/blob/v1.0.0-beta.2/best-practices.md>`_.
+This will lay out the HREFs of the STAC according to the :stac-spec:`best practices
+document <best-practices.md>`.
 
 Layouts
 ~~~~~~~
@@ -74,16 +82,18 @@ variable. For example:
     catalog.normalize_hrefs('/some/location', strategy=strategy)
     catalog.save(catalog_type=CatalogType.SELF_CONTAINED)
 
-The above code will save items in subfolders based on the collection ID, year and month of
-it's datetime (or start_datetime if a date range is defined and no datetime is defined).
+The above code will save items in subfolders based on the collection ID, year and month
+of it's datetime (or start_datetime if a date range is defined and no datetime is
+defined).
 
 You can use dot notation to specify attributes of objects or keys in dictionaries for
-template variables. PySTAC will look at the object, it's ``properties`` and its ``extra_fields``
-for property names or dictionary keys. Some special cases, like ``year``, ``month``, ``day`` and
-``date`` exist for datetime on Items, as well as ``collection`` for Item's Collection's ID.
+template variables. PySTAC will look at the object, it's ``properties`` and its
+``extra_fields`` for property names or dictionary keys. Some special cases, like
+``year``, ``month``, ``day`` and ``date`` exist for datetime on Items, as well as
+``collection`` for Item's Collection's ID.
 
-See the documentation on :class:`~pystac.layout.LayoutTemplate` for more documentation on
-how layout templates work.
+See the documentation on :class:`~pystac.layout.LayoutTemplate` for more documentation
+on how layout templates work.
 
 Using custom functions
 ''''''''''''''''''''''
@@ -91,51 +101,63 @@ Using custom functions
 If you want to build your own strategy, you can subclass ``HrefLayoutStrategy`` or use
 :class:`~pystac.layout.CustomLayoutStrategy` to provide functions that work with
 Catalogs, Collections or Items. Similar to the templating strategy, you can provide a
-fallback strategy (which defaults to :class:`~pystac.layout.BestPracticesLayoutStrategy`)
-for any stac object type that you don't supply a function for.
+fallback strategy (which defaults to
+:class:`~pystac.layout.BestPracticesLayoutStrategy`) for any stac object type that you
+don't supply a function for.
 
 .. _catalog types:
 
 Catalog Types
 -------------
 
-The STAC `best practices document <https://github.com/radiantearth/stac-spec/blob/v1.0.0-beta.2/best-practices.md>`_ lays out different catalog types, and how their links should be formatted. A brief description is below, but check out the document for the official take on these types:
+The STAC :stac-spec:`best practices document <best-practices.md>` lays out different
+catalog types, and how their links should be formatted. A brief description is below,
+but check out the document for the official take on these types:
 
-The catalog types will also dictate the asset HREF formats. Asset HREFs in any catalog type can be relative or absolute may be absolute depending on their location; see the section on :ref:`rel vs abs asset` below.
+The catalog types will also dictate the asset HREF formats. Asset HREFs in any catalog
+type can be relative or absolute may be absolute depending on their location; see the
+section on :ref:`rel vs abs asset` below.
 
 
 Self-Contained Catalogs
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-A self-contained catalog (indicated by ``catalog_type=CatalogType.SELF_CONTAINED``) applies
-to STACs that do not have a long term location, and can be moved around. These STACs are
-useful for copying data to and from locations, without having to change any link metadata.
+A self-contained catalog (indicated by ``catalog_type=CatalogType.SELF_CONTAINED``)
+applies to STACs that do not have a long term location, and can be moved around. These
+STACs are useful for copying data to and from locations, without having to change any
+link metadata.
 
 A self-contained catalog has two important properties:
 
 - It contains only relative links
 - It contains **no** self links.
 
-For a catalog that is the most easy to copy around, it's recommended that item assets use relative links, and reside in the same directory as the item's STAC metadata file.
+For a catalog that is the most easy to copy around, it's recommended that item assets
+use relative links, and reside in the same directory as the item's STAC metadata file.
 
 Relative Published Catalogs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A relative published catalog (indicated by ``catalog_type=CatalogType.RELATIVE_PUBLISHED``) is
-one that is tied at it's root to a specific location, but otherwise contains relative links.
-This is designed so that a self-contained catalog can be 'published' online by just adding
-one field (the self link) to its root catalog.
+A relative published catalog (indicated by
+``catalog_type=CatalogType.RELATIVE_PUBLISHED``) is one that is tied at it's root to a
+specific location, but otherwise contains relative links. This is designed so that a
+self-contained catalog can be 'published' online by just adding one field (the self
+link) to its root catalog.
 
 A relative published catalog has the following properties:
 
-- It contains **only one** self link: the root of the catalog contains a (necessarily absolute) link to it's published location.
+- It contains **only one** self link: the root of the catalog contains a (necessarily
+  absolute) link to it's published location.
 - All other objects in the STAC contain relative links, and no self links.
 
 
 Absolute Published Catalogs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-An absolute published catalog (indicated by ``catalog_type=CatalogType.ABSOLUTE_PUBLISHED``) uses absolute links for everything. It is preferable where possible, since it allows for the easiest provenance tracking out of all the catalog types.
+An absolute published catalog (indicated by
+``catalog_type=CatalogType.ABSOLUTE_PUBLISHED``) uses absolute links for everything. It
+is preferable where possible, since it allows for the easiest provenance tracking out of
+all the catalog types.
 
 An absolute published catalog has the following properties:
 
@@ -155,40 +177,71 @@ Relative vs Absolute Link HREFs
 
 Absolute links point to their file locations in a fully described way. Relative links
 are relative to the linking object's file location. For example, if a catalog at
-``/some/location/catalog.json`` has a link to an item that has an HREF set to ``item-id/item-id.json``,
-then that link should resolve to the absolute path ``/some/location/item-id/item-id.json``.
+``/some/location/catalog.json`` has a link to an item that has an HREF set to
+``item-id/item-id.json``, then that link should resolve to the absolute path
+``/some/location/item-id/item-id.json``.
 
-Links are set as absolute or relative HREFs at save time, as determine by the root catalog's catalog_type
-:attr:`~pystac.Catalog.catalog_type`. This means that, even if the stored HREF of the link is absolute,
-if the root ``catalog_type=CatalogType.RELATIVE_PUBLISHED`` or ``catalog_type=CatalogType.SELF_CONTAINED``
-and subsequent serializing of the any links in the catalog will produce a relative link,
-based on the self link of the parent object.
+Links are set as absolute or relative HREFs at save time, as determine by the root
+catalog's catalog_type :attr:`~pystac.Catalog.catalog_type`. This means that, even if
+the stored HREF of the link is absolute, if the root
+``catalog_type=CatalogType.RELATIVE_PUBLISHED`` or
+``catalog_type=CatalogType.SELF_CONTAINED`` and subsequent serializing of the any links
+in the catalog will produce a relative link, based on the self link of the parent
+object.
 
-You can make all the links of a catalog relative or absolute by setting the :func:`Catalog.catalog_type` field
-then resaving the entire catalog.
+You can make all the links of a catalog relative or absolute by setting the
+:func:`Catalog.catalog_type` field then resaving the entire catalog.
 
 .. _rel vs abs asset:
 
 Relative vs Absolute Asset HREFs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Asset HREFs can also be relative or absolute. If an asset HREF is relative, then it is relative to the Item's metadata file. For example, if the item at ``/some/location/item-id/item-id.json`` had an asset with an HREF of ``./image.tif``, then the fully resolved path for that image would be ``/some/location/item-id/image.tif``
+Asset HREFs can also be relative or absolute. If an asset HREF is relative, then it is
+relative to the Item's metadata file. For example, if the item at
+``/some/location/item-id/item-id.json`` had an asset with an HREF of ``./image.tif``,
+then the fully resolved path for that image would be
+``/some/location/item-id/image.tif``
 
-You can make all the asset HREFs of a catalog relative or absolute using the :func:`Catalog.make_all_asset_hrefs_relative <pystac.Catalog.make_all_asset_hrefs_relative>` and :func:`Catalog.make_all_asset_hrefs_absolute <pystac.Catalog.make_all_asset_hrefs_absolute>` methods. Note that these will not move any files around, and if the file location does not share a common parent with the asset's item's self HREF, then the asset HREF will remain absolute as no relative path is possible.
+You can make all the asset HREFs of a catalog relative or absolute using the
+:func:`Catalog.make_all_asset_hrefs_relative
+<pystac.Catalog.make_all_asset_hrefs_relative>` and
+:func:`Catalog.make_all_asset_hrefs_absolute
+<pystac.Catalog.make_all_asset_hrefs_absolute>` methods. Note that these will not move
+any files around, and if the file location does not share a common parent with the
+asset's item's self HREF, then the asset HREF will remain absolute as no relative path
+is possible.
 
 Including a ``self`` link
 -------------------------
 
-Every stac object has a :func:`~pystac.STACObject.save_object` method, that takes as an argument whether or not to include the object's self link. As noted in the section on :ref:`catalog types`, a self link is necessarily absolute; if an object only contains relative links, then it cannot contain the self link. PySTAC uses self links as a way of tracking the object's file location, either what it was read from or it's pending save location, so each object can have a self link even if you don't ever want that self link written (e.g. if you are working with self-contained catalogs).
+Every stac object has a :func:`~pystac.STACObject.save_object` method, that takes as an
+argument whether or not to include the object's self link. As noted in the section on
+:ref:`catalog types`, a self link is necessarily absolute; if an object only contains
+relative links, then it cannot contain the self link. PySTAC uses self links as a way of
+tracking the object's file location, either what it was read from or it's pending save
+location, so each object can have a self link even if you don't ever want that self link
+written (e.g. if you are working with self-contained catalogs).
 
 .. _using stac_io:
 
 Using STAC_IO
 =============
 
-The :class:`~pystac.STAC_IO` class is the way PySTAC reads and writes text from file locations. Since PySTAC aims to be dependency-free, there is no default mechanisms to read and write from anything but the local file system. However, users of PySTAC may want to read and write from other file systems, such as HTTP or cloud object storage. STAC_IO allows users to hook into PySTAC and define their own reading and writing primitives to allow for those use cases.
+The :class:`~pystac.STAC_IO` class is the way PySTAC reads and writes text from file
+locations. Since PySTAC aims to be dependency-free, there is no default mechanisms to
+read and write from anything but the local file system. However, users of PySTAC may
+want to read and write from other file systems, such as HTTP or cloud object storage.
+STAC_IO allows users to hook into PySTAC and define their own reading and writing
+primitives to allow for those use cases.
 
-To enable reading from other types of file systems, it is recommended that in the `__init__.py` of the client module, or at the beginning of the script using PySTAC, you overwrite the :func:`STAC_IO.read_text_method <pystac.STAC_IO.read_text_method>` and :func:`STAC_IO.write_text_method <pystac.STAC_IO.write_text_method>` members of STAC_IO with functions that read and write however you need. For example, this code will allow for reading from AWS's S3 cloud object storage using `boto3 <https://boto3.amazonaws.com/v1/documentation/api/latest/index.html>`_:
+To enable reading from other types of file systems, it is recommended that in the
+`__init__.py` of the client module, or at the beginning of the script using PySTAC, you
+overwrite the :func:`STAC_IO.read_text_method <pystac.STAC_IO.read_text_method>` and
+:func:`STAC_IO.write_text_method <pystac.STAC_IO.write_text_method>` members of STAC_IO
+with functions that read and write however you need. For example, this code will allow
+for reading from AWS's S3 cloud object storage using `boto3
+<https://boto3.amazonaws.com/v1/documentation/api/latest/index.html>`_:
 
 .. code-block:: python
 
@@ -220,7 +273,9 @@ To enable reading from other types of file systems, it is recommended that in th
    STAC_IO.read_text_method = my_read_method
    STAC_IO.write_text_method = my_write_method
 
-If you are only going to read from another source, e.g. HTTP, you could only replace the read method. For example, using the `requests library <https://requests.kennethreitz.org/en/master>`_:
+If you are only going to read from another source, e.g. HTTP, you could only replace the
+read method. For example, using the `requests library
+<https://requests.kennethreitz.org/en/master>`_:
 
 .. code-block:: python
 
@@ -240,33 +295,39 @@ If you are only going to read from another source, e.g. HTTP, you could only rep
 Validation
 ==========
 
-PySTAC includes validation functionality that allows users to validate PySTAC objects as well JSON-encoded STAC objects from STAC versions `0.8.0` and later.
+PySTAC includes validation functionality that allows users to validate PySTAC objects as
+well JSON-encoded STAC objects from STAC versions `0.8.0` and later.
 
 Enabling validation
 -------------------
 
-To enable the validation feature you'll need to have installed PySTAC with the optional dependency via:
+To enable the validation feature you'll need to have installed PySTAC with the optional
+dependency via:
 
 .. code-block:: bash
 
    > pip install pystac[validation]
 
-This installs the ``jsonschema`` package which is used with the default validator. If you
-define your own validation class as described below, you are not required to have this
-extra dependency.
+This installs the ``jsonschema`` package which is used with the default validator. If
+you define your own validation class as described below, you are not required to have
+this extra dependency.
 
 Validating PySTAC objects
 -------------------------
 
-You can validate any :class:`~pystac.Catalog`, :class:`~pystac.Collection` or :class:`~pystac.Item` by calling the :meth:`~pystac.STACObject.validate` method:
+You can validate any :class:`~pystac.Catalog`, :class:`~pystac.Collection` or
+:class:`~pystac.Item` by calling the :meth:`~pystac.STACObject.validate` method:
 
 .. code-block:: python
 
    item.validate()
 
-This will validate against the latest set of JSON schemas hosted at https://schemas.stacspec.org, including any extensions that the object extends. If there are validation errors, a :class:`~pystac.validation.STACValidationError` will be raised.
+This will validate against the latest set of JSON schemas hosted at
+https://schemas.stacspec.org, including any extensions that the object extends. If there
+are validation errors, a :class:`~pystac.validation.STACValidationError` will be raised.
 
-You can also call :meth:`~pystac.Catalog.validate_all` on a Catalog or Collection to recursively walk through a catalog and validate all objects within it.
+You can also call :meth:`~pystac.Catalog.validate_all` on a Catalog or Collection to
+recursively walk through a catalog and validate all objects within it.
 
 .. code-block:: python
 
@@ -275,7 +336,8 @@ You can also call :meth:`~pystac.Catalog.validate_all` on a Catalog or Collectio
 Validating STAC JSON
 --------------------
 
-You can validate STAC JSON represented as a ``dict`` using the :meth:`pystac.validation.validate_dict` method:
+You can validate STAC JSON represented as a ``dict`` using the
+:meth:`pystac.validation.validate_dict` method:
 
 .. code-block:: python
 
@@ -286,8 +348,8 @@ You can validate STAC JSON represented as a ``dict`` using the :meth:`pystac.val
        js = json.load(f)
    validate_dict(js)
 
-You can also recursively validate all of the catalogs, collections and items across STAC versions
-using the :meth:`pystac.validation.validate_all` method:
+You can also recursively validate all of the catalogs, collections and items across STAC
+versions using the :meth:`pystac.validation.validate_all` method:
 
 .. code-block:: python
 
@@ -301,19 +363,25 @@ using the :meth:`pystac.validation.validate_all` method:
 Using your own validator
 ------------------------
 
-By default PySTAC uses the :class:`~pystac.validation.JsonSchemaSTACValidator` implementation for validation. Users can define their own implementations of :class:`~pystac.validation.STACValidator` and register it with pystac using :meth:`pystac.validation.set_validator`.
+By default PySTAC uses the :class:`~pystac.validation.JsonSchemaSTACValidator`
+implementation for validation. Users can define their own implementations of
+:class:`~pystac.validation.STACValidator` and register it with pystac using
+:meth:`pystac.validation.set_validator`.
 
-The :class:`~pystac.validation.JsonSchemaSTACValidator` takes a :class:`~pystac.validation.SchemaUriMap`, which by default uses the :class:`~pystac.validation.schema_uri_map.DefaultSchemaUriMap`. If desirable, users cn create their own implementation of :class:`~pystac.validation.SchemaUriMap` and register a new instance of :class:`~pystac.validation.JsonSchemaSTACValidator` using that schema map with :meth:`pystac.validation.set_validator`.
-
+The :class:`~pystac.validation.JsonSchemaSTACValidator` takes a
+:class:`~pystac.validation.SchemaUriMap`, which by default uses the
+:class:`~pystac.validation.schema_uri_map.DefaultSchemaUriMap`. If desirable, users cn
+create their own implementation of :class:`~pystac.validation.SchemaUriMap` and register
+a new instance of :class:`~pystac.validation.JsonSchemaSTACValidator` using that schema
+map with :meth:`pystac.validation.set_validator`.
 
 Extensions
 ==========
 
-From the documentation on `STAC Spec Extensions 
-<https://github.com/radiantearth/stac-spec/tree/master/extensions>`__:
+From the documentation on :stac-spec:`STAC Spec Extensions <extensions>`:
 
    Extensions to the core STAC specification provide additional JSON fields that can be
-   used to better describe the data. Most tend to be about describing a particular 
+   used to better describe the data. Most tend to be about describing a particular
    domain or type of data, but some imply functionality.
 
 This library makes an effort to support all extensions that are part of the
@@ -375,8 +443,9 @@ can therefore mutate those properties.* For instance:
    print(item.properties["eo:cloud_cover"])
    # 45
 
-There is also a :attr:`~pystac.extensions.base.PropertiesExtension.additional_read_properties`
-attribute that, if present, gives read-only access to properties of any objects that own the
+There is also a
+:attr:`~pystac.extensions.base.PropertiesExtension.additional_read_properties` attribute
+that, if present, gives read-only access to properties of any objects that own the
 extended object. For instance, an extended :class:`pystac.Asset` instance would have
 read access to the properties of the :class:`pystac.Item` that owns it (if there is
 one). If a property exists in both additional_read_properties and properties, the value
@@ -407,7 +476,8 @@ extension implementations that extend existing STAC objects should inherit from 
 :class:`~pystac.extensions.base.ExtensionManagementMixin` class, and will therefore have
 this method available. The
 :meth:`~pystac.extensions.base.ExtensionManagementMixin.add_to` adds the correct schema
-URI to the :attr:`~pystac.STACObject.stac_extensions` list for the object being extended.
+URI to the :attr:`~pystac.STACObject.stac_extensions` list for the object being
+extended.
 
 .. code-block:: python
 
@@ -429,20 +499,34 @@ Extension classes like :class:`~pystac.extensions.eo.EOExtension` may also provi
 method returns a class inheriting from
 :class:`pystac.extensions.base.SummariesExtension` that provides tools for summarizing
 the properties defined by that extension. These classes also hold a reference to the
-Collection's :class:`pystac.Summaries` instance in the ``summaries`` attribute. 
+Collection's :class:`pystac.Summaries` instance in the ``summaries`` attribute.
 
 See :class:`pystac.extensions.eo.SummariesEOExtension` for an example implementation.
 
 Item Asset properties
 =====================
 
-Properties that apply to Items can be found in two places: the Item's properties or in any of an Item's Assets. If the property is on an Asset, it applies only that specific asset. For example, gsd defined for an Item represents the best Ground Sample Distance (resolution) for the data within the Item. However, some assets may be lower resolution and thus have a higher gsd. In that case, the `gsd` can be found on the Asset.
+Properties that apply to Items can be found in two places: the Item's properties or in
+any of an Item's Assets. If the property is on an Asset, it applies only that specific
+asset. For example, gsd defined for an Item represents the best Ground Sample Distance
+(resolution) for the data within the Item. However, some assets may be lower resolution
+and thus have a higher gsd. In that case, the `gsd` can be found on the Asset.
 
-See the STAC documentation on `Additional Fields for Assets <https://github.com/radiantearth/stac-spec/blob/v1.0.0-beta.2/item-spec/item-spec.md#additional-fields-for-assets>`_ and the relevant `Best Practices <https://github.com/radiantearth/stac-spec/blob/v1.0.0-beta.2/best-practices.md#common-use-cases-of-additional-fields-for-assets>`__ for more information.
+See the STAC documentation on :stac-spec:`Additional Fields for Assets
+<item-spec/item-spec.md#additional-fields-for-assets>` and the relevant :stac-spec:`Best
+Practices <best-practices.md#common-use-cases-of-additional-fields-for-assets>` for more
+information.
 
-The implementation of this feature in PySTAC uses the method described here and is consistent across Item and ItemExtensions. The bare property names represent values for the Item only, but for each property where it is possible to set on both the Item or the Asset there is a ``get_`` and ``set_`` methods that optionally take an Asset. For the ``get_`` methods, if the property is found on the Asset, the Asset's value is used; otherwise the Item's value will be used. For the ``set_`` method, if an Asset is passed in the value will be applied to the Asset and not the Item.
+The implementation of this feature in PySTAC uses the method described here and is
+consistent across Item and ItemExtensions. The bare property names represent values for
+the Item only, but for each property where it is possible to set on both the Item or the
+Asset there is a ``get_`` and ``set_`` methods that optionally take an Asset. For the
+``get_`` methods, if the property is found on the Asset, the Asset's value is used;
+otherwise the Item's value will be used. For the ``set_`` method, if an Asset is passed
+in the value will be applied to the Asset and not the Item.
 
-For example, if we have an Item with a ``gsd`` of 10 with three bands, and only asset "band3" having a ``gsd`` of 20, the ``get_gsd`` method will behave in the following way:
+For example, if we have an Item with a ``gsd`` of 10 with three bands, and only asset
+"band3" having a ``gsd`` of 20, the ``get_gsd`` method will behave in the following way:
 
   .. code-block:: python
 
@@ -451,7 +535,8 @@ For example, if we have an Item with a ``gsd`` of 10 with three bands, and only 
      assert item.common_metadata.get_gsd(item.asset['band1']) == 10
      assert item.common_metadata.get_gsd(item.asset['band3']) == 20
 
-Similarly, if we set the asset at 'band2' to have a ``gsd`` of 30, it will only affect that asset:
+Similarly, if we set the asset at 'band2' to have a ``gsd`` of 30, it will only affect
+that asset:
 
   .. code-block:: python
 
@@ -462,14 +547,18 @@ Similarly, if we set the asset at 'band2' to have a ``gsd`` of 30, it will only 
 Manipulating STACs
 ==================
 
-PySTAC is designed to allow for STACs to be manipulated in-memory. This includes :ref:`copy stacs`, walking over all objects in a STAC and mutating their properties, or using collection-style `map` methods for mapping over items.
+PySTAC is designed to allow for STACs to be manipulated in-memory. This includes
+:ref:`copy stacs`, walking over all objects in a STAC and mutating their properties, or
+using collection-style `map` methods for mapping over items.
 
 
 Walking over a STAC
 -------------------
 
 You can walk through all sub-catalogs and items of a catalog with a method inspired
-by the Python Standard Library `os.walk() <https://docs.python.org/3/library/os.html#os.walk>`_ method: :func:`Catalog.walk() <pystac.Catalog.walk>`:
+by the Python Standard Library `os.walk()
+<https://docs.python.org/3/library/os.html#os.walk>`_ method: :func:`Catalog.walk()
+<pystac.Catalog.walk>`:
 
 .. code-block:: python
 
@@ -488,7 +577,12 @@ by the Python Standard Library `os.walk() <https://docs.python.org/3/library/os.
 Mapping over Items
 ------------------
 
-The :func:`Catalog.map_items <pystac.Catalog.map_items>` method is useful for manipulating items in a STAC. This will create a full copy of the STAC, so will leave the original catalog unmodified. In the method that manipulates and returns the modified item, you can return multiple items, in case you are generating new objects (e.g. creating a :class:`~pystac.LabelItem` for image items in a stac), or splitting items into smaller chunks (e.g. tiling out large image items).
+The :func:`Catalog.map_items <pystac.Catalog.map_items>` method is useful for
+manipulating items in a STAC. This will create a full copy of the STAC, so will leave
+the original catalog unmodified. In the method that manipulates and returns the modified
+item, you can return multiple items, in case you are generating new objects (e.g.
+creating a :class:`~pystac.LabelItem` for image items in a stac), or splitting items
+into smaller chunks (e.g. tiling out large image items).
 
 .. code-block:: python
 
@@ -529,42 +623,80 @@ The :func:`Catalog.map_items <pystac.Catalog.map_items>` method is useful for ma
 Copying STACs in-memory
 -----------------------
 
-The in-memory copying of STACs to create new ones is crucial to correct manipulations and mutations of STAC data. The :func:`STACObject.full_copy <pystac.STACObject.full_copy>` mechanism handles this in a way that ties the elements of the copies STAC together correctly. This includes situations where there might be cycles in the graph of connected objects of the STAC (which otherwise would be `a tree <https://en.wikipedia.org/wiki/Tree_(graph_theory)>`_). For example, if a :class:`~pystac.LabelItem` lists a :attr:`~pystac.LabelItem.source` that is an item also contained in the root catalog; the full copy of the STAC will ensure that the :class:`~pystac.Item` instance representing the source imagery item is the same instance that is linked to by the :class:`~pystac.LabelItem`.
+The in-memory copying of STACs to create new ones is crucial to correct manipulations
+and mutations of STAC data. The :func:`STACObject.full_copy
+<pystac.STACObject.full_copy>` mechanism handles this in a way that ties the elements of
+the copies STAC together correctly. This includes situations where there might be cycles
+in the graph of connected objects of the STAC (which otherwise would be `a tree
+<https://en.wikipedia.org/wiki/Tree_(graph_theory)>`_). For example, if a
+:class:`~pystac.LabelItem` lists a :attr:`~pystac.LabelItem.source` that is an item also
+contained in the root catalog; the full copy of the STAC will ensure that the
+:class:`~pystac.Item` instance representing the source imagery item is the same instance
+that is linked to by the :class:`~pystac.LabelItem`.
 
 Resolving STAC objects
 ======================
 
-PySTAC tries to only "resolve" STAC Objects - that is, load the metadata contained by STAC files pointed to by links into Python objects in-memory - when necessary. It also ensures that two links that point to the same object resolve to the same in-memory object.
+PySTAC tries to only "resolve" STAC Objects - that is, load the metadata contained by
+STAC files pointed to by links into Python objects in-memory - when necessary. It also
+ensures that two links that point to the same object resolve to the same in-memory
+object.
 
 Lazy resolution of STAC objects
 -------------------------------
 
-Links are read only when they need to be. For instance, when you load a catalog using :func:`Catalog.from_file <pystac.Catalog.from_file>`, the catalog and all of its links are read into a :class:`~pystac.Catalog` instance. If you iterate through :attr:`Catalog.links <pystac.Catalog.links>`, you'll see the :attr:`~pystac.Link.target` of the :class:`~pystac.Link` will refer to a string - that is the HREF of the link. However, if you call :func:`Catalog.get_items <pystac.Catalog.get_items>`, for instance, you'll get back the actual :class:`~pystac.Item` instances that are referred to by each item link in the Catalog. That's because at the time you call ``get_items``, PySTAC is "resolving" the links for any link that represents an item in the catalog.
+Links are read only when they need to be. For instance, when you load a catalog using
+:func:`Catalog.from_file <pystac.Catalog.from_file>`, the catalog and all of its links
+are read into a :class:`~pystac.Catalog` instance. If you iterate through
+:attr:`Catalog.links <pystac.Catalog.links>`, you'll see the :attr:`~pystac.Link.target`
+of the :class:`~pystac.Link` will refer to a string - that is the HREF of the link.
+However, if you call :func:`Catalog.get_items <pystac.Catalog.get_items>`, for instance,
+you'll get back the actual :class:`~pystac.Item` instances that are referred to by each
+item link in the Catalog. That's because at the time you call ``get_items``, PySTAC is
+"resolving" the links for any link that represents an item in the catalog.
 
-The resolution mechanism is accomplished through :func:`Link.resolve_stac_object <pystac.Link.resolve_stac_object>`. Though this method is used extensively internally to PySTAC, ideally this is completely transparent to users of PySTAC, and you won't have to worry about how and when links get resolved. However, one important aspect to understand is how object resolution caching happens.
+The resolution mechanism is accomplished through :func:`Link.resolve_stac_object
+<pystac.Link.resolve_stac_object>`. Though this method is used extensively internally to
+PySTAC, ideally this is completely transparent to users of PySTAC, and you won't have to
+worry about how and when links get resolved. However, one important aspect to understand
+is how object resolution caching happens.
 
 Resolution Caching
 ------------------
 
-The root :class:`~pystac.Catalog` instance of a STAC (the Catalog which is linked to by every associated object's ``root`` link) contains a cache of resolved objects. This cache points to in-memory instances of :class:`~pystac.STACObject` s that have already been resolved through PySTAC crawling links associated with that root catalog. The cache works off of the stac object's ID, which is why **it is necessary for every STAC object in the catalog to have a unique identifier, which is unique across the entire STAC**.
+The root :class:`~pystac.Catalog` instance of a STAC (the Catalog which is linked to by
+every associated object's ``root`` link) contains a cache of resolved objects. This
+cache points to in-memory instances of :class:`~pystac.STACObject` s that have already
+been resolved through PySTAC crawling links associated with that root catalog. The cache
+works off of the stac object's ID, which is why **it is necessary for every STAC object
+in the catalog to have a unique identifier, which is unique across the entire STAC**.
 
-When a link is being resolved from a STACObject that has it's root set, that root is passed into the :func:`Link.resolve_stac_object <pystac.Link.resolve_stac_object>` call. That root's :class:`~pystac.resolved_object_cache.ResolvedObjectCache` will be used to ensure that if the link is pointing to an object that has already been resolved, then that link will point to the same, single instance in the cache. This ensures working with STAC objects in memory doesn't create a situation where multiple copies of the same STAC objects are created from different links, manipulated, and written over each other.
+When a link is being resolved from a STACObject that has it's root set, that root is
+passed into the :func:`Link.resolve_stac_object <pystac.Link.resolve_stac_object>` call.
+That root's :class:`~pystac.resolved_object_cache.ResolvedObjectCache` will be used to
+ensure that if the link is pointing to an object that has already been resolved, then
+that link will point to the same, single instance in the cache. This ensures working
+with STAC objects in memory doesn't create a situation where multiple copies of the same
+STAC objects are created from different links, manipulated, and written over each other.
 
 Working with STAC JSON
 ======================
 
-The ``pystac.serialization`` package has some functionality around working directly with STAC
-JSON objects, without utilizing PySTAC object types. This is used internally by PySTAC, but might also be useful to users working directly with JSON (e.g. on validation).
+The ``pystac.serialization`` package has some functionality around working directly with
+STAC JSON objects, without utilizing PySTAC object types. This is used internally by
+PySTAC, but might also be useful to users working directly with JSON (e.g. on
+validation).
 
 
 Identifying STAC objects from JSON
 ----------------------------------
 
 Users can identify STAC information, including the object type, version and extensions,
-from JSON. The main method for this is :func:`~pystac.serialization.identify_stac_object`,
-which returns an object that contains the object type, the range of versions this object is
-valid for (according to PySTAC's best guess), the common extensions implemented by this object,
-and any custom extensions (represented by URIs to JSON Schemas).
+from JSON. The main method for this is
+:func:`~pystac.serialization.identify_stac_object`, which returns an object that
+contains the object type, the range of versions this object is valid for (according to
+PySTAC's best guess), the common extensions implemented by this object, and any custom
+extensions (represented by URIs to JSON Schemas).
 
 .. code-block:: python
 
@@ -589,7 +721,11 @@ and any custom extensions (represented by URIs to JSON Schemas).
 Merging common properties
 -------------------------
 
-For pre-1.0.0 STAC, The :func:`~pystac.serialization.merge_common_properties` will take a JSON dict that represents an item, and if it is associated with a collection, merge in the collection's properties. You can pass in a dict that contains previously read collections that caches collections by the HREF of the collection link and/or the collection ID, which can help avoid multiple reads of
+For pre-1.0.0 STAC, The :func:`~pystac.serialization.merge_common_properties` will take
+a JSON dict that represents an item, and if it is associated with a collection, merge in
+the collection's properties. You can pass in a dict that contains previously read
+collections that caches collections by the HREF of the collection link and/or the
+collection ID, which can help avoid multiple reads of
 collection links.
 
 Note that this feature was dropped in STAC 1.0.0-beta.1

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -108,7 +108,7 @@ html_theme = 'alabaster'
 #
 html_theme_options = {
     "show_powered_by": False,
-    "github_user": "azavea",
+    "github_user": "stac-utils",
     "github_repo": "pystac",
     "github_banner": True,
     "show_related": False,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,7 +62,7 @@ extensions = [
 extlinks = {
     'tutorial': ('https://github.com/azavea/pystac/'
                   'tree/{}/docs/tutorials/%s'.format(git_branch), 'tutorial'),
-    'stac-spec': ('https://github.com/radiantearth/stac-spec/blob/'
+    'stac-spec': ('https://github.com/radiantearth/stac-spec/tree/'
                   'v{}/%s'.format(STACVersion.DEFAULT_STAC_VERSION), 'path'),
     'stac-ext': ('https://github.com/stac-extensions/%s', '%s extension')
 }

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -45,24 +45,32 @@ More details on using ``unittest`` are `here
 Code quality checks
 ^^^^^^^^^^^^^^^^^^^
 
-PySTAC uses `flake8 <http://flake8.pycqa.org/en/latest/>`_ and `yapf
-<https://github.com/google/yapf>`_ for code formatting and style checks.
+PySTAC uses `flake8 <http://flake8.pycqa.org/en/latest/>`_ and`black
+<https://github.com/psf/black>`_ for code formatting and style checks.
 
 To run the flake8 style checks:
 
 .. code-block:: bash
 
-    > flake8 pystac
-    > flake8 tests
+    > flake8 pystac tests
 
 To format code:
 
 .. code-block:: bash
 
-   > yapf -ipr pystac
-   > yapf -ipr tests
+    > ./scripts/format
 
-You can also run the ``./scripts/test`` script to check flake8 and yapf.
+We also use `doc8 <https://github.com/pycqa/doc8>`__ for style checking on RST files in
+the docs.
+
+To check doc formatting:
+
+.. code-block:: bash
+
+    > doc8 docs
+
+You can also run the ``./scripts/test`` script to run unit tests, check code style with
+``flake8`` and ``black``, and check type annotations using ``mypy`` and ``pyright``.
 
 CHANGELOG
 ^^^^^^^^^

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,53 +1,59 @@
 Contributing
 ============
 
-A list of issues and ongoing work is available on the PySTAC `issues page <https://github.com/azavea/pystac/issues>`_. If you want to contribute code, the best way is to coordinate with the core developers via an issue or pull request conversation.
+A list of issues and ongoing work is available on the PySTAC `issues page
+<https://github.com/azavea/pystac/issues>`_. If you want to contribute code, the best
+way is to coordinate with the core developers via an issue or pull request conversation.
 
 Development installation
 ^^^^^^^^^^^^^^^^^^^^^^^^
-Fork PySTAC into your GitHub account. Then, clone the repo and install it locally with pip as follows:
+Fork PySTAC into your GitHub account. Then, clone the repo and install it locally with
+pip as follows:
 
 .. code-block:: bash
 
-	$ git clone git@github.com:your_user_name/pystac.git
-	$ cd  pystac
-	$ pip install -e .
+    $ git clone git@github.com:your_user_name/pystac.git
+    $ cd  pystac
+    $ pip install -e .
 
 Testing
 ^^^^^^^
-PySTAC runs tests using ``unittest``. You can find unit tests in the ``tests/`` directory.
+PySTAC runs tests using ``unittest``. You can find unit tests in the ``tests/``
+directory.
 
 Run a single test with:
 
 .. code-block:: bash
 
-	python -m unittest tests/test_catalog.py
+    python -m unittest tests/test_catalog.py
 
 or an entire folder using:
 
 .. code-block:: bash
 
-	python -m unittest discover -v -s tests/
+    python -m unittest discover -v -s tests/
 
 or the entire project using:
 
 .. code-block:: bash
 
-	./scripts/test
+    ./scripts/test
 
-More details on using ``unittest`` are `here <https://docs.python.org/3/library/unittest.html>`_.
+More details on using ``unittest`` are `here
+<https://docs.python.org/3/library/unittest.html>`_.
 
 Code quality checks
 ^^^^^^^^^^^^^^^^^^^
 
-PySTAC uses `flake8 <http://flake8.pycqa.org/en/latest/>`_ and `yapf <https://github.com/google/yapf>`_ for code formatting and style checks.
+PySTAC uses `flake8 <http://flake8.pycqa.org/en/latest/>`_ and `yapf
+<https://github.com/google/yapf>`_ for code formatting and style checks.
 
 To run the flake8 style checks:
 
 .. code-block:: bash
 
-   > flake8 pystac
-   > flake8 tests
+    > flake8 pystac
+    > flake8 tests
 
 To format code:
 
@@ -66,10 +72,13 @@ to track changes between releases. All PRs should make a changelog entry unless
 the change is trivial (e.g. fixing typos) or is entirely invisible to users who may
 be upgrading versions (e.g. an improvement to the CI system).
 
-For changelog entries, please link to the PR of that change. This needs to happen in a few steps:
+For changelog entries, please link to the PR of that change. This needs to happen in a
+few steps:
 
 - Make a PR to PySTAC with your changes
 - Record the link to the PR
-- Push an additional commit to your branch with the changelog entry with the link to the PR.
+- Push an additional commit to your branch with the changelog entry with the link to the
+  PR.
 
-For more information on changelogs and how to write a good entry, see `keep a changelog <https://keepachangelog.com/en/1.0.0/>`_
+For more information on changelogs and how to write a good entry, see `keep a changelog
+<https://keepachangelog.com/en/1.0.0/>`_.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,11 +24,15 @@ Standard pip install
 PySTAC Features
 ===============
 
-* Reads and writes STAC version 0.8. Future versions will read older versions of STAC, but always write one version.
+* Reads and writes STAC version 0.8. Future versions will read older versions of STAC,
+  but always write one version.
 * Allows in-memory manipulations of STAC catalogs.
-* Allows users to extend the IO of STAC metadata to provide support e.g. cloud providers.
+* Allows users to extend the IO of STAC metadata to provide support e.g. cloud
+  providers.
 * Allows easy iteration over STAC objects. STAC objects are only read in when needed.
-* Allows users to easily write "absolute published", "relative published" and "self-contained" catalogs as `described in the best practices documentation <https://github.com/radiantearth/stac-spec/blob/v0.8.1/best-practices.md#use-of-links>`_.
+* Allows users to easily write "absolute published", "relative published" and
+  "self-contained" catalogs as :stac-spec:`described in the best practices documentation
+  <best-practices.md#use-of-links>`.
 
 Acknowledgments
 ================

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -25,7 +25,11 @@ How to create STAC Catalogs with PySTAC
 - :tutorial:`GitHub version <how-to-create-stac-catalogs.ipynb>`
 - :ref:`Docs version </tutorials/how-to-create-stac-catalogs.ipynb>`
 
-This was a tutorial that was part of a 30 minute presentation at the `community STAC sprint <https://github.com/radiantearth/community-sprints/tree/master/11052019-arlignton-va>`_ in Arlington, VA in November 2019. It runs through creating a STAC of image or label items from the `SpaceNet 5 <https://www.topcoder.com/challenges/30099956>`_ dataset.
+This was a tutorial that was part of a 30 minute presentation at the `community STAC
+sprint
+<https://github.com/radiantearth/community-sprints/tree/master/11052019-arlignton-va>`_
+in Arlington, VA in November 2019. It runs through creating a STAC of image or label
+items from the `SpaceNet 5 <https://www.topcoder.com/challenges/30099956>`_ dataset.
 
 Creating a Landsat 8 STAC
 -------------------------
@@ -33,7 +37,9 @@ Creating a Landsat 8 STAC
 - :tutorial:`GitHub version <creating-a-landsat-stac.ipynb>`
 - :ref:`Docs version </tutorials/creating-a-landsat-stac.ipynb>`
 
-This tutorial was presented at [Cloud Native Geospatial Outreach Day](https://sites.google.com/radiant.earth/cng-agenda/) on September 8th, 2020. It shows how to create a STAC collection from a subset of Landsat 8 scenes over a location.
+This tutorial was presented at [Cloud Native Geospatial Outreach
+Day](https://sites.google.com/radiant.earth/cng-agenda/) on September 8th, 2020. It
+shows how to create a STAC collection from a subset of Landsat 8 scenes over a location.
 
 Adding New and Custom Extensions
 --------------------------------
@@ -41,5 +47,5 @@ Adding New and Custom Extensions
 - :tutorial:`GitHub version <adding-new-and-custom-extensions.ipynb>`
 - :ref:`Docs version </tutorials/adding-new-and-custom-extensions.ipynb>`
 
-This tutorial goes over how to contribute new extensions to PySTAC as well as how to implement
-your own custom extensions.
+This tutorial goes over how to contribute new extensions to PySTAC as well as how to
+implement your own custom extensions.

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -40,7 +40,7 @@ class CatalogType(str, Enum):
     local computer, so all links need to be relative.
 
     See:
-        `The best practices documentation on self-contained catalogs <https://github.com/radiantearth/stac-spec/blob/v0.8.1/best-practices.md#self-contained-catalogs>`_
+        :stac-spec:`The best practices documentation on self-contained catalogs <best-practices.md#self-contained-catalogs>`
     """  # noqa E501
 
     ABSOLUTE_PUBLISHED = "ABSOLUTE_PUBLISHED"
@@ -49,7 +49,7 @@ class CatalogType(str, Enum):
     both in the links objects and in the asset hrefs.
 
     See:
-        `The best practices documentation on published catalogs <https://github.com/radiantearth/stac-spec/blob/v0.8.1/best-practices.md#published-catalogs>`_
+        :stac-spec:`The best practices documentation on published catalogs <best-practices.md#published-catalogs>`
     """  # noqa E501
 
     RELATIVE_PUBLISHED = "RELATIVE_PUBLISHED"
@@ -58,7 +58,7 @@ class CatalogType(str, Enum):
     but includes an absolute self link at the root catalog, to identify its online location.
 
     See:
-        `The best practices documentation on published catalogs <https://github.com/radiantearth/stac-spec/blob/v0.8.1/best-practices.md#published-catalogs>`_
+        :stac-spec:`The best practices documentation on published catalogs <best-practices.md#published-catalogs>`
     """  # noqa E501
 
     @classmethod
@@ -545,7 +545,7 @@ class Catalog(STACObject):
                 for this catalog. Defaults to :class:`~pystac.layout.BestPracticesLayoutStrategy`
 
         See:
-            `STAC best practices document <https://github.com/radiantearth/stac-spec/blob/v0.8.1/best-practices.md#catalog-layout>`_ for the canonical layout of a STAC.
+            :stac-spec:`STAC best practices document <best-practices.md#catalog-layout>` for the canonical layout of a STAC.
         """  # noqa E501
         if strategy is None:
             _strategy: HrefLayoutStrategy = BestPracticesLayoutStrategy()

--- a/pystac/extensions/label.py
+++ b/pystac/extensions/label.py
@@ -471,7 +471,7 @@ class LabelExtension(ExtensionManagementMixin[pystac.Item]):
         item : The Item that is being extended.
 
     See:
-        `Item fields in the label extension spec <https://github.com/radiantearth/stac-spec/tree/v0.8.1/extensions/label#item-fields>`_
+        :stac-ext:`Item fields in the label extension spec <label#item-properties>`
 
     Note:
         Using LabelItemExt to directly wrap an item will add the 'label' extension ID to

--- a/pystac/layout.py
+++ b/pystac/layout.py
@@ -406,8 +406,8 @@ class TemplateLayoutStrategy(HrefLayoutStrategy):
 
 class BestPracticesLayoutStrategy(HrefLayoutStrategy):
     """Layout strategy that represents the catalog layout described
-    in the `STAC Best Practices documentation
-    <https://github.com/radiantearth/stac-spec/blob/v1.0.0-beta.2/best-practices.md>`_
+    in the :stac-spec:`STAC Best Practices documentation
+    <best-practices.md>`
 
     For a root catalog or collection, this will use the filename 'catalog.json'
     or 'collection.json' to the given directory. For a non-root catalog or collection,

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -320,9 +320,9 @@ class STACObject(ABC):
             raised.
 
         Note:
-            When to include a self link is described in the `Use of Links section of the
-            STAC best practices document
-            <https://github.com/radiantearth/stac-spec/blob/v0.8.1/best-practices.md#use-of-links>`_
+            When to include a self link is described in the :stac-spec:`Use of Links
+            section of the STAC best practices document
+            <best-practices.md#use-of-links>`
         """
         if stac_io is None:
             root = self.get_root()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,6 +11,7 @@ sphinx-autobuild==0.7.1
 sphinxcontrib-fulltoc==1.2.0
 nbsphinx==0.7.1
 coverage==5.2.*
+doc8==0.8.1
 
 # https://github.com/pydata/xarray/issues/5299#issuecomment-840730954
 jinja2<3.0

--- a/scripts/test
+++ b/scripts/test
@@ -36,6 +36,12 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         flake8 pystac tests
 
         echo
+        echo " -- LINTING RST FILES WITH DOC8 --"
+        echo
+
+        doc8 docs -q
+
+        echo
         echo " -- CHECKING FORMAT WITH BLACK --"
         echo
 


### PR DESCRIPTION
**Description:**

* Fixes GitHub username in `docs/conf.py`
* Uses the `:stac-spec:` extlink for all links to the STAC spec. This will automatically generate links to the version of the spec from `pystac.version.STACVersion.DEFAULT_STAC_VERSION` (there were a number of these links that were still pointing to old spec versions).
* Uses the `:stac-ext:` extlink for all links to STAC Extensions specs.
* Updates RST files to have a max line length of 88 to match linting on other files
* Uses [`doc8`](https://github.com/pycqa/doc8) to lint all source files for the docs (except tutorials) as part of `./scripts/test`
    If this last one seems too heavy-handed I'm happy to remove it, but I thought it would help keep us from getting some of the really long lines that had snuck in before.

**PR Checklist:**

- [x] Code is formatted (run `scripts/format`)
- [x] Tests pass (run `scripts/test`)
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.