### PR TITLE
Use environment variable for tmp dir location

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -54,15 +54,17 @@ jobs:
           path: ~\AppData\Local\pip\Cache
           # Cache based on OS, Python version, and dependency hash
           key: pip-${{ runner.os }}-python${{ matrix.python-version }}-${{ hashFiles('requirements-test.txt') }}
-      
+
       - name: Install dependencies
         run: |
           pip install -r requirements-test.txt
           pip install -e ".[validation]"
-
+      
       - name: Execute test suite
         run: ./scripts/test
         shell: bash
+        env:
+          TMPDIR: "${{ matrix.os == 'windows-latest' && 'D:\\a\\_temp' || '' }}"
       
       - name: Upload All coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-tmp*
 *.pyc
 *.egg-info
 *.eggs

--- a/tests/data-files/get_examples.py
+++ b/tests/data-files/get_examples.py
@@ -6,7 +6,7 @@ import os
 import argparse
 import json
 from subprocess import call
-from tempfile import TemporaryDirectory
+import tempfile
 from typing import Any, Dict, List, Optional
 from urllib.error import HTTPError
 
@@ -50,7 +50,7 @@ if __name__ == "__main__":
 
     examples_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "examples"))
 
-    with TemporaryDirectory() as tmp_dir:
+    with tempfile.TemporaryDirectory() as tmp_dir:
         call(
             [
                 "git",

--- a/tests/data-files/get_examples.py
+++ b/tests/data-files/get_examples.py
@@ -6,12 +6,12 @@ import os
 import argparse
 import json
 from subprocess import call
+from tempfile import TemporaryDirectory
 from typing import Any, Dict, List, Optional
 from urllib.error import HTTPError
 
 import pystac
 from pystac.serialization import identify_stac_object
-from tests.utils import get_temp_dir
 
 
 def remove_bad_collection(js: Dict[str, Any]) -> Dict[str, Any]:
@@ -50,7 +50,7 @@ if __name__ == "__main__":
 
     examples_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "examples"))
 
-    with get_temp_dir() as tmp_dir:
+    with TemporaryDirectory() as tmp_dir:
         call(
             [
                 "git",

--- a/tests/extensions/test_label.py
+++ b/tests/extensions/test_label.py
@@ -1,6 +1,7 @@
 import json
 import os
 import unittest
+from tempfile import TemporaryDirectory
 
 import pystac
 from pystac import Catalog, Item, CatalogType
@@ -15,7 +16,7 @@ from pystac.extensions.label import (
 )
 import pystac.validation
 from pystac.utils import get_opt
-from tests.utils import TestCases, assert_to_from_dict, get_temp_dir
+from tests.utils import TestCases, assert_to_from_dict
 
 
 class LabelTest(unittest.TestCase):
@@ -85,7 +86,7 @@ class LabelTest(unittest.TestCase):
             label_example_1_dict, pystac.STACObjectType.ITEM
         )
 
-        with get_temp_dir() as tmp_dir:
+        with TemporaryDirectory() as tmp_dir:
             cat_dir = os.path.join(tmp_dir, "catalog")
             catalog = TestCases.test_case_1()
             catalog.normalize_and_save(cat_dir, catalog_type=CatalogType.SELF_CONTAINED)

--- a/tests/extensions/test_label.py
+++ b/tests/extensions/test_label.py
@@ -1,7 +1,7 @@
 import json
 import os
 import unittest
-from tempfile import TemporaryDirectory
+import tempfile
 
 import pystac
 from pystac import Catalog, Item, CatalogType
@@ -86,7 +86,7 @@ class LabelTest(unittest.TestCase):
             label_example_1_dict, pystac.STACObjectType.ITEM
         )
 
-        with TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory() as tmp_dir:
             cat_dir = os.path.join(tmp_dir, "catalog")
             catalog = TestCases.test_case_1()
             catalog.normalize_and_save(cat_dir, catalog_type=CatalogType.SELF_CONTAINED)

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,5 +1,6 @@
 import os
 import json
+from tempfile import TemporaryDirectory
 from typing import Any, Dict, List, Tuple, Union, cast
 import unittest
 from datetime import datetime
@@ -22,14 +23,13 @@ from tests.utils import (
     ARBITRARY_GEOM,
     ARBITRARY_BBOX,
     MockStacIO,
-    get_temp_dir,
 )
 
 
 class CatalogTypeTest(unittest.TestCase):
     def test_determine_type_for_absolute_published(self) -> None:
         cat = TestCases.test_case_1()
-        with get_temp_dir() as tmp_dir:
+        with TemporaryDirectory() as tmp_dir:
             cat.normalize_and_save(tmp_dir, catalog_type=CatalogType.ABSOLUTE_PUBLISHED)
             cat_json = pystac.StacIO.default().read_json(
                 os.path.join(tmp_dir, "catalog.json")
@@ -40,7 +40,7 @@ class CatalogTypeTest(unittest.TestCase):
 
     def test_determine_type_for_relative_published(self) -> None:
         cat = TestCases.test_case_2()
-        with get_temp_dir() as tmp_dir:
+        with TemporaryDirectory() as tmp_dir:
             cat.normalize_and_save(tmp_dir, catalog_type=CatalogType.RELATIVE_PUBLISHED)
             cat_json = pystac.StacIO.default().read_json(
                 os.path.join(tmp_dir, "catalog.json")
@@ -68,7 +68,7 @@ class CatalogTypeTest(unittest.TestCase):
 
 class CatalogTest(unittest.TestCase):
     def test_create_and_read(self) -> None:
-        with get_temp_dir() as tmp_dir:
+        with TemporaryDirectory() as tmp_dir:
             cat_dir = os.path.join(tmp_dir, "catalog")
             catalog = TestCases.test_case_1()
 
@@ -288,7 +288,7 @@ class CatalogTest(unittest.TestCase):
     def test_save_uses_previous_catalog_type(self) -> None:
         catalog = TestCases.test_case_1()
         assert catalog.catalog_type == CatalogType.SELF_CONTAINED
-        with get_temp_dir() as tmp_dir:
+        with TemporaryDirectory() as tmp_dir:
             catalog.normalize_hrefs(tmp_dir)
             href = catalog.self_href
             catalog.save()
@@ -365,7 +365,7 @@ class CatalogTest(unittest.TestCase):
 
         catalog.generate_subcatalogs("${year}/${day}")
 
-        with get_temp_dir() as tmp_dir:
+        with TemporaryDirectory() as tmp_dir:
             catalog.normalize_hrefs(tmp_dir)
             catalog.save(pystac.CatalogType.SELF_CONTAINED)
 
@@ -494,7 +494,7 @@ class CatalogTest(unittest.TestCase):
             item.properties["ITEM_MAPPER"] = "YEP"
             return item
 
-        with get_temp_dir() as tmp_dir:
+        with TemporaryDirectory() as tmp_dir:
             catalog = TestCases.test_case_1()
 
             new_cat = catalog.map_items(item_mapper)
@@ -518,7 +518,7 @@ class CatalogTest(unittest.TestCase):
             item2.properties["ITEM_MAPPER_2"] = "YEP"
             return [item, item2]
 
-        with get_temp_dir() as tmp_dir:
+        with TemporaryDirectory() as tmp_dir:
             catalog = TestCases.test_case_1()
             catalog_items = catalog.get_all_items()
 
@@ -623,7 +623,7 @@ class CatalogTest(unittest.TestCase):
 
             return asset
 
-        with get_temp_dir() as tmp_dir:
+        with TemporaryDirectory() as tmp_dir:
             catalog = TestCases.test_case_2()
 
             new_cat = catalog.map_assets(asset_mapper)
@@ -656,7 +656,7 @@ class CatalogTest(unittest.TestCase):
             else:
                 return asset
 
-        with get_temp_dir() as tmp_dir:
+        with TemporaryDirectory() as tmp_dir:
             catalog = TestCases.test_case_2()
 
             new_cat = catalog.map_assets(asset_mapper)
@@ -696,7 +696,7 @@ class CatalogTest(unittest.TestCase):
             else:
                 return asset
 
-        with get_temp_dir() as tmp_dir:
+        with TemporaryDirectory() as tmp_dir:
             catalog = TestCases.test_case_2()
 
             new_cat = catalog.map_assets(asset_mapper)
@@ -771,7 +771,7 @@ class CatalogTest(unittest.TestCase):
         test_cases = TestCases.all_test_catalogs()
 
         for catalog in test_cases:
-            with get_temp_dir() as tmp_dir:
+            with TemporaryDirectory() as tmp_dir:
                 c2 = catalog.full_copy()
                 c2.normalize_hrefs(tmp_dir)
                 c2.catalog_type = CatalogType.RELATIVE_PUBLISHED
@@ -797,7 +797,7 @@ class CatalogTest(unittest.TestCase):
 
         catalog.extra_fields["custom_field"] = "Special content"
 
-        with get_temp_dir() as tmp_dir:
+        with TemporaryDirectory() as tmp_dir:
             p = os.path.join(tmp_dir, "catalog.json")
             catalog.save_object(include_self_link=False, dest_href=p)
             with open(p) as f:
@@ -822,7 +822,7 @@ class CatalogTest(unittest.TestCase):
         item = cat.get_item("area-1-1-labels", recursive=True)
         assert item is not None
         item.geometry = {"type": "INVALID", "coordinates": "NONE"}
-        with get_temp_dir() as tmp_dir:
+        with TemporaryDirectory() as tmp_dir:
             cat.normalize_hrefs(tmp_dir)
             cat.save(catalog_type=pystac.CatalogType.SELF_CONTAINED)
 
@@ -843,7 +843,7 @@ class CatalogTest(unittest.TestCase):
             year += 1
             month += 1
 
-        with get_temp_dir() as tmp_dir:
+        with TemporaryDirectory() as tmp_dir:
             for root, _, items in catalog.walk():
 
                 # Set root's HREF based off the parent
@@ -933,7 +933,7 @@ class CatalogTest(unittest.TestCase):
         for item in cat.get_all_items():
             pass
 
-        with get_temp_dir() as tmp_dir:
+        with TemporaryDirectory() as tmp_dir:
             new_stac_uri = os.path.join(tmp_dir, "test-case-6")
             cat.normalize_hrefs(new_stac_uri)
             cat.save(catalog_type=CatalogType.SELF_CONTAINED)
@@ -1003,7 +1003,7 @@ class FullCopyTest(unittest.TestCase):
             self.check_item(item, tag)
 
     def test_full_copy_1(self) -> None:
-        with get_temp_dir() as tmp_dir:
+        with TemporaryDirectory() as tmp_dir:
             cat = Catalog(id="test", description="test catalog")
 
             item = Item(
@@ -1024,7 +1024,7 @@ class FullCopyTest(unittest.TestCase):
             self.check_catalog(cat2, "dest")
 
     def test_full_copy_2(self) -> None:
-        with get_temp_dir() as tmp_dir:
+        with TemporaryDirectory() as tmp_dir:
             cat = Catalog(id="test", description="test catalog")
             image_item = Item(
                 id="Imagery",
@@ -1071,7 +1071,7 @@ class FullCopyTest(unittest.TestCase):
             self.check_catalog(cat2, "dest")
 
     def test_full_copy_3(self) -> None:
-        with get_temp_dir() as tmp_dir:
+        with TemporaryDirectory() as tmp_dir:
             root_cat = TestCases.test_case_1()
             root_cat.normalize_hrefs(
                 os.path.join(tmp_dir, "catalog-full-copy-3-source")
@@ -1085,7 +1085,7 @@ class FullCopyTest(unittest.TestCase):
             self.check_catalog(cat2, "dest")
 
     def test_full_copy_4(self) -> None:
-        with get_temp_dir() as tmp_dir:
+        with TemporaryDirectory() as tmp_dir:
             root_cat = TestCases.test_case_2()
             root_cat.normalize_hrefs(
                 os.path.join(tmp_dir, "catalog-full-copy-4-source")

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,6 +1,6 @@
 import os
 import json
-from tempfile import TemporaryDirectory
+import tempfile
 from typing import Any, Dict, List, Tuple, Union, cast
 import unittest
 from datetime import datetime
@@ -29,7 +29,7 @@ from tests.utils import (
 class CatalogTypeTest(unittest.TestCase):
     def test_determine_type_for_absolute_published(self) -> None:
         cat = TestCases.test_case_1()
-        with TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory() as tmp_dir:
             cat.normalize_and_save(tmp_dir, catalog_type=CatalogType.ABSOLUTE_PUBLISHED)
             cat_json = pystac.StacIO.default().read_json(
                 os.path.join(tmp_dir, "catalog.json")
@@ -40,7 +40,7 @@ class CatalogTypeTest(unittest.TestCase):
 
     def test_determine_type_for_relative_published(self) -> None:
         cat = TestCases.test_case_2()
-        with TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory() as tmp_dir:
             cat.normalize_and_save(tmp_dir, catalog_type=CatalogType.RELATIVE_PUBLISHED)
             cat_json = pystac.StacIO.default().read_json(
                 os.path.join(tmp_dir, "catalog.json")
@@ -68,7 +68,7 @@ class CatalogTypeTest(unittest.TestCase):
 
 class CatalogTest(unittest.TestCase):
     def test_create_and_read(self) -> None:
-        with TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory() as tmp_dir:
             cat_dir = os.path.join(tmp_dir, "catalog")
             catalog = TestCases.test_case_1()
 
@@ -288,7 +288,7 @@ class CatalogTest(unittest.TestCase):
     def test_save_uses_previous_catalog_type(self) -> None:
         catalog = TestCases.test_case_1()
         assert catalog.catalog_type == CatalogType.SELF_CONTAINED
-        with TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory() as tmp_dir:
             catalog.normalize_hrefs(tmp_dir)
             href = catalog.self_href
             catalog.save()
@@ -365,7 +365,7 @@ class CatalogTest(unittest.TestCase):
 
         catalog.generate_subcatalogs("${year}/${day}")
 
-        with TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory() as tmp_dir:
             catalog.normalize_hrefs(tmp_dir)
             catalog.save(pystac.CatalogType.SELF_CONTAINED)
 
@@ -494,7 +494,7 @@ class CatalogTest(unittest.TestCase):
             item.properties["ITEM_MAPPER"] = "YEP"
             return item
 
-        with TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory() as tmp_dir:
             catalog = TestCases.test_case_1()
 
             new_cat = catalog.map_items(item_mapper)
@@ -518,7 +518,7 @@ class CatalogTest(unittest.TestCase):
             item2.properties["ITEM_MAPPER_2"] = "YEP"
             return [item, item2]
 
-        with TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory() as tmp_dir:
             catalog = TestCases.test_case_1()
             catalog_items = catalog.get_all_items()
 
@@ -623,7 +623,7 @@ class CatalogTest(unittest.TestCase):
 
             return asset
 
-        with TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory() as tmp_dir:
             catalog = TestCases.test_case_2()
 
             new_cat = catalog.map_assets(asset_mapper)
@@ -656,7 +656,7 @@ class CatalogTest(unittest.TestCase):
             else:
                 return asset
 
-        with TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory() as tmp_dir:
             catalog = TestCases.test_case_2()
 
             new_cat = catalog.map_assets(asset_mapper)
@@ -696,7 +696,7 @@ class CatalogTest(unittest.TestCase):
             else:
                 return asset
 
-        with TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory() as tmp_dir:
             catalog = TestCases.test_case_2()
 
             new_cat = catalog.map_assets(asset_mapper)
@@ -771,7 +771,7 @@ class CatalogTest(unittest.TestCase):
         test_cases = TestCases.all_test_catalogs()
 
         for catalog in test_cases:
-            with TemporaryDirectory() as tmp_dir:
+            with tempfile.TemporaryDirectory() as tmp_dir:
                 c2 = catalog.full_copy()
                 c2.normalize_hrefs(tmp_dir)
                 c2.catalog_type = CatalogType.RELATIVE_PUBLISHED
@@ -797,7 +797,7 @@ class CatalogTest(unittest.TestCase):
 
         catalog.extra_fields["custom_field"] = "Special content"
 
-        with TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory() as tmp_dir:
             p = os.path.join(tmp_dir, "catalog.json")
             catalog.save_object(include_self_link=False, dest_href=p)
             with open(p) as f:
@@ -822,7 +822,7 @@ class CatalogTest(unittest.TestCase):
         item = cat.get_item("area-1-1-labels", recursive=True)
         assert item is not None
         item.geometry = {"type": "INVALID", "coordinates": "NONE"}
-        with TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory() as tmp_dir:
             cat.normalize_hrefs(tmp_dir)
             cat.save(catalog_type=pystac.CatalogType.SELF_CONTAINED)
 
@@ -843,7 +843,7 @@ class CatalogTest(unittest.TestCase):
             year += 1
             month += 1
 
-        with TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory() as tmp_dir:
             for root, _, items in catalog.walk():
 
                 # Set root's HREF based off the parent
@@ -933,7 +933,7 @@ class CatalogTest(unittest.TestCase):
         for item in cat.get_all_items():
             pass
 
-        with TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory() as tmp_dir:
             new_stac_uri = os.path.join(tmp_dir, "test-case-6")
             cat.normalize_hrefs(new_stac_uri)
             cat.save(catalog_type=CatalogType.SELF_CONTAINED)
@@ -1003,7 +1003,7 @@ class FullCopyTest(unittest.TestCase):
             self.check_item(item, tag)
 
     def test_full_copy_1(self) -> None:
-        with TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory() as tmp_dir:
             cat = Catalog(id="test", description="test catalog")
 
             item = Item(
@@ -1024,7 +1024,7 @@ class FullCopyTest(unittest.TestCase):
             self.check_catalog(cat2, "dest")
 
     def test_full_copy_2(self) -> None:
-        with TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory() as tmp_dir:
             cat = Catalog(id="test", description="test catalog")
             image_item = Item(
                 id="Imagery",
@@ -1071,7 +1071,7 @@ class FullCopyTest(unittest.TestCase):
             self.check_catalog(cat2, "dest")
 
     def test_full_copy_3(self) -> None:
-        with TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory() as tmp_dir:
             root_cat = TestCases.test_case_1()
             root_cat.normalize_hrefs(
                 os.path.join(tmp_dir, "catalog-full-copy-3-source")
@@ -1085,7 +1085,7 @@ class FullCopyTest(unittest.TestCase):
             self.check_catalog(cat2, "dest")
 
     def test_full_copy_4(self) -> None:
-        with TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory() as tmp_dir:
             root_cat = TestCases.test_case_2()
             root_cat.normalize_hrefs(
                 os.path.join(tmp_dir, "catalog-full-copy-4-source")

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -3,13 +3,14 @@ import os
 import json
 from datetime import datetime
 from dateutil import tz
+from tempfile import TemporaryDirectory
 
 import pystac
 from pystac.extensions.eo import EOExtension
 from pystac.validation import validate_dict
 from pystac import Collection, Item, Extent, SpatialExtent, TemporalExtent, CatalogType
 from pystac.utils import datetime_to_str
-from tests.utils import TestCases, ARBITRARY_GEOM, ARBITRARY_BBOX, get_temp_dir
+from tests.utils import TestCases, ARBITRARY_GEOM, ARBITRARY_BBOX
 
 TEST_DATETIME = datetime(2020, 3, 14, 16, 32)
 
@@ -34,7 +35,7 @@ class CollectionTest(unittest.TestCase):
         collection = TestCases.test_case_8()
         assert collection.STAC_OBJECT_TYPE == pystac.STACObjectType.COLLECTION
         self.assertEqual(collection.catalog_type, CatalogType.SELF_CONTAINED)
-        with get_temp_dir() as tmp_dir:
+        with TemporaryDirectory() as tmp_dir:
             collection.normalize_hrefs(tmp_dir)
             href = collection.self_href
             collection.save()
@@ -83,7 +84,7 @@ class CollectionTest(unittest.TestCase):
 
         collection.extra_fields["test"] = "extra"
 
-        with get_temp_dir() as tmp_dir:
+        with TemporaryDirectory() as tmp_dir:
             p = os.path.join(tmp_dir, "collection.json")
             collection.save_object(include_self_link=False, dest_href=p)
             with open(p) as f:

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -3,7 +3,7 @@ import os
 import json
 from datetime import datetime
 from dateutil import tz
-from tempfile import TemporaryDirectory
+import tempfile
 
 import pystac
 from pystac.extensions.eo import EOExtension
@@ -35,7 +35,7 @@ class CollectionTest(unittest.TestCase):
         collection = TestCases.test_case_8()
         assert collection.STAC_OBJECT_TYPE == pystac.STACObjectType.COLLECTION
         self.assertEqual(collection.catalog_type, CatalogType.SELF_CONTAINED)
-        with TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory() as tmp_dir:
             collection.normalize_hrefs(tmp_dir)
             href = collection.self_href
             collection.save()
@@ -84,7 +84,7 @@ class CollectionTest(unittest.TestCase):
 
         collection.extra_fields["test"] = "extra"
 
-        with TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory() as tmp_dir:
             p = os.path.join(tmp_dir, "collection.json")
             collection.save_object(include_self_link=False, dest_href=p)
             with open(p) as f:

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -1,6 +1,7 @@
 import os
 from datetime import datetime
 import json
+from tempfile import TemporaryDirectory
 from typing import Any, Dict, List
 import unittest
 
@@ -10,7 +11,7 @@ from pystac.validation import validate_dict
 import pystac.serialization.common_properties
 from pystac.item import CommonMetadata
 from pystac.utils import datetime_to_str, get_opt, str_to_datetime, is_absolute_href
-from tests.utils import TestCases, assert_to_from_dict, get_temp_dir
+from tests.utils import TestCases, assert_to_from_dict
 
 
 class ItemTest(unittest.TestCase):
@@ -72,7 +73,7 @@ class ItemTest(unittest.TestCase):
 
         item.extra_fields["test"] = "extra"
 
-        with get_temp_dir() as tmp_dir:
+        with TemporaryDirectory() as tmp_dir:
             p = os.path.join(tmp_dir, "item.json")
             item.save_object(include_self_link=False, dest_href=p)
             with open(p) as f:

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -1,7 +1,7 @@
 import os
 from datetime import datetime
 import json
-from tempfile import TemporaryDirectory
+import tempfile
 from typing import Any, Dict, List
 import unittest
 
@@ -73,7 +73,7 @@ class ItemTest(unittest.TestCase):
 
         item.extra_fields["test"] = "extra"
 
-        with TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory() as tmp_dir:
             p = os.path.join(tmp_dir, "item.json")
             item.save_object(include_self_link=False, dest_href=p)
             with open(p) as f:

--- a/tests/test_stac_io.py
+++ b/tests/test_stac_io.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 import warnings
-from tempfile import TemporaryDirectory
+import tempfile
 
 import pystac
 from pystac.stac_io import STAC_IO
@@ -26,14 +26,14 @@ class StacIOTest(unittest.TestCase):
         collection = pystac.read_file(
             TestCases.get_path("data-files/collections/multi-extent.json")
         )
-        with TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory() as tmp_dir:
             dest_href = os.path.join(tmp_dir, "collection.json")
             pystac.write_file(collection, dest_href=dest_href)
             self.assertTrue(os.path.exists(dest_href), msg="File was not written.")
 
     def test_read_item(self) -> None:
         item = pystac.read_file(TestCases.get_path("data-files/item/sample-item.json"))
-        with TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory() as tmp_dir:
             dest_href = os.path.join(tmp_dir, "item.json")
             pystac.write_file(item, dest_href=dest_href)
             self.assertTrue(os.path.exists(dest_href), msg="File was not written.")
@@ -42,7 +42,7 @@ class StacIOTest(unittest.TestCase):
         catalog = pystac.read_file(
             TestCases.get_path("data-files/catalogs/test-case-1/catalog.json")
         )
-        with TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory() as tmp_dir:
             dest_href = os.path.join(tmp_dir, "catalog.json")
             pystac.write_file(catalog, dest_href=dest_href)
             self.assertTrue(os.path.exists(dest_href), msg="File was not written.")

--- a/tests/test_stac_io.py
+++ b/tests/test_stac_io.py
@@ -1,10 +1,11 @@
 import os
 import unittest
 import warnings
+from tempfile import TemporaryDirectory
 
 import pystac
 from pystac.stac_io import STAC_IO
-from tests.utils import TestCases, get_temp_dir
+from tests.utils import TestCases
 
 
 class StacIOTest(unittest.TestCase):
@@ -25,14 +26,14 @@ class StacIOTest(unittest.TestCase):
         collection = pystac.read_file(
             TestCases.get_path("data-files/collections/multi-extent.json")
         )
-        with get_temp_dir() as tmp_dir:
+        with TemporaryDirectory() as tmp_dir:
             dest_href = os.path.join(tmp_dir, "collection.json")
             pystac.write_file(collection, dest_href=dest_href)
             self.assertTrue(os.path.exists(dest_href), msg="File was not written.")
 
     def test_read_item(self) -> None:
         item = pystac.read_file(TestCases.get_path("data-files/item/sample-item.json"))
-        with get_temp_dir() as tmp_dir:
+        with TemporaryDirectory() as tmp_dir:
             dest_href = os.path.join(tmp_dir, "item.json")
             pystac.write_file(item, dest_href=dest_href)
             self.assertTrue(os.path.exists(dest_href), msg="File was not written.")
@@ -41,7 +42,7 @@ class StacIOTest(unittest.TestCase):
         catalog = pystac.read_file(
             TestCases.get_path("data-files/catalogs/test-case-1/catalog.json")
         )
-        with get_temp_dir() as tmp_dir:
+        with TemporaryDirectory() as tmp_dir:
             dest_href = os.path.join(tmp_dir, "catalog.json")
             pystac.write_file(catalog, dest_href=dest_href)
             self.assertTrue(os.path.exists(dest_href), msg="File was not written.")

--- a/tests/test_writing.py
+++ b/tests/test_writing.py
@@ -1,4 +1,5 @@
 import unittest
+from tempfile import TemporaryDirectory
 from typing import Any, List
 
 import pystac
@@ -6,7 +7,7 @@ from pystac import Collection, CatalogType, HIERARCHICAL_LINKS
 from pystac.utils import is_absolute_href, make_absolute_href, make_relative_href
 from pystac.validation import validate_dict
 
-from tests.utils import TestCases, get_temp_dir
+from tests.utils import TestCases
 
 
 class STACWritingTest(unittest.TestCase):
@@ -104,7 +105,7 @@ class STACWritingTest(unittest.TestCase):
     def do_test(
         self, catalog: pystac.Catalog, catalog_type: pystac.CatalogType
     ) -> None:
-        with get_temp_dir() as tmp_dir:
+        with TemporaryDirectory() as tmp_dir:
             catalog.normalize_hrefs(tmp_dir)
             self.validate_catalog(catalog)
 

--- a/tests/test_writing.py
+++ b/tests/test_writing.py
@@ -1,5 +1,5 @@
 import unittest
-from tempfile import TemporaryDirectory
+import tempfile
 from typing import Any, List
 
 import pystac
@@ -105,7 +105,7 @@ class STACWritingTest(unittest.TestCase):
     def do_test(
         self, catalog: pystac.Catalog, catalog_type: pystac.CatalogType
     ) -> None:
-        with TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory() as tmp_dir:
             catalog.normalize_hrefs(tmp_dir)
             self.validate_catalog(catalog)
 

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -17,7 +17,7 @@ import pystac
 from tests.utils.stac_io_mock import MockStacIO
 
 if TYPE_CHECKING:
-    from tempfile import TemporaryDirectory as TemporaryDirectory_Type
+    import tempfile as TemporaryDirectory_Type
 
 
 def assert_to_from_dict(

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,8 +1,6 @@
 # flake8: noqa
 
-import os
-from tempfile import TemporaryDirectory
-from typing import Any, AnyStr, Dict, TYPE_CHECKING, Type
+from typing import Any, Dict, TYPE_CHECKING, Type
 import unittest
 from tests.utils.test_cases import (
     TestCases,
@@ -46,14 +44,3 @@ def assert_to_from_dict(
     _parse_times(d1)
     _parse_times(d2)
     test_class.assertDictEqual(d1, d2)
-
-
-# Use suggestion from https://github.com/python/mypy/issues/5264#issuecomment-399407428
-# to solve type errors.
-def get_temp_dir() -> "TemporaryDirectory_Type[str]":
-    """In the GitHub Actions Windows runner the default TMPDIR directory is on a
-    different drive (C:\\) than the code and test data files (D:\\). This was causing
-    failures in os.path.relpath on Windows, so we put the temp directories in the
-    current working directory instead. There os a "tmp*" line in the .gitignore file
-    that ignores these directories."""
-    return TemporaryDirectory(dir=os.getcwd())

--- a/tests/validation/test_validate.py
+++ b/tests/validation/test_validate.py
@@ -5,7 +5,7 @@ from typing import Any, Dict
 from pystac.utils import get_opt
 import shutil
 import unittest
-from tempfile import TemporaryDirectory
+import tempfile
 
 import jsonschema
 
@@ -99,7 +99,7 @@ class ValidateTest(unittest.TestCase):
         # Modify a 0.8.1 collection in a catalog to be invalid with a
         # since-renamed extension and make sure it catches the validation error.
 
-        with TemporaryDirectory() as tmp_dir:
+        with tempfile.TemporaryDirectory() as tmp_dir:
             dst_dir = os.path.join(tmp_dir, "catalog")
             # Copy test case 7 to the temporary directory
             catalog_href = get_opt(TestCases.test_case_7().get_self_href())

--- a/tests/validation/test_validate.py
+++ b/tests/validation/test_validate.py
@@ -5,6 +5,7 @@ from typing import Any, Dict
 from pystac.utils import get_opt
 import shutil
 import unittest
+from tempfile import TemporaryDirectory
 
 import jsonschema
 
@@ -12,7 +13,7 @@ import pystac
 import pystac.validation
 from pystac.cache import CollectionCache
 from pystac.serialization.common_properties import merge_common_properties
-from tests.utils import TestCases, get_temp_dir
+from tests.utils import TestCases
 
 
 class ValidateTest(unittest.TestCase):
@@ -98,7 +99,7 @@ class ValidateTest(unittest.TestCase):
         # Modify a 0.8.1 collection in a catalog to be invalid with a
         # since-renamed extension and make sure it catches the validation error.
 
-        with get_temp_dir() as tmp_dir:
+        with TemporaryDirectory() as tmp_dir:
             dst_dir = os.path.join(tmp_dir, "catalog")
             # Copy test case 7 to the temporary directory
             catalog_href = get_opt(TestCases.test_case_7().get_self_href())


### PR DESCRIPTION
**Related Issue(s):** #

* Closes #418

**Description:**

Uses `TMPDIR` environment variable to change temporary directory location in Windows builds instead of hard-coding the CWD.

**PR Checklist:**

- [x] Code is formatted (run `scripts/format`)
- [ ] Tests pass (run `scripts/test`)
- [ ] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.