### PR TITLE
Test against Python 3.9

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,6 +18,7 @@ jobs:
           - "3.6"
           - "3.7"
           - "3.8"
+          - "3.9"
         os:
           - ubuntu-latest
           - windows-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Code of Conduct ([#399](https://github.com/stac-utils/pystac/pull/399))
 - `ItemCollection` class for working with GeoJSON FeatureCollections containing only
   STAC Items ([#430](https://github.com/stac-utils/pystac/pull/430))
+- Support for Python 3.9 ([#420](https://github.com/stac-utils/pystac/pull/420))
 
 ### Changed
 

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     project_urls={
         "Tracker": "https://github.com/stac-utils/pystac/issues",


### PR DESCRIPTION
**Description:**

Expands CI test matrix to include Python 3.9 and 3.10. Python 3.10 is marked as "experimental", so the CI workflow will still succeed even if that job fails.

**PR Checklist:**

- [x] Code is formatted (run `scripts/format`)
- [x] Tests pass (run `scripts/test`)
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.