### PR TITLE
Point coverage badge to main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ![Build Status](https://github.com/stac-utils/pystac/workflows/CI/badge.svg?branch=develop)
 [![PyPI version](https://badge.fury.io/py/pystac.svg)](https://badge.fury.io/py/pystac)
 [![Documentation](https://readthedocs.org/projects/pystac/badge/?version=latest)](https://pystac.readthedocs.io/en/latest/)
-[![codecov](https://codecov.io/gh/stac-utils/pystac/branch/develop/graph/badge.svg)](https://codecov.io/gh/stac-utils/pystac)
+[![codecov](https://codecov.io/gh/stac-utils/pystac/branch/main/graph/badge.svg)](https://codecov.io/gh/stac-utils/pystac)
 [![Gitter chat](https://badges.gitter.im/azavea/pystac.svg)](https://gitter.im/azavea/pystac)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 


### PR DESCRIPTION
**Description:**

* Fixes Codecov badge to point to `main` branch instead of `develop`

**PR Checklist:**

- [ ] Code is formatted (run `scripts/format`)
- [ ] Tests pass (run `scripts/test`)
- [ ] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.