### PR TITLE
Make ExtensionManagementMixin.add_to idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 - `identify_stac_object_type` returns `None` and `identify_stac_object` raises `STACTypeError` for non-STAC objects
   ([#402](https://github.com/stac-utils/pystac/pull/402))
 - `ExtensionManagementMixin.add_to` is now idempotent (only adds schema URI to
-  `stac_extensions` once per `Item` regardless of the number of calls)
+  `stac_extensions` once per `Item` regardless of the number of calls) ([#419](https://github.com/stac-utils/pystac/pull/419))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@
 - `EOExtension.get_bands` returns `None` for asset without EO bands ([#406](https://github.com/stac-utils/pystac/pull/406))
 - `identify_stac_object_type` returns `None` and `identify_stac_object` raises `STACTypeError` for non-STAC objects
   ([#402](https://github.com/stac-utils/pystac/pull/402))
+- `ExtensionManagementMixin.add_to` is now idempotent (only adds schema URI to
+  `stac_extensions` once per `Item` regardless of the number of calls)
 
 ### Removed
 

--- a/pystac/extensions/base.py
+++ b/pystac/extensions/base.py
@@ -100,10 +100,11 @@ class ExtensionManagementMixin(Generic[S], ABC):
     @classmethod
     def add_to(cls, obj: S) -> None:
         """Add the schema URI for this extension to the
-        :attr:`pystac.STACObject.stac_extensions` list for the given object."""
+        :attr:`~pystac.STACObject.stac_extensions` list for the given object, if it is
+        not already present."""
         if obj.stac_extensions is None:
             obj.stac_extensions = [cls.get_schema_uri()]
-        else:
+        elif cls.get_schema_uri() not in obj.stac_extensions:
             obj.stac_extensions.append(cls.get_schema_uri())
 
     @classmethod

--- a/tests/extensions/test_eo.py
+++ b/tests/extensions/test_eo.py
@@ -43,6 +43,7 @@ class EOTest(unittest.TestCase):
     )
     EO_COLLECTION_URI = TestCases.get_path("data-files/eo/eo-collection.json")
     S2_ITEM_URI = TestCases.get_path("data-files/eo/eo-sentinel2-item.json")
+    PLAIN_ITEM = TestCases.get_path("data-files/item/sample-item.json")
 
     def setUp(self) -> None:
         self.maxDiff = None
@@ -51,6 +52,24 @@ class EOTest(unittest.TestCase):
         with open(self.LANDSAT_EXAMPLE_URI) as f:
             item_dict = json.load(f)
         assert_to_from_dict(self, Item, item_dict)
+
+    def test_add_to(self) -> None:
+        item = Item.from_file(self.PLAIN_ITEM)
+        self.assertNotIn(EOExtension.get_schema_uri(), item.stac_extensions)
+
+        # Check that the URI gets added to stac_extensions
+        EOExtension.add_to(item)
+        self.assertIn(EOExtension.get_schema_uri(), item.stac_extensions)
+
+        # Check that the URI only gets added once, regardless of how many times add_to
+        # is called.
+        EOExtension.add_to(item)
+        EOExtension.add_to(item)
+
+        eo_uris = [
+            uri for uri in item.stac_extensions if uri == EOExtension.get_schema_uri()
+        ]
+        self.assertEqual(len(eo_uris), 1)
 
     def test_validate_eo(self) -> None:
         item = pystac.Item.from_file(self.LANDSAT_EXAMPLE_URI)


### PR DESCRIPTION
**Related Issue(s):** #

* Closes #369 

**Description:**

`pystac.extensions.base.ExtensionManagementMixin.add_to` will only add the schema URI for the inheriting extension class if it is not already in the object's `stac_extensions` list. 

I looked into making `stac_extensions` a `set` instead of a `list`, but the extra complexity to ensure that the set was properly serialized and deserialized did not seem worth the effort. If that seems like the better approach, I can explore it in more depth, though.

**PR Checklist:**

- [x] Code is formatted (run `scripts/format`)
- [x] Tests pass (run `scripts/test`)
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.