### PR TITLE
Add args/kwargs to StacIO.read_json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 ### Changed
 
 - Package author to `stac-utils`, email to `stac@radiant.earth`, url to this repo ([#409](https://github.com/stac-utils/pystac/pull/409))
+- `StacIO.read_json` passes arbitrary positional and keyword arguments to
+  `StacIO.read_text` ([#433](https://github.com/stac-utils/pystac/pull/433))
 
 ### Fixed
 

--- a/pystac/stac_io.py
+++ b/pystac/stac_io.py
@@ -102,7 +102,9 @@ class StacIO(ABC):
             result._stac_io = self
         return result
 
-    def read_json(self, source: Union[str, "Link_Type"]) -> Dict[str, Any]:
+    def read_json(
+        self, source: Union[str, "Link_Type"], *args: Any, **kwargs: Any
+    ) -> Dict[str, Any]:
         """Read a dict from the given source.
 
         See :func:`StacIO.read_text <pystac.StacIO.read_text>` for usage of
@@ -115,7 +117,7 @@ class StacIO(ABC):
             dict: A dict representation of the JSON contained in the file at the
             given source.
         """
-        txt = self.read_text(source)
+        txt = self.read_text(source, *args, **kwargs)
         return self._json_loads(txt, source)
 
     def read_stac_object(


### PR DESCRIPTION
**Related Issue(s):** #

* Closes #411 

**Description:**

Adds `*args` and `**kwargs` parameters to `StacIO.read_json` and passes them to `StacIO.read_text`.

**PR Checklist:**

- [x] Code is formatted (run `scripts/format`)
- [x] Tests pass (run `scripts/test`)
- [ ] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.