### PR TITLE
chore: Lock Python development dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,9 @@
 ipython==7.16.1
+# https://github.com/pydata/xarray/issues/5299#issuecomment-840730954
+Jinja2==2.11.3
+nbsphinx==0.7.1
 Sphinx==3.5.4
 sphinx-autobuild==0.7.1
 sphinxcontrib-fulltoc==1.2.0
-nbsphinx==0.7.1
-
-# https://github.com/pydata/xarray/issues/5299#issuecomment-840730954
-jinja2<3.0
 
 -r ./requirements-test.txt

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,13 +1,9 @@
-mypy==0.812
-flake8==3.8.*
 black==21.4b2
-
 codespell==1.17.1
-
-jsonschema==3.2.0
-pylint==1.9.1
-coverage==5.2.*
+coverage==5.2.1
 doc8==0.8.1
-
-# optional dependencies
+flake8==3.8.4
+jsonschema==3.2.0
+mypy==0.812
 orjson==3.5.2
+pylint==1.9.1


### PR DESCRIPTION
**Related Issue(s):** N/A


**Description:**

- Avoids breakage in case of incompatible third party upgrades
- Improves consistency between builds

**PR Checklist:**

- [x] Code is formatted (run `scripts/format`)
- [x] Tests pass (run `scripts/test`)
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.