### PR TITLE
[WIP] Improve STACObject inheritance

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -164,11 +164,18 @@ RelType
 IO
 --
 
+StacIO
+~~~~~~
+
+.. autoclass:: pystac.StacIO
+   :members:
+   :undoc-members:
+
 STAC_IO
 ~~~~~~~
 
-STAC_IO is the utility mechanism that PySTAC uses for reading and writing. Users of
-PySTAC can hook into PySTAC by overriding members to utilize their own IO methods.
+.. deprecated:: 1.0.0-beta.1
+   Use :class:`pystac.StacIO` instead. This class will be removed in v1.0.0.
 
 .. autoclass:: pystac.stac_io.STAC_IO
    :members:

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -945,8 +945,18 @@ class Catalog(STACObject):
         return cast(Catalog, super().full_copy(root, parent))
 
     @classmethod
-    def from_file(cls, href: str, stac_io: Optional[pystac.StacIO] = None) -> "Catalog":
-        result = super().from_file(href, stac_io)
+    def from_file(
+        cls,
+        href: str,
+        stac_io: Optional[pystac.StacIO] = None,
+        migrate: bool = False,
+    ) -> "Catalog":
+        if stac_io is None:
+            stac_io = pystac.StacIO.default()
+
+        result = super().from_file(href, stac_io, migrate)
         if not isinstance(result, Catalog):
             raise pystac.STACTypeError(f"{result} is not a {Catalog}.")
+        result._stac_io = stac_io
+
         return result

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -919,7 +919,7 @@ class Catalog(STACObject):
 
         d.pop("stac_version")
 
-        cat = Catalog(
+        cat = cls(
             id=id,
             description=description,
             title=title,

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -904,7 +904,7 @@ class Catalog(STACObject):
         if migrate:
             result = pystac.read_dict(d, href=href, root=root)
             if not isinstance(result, Catalog):
-                raise pystac.STACError(f"{result} is not a Catalog")
+                raise pystac.STACTypeError(f"{result} is not a Catalog")
             return result
 
         catalog_type = CatalogType.determine_type(d)

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -610,7 +610,7 @@ class Collection(Catalog):
 
         d.pop("stac_version")
 
-        collection = Collection(
+        collection = cls(
             id=id,
             description=description,
             extent=extent,

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -670,9 +670,12 @@ class Collection(Catalog):
 
     @classmethod
     def from_file(
-        cls, href: str, stac_io: Optional[pystac.StacIO] = None
+        cls,
+        href: str,
+        stac_io: Optional[pystac.StacIO] = None,
+        migrate: bool = False,
     ) -> "Collection":
-        result = super().from_file(href, stac_io)
+        result = super().from_file(href, stac_io, migrate)
         if not isinstance(result, Collection):
             raise pystac.STACTypeError(f"{result} is not a {Collection}.")
         return result

--- a/pystac/serialization/__init__.py
+++ b/pystac/serialization/__init__.py
@@ -1,7 +1,4 @@
 # flake8: noqa
-from typing import Any, Dict, Optional, TYPE_CHECKING
-
-import pystac
 from pystac.serialization.identify import (
     STACVersionRange,
     identify_stac_object,
@@ -9,46 +6,3 @@ from pystac.serialization.identify import (
 )
 from pystac.serialization.common_properties import merge_common_properties
 from pystac.serialization.migrate import migrate_to_latest
-
-if TYPE_CHECKING:
-    from pystac.stac_object import STACObject
-    from pystac.catalog import Catalog
-
-
-def stac_object_from_dict(
-    d: Dict[str, Any], href: Optional[str] = None, root: Optional["Catalog"] = None
-) -> "STACObject":
-    """Determines how to deserialize a dictionary into a STAC object.
-
-    Args:
-        d : The dict to parse.
-        href : Optional href that is the file location of the object being
-            parsed.
-        root : Optional root of the catalog for this object.
-            If provided, the root's resolved object cache can be used to search for
-            previously resolved instances of the STAC object.
-
-    Note: This is used internally in StacIO instances to deserialize STAC Objects.
-    """
-    if identify_stac_object_type(d) == pystac.STACObjectType.ITEM:
-        collection_cache = None
-        if root is not None:
-            collection_cache = root._resolved_objects.as_collection_cache()
-
-        # Merge common properties in case this is an older STAC object.
-        merge_common_properties(d, json_href=href, collection_cache=collection_cache)
-
-    info = identify_stac_object(d)
-
-    d = migrate_to_latest(d, info)
-
-    if info.object_type == pystac.STACObjectType.CATALOG:
-        return pystac.Catalog.from_dict(d, href=href, root=root, migrate=False)
-
-    if info.object_type == pystac.STACObjectType.COLLECTION:
-        return pystac.Collection.from_dict(d, href=href, root=root, migrate=False)
-
-    if info.object_type == pystac.STACObjectType.ITEM:
-        return pystac.Item.from_dict(d, href=href, root=root, migrate=False)
-
-    raise pystac.STACTypeError(f"Unknown STAC object type {info.object_type}")

--- a/pystac/stac_io.py
+++ b/pystac/stac_io.py
@@ -271,22 +271,28 @@ class STAC_IO:
     """
 
     @staticmethod
-    def read_text_method(uri: str) -> str:
+    def issue_deprecation_warning() -> None:
         warnings.warn(
-            "STAC_IO is deprecated. "
-            "Please use instances of StacIO (e.g. StacIO.default()).",
+            "STAC_IO is deprecated and will be removed in v1.0.0. "
+            "Please use instances of StacIO (e.g. StacIO.default()) instead.",
             DeprecationWarning,
         )
+
+    def __init__(self) -> None:
+        STAC_IO.issue_deprecation_warning()
+
+    def __init_subclass__(cls) -> None:
+        STAC_IO.issue_deprecation_warning()
+
+    @staticmethod
+    def read_text_method(uri: str) -> str:
+        STAC_IO.issue_deprecation_warning()
         return StacIO.default().read_text(uri)
 
     @staticmethod
     def write_text_method(uri: str, txt: str) -> None:
         """Default method for writing text."""
-        warnings.warn(
-            "STAC_IO is deprecated. "
-            "Please use instances of StacIO (e.g. StacIO.default()).",
-            DeprecationWarning,
-        )
+        STAC_IO.issue_deprecation_warning()
         return StacIO.default().write_text(uri, txt)
 
     @staticmethod
@@ -295,11 +301,7 @@ class STAC_IO:
         href: Optional[str] = None,
         root: Optional["Catalog_Type"] = None,
     ) -> "STACObject_Type":
-        warnings.warn(
-            "STAC_IO is deprecated. "
-            "Please use instances of StacIO (e.g. StacIO.default()).",
-            DeprecationWarning,
-        )
+        STAC_IO.issue_deprecation_warning()
         return pystac.serialization.stac_object_from_dict(d, href, root)
 
     # This is set in __init__.py
@@ -356,6 +358,7 @@ class STAC_IO:
             STAC_IO in order to enable additional URI types, replace that member
             with your own implementation.
         """
+        STAC_IO.issue_deprecation_warning()
         result: Dict[str, Any] = json.loads(STAC_IO.read_text(uri))
         return result
 

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -488,10 +488,10 @@ class STACObject(ABC):
 
         # If this is a root catalog, set the root to the catalog instance.
         root_link = o.get_root_link()
-        if root_link is not None:
+        if isinstance(o, pystac.Catalog) and root_link is not None:
             if not root_link.is_resolved():
                 if root_link.get_absolute_href() == href:
-                    o.set_root(cast(pystac.Catalog, o))
+                    o.set_root(o)
         return o
 
     @classmethod

--- a/tests/extensions/test_eo.py
+++ b/tests/extensions/test_eo.py
@@ -53,8 +53,8 @@ class EOTest(unittest.TestCase):
         assert_to_from_dict(self, Item, item_dict)
 
     def test_validate_eo(self) -> None:
-        item = pystac.Item.from_file(self.LANDSAT_EXAMPLE_URI)
-        item2 = pystac.Item.from_file(self.BANDS_IN_ITEM_URI)
+        item = pystac.Item.from_file(self.LANDSAT_EXAMPLE_URI, migrate=True)
+        item2 = pystac.Item.from_file(self.BANDS_IN_ITEM_URI, migrate=True)
         item.validate()
         item2.validate()
 
@@ -198,8 +198,9 @@ class EOTest(unittest.TestCase):
     def test_read_pre_09_fields_into_common_metadata(self) -> None:
         eo_item = pystac.Item.from_file(
             TestCases.get_path(
-                "data-files/examples/0.8.1/item-spec/examples/" "landsat8-sample.json"
-            )
+                "data-files/examples/0.8.1/item-spec/examples/landsat8-sample.json"
+            ),
+            migrate=True,
         )
 
         self.assertEqual(eo_item.common_metadata.platform, "landsat-8")
@@ -208,8 +209,9 @@ class EOTest(unittest.TestCase):
     def test_reads_asset_bands_in_pre_1_0_version(self) -> None:
         item = pystac.Item.from_file(
             TestCases.get_path(
-                "data-files/examples/0.9.0/item-spec/examples/" "landsat8-sample.json"
-            )
+                "data-files/examples/0.9.0/item-spec/examples/landsat8-sample.json"
+            ),
+            migrate=True,
         )
 
         bands = EOExtension.ext(item.assets["B9"]).bands
@@ -220,8 +222,9 @@ class EOTest(unittest.TestCase):
     def test_reads_gsd_in_pre_1_0_version(self) -> None:
         eo_item = pystac.Item.from_file(
             TestCases.get_path(
-                "data-files/examples/0.9.0/item-spec/examples/" "landsat8-sample.json"
-            )
+                "data-files/examples/0.9.0/item-spec/examples/landsat8-sample.json"
+            ),
+            migrate=True,
         )
 
         self.assertEqual(eo_item.common_metadata.gsd, 30.0)

--- a/tests/extensions/test_file.py
+++ b/tests/extensions/test_file.py
@@ -81,7 +81,7 @@ class FileTest(unittest.TestCase):
             "data-files/examples/1.0.0-beta.2/"
             "extensions/checksum/examples/sentinel1.json"
         )
-        item = pystac.Item.from_file(example_path)
+        item = pystac.Item.from_file(example_path, migrate=True)
 
         self.assertTrue(FileExtension.has_extension(item))
         self.assertEqual(

--- a/tests/extensions/test_pointcloud.py
+++ b/tests/extensions/test_pointcloud.py
@@ -44,7 +44,7 @@ class PointcloudTest(unittest.TestCase):
         self.assertTrue(PointcloudExtension.has_extension(item))
 
     def test_validate_pointcloud(self) -> None:
-        item = pystac.Item.from_file(self.example_uri)
+        item = pystac.Item.from_file(self.example_uri, migrate=True)
         item.validate()
 
     def test_count(self) -> None:

--- a/tests/extensions/test_raster.py
+++ b/tests/extensions/test_raster.py
@@ -33,8 +33,8 @@ class RasterTest(unittest.TestCase):
         assert_to_from_dict(self, Item, item_dict)
 
     def test_validate_raster(self) -> None:
-        item = pystac.Item.from_file(self.PLANET_EXAMPLE_URI)
-        item2 = pystac.Item.from_file(self.SENTINEL2_EXAMPLE_URI)
+        item = pystac.Item.from_file(self.PLANET_EXAMPLE_URI, migrate=True)
+        item2 = pystac.Item.from_file(self.SENTINEL2_EXAMPLE_URI, migrate=True)
 
         item.validate()
         item2.validate()

--- a/tests/extensions/test_timestamps.py
+++ b/tests/extensions/test_timestamps.py
@@ -59,7 +59,7 @@ class TimestampsTest(unittest.TestCase):
             self.assertNotIn(p, item.properties)
 
     def test_validate_timestamps(self) -> None:
-        item = pystac.Item.from_file(self.example_uri)
+        item = pystac.Item.from_file(self.example_uri, migrate=True)
         item.validate()
 
     def test_expires(self) -> None:

--- a/tests/serialization/test_migrate.py
+++ b/tests/serialization/test_migrate.py
@@ -53,7 +53,8 @@ class MigrateTest(unittest.TestCase):
         item = pystac.Item.from_file(
             TestCases.get_path(
                 "data-files/examples/0.8.1/extensions/sar/examples/sentinel1.json"
-            )
+            ),
+            migrate=True,
         )
         self.assertFalse("dtr" in item.stac_extensions)
         self.assertEqual(
@@ -65,7 +66,8 @@ class MigrateTest(unittest.TestCase):
         item = pystac.Item.from_file(
             TestCases.get_path(
                 "data-files/examples/0.8.1/item-spec/" "examples/planet-sample.json"
-            )
+            ),
+            migrate=True,
         )
         self.assertTrue(ViewExtension.has_extension(item))
         view_ext = ViewExtension.ext(item)
@@ -78,7 +80,8 @@ class MigrateTest(unittest.TestCase):
             TestCases.get_path(
                 "data-files/examples/0.9.0/extensions/asset/"
                 "examples/example-landsat8.json"
-            )
+            ),
+            migrate=True,
         )
 
         self.assertTrue(ItemAssetsExtension.has_extension(collection))

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1107,3 +1107,22 @@ class FullCopyTest(unittest.TestCase):
             ].get_absolute_href()
             assert href is not None
             self.assertTrue(os.path.exists(href))
+
+
+class CatalogSubClassTest(unittest.TestCase):
+    """This tests cases related to creating classes inheriting from pystac.Catalog to
+    ensure that inheritance, class methods, etc. function as expected."""
+
+    TEST_CASE_1 = TestCases.get_path("data-files/catalogs/test-case-1/catalog.json")
+
+    class BasicCustomCatalog(pystac.Catalog):
+        pass
+
+    def setUp(self) -> None:
+        self.stac_io = pystac.StacIO.default()
+
+    def test_from_dict_returns_subclass(self) -> None:
+
+        catalog_dict = self.stac_io.read_json(self.TEST_CASE_1)
+        custom_catalog = self.BasicCustomCatalog.from_dict(catalog_dict)
+        self.assertIsInstance(custom_catalog, self.BasicCustomCatalog)

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1122,7 +1122,12 @@ class CatalogSubClassTest(unittest.TestCase):
         self.stac_io = pystac.StacIO.default()
 
     def test_from_dict_returns_subclass(self) -> None:
-
         catalog_dict = self.stac_io.read_json(self.TEST_CASE_1)
         custom_catalog = self.BasicCustomCatalog.from_dict(catalog_dict)
+
+        self.assertIsInstance(custom_catalog, self.BasicCustomCatalog)
+
+    def test_from_file_returns_subclass(self) -> None:
+        custom_catalog = self.BasicCustomCatalog.from_file(self.TEST_CASE_1)
+
         self.assertIsInstance(custom_catalog, self.BasicCustomCatalog)

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -249,3 +249,22 @@ class ExtentTest(unittest.TestCase):
 
         self.assertEqual(interval[0], datetime(2000, 1, 1, 12, 0, 0, 0, tzinfo=tz.UTC))
         self.assertEqual(interval[1], datetime(2001, 1, 1, 12, 0, 0, 0, tzinfo=tz.UTC))
+
+
+class CollectionSubClassTest(unittest.TestCase):
+    """This tests cases related to creating classes inheriting from pystac.Catalog to
+    ensure that inheritance, class methods, etc. function as expected."""
+
+    MULTI_EXTENT = TestCases.get_path("data-files/collections/multi-extent.json")
+
+    class BasicCustomCollection(pystac.Collection):
+        pass
+
+    def setUp(self) -> None:
+        self.stac_io = pystac.StacIO.default()
+
+    def test_from_dict_returns_subclass(self) -> None:
+
+        collection_dict = self.stac_io.read_json(self.MULTI_EXTENT)
+        custom_collection = self.BasicCustomCollection.from_dict(collection_dict)
+        self.assertIsInstance(custom_collection, self.BasicCustomCollection)

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -264,7 +264,12 @@ class CollectionSubClassTest(unittest.TestCase):
         self.stac_io = pystac.StacIO.default()
 
     def test_from_dict_returns_subclass(self) -> None:
-
         collection_dict = self.stac_io.read_json(self.MULTI_EXTENT)
         custom_collection = self.BasicCustomCollection.from_dict(collection_dict)
+
+        self.assertIsInstance(custom_collection, self.BasicCustomCollection)
+
+    def test_from_file_returns_subclass(self) -> None:
+        custom_collection = self.BasicCustomCollection.from_file(self.MULTI_EXTENT)
+
         self.assertIsInstance(custom_collection, self.BasicCustomCollection)

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -697,3 +697,22 @@ class CommonMetadataTest(unittest.TestCase):
         new_a1_value = cm.get_updated(item.assets["analytic"])
         self.assertEqual(new_a1_value, set_value)
         self.assertEqual(cm.updated, item_value)
+
+
+class ItemSubClassTest(unittest.TestCase):
+    """This tests cases related to creating classes inheriting from pystac.Catalog to
+    ensure that inheritance, class methods, etc. function as expected."""
+
+    SAMPLE_ITEM = TestCases.get_path("data-files/item/sample-item.json")
+
+    class BasicCustomItem(pystac.Item):
+        pass
+
+    def setUp(self) -> None:
+        self.stac_io = pystac.StacIO.default()
+
+    def test_from_dict_returns_subclass(self) -> None:
+
+        item_dict = self.stac_io.read_json(self.SAMPLE_ITEM)
+        custom_item = self.BasicCustomItem.from_dict(item_dict)
+        self.assertIsInstance(custom_item, self.BasicCustomItem)

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -712,7 +712,12 @@ class ItemSubClassTest(unittest.TestCase):
         self.stac_io = pystac.StacIO.default()
 
     def test_from_dict_returns_subclass(self) -> None:
-
         item_dict = self.stac_io.read_json(self.SAMPLE_ITEM)
         custom_item = self.BasicCustomItem.from_dict(item_dict)
+
+        self.assertIsInstance(custom_item, self.BasicCustomItem)
+
+    def test_from_file_returns_subclass(self) -> None:
+        custom_item = self.BasicCustomItem.from_file(self.SAMPLE_ITEM)
+
         self.assertIsInstance(custom_item, self.BasicCustomItem)

--- a/tests/validation/test_validate.py
+++ b/tests/validation/test_validate.py
@@ -18,7 +18,8 @@ from tests.utils import TestCases, get_temp_dir
 class ValidateTest(unittest.TestCase):
     def test_validate_current_version(self) -> None:
         catalog = pystac.read_file(
-            TestCases.get_path("data-files/catalogs/test-case-1/" "catalog.json")
+            TestCases.get_path("data-files/catalogs/test-case-1/" "catalog.json"),
+            migrate=True,
         )
         catalog.validate()
 


### PR DESCRIPTION
**Related Issue(s):** #

* #410 

**Description:**

Based on #410 and conversation with @matthewhanson, this is a start on some work to:

1) Allow developers to create their own sub-classes of `Item`, `Collection`, and `Catalog` and have the classmethods return the expected sub-classes (see [this Catalog test](https://github.com/stac-utils/pystac/compare/main...duckontheweb:change/improve-inheritance?expand=1#diff-dad40ec903acd3037d7ca2f6ac1189e05d804df131b03727dc41e80c0f43c0ebR1112) for an example use-case).

2) Decouple migration from serialization (or at least make it more explicit and transparent)

3) Simplify some of the interplay between the `stac_io`, `STACObject`, and the `serialization` module.

I haven't made as much headway on the 3rd point, but I'm interested in feedback on the approach so far.

This also updates the deprecation notice for `STAC_IO`. If this PR ends up needing more time I can break that off into a separate PR so we can get it into the next pre-release.

cc: @matthewhanson @lossyrob 

**PR Checklist:**

- [ ] Code is formatted (run `scripts/format`)
- [ ] Tests pass (run `scripts/test`)
- [ ] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.