### PR TITLE
Handle `tests.utils.test_to_from_dict` conflict with other test runners

### DIFF
--- a/tests/extensions/test_eo.py
+++ b/tests/extensions/test_eo.py
@@ -6,7 +6,7 @@ from pystac import Item
 from pystac.collection import RangeSummary
 from pystac.utils import get_opt
 from pystac.extensions.eo import EOExtension, Band
-from tests.utils import TestCases, test_to_from_dict
+from tests.utils import TestCases, assert_to_from_dict
 
 
 class BandsTest(unittest.TestCase):
@@ -49,7 +49,7 @@ class EOTest(unittest.TestCase):
     def test_to_from_dict(self) -> None:
         with open(self.LANDSAT_EXAMPLE_URI) as f:
             item_dict = json.load(f)
-        test_to_from_dict(self, Item, item_dict)
+        assert_to_from_dict(self, Item, item_dict)
 
     def test_validate_eo(self) -> None:
         item = pystac.read_file(self.LANDSAT_EXAMPLE_URI)

--- a/tests/extensions/test_file.py
+++ b/tests/extensions/test_file.py
@@ -2,7 +2,7 @@ import json
 import unittest
 
 import pystac
-from tests.utils import TestCases, test_to_from_dict
+from tests.utils import TestCases, assert_to_from_dict
 from pystac.extensions.file import FileExtension, FileDataType
 
 
@@ -15,7 +15,7 @@ class FileTest(unittest.TestCase):
     def test_to_from_dict(self) -> None:
         with open(self.FILE_EXAMPLE_URI) as f:
             item_dict = json.load(f)
-        test_to_from_dict(self, pystac.Item, item_dict)
+        assert_to_from_dict(self, pystac.Item, item_dict)
 
     def test_validate_file(self) -> None:
         item = pystac.Item.from_file(self.FILE_EXAMPLE_URI)

--- a/tests/extensions/test_label.py
+++ b/tests/extensions/test_label.py
@@ -16,7 +16,7 @@ from pystac.extensions.label import (
 )
 import pystac.validation
 from pystac.utils import get_opt
-from tests.utils import TestCases, test_to_from_dict
+from tests.utils import TestCases, assert_to_from_dict
 
 
 class LabelTest(unittest.TestCase):
@@ -36,7 +36,7 @@ class LabelTest(unittest.TestCase):
         with open(self.label_example_1_uri) as f:
             label_example_1_dict = json.load(f)
 
-        test_to_from_dict(self, Item, label_example_1_dict)
+        assert_to_from_dict(self, Item, label_example_1_dict)
 
     def test_from_file(self) -> None:
         label_example_1 = Item.from_file(self.label_example_1_uri)

--- a/tests/extensions/test_pointcloud.py
+++ b/tests/extensions/test_pointcloud.py
@@ -13,7 +13,7 @@ from pystac.extensions.pointcloud import (
     PointcloudSchema,
     PointcloudStatistic,
 )
-from tests.utils import TestCases, test_to_from_dict
+from tests.utils import TestCases, assert_to_from_dict
 
 
 class PointcloudTest(unittest.TestCase):
@@ -27,7 +27,7 @@ class PointcloudTest(unittest.TestCase):
     def test_to_from_dict(self) -> None:
         with open(self.example_uri) as f:
             d = json.load(f)
-        test_to_from_dict(self, pystac.Item, d)
+        assert_to_from_dict(self, pystac.Item, d)
 
     def test_apply(self) -> None:
         item = next(iter(TestCases.test_case_2().get_all_items()))

--- a/tests/extensions/test_projection.py
+++ b/tests/extensions/test_projection.py
@@ -6,7 +6,7 @@ from copy import deepcopy
 import pystac
 from pystac.extensions.projection import ProjectionExtension
 from pystac.utils import get_opt
-from tests.utils import TestCases, test_to_from_dict
+from tests.utils import TestCases, assert_to_from_dict
 
 WKT2 = """
 GEOGCS["WGS 84",
@@ -80,7 +80,7 @@ class ProjectionTest(unittest.TestCase):
     def test_to_from_dict(self) -> None:
         with open(self.example_uri) as f:
             d = json.load(f)
-        test_to_from_dict(self, pystac.Item, d)
+        assert_to_from_dict(self, pystac.Item, d)
 
     def test_apply(self) -> None:
         item = next(iter(TestCases.test_case_2().get_all_items()))

--- a/tests/extensions/test_raster.py
+++ b/tests/extensions/test_raster.py
@@ -12,7 +12,7 @@ from pystac.extensions.raster import (
     DataType,
     Statistics,
 )
-from tests.utils import TestCases, test_to_from_dict
+from tests.utils import TestCases, assert_to_from_dict
 
 
 class RasterTest(unittest.TestCase):
@@ -30,7 +30,7 @@ class RasterTest(unittest.TestCase):
     def test_to_from_dict(self) -> None:
         with open(self.PLANET_EXAMPLE_URI) as f:
             item_dict = json.load(f)
-        test_to_from_dict(self, Item, item_dict)
+        assert_to_from_dict(self, Item, item_dict)
 
     def test_validate_raster(self) -> None:
         item = pystac.read_file(self.PLANET_EXAMPLE_URI)

--- a/tests/extensions/test_timestamps.py
+++ b/tests/extensions/test_timestamps.py
@@ -5,7 +5,7 @@ from datetime import datetime
 import pystac
 from pystac.extensions.timestamps import TimestampsExtension
 from pystac.utils import get_opt, str_to_datetime, datetime_to_str
-from tests.utils import TestCases, test_to_from_dict
+from tests.utils import TestCases, assert_to_from_dict
 
 
 class TimestampsTest(unittest.TestCase):
@@ -20,7 +20,7 @@ class TimestampsTest(unittest.TestCase):
         self.sample_datetime = str_to_datetime(self.sample_datetime_str)
 
     def test_to_from_dict(self) -> None:
-        test_to_from_dict(self, pystac.Item, self.item_dict)
+        assert_to_from_dict(self, pystac.Item, self.item_dict)
 
     def test_apply(self) -> None:
         item = next(iter(TestCases.test_case_2().get_all_items()))

--- a/tests/extensions/test_view.py
+++ b/tests/extensions/test_view.py
@@ -3,7 +3,7 @@ import unittest
 
 import pystac
 from pystac.extensions.view import ViewExtension
-from tests.utils import TestCases, test_to_from_dict
+from tests.utils import TestCases, assert_to_from_dict
 
 
 class ViewTest(unittest.TestCase):
@@ -14,7 +14,7 @@ class ViewTest(unittest.TestCase):
     def test_to_from_dict(self) -> None:
         with open(self.example_uri) as f:
             d = json.load(f)
-        test_to_from_dict(self, pystac.Item, d)
+        assert_to_from_dict(self, pystac.Item, d)
 
     def test_apply(self) -> None:
         item = next(iter(TestCases.test_case_2().get_all_items()))

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -11,7 +11,7 @@ from pystac.validation import validate_dict
 import pystac.serialization.common_properties
 from pystac.item import CommonMetadata
 from pystac.utils import datetime_to_str, get_opt, str_to_datetime, is_absolute_href
-from tests.utils import TestCases, test_to_from_dict
+from tests.utils import TestCases, assert_to_from_dict
 
 
 class ItemTest(unittest.TestCase):
@@ -26,7 +26,7 @@ class ItemTest(unittest.TestCase):
 
         item_dict = self.get_example_item_dict()
 
-        test_to_from_dict(self, Item, item_dict)
+        assert_to_from_dict(self, Item, item_dict)
         item = Item.from_dict(item_dict)
         self.assertEqual(item.id, "CS3-20160503_132131_05")
 

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -17,7 +17,7 @@ import pystac
 from tests.utils.stac_io_mock import MockStacIO  #  type:ignore
 
 
-def test_to_from_dict(
+def assert_to_from_dict(
     test_class: unittest.TestCase,
     stac_object_class: Type[pystac.STACObject],
     d: Dict[str, Any],


### PR DESCRIPTION
**Related Issue(s):** 
Fixes #387 


**Description:**
Modifies `def test_to_from_dict` in `tests/utils/__init__.py` to `def assert_to_from_dict` to avoid conflict with other test runners

**PR Checklist:**

- [ ] Code is formatted (run `scripts/format`)
- [ ] Tests pass (run `scripts/test`)
- [ ] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.