### PR TITLE
feat: Upgrade Python packages automatically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
**Related Issue(s):** N/A


**Description:** Tell Dependabot to automatically generate pull requests to change the requirements file when updated Python packages are available. This should allow the project to easily keep up with package updates.

[Example PR](https://github.com/linz/geostore/pull/753) created by Dependabot. As you can see, it includes some excellent information, including previous and new version number, release notes, change log, and commits involved in the upstream change.

**PR Checklist:**

- [x] Code is formatted (run `scripts/format`)
- [x] Tests pass (run `scripts/test`)
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.