### PR TITLE
Update docs and tests for Version, Label, and File Info extensions

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,5 @@
 [report]
-fail_under = 89
+fail_under = 90
 
 [run]
 source = pystac

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 - Package author to `stac-utils`, email to `stac@radiant.earth`, url to this repo ([#409](https://github.com/stac-utils/pystac/pull/409))
 - `StacIO.read_json` passes arbitrary positional and keyword arguments to
   `StacIO.read_text` ([#433](https://github.com/stac-utils/pystac/pull/433))
+- `FileExtension` updated to work with File Info Extension v2.0.0 ([#442](https://github.com/stac-utils/pystac/pull/442))
+- `FileExtension` only operates on `pystac.Asset` instances ([#442](https://github.com/stac-utils/pystac/pull/442))
 
 ### Fixed
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -310,12 +310,6 @@ FileExtension
    :show-inheritance:
    :undoc-members:
 
-.. autoclass:: pystac.extensions.file.AssetFileExtension
-   :members:
-   :show-inheritance:
-   :undoc-members:
-
-
 Label Extension
 ---------------
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -283,20 +283,43 @@ SummariesEOExtension
    :undoc-members:
    :show-inheritance:
 
+File Info Extension
+-------------------
+
+These classes are representations of the :stac-ext:`File Info Extension Spec <file>`.
+
+ByteOrder
+~~~~~~~~~
+
+.. autoclass:: pystac.extensions.file.ByteOrder
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+MappingObject
+~~~~~~~~~~~~~
+
+.. autoclass:: pystac.extensions.file.MappingObject
+   :members:
+
+FileExtension
+~~~~~~~~~~~~~
+
+.. autoclass:: pystac.extensions.file.FileExtension
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+.. autoclass:: pystac.extensions.file.AssetFileExtension
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+
 Label Extension
 ---------------
 
 These classes are representations of the :stac-ext:`Label Extension Spec <label>`.
-
-LabelItemExt
-~~~~~~~~~~~~
-
-**TEMPORARILY REMOVED**
-
-.. .. autoclass:: pystac.extensions.label.LabelItemExt
-..    :members:
-..    :undoc-members:
-..    :show-inheritance:
 
 LabelRelType
 ~~~~~~~~~~~~
@@ -339,6 +362,14 @@ LabelStatistics
 .. autoclass:: pystac.extensions.label.LabelStatistics
    :members:
    :undoc-members:
+
+LabelExtension
+~~~~~~~~~~~~~~
+
+.. autoclass:: pystac.extensions.label.LabelExtension
+   :members:
+   :undoc-members:
+   :show-inheritance:
 
 Pointcloud Extension
 --------------------
@@ -460,26 +491,6 @@ SatItemExt
 ..    :members:
 ..    :undoc-members:
 ..    :show-inheritance:
-
-Single File STAC Extension
---------------------------
-
-These classes are representations of the :stac-ext:`Single File STAC Extension
-<single-file-stac>`.
-
-**TEMPORARILY REMOVED**
-
-.. .. automodule:: pystac.extensions.single_file_stac
-..    :members: create_single_file_stac
-
-SingleFileSTACCatalogExt
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-**TEMPORARILY REMOVED**
-
-.. .. autoclass:: pystac.extensions.single_file_stac.SingleFileSTACCatalogExt
-..    :members:
-..    :undoc-members:
 
 Version Extension
 -----------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -484,7 +484,7 @@ SingleFileSTACCatalogExt
 Version Extension
 -----------------
 
-Implements the :stac-ext:`Version Extension <version>`.
+Implements the :stac-ext:`Versioning Indicators Extension <version>`.
 
 VersionRelType
 ~~~~~~~~~~~~~~
@@ -493,25 +493,26 @@ VersionRelType
    :members:
    :show-inheritance:
 
-VersionCollectionExt
+VersionExtension
+~~~~~~~~~~~~~~~~
+
+.. autoclass:: pystac.extensions.version.VersionExtension
+   :members:
+   :show-inheritance:
+
+CollectionVersionExtension
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: pystac.extensions.version.CollectionVersionExtension
+   :members:
+   :show-inheritance:
+
+ItemVersionExtension
 ~~~~~~~~~~~~~~~~~~~~
 
-**TEMPORARILY REMOVED**
-
-.. .. autoclass:: pystac.extensions.version.VersionCollectionExt
-..    :members:
-..    :undoc-members:
-..    :show-inheritance:
-
-VersionItemExt
-~~~~~~~~~~~~~~
-
-**TEMPORARILY REMOVED**
-
-.. .. autoclass:: pystac.extensions.version.VersionItemExt
-..    :members:
-..    :undoc-members:
-..    :show-inheritance:
+.. autoclass:: pystac.extensions.version.ItemVersionExtension
+   :members:
+   :show-inheritance:
 
 View Geometry Extension
 -----------------------

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -289,7 +289,7 @@ class EOExtension(
     .. code-block:: python
 
        >>> item: pystac.Item = ...
-       >>> view_ext = ViewExtension.ext(item)
+       >>> eo_ext = EOExtension.ext(item)
     """
 
     def apply(

--- a/pystac/extensions/file.py
+++ b/pystac/extensions/file.py
@@ -3,54 +3,91 @@
 https://github.com/stac-extensions/file
 """
 
-import enum
+from enum import Enum
 from typing import Any, Dict, Generic, List, Optional, Set, TypeVar, cast
 
 import pystac
-from pystac.extensions.base import (
-    ExtensionManagementMixin,
-    PropertiesExtension,
-    SummariesExtension,
-)
+from pystac.extensions.base import ExtensionManagementMixin, PropertiesExtension
 from pystac.extensions.hooks import ExtensionHooks
 from pystac.serialization.identify import (
     OldExtensionShortIDs,
     STACJSONDescription,
     STACVersionID,
 )
-from pystac.utils import map_opt
+from pystac.utils import get_required
 
 T = TypeVar("T", pystac.Item, pystac.Asset)
 
-SCHEMA_URI = "https://stac-extensions.github.io/file/v1.0.0/schema.json"
+SCHEMA_URI = "https://stac-extensions.github.io/file/v2.0.0/schema.json"
 
 PREFIX = "file:"
-DATA_TYPE_PROP = PREFIX + "data_type"
-SIZE_PROP = PREFIX + "size"
-NODATA_PROP = PREFIX + "nodata"
+BYTE_ORDER_PROP = PREFIX + "byte_order"
 CHECKSUM_PROP = PREFIX + "checksum"
+HEADER_SIZE_PROP = PREFIX + "header_size"
+SIZE_PROP = PREFIX + "size"
+VALUES_PROP = PREFIX + "values"
 
 
-class FileDataType(str, enum.Enum):
+class ByteOrder(str, Enum):
+    """List of allows values for the ``"file:byte_order"`` field defined by the
+    :stac-ext:`File Info Extension <file>`."""
+
     def __str__(self) -> str:
         return str(self.value)
 
-    INT8 = "int8"
-    INT16 = "int16"
-    INT32 = "int32"
-    INT64 = "int64"
-    UINT8 = "uint8"
-    UINT16 = "uint16"
-    UINT32 = "uint32"
-    UINT64 = "uint64"
-    FLOAT16 = "float16"
-    FLOAT32 = "float32"
-    FLOAT64 = "float64"
-    CINT16 = "cint16"
-    CINT32 = "cint32"
-    CFLOAT32 = "cfloat32"
-    CFLOAT64 = "cfloat64"
-    OTHER = "other"
+    LITTLE_ENDIAN = "little-endian"
+    BIG_ENDIAN = "big-endian"
+
+
+class MappingObject:
+    """Represents a value map used by assets that are used as classification layers, and
+    give details about the values in the asset and their meanings."""
+
+    properties: Dict[str, Any]
+
+    def __init__(self, properties: Dict[str, Any]) -> None:
+        self.properties = properties
+
+    def apply(self, values: List[Any], summary: str) -> None:
+        """Sets the properties for this :class:`~MappingObject` instance.
+
+        Args:
+            values : The value(s) in the file. At least one array element is required.
+            summary : A short description of the value(s).
+        """
+        self.values = values
+        self.summary = summary
+
+    @classmethod
+    def create(cls, values: List[Any], summary: str) -> "MappingObject":
+        """Creates a new :class:`~MapptingObject` instance.
+
+        Args:
+            values : The value(s) in the file. At least one array element is required.
+            summary : A short description of the value(s).
+        """
+        m = cls({})
+        m.apply(values=values, summary=summary)
+        return m
+
+    @property
+    def values(self) -> List[Any]:
+        """Gets or sets the list of value(s) in the file. At least one array element is
+        required."""
+        return get_required(self.properties["values"], self, "values")
+
+    @values.setter
+    def values(self, v: List[Any]) -> None:
+        self.properties["values"] = v
+
+    @property
+    def summary(self) -> str:
+        """Gets or sets the short description of the value(s)."""
+        return get_required(self.properties["summary"], self, "summary")
+
+    @summary.setter
+    def summary(self, v: str) -> None:
+        self.properties["summary"] = v
 
 
 class FileExtension(
@@ -73,39 +110,64 @@ class FileExtension(
 
     def apply(
         self,
-        data_type: Optional[FileDataType] = None,
-        size: Optional[int] = None,
-        nodata: Optional[List[Any]] = None,
+        byte_order: Optional[ByteOrder] = None,
         checksum: Optional[str] = None,
+        header_size: Optional[int] = None,
+        size: Optional[int] = None,
+        values: Optional[List[MappingObject]] = None,
     ) -> None:
         """Applies file extension properties to the extended Item.
 
         Args:
-            data_type : The data type of the file.
-            size : size of the file in bytes.
-            nodata : Value(s) for no-data.
-            checksum : Multihash for the corresponding file,
+            byte_order : Optional byte order of integer values in the file. One of
+                ``"big-endian"`` or ``"little-endian"``.
+            checksum : Optional multihash for the corresponding file,
                 encoded as hexadecimal (base 16) string with lowercase letters.
+            header_size : Optional header size of the file, in bytes.
+            size : Optional size of the file, in bytes.
+            values : Optional list of :class:`~MappingObject` instances that lists the
+                values that are in the file and describe their meaning. See the
+                :stac-ext:`Mapping Object <file#mapping-object>` docs for an example.
+                If given, at least one array element is required.
         """
-        self.data_type = data_type
-        self.size = size
-        self.nodata = nodata
+        self.byte_order = byte_order
         self.checksum = checksum
+        self.header_size = header_size
+        self.size = size
+        self.values = values
 
     @property
-    def data_type(self) -> Optional[FileDataType]:
-        """Get or sets the data_type of the file."""
-        return map_opt(
-            lambda s: FileDataType(s), self._get_property(DATA_TYPE_PROP, str)
-        )
+    def byte_order(self) -> Optional[ByteOrder]:
+        """Gets or sets the byte order of integer values in the file. One of big-endian
+        or little-endian."""
+        return self._get_property(BYTE_ORDER_PROP, ByteOrder)
 
-    @data_type.setter
-    def data_type(self, v: Optional[FileDataType]) -> None:
-        self._set_property(DATA_TYPE_PROP, str(v))
+    @byte_order.setter
+    def byte_order(self, v: Optional[ByteOrder]) -> None:
+        self._set_property(BYTE_ORDER_PROP, v)
+
+    @property
+    def checksum(self) -> Optional[str]:
+        """Get or sets the multihash for the corresponding file, encoded as hexadecimal
+        (base 16) string with lowercase letters."""
+        return self._get_property(CHECKSUM_PROP, str)
+
+    @checksum.setter
+    def checksum(self, v: Optional[str]) -> None:
+        self._set_property(CHECKSUM_PROP, v)
+
+    @property
+    def header_size(self) -> Optional[int]:
+        """Get or sets the header size of the file, in bytes."""
+        return self._get_property(HEADER_SIZE_PROP, int)
+
+    @header_size.setter
+    def header_size(self, v: Optional[int]) -> None:
+        self._set_property(HEADER_SIZE_PROP, v)
 
     @property
     def size(self) -> Optional[int]:
-        """Get or sets the size in bytes of the file."""
+        """Get or sets the size of the file, in bytes."""
         return self._get_property(SIZE_PROP, int)
 
     @size.setter
@@ -113,22 +175,16 @@ class FileExtension(
         self._set_property(SIZE_PROP, v)
 
     @property
-    def nodata(self) -> Optional[List[Any]]:
-        """Get or sets the no data values."""
-        return self._get_property(NODATA_PROP, List[Any])
+    def values(self) -> Optional[List[MappingObject]]:
+        """Get or sets the list of :class:`~MappingObject` instances that lists the
+        values that are in the file and describe their meaning. See the
+        :stac-ext:`Mapping Object <file#mapping-object>` docs for an example. If given,
+        at least one array element is required."""
+        return self._get_property(VALUES_PROP, List[MappingObject])
 
-    @nodata.setter
-    def nodata(self, v: Optional[List[Any]]) -> None:
-        self._set_property(NODATA_PROP, v)
-
-    @property
-    def checksum(self) -> Optional[str]:
-        """Get or sets the checksum"""
-        return self._get_property(CHECKSUM_PROP, str)
-
-    @checksum.setter
-    def checksum(self, v: Optional[str]) -> None:
-        self._set_property(CHECKSUM_PROP, v)
+    @values.setter
+    def values(self, v: Optional[List[MappingObject]]) -> None:
+        self._set_property(VALUES_PROP, v)
 
     @classmethod
     def get_schema_uri(cls) -> str:
@@ -154,10 +210,6 @@ class FileExtension(
             raise pystac.ExtensionTypeError(
                 f"File extension does not apply to type {type(obj)}"
             )
-
-    @staticmethod
-    def summaries(obj: pystac.Collection) -> "SummariesFileExtension":
-        return SummariesFileExtension(obj)
 
 
 class ItemFileExtension(FileExtension[pystac.Item]):
@@ -194,39 +246,6 @@ class AssetFileExtension(FileExtension[pystac.Asset]):
 
     def __repr__(self) -> str:
         return "<AssetFileExtension Asset href={}>".format(self.asset_href)
-
-
-class SummariesFileExtension(SummariesExtension):
-    @property
-    def data_type(self) -> Optional[List[FileDataType]]:
-        """Get or sets the summary of data_type values for this Collection."""
-
-        return map_opt(
-            lambda x: [FileDataType(t) for t in x],
-            self.summaries.get_list(DATA_TYPE_PROP),
-        )
-
-    @data_type.setter
-    def data_type(self, v: Optional[List[FileDataType]]) -> None:
-        self._set_summary(DATA_TYPE_PROP, map_opt(lambda x: [str(t) for t in x], v))
-
-    @property
-    def size(self) -> Optional[pystac.RangeSummary[int]]:
-        """Get or sets the summary of size values for this Collection."""
-        return self.summaries.get_range(SIZE_PROP)
-
-    @size.setter
-    def size(self, v: Optional[pystac.RangeSummary[int]]) -> None:
-        self._set_summary(SIZE_PROP, v)
-
-    @property
-    def nodata(self) -> Optional[List[Any]]:
-        """Get or sets the summary of nodata values for this Collection."""
-        return self.summaries.get_list(NODATA_PROP)
-
-    @nodata.setter
-    def nodata(self, v: Optional[List[Any]]) -> None:
-        self._set_summary(NODATA_PROP, v)
 
 
 class FileExtensionHooks(ExtensionHooks):

--- a/pystac/extensions/file.py
+++ b/pystac/extensions/file.py
@@ -16,7 +16,7 @@ from pystac.serialization.identify import (
 )
 from pystac.utils import get_required
 
-T = TypeVar("T", pystac.Item, pystac.Asset)
+T = TypeVar("T", bound=pystac.Asset)
 
 SCHEMA_URI = "https://stac-extensions.github.io/file/v2.0.0/schema.json"
 
@@ -60,7 +60,7 @@ class MappingObject:
 
     @classmethod
     def create(cls, values: List[Any], summary: str) -> "MappingObject":
-        """Creates a new :class:`~MapptingObject` instance.
+        """Creates a new :class:`~MappingObject` instance.
 
         Args:
             values : The value(s) in the file. At least one array element is required.
@@ -96,16 +96,15 @@ class FileExtension(
     """An abstract class that can be used to extend the properties of an
     :class:`~pystac.Item` or :class:`~pystac.Asset` with properties from the
     :stac-ext:`File Info Extension <file>`. This class is generic over the type of
-    STAC Object to be extended (e.g. :class:`~pystac.Item`,
-    :class:`~pystac.Asset`).
+    STAC Object to be extended (e.g. :class:`~pystac.Asset`).
 
     To create a concrete instance of :class:`FileExtension`, use the
     :meth:`FileExtension.ext` method. For example:
 
     .. code-block:: python
 
-       >>> item: pystac.Item = ...
-       >>> file_ext = FileExtension.ext(item)
+       >>> asset: pystac.Asset = ...
+       >>> file_ext = FileExtension.ext(asset)
     """
 
     def apply(
@@ -195,38 +194,18 @@ class FileExtension(
         """Extends the given STAC Object with properties from the :stac-ext:`File Info
         Extension <file>`.
 
-        This extension can be applied to instances of :class:`~pystac.Item` or
-        :class:`~pystac.Asset`.
+        This extension can be applied to instances of :class:`~pystac.Asset`.
 
         Raises:
 
             pystac.ExtensionTypeError : If an invalid object type is passed.
         """
-        if isinstance(obj, pystac.Item):
-            return cast(FileExtension[T], ItemFileExtension(obj))
-        elif isinstance(obj, pystac.Asset):
+        if isinstance(obj, pystac.Asset):
             return cast(FileExtension[T], AssetFileExtension(obj))
         else:
             raise pystac.ExtensionTypeError(
                 f"File extension does not apply to type {type(obj)}"
             )
-
-
-class ItemFileExtension(FileExtension[pystac.Item]):
-    """A concrete implementation of :class:`FileExtension` on an :class:`~pystac.Item`
-    that extends the properties of the Item to include properties defined in the
-    :stac-ext:`File Info Extension <file>`.
-
-    This class should generally not be instantiated directly. Instead, call
-    :meth:`FileExtension.ext` on an :class:`~pystac.Item` to extend it.
-    """
-
-    def __init__(self, item: pystac.Item):
-        self.item = item
-        self.properties = item.properties
-
-    def __repr__(self) -> str:
-        return "<ItemFileExtension Item id={}>".format(self.item.id)
 
 
 class AssetFileExtension(FileExtension[pystac.Asset]):

--- a/pystac/extensions/label.py
+++ b/pystac/extensions/label.py
@@ -381,10 +381,10 @@ class LabelOverview:
 
 
 class LabelExtension(ExtensionManagementMixin[pystac.Item]):
-    """An abstract class that can be used to extend the properties of an
+    """A class that can be used to extend the properties of an
     :class:`~pystac.Item` with properties from the :stac-ext:`Label Extension <label>`.
 
-    To create a concrete instance of :class:`LabeExtension`, use the
+    To create an instance of :class:`LabeExtension`, use the
     :meth:`LabelExtension.ext` method. For example:
 
     .. code-block:: python
@@ -644,10 +644,6 @@ class LabelExtension(ExtensionManagementMixin[pystac.Item]):
         Extension <label>`.
 
         This extension can be applied to instances of :class:`~pystac.Item`.
-
-        Raises:
-
-            pystac.ExtensionTypeError : If an invalid object type is passed.
         """
         return cls(obj)
 

--- a/pystac/extensions/label.py
+++ b/pystac/extensions/label.py
@@ -29,7 +29,7 @@ class LabelRelType(str, Enum):
 
 
 class LabelType(str, Enum):
-    """Enumerates valid label types (RASTER or VECTOR)."""
+    """Enumerates valid label types ("raster" or "vector")."""
 
     def __str__(self) -> str:
         return str(self.value)
@@ -42,9 +42,9 @@ class LabelType(str, Enum):
 
 
 class LabelClasses:
-    """Defines the list of possible class names (e.g., tree, building, car, hippo)
+    """Defines the list of possible class names (e.g., tree, building, car, hippo).
 
-    Use LabelClasses.create to create a new instance of LabelClasses from
+    Use :meth:`LabelClasses.create` to create a new instance of ``LabelClasses`` from
     property values.
     """
 
@@ -56,11 +56,10 @@ class LabelClasses:
         classes: Union[List[str], List[int], List[float]],
         name: Optional[str] = None,
     ) -> None:
-        """Sets the properties for this LabelClasses.
+        """Sets the properties for this instance.
 
         Args:
-            classes : The different possible
-                class values.
+            classes : The different possible class values.
             name : The property key within the asset's each Feature corresponding
                 to class labels. If labels are raster-formatted, do not supply;
                 required otherwise.
@@ -74,17 +73,13 @@ class LabelClasses:
         classes: Union[List[str], List[int], List[float]],
         name: Optional[str] = None,
     ) -> "LabelClasses":
-        """Creates a new LabelClasses.
+        """Creates a new ``LabelClasses`` instance.
 
         Args:
-            classes : The different possible
-                class values.
+            classes : The different possible class values.
             name : The property key within the asset's each Feature corresponding
                 to class labels. If labels are raster-formatted, do not supply;
                 required otherwise.
-
-        Returns:
-            LabelClasses
         """
         c = cls({})
         c.apply(classes, name)
@@ -92,11 +87,7 @@ class LabelClasses:
 
     @property
     def classes(self) -> Union[List[str], List[int], List[float]]:
-        """Get or sets the class values.
-
-        Returns:
-            List[str] or List[int] or List[float]
-        """
+        """Gets or sets the class values."""
         result: Optional[
             Union[List[str], List[int], List[float]]
         ] = self.properties.get("classes")
@@ -117,8 +108,9 @@ class LabelClasses:
 
     @property
     def name(self) -> Optional[str]:
-        """Get or sets the property key within the asset's each Feature corresponding to
-        class labels. If labels are raster-formatted, do not supply; required otherwise.
+        """Gets or sets the property key within each Feature in the asset corresponding
+        to class labels. If labels are raster-formatted, do not supply; required
+        otherwise.
         """
         return self.properties.get("name")
 
@@ -135,18 +127,14 @@ class LabelClasses:
         )
 
     def to_dict(self) -> Dict[str, Any]:
-        """Returns the dictionary representing the JSON of this LabelClasses.
-
-        Returns:
-            dict: The wrapped dict of the LabelClasses that can be written out as JSON.
-        """
+        """Returns the dictionary representing the JSON of this LabelClasses."""
         return self.properties
 
 
 class LabelCount:
     """Contains counts for categorical data.
 
-    Use LabelCount.create to create a new LabelCount
+    Use :meth:`LabelCount.create` to create a new instance.
     """
 
     def __init__(self, properties: Dict[str, Any]):
@@ -164,7 +152,7 @@ class LabelCount:
 
     @classmethod
     def create(cls, name: str, count: int) -> "LabelCount":
-        """Creates a LabelCount.
+        """Creates a ``LabelCount`` instance.
 
         Args:
             name : One of the different possible classes within the property.
@@ -176,11 +164,7 @@ class LabelCount:
 
     @property
     def name(self) -> str:
-        """Get or sets the class that this count represents.
-
-        Returns:
-            str
-        """
+        """Gets or sets the class that this count represents."""
         result: Optional[str] = self.properties.get("name")
         if result is None:
             raise pystac.STACError(
@@ -194,11 +178,7 @@ class LabelCount:
 
     @property
     def count(self) -> int:
-        """Get or sets the number of occurrences of the class.
-
-        Returns:
-            int
-        """
+        """Get or sets the number of occurrences of the class."""
         result: Optional[int] = self.properties.get("count")
         if result is None:
             raise pystac.STACError(
@@ -211,18 +191,14 @@ class LabelCount:
         self.properties["count"] = v
 
     def to_dict(self) -> Dict[str, Any]:
-        """Returns the dictionary representing the JSON of this LabelCount.
-
-        Returns:
-            dict: The wrapped dict of the LabelCount that can be written out as JSON.
-        """
+        """Returns the dictionary representing the JSON of this instance."""
         return {"name": self.name, "count": self.count}
 
 
 class LabelStatistics:
     """Contains statistics for regression/continuous numeric value data.
 
-    Use LabelStatistics.create to create a new instance.
+    Use :meth:`LabelStatistics.create` to create a new instance.
     """
 
     def __init__(self, properties: Dict[str, Any]) -> None:
@@ -252,11 +228,7 @@ class LabelStatistics:
 
     @property
     def name(self) -> str:
-        """Get or sets the name of the statistic being reported.
-
-        Returns:
-            str
-        """
+        """Gets or sets the name of the statistic being reported."""
         result: Optional[str] = self.properties.get("name")
         if result is None:
             raise pystac.STACError(
@@ -270,11 +242,7 @@ class LabelStatistics:
 
     @property
     def value(self) -> float:
-        """Get or sets the value of the statistic
-
-        Returns:
-            float
-        """
+        """Gets or sets the value of the statistic."""
         result: Optional[float] = self.properties.get("value")
         if result is None:
             raise pystac.STACError(
@@ -287,12 +255,7 @@ class LabelStatistics:
         self.properties["value"] = v
 
     def to_dict(self) -> Dict[str, Any]:
-        """Returns the dictionary representing the JSON of this LabelStatistics.
-
-        Returns:
-            dict: The wrapped dict of the LabelStatistics that can be written out as
-            JSON.
-        """
+        """Returns the dictionary representing the JSON of this LabelStatistics."""
         return {"name": self.name, "value": self.value}
 
 
@@ -300,7 +263,7 @@ class LabelOverview:
     """Stores counts (for classification-type data) or summary statistics (for
     continuous numerical/regression data).
 
-    Use LabelOverview.create to create a new LabelOverview.
+    Use :meth:`LabelOverview.create` to create a new instance.
     """
 
     def __init__(self, properties: Dict[str, Any]):
@@ -312,7 +275,7 @@ class LabelOverview:
         counts: Optional[List[LabelCount]] = None,
         statistics: Optional[List[LabelStatistics]] = None,
     ) -> None:
-        """Sets the properties for this LabelOverview.
+        """Sets the properties for this instance.
 
         Either ``counts`` or ``statistics``, or both, can be placed in an overview;
         at least one is required.
@@ -321,10 +284,10 @@ class LabelOverview:
             property_key : The property key within the asset corresponding to
                 class labels that these counts or statistics are referencing. If the
                 label data is raster data, this should be None.
-            counts: Optional list of LabelCounts containing counts
+            counts: Optional list of :class:`LabelCounts` containing counts
                 for categorical data.
-            statistics: Optional list of statistics containing statistics for
-                regression/continuous numeric value data.
+            statistics: Optional list of :class:`LabelStatistics` containing statistics
+                for regression/continuous numeric value data.
         """
         self.property_key = property_key
         self.counts = counts
@@ -337,7 +300,7 @@ class LabelOverview:
         counts: Optional[List[LabelCount]] = None,
         statistics: Optional[List[LabelStatistics]] = None,
     ) -> "LabelOverview":
-        """Creates a new LabelOverview.
+        """Creates a new instance.
 
         Either ``counts`` or ``statistics``, or both, can be placed in an overview;
         at least one is required.
@@ -345,10 +308,10 @@ class LabelOverview:
         Args:
             property_key : The property key within the asset corresponding to
                 class labels.
-            counts: Optional list of LabelCounts containing counts for
+            counts: Optional list of :class:`LabelCounts` containing counts for
                 categorical data.
-            statistics: Optional list of Statistics containing statistics for
-                regression/continuous numeric value data.
+            statistics: Optional list of :class:`LabelStatistics` containing statistics
+                for regression/continuous numeric value data.
         """
         x = LabelOverview({})
         x.apply(property_key, counts, statistics)
@@ -356,11 +319,8 @@ class LabelOverview:
 
     @property
     def property_key(self) -> Optional[str]:
-        """Get or sets the property key within the asset corresponding to class labels.
-
-        Returns:
-            str
-        """
+        """Gets or sets the property key within the asset corresponding to class
+        labels."""
         return self.properties.get("property_key")
 
     @property_key.setter
@@ -369,11 +329,8 @@ class LabelOverview:
 
     @property
     def counts(self) -> Optional[List[LabelCount]]:
-        """Get or sets the list of LabelCounts containing counts for categorical data.
-
-        Returns:
-            List[LabelCount]
-        """
+        """Gets or sets the list of :class:`LabelCounts` containing counts for
+        categorical data."""
         counts = self.properties.get("counts")
         if counts is None:
             return None
@@ -393,12 +350,8 @@ class LabelOverview:
 
     @property
     def statistics(self) -> Optional[List[LabelStatistics]]:
-        """Get or sets the list of Statistics containing statistics for
-        regression/continuous numeric value data.
-
-        Returns:
-            List[Statistics]
-        """
+        """Gets or sets the list of :class:`LabelStatistics` containing statistics for
+        regression/continuous numeric value data."""
         statistics = self.properties.get("statistics")
         if statistics is None:
             return None
@@ -419,13 +372,13 @@ class LabelOverview:
 
     def merge_counts(self, other: "LabelOverview") -> "LabelOverview":
         """Merges the counts associated with this overview with another overview.
-        Creates a new LabelOverview.
+        Creates a new instance.
 
         Args:
             other : The other LabelOverview to merge.
 
         Returns:
-            LabelOverview: A new LabelOverview with the counts merged. This will
+            A new LabelOverview with the counts merged. This will
             drop any statistics associated with either of the LabelOverviews.
         """
         assert self.property_key == other.property_key
@@ -452,32 +405,22 @@ class LabelOverview:
         return LabelOverview.create(self.property_key, counts=new_counts)
 
     def to_dict(self) -> Dict[str, Any]:
-        """Returns the dictionary representing the JSON of this LabelOverview.
-
-        Returns:
-            dict: The wrapped dict of the LabelOverview that can be written out as JSON.
-        """
+        """Returns the dictionary representing the JSON of this LabelOverview."""
         return self.properties
 
 
 class LabelExtension(ExtensionManagementMixin[pystac.Item]):
-    """A LabelItemExt is the extension of the Item in the label extension which
-    represents a polygon, set of polygons, or raster data defining
-    labels and label metadata and should be part of a Collection.
+    """An abstract class that can be used to extend the properties of an
+    :class:`~pystac.Item` with properties from the :stac-ext:`Label Extension <label>`.
 
-    Args:
-        item : The item to be extended.
+    To create a concrete instance of :class:`LabeExtension`, use the
+    :meth:`LabelExtension.ext` method. For example:
 
-    Attributes:
-        item : The Item that is being extended.
+    .. code-block:: python
 
-    See:
-        :stac-ext:`Item fields in the label extension spec <label#item-properties>`
-
-    Note:
-        Using LabelItemExt to directly wrap an item will add the 'label' extension ID to
-        the item's stac_extensions.
-    """  # noqa E501
+       >>> item: pystac.Item = ...
+       >>> label_ext = LabelExtension.ext(item)
+    """
 
     def __init__(self, item: pystac.Item) -> None:
         self.obj = item
@@ -498,23 +441,24 @@ class LabelExtension(ExtensionManagementMixin[pystac.Item]):
         Args:
             label_description : A description of the label, how it was created,
                 and what it is recommended for
-            label_type : An ENUM of either vector label type or raster label type. Use
+            label_type : An Enum of either vector label type or raster label type. Use
                 one of :class:`~pystac.LabelType`.
             label_properties : These are the names of the property field(s) in each
                 Feature of the label asset's FeatureCollection that contains the classes
                 (keywords from label:classes if the property defines classes).
                 If labels are rasters, this should be None.
             label_classes : Optional, but required if using categorical data.
-                A list of LabelClasses defining the list of possible class names for each
-                label:properties. (e.g., tree, building, car, hippo)
+                A list of :class:`LabelClasses` instances defining the list of possible
+                class names for each label:properties. (e.g., tree, building, car,
+                hippo)
             label_tasks : Recommended to be a subset of 'regression', 'classification',
                 'detection', or 'segmentation', but may be an arbitrary value.
             label_methods: Recommended to be a subset of 'automated' or 'manual',
                 but may be an arbitrary value.
-            label_overviews : Optional list of LabelOverview classes
-                that store counts (for classification-type data) or summary statistics (for
-                continuous numerical/regression data).
-        """  # noqa E501
+            label_overviews : Optional list of :class:`LabelOverview` instances
+                that store counts (for classification-type data) or summary statistics
+                (for continuous numerical/regression data).
+        """
         self.label_description = label_description
         self.label_type = label_type
         self.label_properties = label_properties
@@ -525,12 +469,8 @@ class LabelExtension(ExtensionManagementMixin[pystac.Item]):
 
     @property
     def label_description(self) -> str:
-        """Get or sets a description of the label, how it was created,
-        and what it is recommended for.
-
-        Returns:
-            str
-        """
+        """Gets or sets a description of the label, how it was created,
+        and what it is recommended for."""
         result: Optional[str] = self.obj.properties.get("label:description")
         if result is None:
             raise pystac.STACError(f"label:description not set for item {self.obj.id}")
@@ -542,7 +482,7 @@ class LabelExtension(ExtensionManagementMixin[pystac.Item]):
 
     @property
     def label_type(self) -> LabelType:
-        """Gets or sets an ENUM of either vector label type or raster label type."""
+        """Gets or sets an Enum of either vector label type or raster label type."""
         result = self.obj.properties.get("label:type")
         if result is None:
             raise pystac.STACError(f"label:type is not set for item {self.obj.id}")
@@ -560,16 +500,10 @@ class LabelExtension(ExtensionManagementMixin[pystac.Item]):
 
     @property
     def label_properties(self) -> Optional[List[str]]:
-        """Label Properties
-
-        Gets or sets the names of the property field(s) in each
+        """Gets or sets the names of the property field(s) in each
         Feature of the label asset's FeatureCollection that contains the classes
         (keywords from label:classes if the property defines classes).
-        If labels are rasters, this should be None.
-
-        Returns:
-            List[str] or None
-        """
+        If labels are rasters, this should be None."""
         return self.obj.properties.get("label:properties")
 
     @label_properties.setter
@@ -584,14 +518,10 @@ class LabelExtension(ExtensionManagementMixin[pystac.Item]):
 
     @property
     def label_classes(self) -> Optional[List[LabelClasses]]:
-        """Get or set a list of LabelClasses defining the list of possible class names for each
-        label:properties. (e.g., tree, building, car, hippo).
+        """Gets or set a list of :class:`LabelClasses` defining the list of possible
+        class names for each label:properties. (e.g., tree, building, car, hippo).
 
-        Optional, but required if using categorical data.
-
-        Returns:
-            List[LabelClasses] or None
-        """
+        Optional, but required if using categorical data."""
         label_classes = self.obj.properties.get("label:classes")
         if label_classes is not None:
             return [LabelClasses(classes) for classes in label_classes]
@@ -613,13 +543,9 @@ class LabelExtension(ExtensionManagementMixin[pystac.Item]):
 
     @property
     def label_tasks(self) -> Optional[List[str]]:
-        """Get or set a list of tasks these labels apply to. Usually a subset of 'regression',
-            'classification', 'detection', or 'segmentation', but may be arbitrary
-            values.
-
-        Returns:
-            List[str] or None
-        """
+        """Gets or set a list of tasks these labels apply to. Usually a subset of 'regression',
+        'classification', 'detection', or 'segmentation', but may be arbitrary
+        values."""
         return self.obj.properties.get("label:tasks")
 
     @label_tasks.setter
@@ -636,13 +562,9 @@ class LabelExtension(ExtensionManagementMixin[pystac.Item]):
 
     @property
     def label_methods(self) -> Optional[List[str]]:
-        """Get or set a list of methods used for labeling.
+        """Gets or set a list of methods used for labeling.
 
-        Usually a subset of 'automated' or 'manual', but may be arbitrary values.
-
-        Returns:
-            List[str] or None
-        """
+        Usually a subset of 'automated' or 'manual', but may be arbitrary values."""
         return self.obj.properties.get("label:methods")
 
     @label_methods.setter
@@ -659,13 +581,9 @@ class LabelExtension(ExtensionManagementMixin[pystac.Item]):
 
     @property
     def label_overviews(self) -> Optional[List[LabelOverview]]:
-        """Get or set a list of LabelOverview classes
+        """Gets or set a list of :class:`LabelOverview` instances
         that store counts (for classification-type data) or summary statistics (for
-        continuous numerical/regression data).
-
-        Returns:
-            List[LabelOverview] or None
-        """
+        continuous numerical/regression data)."""
         overviews = self.obj.properties.get("label:overviews")
         if overviews is not None:
             return [LabelOverview(overview) for overview in overviews]
@@ -719,8 +637,8 @@ class LabelExtension(ExtensionManagementMixin[pystac.Item]):
         this LabelItem.
 
         Returns:
-            Generator[Items]: A possibly empty list of source imagery items. Determined
-            by links of this LabelItem that have ``rel=='source'``.
+            A possibly empty list of source imagery items. Determined by links of this
+            LabelItem that have ``rel=='source'``.
         """
         return map(lambda x: cast(pystac.Item, x), self.obj.get_stac_objects("source"))
 
@@ -781,6 +699,15 @@ class LabelExtension(ExtensionManagementMixin[pystac.Item]):
 
     @classmethod
     def ext(cls, obj: pystac.Item) -> "LabelExtension":
+        """Extends the given STAC Object with properties from the :stac-ext:`Label
+        Extension <label>`.
+
+        This extension can be applied to instances of :class:`~pystac.Item`.
+
+        Raises:
+
+            pystac.ExtensionTypeError : If an invalid object type is passed.
+        """
         return cls(obj)
 
 

--- a/pystac/extensions/version.py
+++ b/pystac/extensions/version.py
@@ -1,6 +1,6 @@
 """Implements the Versioning Indicators extension.
 
-:stac-ext:version
+https://github.com/stac-extensions/version
 """
 from enum import Enum
 from pystac.utils import get_required, map_opt

--- a/tests/data-files/file/collection.json
+++ b/tests/data-files/file/collection.json
@@ -1,0 +1,50 @@
+{
+    "stac_version": "1.0.0",
+    "stac_extensions": [
+      "https://stac-extensions.github.io/file/v2.0.0/schema.json"
+    ],
+    "id": "example",
+    "type": "Collection",
+    "title": "File Example",
+    "description": "This examples shows how to use the file extension for collection assets.",
+    "extent": {
+      "spatial": {
+        "bbox": [
+          [
+            -180,
+            -90,
+            180,
+            90
+          ]
+        ]
+      },
+      "temporal": {
+        "interval": [
+          [
+            "2012-01-15T12:00:00Z",
+            "2014-12-15T12:00:00Z"
+          ]
+        ]
+      }
+    },
+    "license": "Apache-2.0",
+    "links": [
+      {
+        "href": "https://example.com",
+        "type": "text/html",
+        "rel": "about"
+      }
+    ],
+    "assets": {
+      "thumbnail": {
+        "href": "logo.png",
+        "title": "A preview image for visualization.",
+        "type": "image/png",
+        "roles": [
+          "thumbnail"
+        ],
+        "file:checksum": "90e4021044a8995dd50b6657a037a7839304535b",
+        "file:size": 153600
+      }
+    }
+  }

--- a/tests/data-files/file/item.json
+++ b/tests/data-files/file/item.json
@@ -1,10 +1,16 @@
 {
+  "id": "S1A_EW_GRDM_1SSH_20181103T235855_20181103T235955_024430_02AD5D_5616",
   "type": "Feature",
   "stac_version": "1.0.0",
-  "id": "S1A_EW_GRDM_1SSH_20181103T235855_20181103T235955_024430_02AD5D_5616",
-  "properties": {
-    "datetime": "2018-11-03T23:58:55Z"
-  },
+  "stac_extensions": [
+    "https://stac-extensions.github.io/file/v2.0.0/schema.json"
+  ],
+  "bbox": [
+    -70.275032,
+    -64.72924,
+    -65.087479,
+    -51.105831
+  ],
   "geometry": {
     "type": "Polygon",
     "coordinates": [
@@ -32,54 +38,58 @@
       ]
     ]
   },
-  "links": [],
+  "properties": {
+    "datetime": "2018-11-03T23:58:55Z"
+  },
   "assets": {
     "noises": {
       "href": "./annotation/calibration/noise-s1a-ew-grd-hh-20181103t235855-20181103t235955-024430-02ad5d-001.xml",
-      "type": "text/xml",
       "title": "Calibration Schema",
+      "type": "text/xml",
       "file:checksum": "90e40210a30d1711e81a4b11ef67b28744321659"
     },
     "calibrations": {
       "href": "./annotation/calibration/calibration-s1a-ew-grd-hh-20181103t235855-20181103t235955-024430-02ad5d-001.xml",
-      "type": "text/xml",
       "title": "Noise Schema",
+      "type": "text/xml",
       "file:checksum": "90e402104fc5351af67db0b8f1746efe421a05e4"
     },
     "products": {
       "href": "./annotation/s1a-ew-grd-hh-20181103t235855-20181103t235955-024430-02ad5d-001.xml",
-      "type": "text/xml",
       "title": "Product Schema",
+      "type": "text/xml",
       "file:checksum": "90e402107a7f2588a85362b9beea2a12d4514d45"
     },
     "measurement": {
       "href": "./measurement/s1a-ew-grd-hh-20181103t235855-20181103t235955-024430-02ad5d-001.tiff",
-      "type": "image/tiff",
       "title": "Measurements",
+      "type": "image/tiff",
+      "sar:polarizations": [
+        "HH"
+      ],
       "file:byte_order": "little-endian",
-      "file:data_type": "uint16",
       "file:size": 209715200,
       "file:header_size": 4096,
       "file:checksum": "90e40210163700a8a6501eccd00b6d3b44ddaed0"
     },
     "thumbnail": {
       "href": "./preview/quick-look.png",
-      "type": "image/png",
       "title": "Thumbnail",
+      "type": "image/png",
       "file:byte_order": "big-endian",
-      "file:data_type": "uint8",
       "file:size": 146484,
-      "file:checksum": "90e40210f52acd32b09769d3b1871b420789456c",
-      "file:nodata": []
+      "file:checksum": "90e40210f52acd32b09769d3b1871b420789456c"
     }
   },
-  "bbox": [
-    -70.275032,
-    -64.72924,
-    -65.087479,
-    -51.105831
-  ],
-  "stac_extensions": [
-    "https://stac-extensions.github.io/file/v1.0.0/schema.json"
+  "links": [
+    {
+      "rel": "self",
+      "href": "./item.json"
+    },
+    {
+      "rel": "parent",
+      "href": "./collection.json",
+      "file:checksum": "11146d97123fd2c02dec9a1b6d3b13136dbe600cf966"
+    }
   ]
 }

--- a/tests/extensions/test_file.py
+++ b/tests/extensions/test_file.py
@@ -3,7 +3,7 @@ import unittest
 
 import pystac
 from tests.utils import TestCases, assert_to_from_dict
-from pystac.extensions.file import FileExtension, FileDataType
+from pystac.extensions.file import FileExtension
 
 
 class FileTest(unittest.TestCase):
@@ -48,32 +48,6 @@ class FileTest(unittest.TestCase):
         new_checksum = "90e40210163700a8a6501eccd00b6d3b44ddaed0"
         FileExtension.ext(asset).checksum = new_checksum
         self.assertEqual(new_checksum, FileExtension.ext(asset).checksum)
-        item.validate()
-
-    def test_asset_data_type(self) -> None:
-        item = pystac.Item.from_file(self.FILE_EXAMPLE_URI)
-        asset = item.assets["thumbnail"]
-
-        # Get
-        self.assertEqual(FileDataType.UINT8, FileExtension.ext(asset).data_type)
-
-        # Set
-        new_data_type = FileDataType.UINT16
-        FileExtension.ext(asset).data_type = new_data_type
-        self.assertEqual(new_data_type, FileExtension.ext(asset).data_type)
-        item.validate()
-
-    def test_asset_nodata(self) -> None:
-        item = pystac.Item.from_file(self.FILE_EXAMPLE_URI)
-        asset = item.assets["thumbnail"]
-
-        # Get
-        self.assertEqual([], FileExtension.ext(asset).nodata)
-
-        # Set
-        new_nodata = [-1]
-        FileExtension.ext(asset).nodata = new_nodata
-        self.assertEqual(new_nodata, FileExtension.ext(asset).nodata)
         item.validate()
 
     def test_migrates_old_checksum(self) -> None:

--- a/tests/extensions/test_file.py
+++ b/tests/extensions/test_file.py
@@ -176,12 +176,6 @@ class FileTest(unittest.TestCase):
             file_ext.__repr__(), f"<AssetFileExtension Asset href={asset.href}>"
         )
 
-    def test_extend_invalid_object(self) -> None:
-        item = pystac.Item.from_file(self.FILE_ITEM_EXAMPLE_URI)
-
-        with self.assertRaises(pystac.ExtensionTypeError):
-            _ = FileExtension.ext(item)
-
     def test_migrates_old_checksum(self) -> None:
         example_path = TestCases.get_path(
             "data-files/examples/1.0.0-beta.2/"

--- a/tests/extensions/test_file.py
+++ b/tests/extensions/test_file.py
@@ -3,26 +3,72 @@ import unittest
 
 import pystac
 from tests.utils import TestCases, assert_to_from_dict
-from pystac.extensions.file import FileExtension
+from pystac.extensions.file import FileExtension, ByteOrder, MappingObject
+
+
+class ByteOrderTest(unittest.TestCase):
+    def test_to_str(self) -> None:
+        self.assertEqual(str(ByteOrder.LITTLE_ENDIAN), "little-endian")
+        self.assertEqual(str(ByteOrder.BIG_ENDIAN), "big-endian")
+
+
+class MappingObjectTest(unittest.TestCase):
+    def test_create(self) -> None:
+        values = [0, 1]
+        summary = "clouds"
+        m = MappingObject.create(values, summary)
+
+        self.assertListEqual(m.values, values)
+        self.assertEqual(m.summary, summary)
+
+    def test_set_properties(self) -> None:
+        values = [0, 1]
+        summary = "clouds"
+        m = MappingObject.create(values, summary)
+
+        new_values = [3, 4]
+        new_summary = "cloud shadow"
+        m.summary = new_summary
+        m.values = new_values
+
+        self.assertListEqual(m.values, new_values)
+        self.assertEqual(m.summary, new_summary)
+
+    def test_apply(self) -> None:
+        values = [0, 1]
+        summary = "clouds"
+        m = MappingObject.create(values, summary)
+
+        new_values = [3, 4]
+        new_summary = "cloud shadow"
+        m.apply(new_values, new_summary)
+
+        self.assertListEqual(m.values, new_values)
+        self.assertEqual(m.summary, new_summary)
 
 
 class FileTest(unittest.TestCase):
-    FILE_EXAMPLE_URI = TestCases.get_path("data-files/file/file-example.json")
+    FILE_ITEM_EXAMPLE_URI = TestCases.get_path("data-files/file/item.json")
+    FILE_COLLECTION_EXAMPLE_URI = TestCases.get_path("data-files/file/collection.json")
 
     def setUp(self) -> None:
         self.maxDiff = None
 
     def test_to_from_dict(self) -> None:
-        with open(self.FILE_EXAMPLE_URI) as f:
+        with open(self.FILE_ITEM_EXAMPLE_URI) as f:
             item_dict = json.load(f)
         assert_to_from_dict(self, pystac.Item, item_dict)
 
-    def test_validate_file(self) -> None:
-        item = pystac.Item.from_file(self.FILE_EXAMPLE_URI)
+    def test_validate_item(self) -> None:
+        item = pystac.Item.from_file(self.FILE_ITEM_EXAMPLE_URI)
         item.validate()
 
-    def test_asset_size(self) -> None:
-        item = pystac.Item.from_file(self.FILE_EXAMPLE_URI)
+    def test_validate_collection(self) -> None:
+        collection = pystac.Collection.from_file(self.FILE_COLLECTION_EXAMPLE_URI)
+        collection.validate()
+
+    def test_item_asset_size(self) -> None:
+        item = pystac.Item.from_file(self.FILE_ITEM_EXAMPLE_URI)
         asset = item.assets["thumbnail"]
 
         # Get
@@ -34,8 +80,21 @@ class FileTest(unittest.TestCase):
         self.assertEqual(new_size, FileExtension.ext(asset).size)
         item.validate()
 
-    def test_asset_checksum(self) -> None:
-        item = pystac.Item.from_file(self.FILE_EXAMPLE_URI)
+    def test_item_asset_header_size(self) -> None:
+        item = pystac.Item.from_file(self.FILE_ITEM_EXAMPLE_URI)
+        asset = item.assets["measurement"]
+
+        # Get
+        self.assertEqual(4096, FileExtension.ext(asset).header_size)
+
+        # Set
+        new_header_size = 8192
+        FileExtension.ext(asset).header_size = new_header_size
+        self.assertEqual(new_header_size, FileExtension.ext(asset).header_size)
+        item.validate()
+
+    def test_item_asset_checksum(self) -> None:
+        item = pystac.Item.from_file(self.FILE_ITEM_EXAMPLE_URI)
         asset = item.assets["thumbnail"]
 
         # Get
@@ -49,6 +108,79 @@ class FileTest(unittest.TestCase):
         FileExtension.ext(asset).checksum = new_checksum
         self.assertEqual(new_checksum, FileExtension.ext(asset).checksum)
         item.validate()
+
+    def test_item_asset_byte_order(self) -> None:
+        # Get
+        item = pystac.Item.from_file(self.FILE_ITEM_EXAMPLE_URI)
+        asset = item.assets["thumbnail"]
+        file_ext = FileExtension.ext(asset)
+
+        self.assertEqual(ByteOrder.BIG_ENDIAN, file_ext.byte_order)
+
+        # Set
+        new_byte_order = ByteOrder.LITTLE_ENDIAN
+        file_ext.byte_order = new_byte_order
+
+        self.assertEqual(file_ext.byte_order, new_byte_order)
+
+        item.validate()
+
+    def test_item_asset_values(self) -> None:
+        # Set/get
+        item = pystac.Item.from_file(self.FILE_ITEM_EXAMPLE_URI)
+        asset = item.assets["thumbnail"]
+        file_ext = FileExtension.ext(asset)
+        values = [MappingObject.create([0], summary="clouds")]
+
+        file_ext.values = values
+
+        self.assertEqual(file_ext.values, values)
+
+    def test_item_asset_apply(self) -> None:
+        item = pystac.Item.from_file(self.FILE_ITEM_EXAMPLE_URI)
+        asset = item.assets["thumbnail"]
+        file_ext = FileExtension.ext(asset)
+
+        new_checksum = "90e40210163700a8a6501eccd00b6d3b44ddaed0"
+        new_size = 1
+        new_header_size = 8192
+        new_values = [MappingObject.create([0], summary="clouds")]
+        new_byte_order = ByteOrder.LITTLE_ENDIAN
+
+        self.assertNotEqual(file_ext.checksum, new_checksum)
+        self.assertNotEqual(file_ext.size, new_size)
+        self.assertNotEqual(file_ext.header_size, new_header_size)
+        self.assertNotEqual(file_ext.values, new_values)
+        self.assertNotEqual(file_ext.byte_order, new_byte_order)
+
+        file_ext.apply(
+            byte_order=new_byte_order,
+            checksum=new_checksum,
+            size=new_size,
+            header_size=new_header_size,
+            values=new_values,
+        )
+
+        self.assertEqual(file_ext.checksum, new_checksum)
+        self.assertEqual(file_ext.size, new_size)
+        self.assertEqual(file_ext.header_size, new_header_size)
+        self.assertEqual(file_ext.values, new_values)
+        self.assertEqual(file_ext.byte_order, new_byte_order)
+
+    def test_repr(self) -> None:
+        item = pystac.Item.from_file(self.FILE_ITEM_EXAMPLE_URI)
+        asset = item.assets["thumbnail"]
+        file_ext = FileExtension.ext(asset)
+
+        self.assertEqual(
+            file_ext.__repr__(), f"<AssetFileExtension Asset href={asset.href}>"
+        )
+
+    def test_extend_invalid_object(self) -> None:
+        item = pystac.Item.from_file(self.FILE_ITEM_EXAMPLE_URI)
+
+        with self.assertRaises(pystac.ExtensionTypeError):
+            _ = FileExtension.ext(item)
 
     def test_migrates_old_checksum(self) -> None:
         example_path = TestCases.get_path(


### PR DESCRIPTION
## Related Issue(s):

* #331 
* #326

## Description: 

### Version Extension

* Updates docstrings to be consistent with other extensions

### File Info Extension

* Updates implementation to be consistent with v2.0.0 of the extension spec
* Makes `FileExtension` a concrete class on Assets since the spec only defines properties on Assets
* Updates docstrings to be consistent with other extensions
* Adds tests to bring coverage up to 95%

### Label Extension

* Updates docstrings to be consistent with other extensions
* Adds tests to improve coverage to 95%
* Brings code style in line with other extensions
    Added constants for all property names, changed the bodies of many of the property methods to rely on type checking for input validation, and used `get_required` and `get_opt` more consistently.

### Other

* Bumps minimum allowed coverage to 90% since this PR brings it over that threshold.

## PR Checklist:

- [x] Code is formatted (run `scripts/format`)
- [x] Tests pass (run `scripts/test`)
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.