### PR TITLE
Update dev dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-ipython==7.16.1
+ipython==7.24.1
 Sphinx==4.0.2
 sphinxcontrib-fulltoc==1.2.0
 nbsphinx==0.8.6

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,8 @@
 ipython==7.16.1
 Sphinx==4.0.2
-sphinx-autobuild==0.7.1
 sphinxcontrib-fulltoc==1.2.0
-nbsphinx==0.7.1
+nbsphinx==0.8.6
 
-# https://github.com/pydata/xarray/issues/5299#issuecomment-840730954
-jinja2<3.0
+jinja2<4.0
 
 -r ./requirements-test.txt

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,8 +1,8 @@
-mypy==0.901
+mypy==0.902
 flake8==3.9.2
 black==21.5b2
 
-codespell==2.0.0
+codespell==2.1.0
 
 jsonschema==3.2.0
 coverage==5.5

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 mypy==0.901
-flake8==3.8.*
+flake8==3.9.2
 black==21.5b2
 
 codespell==2.0.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,11 +1,10 @@
 mypy==0.901
 flake8==3.8.*
-black==21.4b2
+black==21.5b2
 
-codespell==1.17.1
+codespell==2.0.0
 
 jsonschema==3.2.0
-pylint==1.9.1
 coverage==5.5
 doc8==0.8.1
 


### PR DESCRIPTION
* Bumps versions of `black`, `codespell`, `nbsphinx`, `jinja2`

    Bumping `nbpshinx` to `0.8.6` fixes spatialaudio/nbsphinx#563, which was the reason we had pinned `jinja2` to `<3.0` in the first place.

* Drops `pylint` and `sphinx-autobuild`

    `pylint` seemed like it was added as a dependency early on, but isn't actually used anymore. `sphinx-autobuild` is not used in our tests, linting, or doc builds, so it seems more appropriate for individual developers to install it themselves if it's part of their personal workflow.


Supersedes #423, #421, #415, #414, and #413

**UPDATE 2021-06-10:**
* Bumps versions of `ipython`, `flake8`
* Also supersedes #428, #427, and #426

**UPDATE 2021-06-11**
* Bumps `mypy` and `codespell` again
* Also supersedes #436 and #435

**PR Checklist:**

- [x] Code is formatted (run `scripts/format`)
- [x] Tests pass (run `scripts/test`)
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.