### PR TITLE
Raise exception when extending object that does not have schema URI

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,5 @@
 [report]
-fail_under = 90
+fail_under = 91
 
 [run]
 source = pystac

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Support for Python 3.9 ([#420](https://github.com/stac-utils/pystac/pull/420))
 - Migration for pre-1.0.0-rc.1 Stats Objects (renamed to Range Objects in 1.0.0-rc.3) ([#447](https://github.com/stac-utils/pystac/pull/447))
 - Attempting to extend a `STACObject` that does not contain the extension's schema URI in
-  `stac_extensions` raises new `ExtensionNotImplementedError`.
+  `stac_extensions` raises new `ExtensionNotImplementedError` ([#450](https://github.com/stac-utils/pystac/pull/450))
 
 ### Changed
 
@@ -22,6 +22,9 @@
   `StacIO.read_text` ([#433](https://github.com/stac-utils/pystac/pull/433))
 - `FileExtension` updated to work with File Info Extension v2.0.0 ([#442](https://github.com/stac-utils/pystac/pull/442))
 - `FileExtension` only operates on `pystac.Asset` instances ([#442](https://github.com/stac-utils/pystac/pull/442))
+- `*Extension.ext` methods now have an optional `add_if_missing` argument, which will
+  add the extension schema URI to the object's `stac_extensions` list if it is not
+  present ([#450](https://github.com/stac-utils/pystac/pull/450))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   STAC Items ([#430](https://github.com/stac-utils/pystac/pull/430))
 - Support for Python 3.9 ([#420](https://github.com/stac-utils/pystac/pull/420))
 - Migration for pre-1.0.0-rc.1 Stats Objects (renamed to Range Objects in 1.0.0-rc.3) ([#447](https://github.com/stac-utils/pystac/pull/447))
+- Attempt to extend a `STACObject` that does not contain the extension's schema URI in
+  `stac_extensions` raises new `ExtensionNotImplementedError`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
   STAC Items ([#430](https://github.com/stac-utils/pystac/pull/430))
 - Support for Python 3.9 ([#420](https://github.com/stac-utils/pystac/pull/420))
 - Migration for pre-1.0.0-rc.1 Stats Objects (renamed to Range Objects in 1.0.0-rc.3) ([#447](https://github.com/stac-utils/pystac/pull/447))
-- Attempt to extend a `STACObject` that does not contain the extension's schema URI in
+- Attempting to extend a `STACObject` that does not contain the extension's schema URI in
   `stac_extensions` raises new `ExtensionNotImplementedError`.
 
 ### Changed
@@ -379,4 +379,3 @@ Initial release.
 [v0.3.2]: <https://github.com/stac-utils/pystac/compare/v0.3.1..v0.3.2>
 [v0.3.1]: <https://github.com/stac-utils/pystac/compare/v0.3.0..v0.3.1>
 [v0.3.0]: <https://github.com/stac-utils/pystac/tree/v0.3.0>
-

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -414,6 +414,43 @@ AssetProjectionExtension
    :members:
    :show-inheritance:
 
+Raster Extension
+----------------
+
+DataType
+~~~~~~~~
+
+.. autoclass:: pystac.extensions.raster.DataType
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Statistics
+~~~~~~~~~~
+
+.. autoclass:: pystac.extensions.raster.Statistics
+   :members:
+
+Histogram
+~~~~~~~~~
+
+.. autoclass:: pystac.extensions.raster.Histogram
+   :members:
+
+RasterBand
+~~~~~~~~~~
+
+.. autoclass:: pystac.extensions.raster.RasterBand
+   :members:
+
+RasterExtension
+~~~~~~~~~~~~~~~
+
+.. autoclass:: pystac.extensions.raster.RasterExtension
+   :members:
+   :show-inheritance:
+   :inherited-members:
+
 Scientific Extension
 --------------------
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -62,7 +62,7 @@ example, to format all the Python code, run ``pre-commit run --all-files black``
 
 You can also install a Git pre-commit hook which will run the relevant linters and
 formatters on any staged code when committing. This will be much faster than running on
-all files, which is usually[#]_ only required when changing the pre-commit version or
+all files, which is usually [#]_ only required when changing the pre-commit version or
 configuration. Once installed you can bypass this check by adding the ``--no-verify``
 flag to Git commit commands, as in ``git commit --no-verify``.
 

--- a/pystac/__init__.py
+++ b/pystac/__init__.py
@@ -7,6 +7,7 @@ from pystac.errors import (
     STACError,
     STACTypeError,
     ExtensionAlreadyExistsError,
+    ExtensionNotImplemented,
     ExtensionTypeError,
     RequiredPropertyMissing,
     STACValidationError,

--- a/pystac/errors.py
+++ b/pystac/errors.py
@@ -35,6 +35,11 @@ class ExtensionAlreadyExistsError(Exception):
     pass
 
 
+class ExtensionNotImplemented(Exception):
+    """Attempted to extend a STAC object that does not implement the given
+    extension."""
+
+
 class RequiredPropertyMissing(Exception):
     """This error is raised when a required value was expected
     to be there but was missing or None. This will happen, for example,

--- a/pystac/extensions/base.py
+++ b/pystac/extensions/base.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Generic, Iterable, List, Optional, Dict, Any, Type, TypeVar, Union
 
-from pystac import Collection, RangeSummary, STACObject, Summaries
+import pystac
 
 
 class SummariesExtension:
@@ -12,16 +12,16 @@ class SummariesExtension:
     extension-specific class that inherits from this class and instantiate that. See
     :class:`~pystac.extensions.eo.SummariesEOExtension` for an example."""
 
-    summaries: Summaries
+    summaries: pystac.Summaries
     """The summaries for the :class:`~pystac.Collection` being extended."""
 
-    def __init__(self, collection: Collection) -> None:
+    def __init__(self, collection: pystac.Collection) -> None:
         self.summaries = collection.summaries
 
     def _set_summary(
         self,
         prop_key: str,
-        v: Optional[Union[List[Any], RangeSummary[Any], Dict[str, Any]]],
+        v: Optional[Union[List[Any], pystac.RangeSummary[Any], Dict[str, Any]]],
     ) -> None:
         if v is None:
             self.summaries.remove(prop_key)
@@ -77,7 +77,7 @@ class PropertiesExtension(ABC):
             self.properties[prop_name] = v
 
 
-S = TypeVar("S", bound=STACObject)
+S = TypeVar("S", bound=pystac.STACObject)
 
 
 class ExtensionManagementMixin(Generic[S], ABC):
@@ -124,3 +124,17 @@ class ExtensionManagementMixin(Generic[S], ABC):
             obj.stac_extensions is not None
             and cls.get_schema_uri() in obj.stac_extensions
         )
+
+    @classmethod
+    def validate_has_extension(cls, obj: Union[S, pystac.Asset]) -> None:
+        """Given a :class:`~pystac.STACObject` or :class:`pystac.Asset` instance, checks
+        if the object (or its owner in the case of an Asset) has this extension's schema
+        URI in it's :attr:`~pystac.STACObject.stac_extensions` list."""
+        extensible = obj.owner if isinstance(obj, pystac.Asset) else obj
+        if (
+            extensible is not None
+            and cls.get_schema_uri() not in extensible.stac_extensions
+        ):
+            raise pystac.ExtensionNotImplemented(
+                f"Could not find extension schema URI {cls.get_schema_uri()} in object."
+            )

--- a/pystac/extensions/datacube.py
+++ b/pystac/extensions/datacube.py
@@ -338,14 +338,20 @@ class DatacubeExtension(
         return SCHEMA_URI
 
     @classmethod
-    def ext(cls, obj: T) -> "DatacubeExtension[T]":
+    def ext(cls, obj: T, add_if_missing: bool = False) -> "DatacubeExtension[T]":
         if isinstance(obj, pystac.Collection):
+            if add_if_missing:
+                cls.add_to(obj)
             cls.validate_has_extension(obj)
             return cast(DatacubeExtension[T], CollectionDatacubeExtension(obj))
         if isinstance(obj, pystac.Item):
+            if add_if_missing:
+                cls.add_to(obj)
             cls.validate_has_extension(obj)
             return cast(DatacubeExtension[T], ItemDatacubeExtension(obj))
         elif isinstance(obj, pystac.Asset):
+            if add_if_missing and obj.owner is not None:
+                cls.add_to(obj.owner)
             cls.validate_has_extension(obj)
             return cast(DatacubeExtension[T], AssetDatacubeExtension(obj))
         else:

--- a/pystac/extensions/datacube.py
+++ b/pystac/extensions/datacube.py
@@ -337,13 +337,16 @@ class DatacubeExtension(
     def get_schema_uri(cls) -> str:
         return SCHEMA_URI
 
-    @staticmethod
-    def ext(obj: T) -> "DatacubeExtension[T]":
+    @classmethod
+    def ext(cls, obj: T) -> "DatacubeExtension[T]":
         if isinstance(obj, pystac.Collection):
+            cls.validate_has_extension(obj)
             return cast(DatacubeExtension[T], CollectionDatacubeExtension(obj))
         if isinstance(obj, pystac.Item):
+            cls.validate_has_extension(obj)
             return cast(DatacubeExtension[T], ItemDatacubeExtension(obj))
         elif isinstance(obj, pystac.Asset):
+            cls.validate_has_extension(obj)
             return cast(DatacubeExtension[T], AssetDatacubeExtension(obj))
         else:
             raise pystac.ExtensionTypeError(

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -347,7 +347,7 @@ class EOExtension(
         return SCHEMA_URI
 
     @classmethod
-    def ext(cls, obj: T) -> "EOExtension[T]":
+    def ext(cls, obj: T, add_if_missing: bool = False) -> "EOExtension[T]":
         """Extends the given STAC Object with properties from the :stac-ext:`Electro-Optical
         Extension <eo>`.
 
@@ -359,9 +359,13 @@ class EOExtension(
             pystac.ExtensionTypeError : If an invalid object type is passed.
         """
         if isinstance(obj, pystac.Item):
+            if add_if_missing:
+                cls.add_to(obj)
             cls.validate_has_extension(obj)
             return cast(EOExtension[T], ItemEOExtension(obj))
         elif isinstance(obj, pystac.Asset):
+            if add_if_missing and isinstance(obj.owner, pystac.Item):
+                cls.add_to(obj.owner)
             cls.validate_has_extension(obj)
             return cast(EOExtension[T], AssetEOExtension(obj))
         else:

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -346,8 +346,8 @@ class EOExtension(
     def get_schema_uri(cls) -> str:
         return SCHEMA_URI
 
-    @staticmethod
-    def ext(obj: T) -> "EOExtension[T]":
+    @classmethod
+    def ext(cls, obj: T) -> "EOExtension[T]":
         """Extends the given STAC Object with properties from the :stac-ext:`Electro-Optical
         Extension <eo>`.
 
@@ -359,8 +359,10 @@ class EOExtension(
             pystac.ExtensionTypeError : If an invalid object type is passed.
         """
         if isinstance(obj, pystac.Item):
+            cls.validate_has_extension(obj)
             return cast(EOExtension[T], ItemEOExtension(obj))
         elif isinstance(obj, pystac.Asset):
+            cls.validate_has_extension(obj)
             return cast(EOExtension[T], AssetEOExtension(obj))
         else:
             raise pystac.ExtensionTypeError(

--- a/pystac/extensions/file.py
+++ b/pystac/extensions/file.py
@@ -193,13 +193,15 @@ class FileExtension(PropertiesExtension, ExtensionManagementMixin[pystac.Item]):
         return SCHEMA_URI
 
     @classmethod
-    def ext(cls, obj: pystac.Asset) -> "FileExtension":
+    def ext(cls, obj: pystac.Asset, add_if_missing: bool = False) -> "FileExtension":
         """Extends the given STAC Object with properties from the :stac-ext:`File Info
         Extension <file>`.
 
         This extension can be applied to instances of :class:`~pystac.Asset`.
         """
         if isinstance(obj, pystac.Asset):
+            if add_if_missing and isinstance(obj.owner, pystac.Item):
+                cls.add_to(obj.owner)
             cls.validate_has_extension(obj)
             return cls(obj)
         else:

--- a/pystac/extensions/file.py
+++ b/pystac/extensions/file.py
@@ -199,7 +199,13 @@ class FileExtension(PropertiesExtension, ExtensionManagementMixin[pystac.Item]):
 
         This extension can be applied to instances of :class:`~pystac.Asset`.
         """
-        return cls(obj)
+        if isinstance(obj, pystac.Asset):
+            cls.validate_has_extension(obj)
+            return cls(obj)
+        else:
+            raise pystac.ExtensionTypeError(
+                f"File Info extension does not apply to type {type(obj)}"
+            )
 
 
 class FileExtensionHooks(ExtensionHooks):

--- a/pystac/extensions/item_assets.py
+++ b/pystac/extensions/item_assets.py
@@ -117,8 +117,17 @@ class ItemAssetsExtension(ExtensionManagementMixin[pystac.Collection]):
         return SCHEMA_URI
 
     @classmethod
-    def ext(cls, collection: pystac.Collection) -> "ItemAssetsExtension":
-        return cls(collection)
+    def ext(
+        cls, obj: pystac.Collection, add_if_missing: bool = False
+    ) -> "ItemAssetsExtension":
+        if isinstance(obj, pystac.Collection):
+            if add_if_missing:
+                cls.add_to(obj)
+            return cls(obj)
+        else:
+            raise pystac.ExtensionTypeError(
+                f"Item Assets extension does not apply to type {type(obj)}"
+            )
 
 
 class ItemAssetsExtensionHooks(ExtensionHooks):

--- a/pystac/extensions/label.py
+++ b/pystac/extensions/label.py
@@ -645,7 +645,13 @@ class LabelExtension(ExtensionManagementMixin[pystac.Item]):
 
         This extension can be applied to instances of :class:`~pystac.Item`.
         """
-        return cls(obj)
+        if isinstance(obj, pystac.Item):
+            cls.validate_has_extension(obj)
+            return cls(obj)
+        else:
+            raise pystac.ExtensionTypeError(
+                f"Label extension does not apply to type {type(obj)}"
+            )
 
 
 class LabelExtensionHooks(ExtensionHooks):

--- a/pystac/extensions/label.py
+++ b/pystac/extensions/label.py
@@ -639,13 +639,15 @@ class LabelExtension(ExtensionManagementMixin[pystac.Item]):
         return SCHEMA_URI
 
     @classmethod
-    def ext(cls, obj: pystac.Item) -> "LabelExtension":
+    def ext(cls, obj: pystac.Item, add_if_missing: bool = False) -> "LabelExtension":
         """Extends the given STAC Object with properties from the :stac-ext:`Label
         Extension <label>`.
 
         This extension can be applied to instances of :class:`~pystac.Item`.
         """
         if isinstance(obj, pystac.Item):
+            if add_if_missing:
+                cls.add_to(obj)
             cls.validate_has_extension(obj)
             return cls(obj)
         else:

--- a/pystac/extensions/pointcloud.py
+++ b/pystac/extensions/pointcloud.py
@@ -522,15 +522,17 @@ class PointcloudExtension(
     def get_schema_uri(cls) -> str:
         return SCHEMA_URI
 
-    @staticmethod
-    def ext(obj: T) -> "PointcloudExtension[T]":
+    @classmethod
+    def ext(cls, obj: T) -> "PointcloudExtension[T]":
         if isinstance(obj, pystac.Item):
+            cls.validate_has_extension(obj)
             return cast(PointcloudExtension[T], ItemPointcloudExtension(obj))
         elif isinstance(obj, pystac.Asset):
+            cls.validate_has_extension(obj)
             return cast(PointcloudExtension[T], AssetPointcloudExtension(obj))
         else:
             raise pystac.ExtensionTypeError(
-                f"File extension does not apply to type {type(obj)}"
+                f"Pointcloud extension does not apply to type {type(obj)}"
             )
 
 

--- a/pystac/extensions/pointcloud.py
+++ b/pystac/extensions/pointcloud.py
@@ -523,11 +523,15 @@ class PointcloudExtension(
         return SCHEMA_URI
 
     @classmethod
-    def ext(cls, obj: T) -> "PointcloudExtension[T]":
+    def ext(cls, obj: T, add_if_missing: bool = False) -> "PointcloudExtension[T]":
         if isinstance(obj, pystac.Item):
+            if add_if_missing:
+                cls.add_to(obj)
             cls.validate_has_extension(obj)
             return cast(PointcloudExtension[T], ItemPointcloudExtension(obj))
         elif isinstance(obj, pystac.Asset):
+            if add_if_missing and isinstance(obj.owner, pystac.Item):
+                cls.add_to(obj.owner)
             cls.validate_has_extension(obj)
             return cast(PointcloudExtension[T], AssetPointcloudExtension(obj))
         else:

--- a/pystac/extensions/projection.py
+++ b/pystac/extensions/projection.py
@@ -238,7 +238,7 @@ class ProjectionExtension(
         return SCHEMA_URI
 
     @classmethod
-    def ext(cls, obj: T) -> "ProjectionExtension[T]":
+    def ext(cls, obj: T, add_if_missing: bool = False) -> "ProjectionExtension[T]":
         """Extends the given STAC Object with properties from the :stac-ext:`Projection
         Extension <projection>`.
 
@@ -250,9 +250,13 @@ class ProjectionExtension(
             pystac.ExtensionTypeError : If an invalid object type is passed.
         """
         if isinstance(obj, pystac.Item):
+            if add_if_missing:
+                cls.add_to(obj)
             cls.validate_has_extension(obj)
             return cast(ProjectionExtension[T], ItemProjectionExtension(obj))
         elif isinstance(obj, pystac.Asset):
+            if add_if_missing and isinstance(obj.owner, pystac.Item):
+                cls.add_to(obj.owner)
             cls.validate_has_extension(obj)
             return cast(ProjectionExtension[T], AssetProjectionExtension(obj))
         else:

--- a/pystac/extensions/projection.py
+++ b/pystac/extensions/projection.py
@@ -237,8 +237,8 @@ class ProjectionExtension(
     def get_schema_uri(cls) -> str:
         return SCHEMA_URI
 
-    @staticmethod
-    def ext(obj: T) -> "ProjectionExtension[T]":
+    @classmethod
+    def ext(cls, obj: T) -> "ProjectionExtension[T]":
         """Extends the given STAC Object with properties from the :stac-ext:`Projection
         Extension <projection>`.
 
@@ -250,12 +250,14 @@ class ProjectionExtension(
             pystac.ExtensionTypeError : If an invalid object type is passed.
         """
         if isinstance(obj, pystac.Item):
+            cls.validate_has_extension(obj)
             return cast(ProjectionExtension[T], ItemProjectionExtension(obj))
         elif isinstance(obj, pystac.Asset):
+            cls.validate_has_extension(obj)
             return cast(ProjectionExtension[T], AssetProjectionExtension(obj))
         else:
             raise pystac.ExtensionTypeError(
-                f"File extension does not apply to type {type(obj)}"
+                f"Projection extension does not apply to type {type(obj)}"
             )
 
     @staticmethod

--- a/pystac/extensions/raster.py
+++ b/pystac/extensions/raster.py
@@ -689,7 +689,7 @@ class RasterExtension(PropertiesExtension, ExtensionManagementMixin[pystac.Item]
         return SCHEMA_URI
 
     @classmethod
-    def ext(cls, obj: pystac.Asset) -> "RasterExtension":
+    def ext(cls, obj: pystac.Asset, add_if_missing: bool = False) -> "RasterExtension":
         """Extends the given STAC Object with properties from the :stac-ext:`Raster
         Extension <raster>`.
 
@@ -700,6 +700,8 @@ class RasterExtension(PropertiesExtension, ExtensionManagementMixin[pystac.Item]
             pystac.ExtensionTypeError : If an invalid object type is passed.
         """
         if isinstance(obj, pystac.Asset):
+            if add_if_missing and isinstance(obj.owner, pystac.Item):
+                cls.add_to(obj.owner)
             cls.validate_has_extension(obj)
             return cls(obj)
         else:

--- a/pystac/extensions/raster.py
+++ b/pystac/extensions/raster.py
@@ -4,7 +4,7 @@ https://github.com/stac-extensions/raster
 """
 
 import enum
-from typing import Any, Dict, Generic, Iterable, List, Optional, TypeVar, cast
+from typing import Any, Dict, Iterable, List, Optional
 
 import pystac
 from pystac.extensions.base import (
@@ -13,8 +13,6 @@ from pystac.extensions.base import (
     SummariesExtension,
 )
 from pystac.utils import get_opt, get_required, map_opt
-
-T = TypeVar("T", pystac.Item, pystac.Asset)
 
 SCHEMA_URI = "https://stac-extensions.github.io/raster/v1.0.0/schema.json"
 
@@ -625,9 +623,7 @@ class RasterBand:
         return self.properties
 
 
-class RasterExtension(
-    Generic[T], PropertiesExtension, ExtensionManagementMixin[pystac.Item]
-):
+class RasterExtension(PropertiesExtension, ExtensionManagementMixin[pystac.Item]):
     """An abstract class that can be used to extend the properties of an
     :class:`~pystac.Item` or :class:`~pystac.Asset` with properties from
     the :stac-ext:`Raster Extension <raster>`. This class is generic over
@@ -638,6 +634,25 @@ class RasterExtension(
     implementation associated with the STAC Object you want to extend (e.g.
     :class:`~ItemRasterExtension` to extend an :class:`~pystac.Item`).
     """
+
+    asset_href: str
+    """The ``href`` value of the :class:`~pystac.Asset` being extended."""
+
+    properties: Dict[str, Any]
+    """The :class:`~pystac.Asset` fields, including extension properties."""
+
+    additional_read_properties: Optional[Iterable[Dict[str, Any]]] = None
+    """If present, this will be a list containing 1 dictionary representing the
+    properties of the owning :class:`~pystac.Item`."""
+
+    def __init__(self, asset: pystac.Asset):
+        self.asset_href = asset.href
+        self.properties = asset.properties
+        if asset.owner and isinstance(asset.owner, pystac.Item):
+            self.additional_read_properties = [asset.owner.properties]
+
+    def __repr__(self) -> str:
+        return "<AssetRasterExtension Asset href={}>".format(self.asset_href)
 
     def apply(self, bands: List[RasterBand]) -> None:
         """Applies raster extension properties to the extended :class:`pystac.Item` or
@@ -673,10 +688,20 @@ class RasterExtension(
     def get_schema_uri(cls) -> str:
         return SCHEMA_URI
 
-    @staticmethod
-    def ext(obj: T) -> "RasterExtension[T]":
+    @classmethod
+    def ext(cls, obj: pystac.Asset) -> "RasterExtension":
+        """Extends the given STAC Object with properties from the :stac-ext:`Raster
+        Extension <raster>`.
+
+        This extension can be applied to instances of :class:`~pystac.Asset`.
+
+        Raises:
+
+            pystac.ExtensionTypeError : If an invalid object type is passed.
+        """
         if isinstance(obj, pystac.Asset):
-            return cast(RasterExtension[T], AssetRasterExtension(obj))
+            cls.validate_has_extension(obj)
+            return cls(obj)
         else:
             raise pystac.ExtensionTypeError(
                 f"Raster extension does not apply to type {type(obj)}"
@@ -685,35 +710,6 @@ class RasterExtension(
     @staticmethod
     def summaries(obj: pystac.Collection) -> "SummariesRasterExtension":
         return SummariesRasterExtension(obj)
-
-
-class AssetRasterExtension(RasterExtension[pystac.Asset]):
-    """A concrete implementation of :class:`RasterExtension` on an :class:`~pystac.Asset`
-    that extends the Asset fields to include properties defined in the
-    :stac-ext:`Raster Extension <raster>`.
-
-    This class should generally not be instantiated directly. Instead, call
-    :meth:`RasterExtension.ext` on an :class:`~pystac.Asset` to extend it.
-    """
-
-    asset_href: str
-    """The ``href`` value of the :class:`~pystac.Asset` being extended."""
-
-    properties: Dict[str, Any]
-    """The :class:`~pystac.Asset` fields, including extension properties."""
-
-    additional_read_properties: Optional[Iterable[Dict[str, Any]]] = None
-    """If present, this will be a list containing 1 dictionary representing the
-    properties of the owning :class:`~pystac.Item`."""
-
-    def __init__(self, asset: pystac.Asset):
-        self.asset_href = asset.href
-        self.properties = asset.properties
-        if asset.owner and isinstance(asset.owner, pystac.Item):
-            self.additional_read_properties = [asset.owner.properties]
-
-    def __repr__(self) -> str:
-        return "<AssetRasterExtension Asset href={}>".format(self.asset_href)
 
 
 class SummariesRasterExtension(SummariesExtension):

--- a/pystac/extensions/sar.py
+++ b/pystac/extensions/sar.py
@@ -305,11 +305,15 @@ class SarExtension(
         return SCHEMA_URI
 
     @classmethod
-    def ext(cls, obj: T) -> "SarExtension[T]":
+    def ext(cls, obj: T, add_if_missing: bool = False) -> "SarExtension[T]":
         if isinstance(obj, pystac.Item):
+            if add_if_missing:
+                cls.add_to(obj)
             cls.validate_has_extension(obj)
             return cast(SarExtension[T], ItemSarExtension(obj))
         elif isinstance(obj, pystac.Asset):
+            if add_if_missing and isinstance(obj.owner, pystac.Item):
+                cls.add_to(obj.owner)
             cls.validate_has_extension(obj)
             return cast(SarExtension[T], AssetSarExtension(obj))
         else:

--- a/pystac/extensions/sar.py
+++ b/pystac/extensions/sar.py
@@ -304,15 +304,17 @@ class SarExtension(
     def get_schema_uri(cls) -> str:
         return SCHEMA_URI
 
-    @staticmethod
-    def ext(obj: T) -> "SarExtension[T]":
+    @classmethod
+    def ext(cls, obj: T) -> "SarExtension[T]":
         if isinstance(obj, pystac.Item):
+            cls.validate_has_extension(obj)
             return cast(SarExtension[T], ItemSarExtension(obj))
         elif isinstance(obj, pystac.Asset):
+            cls.validate_has_extension(obj)
             return cast(SarExtension[T], AssetSarExtension(obj))
         else:
             raise pystac.ExtensionTypeError(
-                f"File extension does not apply to type {type(obj)}"
+                f"SAR extension does not apply to type {type(obj)}"
             )
 
 

--- a/pystac/extensions/sat.py
+++ b/pystac/extensions/sat.py
@@ -96,11 +96,15 @@ class SatExtension(
         return SCHEMA_URI
 
     @classmethod
-    def ext(cls, obj: T) -> "SatExtension[T]":
+    def ext(cls, obj: T, add_if_missing: bool = False) -> "SatExtension[T]":
         if isinstance(obj, pystac.Item):
+            if add_if_missing:
+                cls.add_to(obj)
             cls.validate_has_extension(obj)
             return cast(SatExtension[T], ItemSatExtension(obj))
         elif isinstance(obj, pystac.Asset):
+            if add_if_missing and isinstance(obj.owner, pystac.Item):
+                cls.add_to(obj.owner)
             cls.validate_has_extension(obj)
             return cast(SatExtension[T], AssetSatExtension(obj))
         else:

--- a/pystac/extensions/sat.py
+++ b/pystac/extensions/sat.py
@@ -95,11 +95,13 @@ class SatExtension(
     def get_schema_uri(cls) -> str:
         return SCHEMA_URI
 
-    @staticmethod
-    def ext(obj: T) -> "SatExtension[T]":
+    @classmethod
+    def ext(cls, obj: T) -> "SatExtension[T]":
         if isinstance(obj, pystac.Item):
+            cls.validate_has_extension(obj)
             return cast(SatExtension[T], ItemSatExtension(obj))
         elif isinstance(obj, pystac.Asset):
+            cls.validate_has_extension(obj)
             return cast(SatExtension[T], AssetSatExtension(obj))
         else:
             raise pystac.ExtensionTypeError(

--- a/pystac/extensions/scientific.py
+++ b/pystac/extensions/scientific.py
@@ -225,7 +225,7 @@ class ScientificExtension(
         return SCHEMA_URI
 
     @classmethod
-    def ext(cls, obj: T) -> "ScientificExtension[T]":
+    def ext(cls, obj: T, add_if_missing: bool = False) -> "ScientificExtension[T]":
         """Extends the given STAC Object with properties from the :stac-ext:`Scientific
         Extension <scientific>`.
 
@@ -237,9 +237,13 @@ class ScientificExtension(
             pystac.ExtensionTypeError : If an invalid object type is passed.
         """
         if isinstance(obj, pystac.Collection):
+            if add_if_missing:
+                cls.add_to(obj)
             cls.validate_has_extension(obj)
             return cast(ScientificExtension[T], CollectionScientificExtension(obj))
         if isinstance(obj, pystac.Item):
+            if add_if_missing:
+                cls.add_to(obj)
             cls.validate_has_extension(obj)
             return cast(ScientificExtension[T], ItemScientificExtension(obj))
         else:

--- a/pystac/extensions/scientific.py
+++ b/pystac/extensions/scientific.py
@@ -224,8 +224,8 @@ class ScientificExtension(
     def get_schema_uri(cls) -> str:
         return SCHEMA_URI
 
-    @staticmethod
-    def ext(obj: T) -> "ScientificExtension[T]":
+    @classmethod
+    def ext(cls, obj: T) -> "ScientificExtension[T]":
         """Extends the given STAC Object with properties from the :stac-ext:`Scientific
         Extension <scientific>`.
 
@@ -237,8 +237,10 @@ class ScientificExtension(
             pystac.ExtensionTypeError : If an invalid object type is passed.
         """
         if isinstance(obj, pystac.Collection):
+            cls.validate_has_extension(obj)
             return cast(ScientificExtension[T], CollectionScientificExtension(obj))
         if isinstance(obj, pystac.Item):
+            cls.validate_has_extension(obj)
             return cast(ScientificExtension[T], ItemScientificExtension(obj))
         else:
             raise pystac.ExtensionTypeError(

--- a/pystac/extensions/timestamps.py
+++ b/pystac/extensions/timestamps.py
@@ -116,11 +116,13 @@ class TimestampsExtension(
     def get_schema_uri(cls) -> str:
         return SCHEMA_URI
 
-    @staticmethod
-    def ext(obj: T) -> "TimestampsExtension[T]":
+    @classmethod
+    def ext(cls, obj: T) -> "TimestampsExtension[T]":
         if isinstance(obj, pystac.Item):
+            cls.validate_has_extension(obj)
             return cast(TimestampsExtension[T], ItemTimestampsExtension(obj))
         elif isinstance(obj, pystac.Asset):
+            cls.validate_has_extension(obj)
             return cast(TimestampsExtension[T], AssetTimestampsExtension(obj))
         else:
             raise pystac.ExtensionTypeError(

--- a/pystac/extensions/timestamps.py
+++ b/pystac/extensions/timestamps.py
@@ -117,11 +117,15 @@ class TimestampsExtension(
         return SCHEMA_URI
 
     @classmethod
-    def ext(cls, obj: T) -> "TimestampsExtension[T]":
+    def ext(cls, obj: T, add_if_missing: bool = False) -> "TimestampsExtension[T]":
         if isinstance(obj, pystac.Item):
+            if add_if_missing:
+                cls.add_to(obj)
             cls.validate_has_extension(obj)
             return cast(TimestampsExtension[T], ItemTimestampsExtension(obj))
         elif isinstance(obj, pystac.Asset):
+            if add_if_missing and isinstance(obj.owner, pystac.Item):
+                cls.add_to(obj.owner)
             cls.validate_has_extension(obj)
             return cast(TimestampsExtension[T], AssetTimestampsExtension(obj))
         else:

--- a/pystac/extensions/version.py
+++ b/pystac/extensions/version.py
@@ -196,7 +196,7 @@ class VersionExtension(
         return SCHEMA_URI
 
     @classmethod
-    def ext(cls, obj: T) -> "VersionExtension[T]":
+    def ext(cls, obj: T, add_if_missing: bool = False) -> "VersionExtension[T]":
         """Extends the given STAC Object with properties from the :stac-ext:`Versioning
         Indicators Extension <version>`.
 
@@ -208,9 +208,13 @@ class VersionExtension(
             pystac.ExtensionTypeError : If an invalid object type is passed.
         """
         if isinstance(obj, pystac.Collection):
+            if add_if_missing:
+                cls.add_to(obj)
             cls.validate_has_extension(obj)
             return cast(VersionExtension[T], CollectionVersionExtension(obj))
         if isinstance(obj, pystac.Item):
+            if add_if_missing:
+                cls.add_to(obj)
             cls.validate_has_extension(obj)
             return cast(VersionExtension[T], ItemVersionExtension(obj))
         else:

--- a/pystac/extensions/version.py
+++ b/pystac/extensions/version.py
@@ -195,8 +195,8 @@ class VersionExtension(
     def get_schema_uri(cls) -> str:
         return SCHEMA_URI
 
-    @staticmethod
-    def ext(obj: T) -> "VersionExtension[T]":
+    @classmethod
+    def ext(cls, obj: T) -> "VersionExtension[T]":
         """Extends the given STAC Object with properties from the :stac-ext:`Versioning
         Indicators Extension <version>`.
 
@@ -208,8 +208,10 @@ class VersionExtension(
             pystac.ExtensionTypeError : If an invalid object type is passed.
         """
         if isinstance(obj, pystac.Collection):
+            cls.validate_has_extension(obj)
             return cast(VersionExtension[T], CollectionVersionExtension(obj))
         if isinstance(obj, pystac.Item):
+            cls.validate_has_extension(obj)
             return cast(VersionExtension[T], ItemVersionExtension(obj))
         else:
             raise pystac.ExtensionTypeError(

--- a/pystac/extensions/view.py
+++ b/pystac/extensions/view.py
@@ -143,8 +143,8 @@ class ViewExtension(
     def get_schema_uri(cls) -> str:
         return SCHEMA_URI
 
-    @staticmethod
-    def ext(obj: T) -> "ViewExtension[T]":
+    @classmethod
+    def ext(cls, obj: T) -> "ViewExtension[T]":
         """Extends the given STAC Object with properties from the :stac-ext:`View
         Geometry Extension <scientific>`.
 
@@ -156,8 +156,10 @@ class ViewExtension(
             pystac.ExtensionTypeError : If an invalid object type is passed.
         """
         if isinstance(obj, pystac.Item):
+            cls.validate_has_extension(obj)
             return cast(ViewExtension[T], ItemViewExtension(obj))
         elif isinstance(obj, pystac.Asset):
+            cls.validate_has_extension(obj)
             return cast(ViewExtension[T], AssetViewExtension(obj))
         else:
             raise pystac.ExtensionTypeError(

--- a/pystac/extensions/view.py
+++ b/pystac/extensions/view.py
@@ -144,7 +144,7 @@ class ViewExtension(
         return SCHEMA_URI
 
     @classmethod
-    def ext(cls, obj: T) -> "ViewExtension[T]":
+    def ext(cls, obj: T, add_if_missing: bool = False) -> "ViewExtension[T]":
         """Extends the given STAC Object with properties from the :stac-ext:`View
         Geometry Extension <scientific>`.
 
@@ -156,9 +156,13 @@ class ViewExtension(
             pystac.ExtensionTypeError : If an invalid object type is passed.
         """
         if isinstance(obj, pystac.Item):
+            if add_if_missing:
+                cls.add_to(obj)
             cls.validate_has_extension(obj)
             return cast(ViewExtension[T], ItemViewExtension(obj))
         elif isinstance(obj, pystac.Asset):
+            if add_if_missing and isinstance(obj.owner, pystac.Item):
+                cls.add_to(obj.owner)
             cls.validate_has_extension(obj)
             return cast(ViewExtension[T], AssetViewExtension(obj))
         else:

--- a/tests/data-files/datacube/item.json
+++ b/tests/data-files/datacube/item.json
@@ -1,0 +1,120 @@
+{
+    "stac_version": "1.0.0-rc.1",
+    "stac_extensions": [
+        "https://stac-extensions.github.io/datacube/v1.0.0/schema.json"
+    ],
+    "id": "datacube-123",
+    "type": "Feature",
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -122.308150179,
+                    37.488035566
+                ],
+                [
+                    -122.597502109,
+                    37.538869539
+                ],
+                [
+                    -122.576687533,
+                    37.613537207
+                ],
+                [
+                    -122.2880486,
+                    37.562818007
+                ],
+                [
+                    -122.308150179,
+                    37.488035566
+                ]
+            ]
+        ]
+    },
+    "bbox": [
+        -122.59750209,
+        37.48803556,
+        -122.2880486,
+        37.613537207
+    ],
+    "properties": {
+        "title": "Multi-dimensional data cube 123 in a STAC Item.",
+        "datetime": "2016-05-03T13:21:30.040Z",
+        "cube:dimensions": {
+            "x": {
+                "type": "spatial",
+                "axis": "x",
+                "extent": [
+                    -122.59750209,
+                    -122.2880486
+                ],
+                "reference_system": 4326
+            },
+            "y": {
+                "type": "spatial",
+                "axis": "y",
+                "extent": [
+                    37.48803556,
+                    37.613537207
+                ],
+                "reference_system": 4326
+            },
+            "pressure_levels": {
+                "type": "spatial",
+                "axis": "z",
+                "extent": [
+                    0,
+                    1000
+                ],
+                "step": 100,
+                "unit": "Pa"
+            },
+            "metered_levels": {
+                "type": "spatial",
+                "axis": "z",
+                "values": [
+                    0,
+                    10,
+                    25,
+                    50,
+                    100,
+                    1000
+                ],
+                "unit": "m"
+            },
+            "time": {
+                "type": "temporal",
+                "values": [
+                    "2016-05-03T13:21:30.040Z"
+                ]
+            },
+            "spectral": {
+                "type": "bands",
+                "values": [
+                    "red",
+                    "green",
+                    "blue"
+                ]
+            }
+        }
+    },
+    "assets": {
+        "data": {
+            "href": "http://cool-sat.com/catalog/datacube-123/data.nc",
+            "type": "application/netcdf",
+            "title": "netCDF Data cube"
+        },
+        "thumbnail": {
+            "href": "http://cool-sat.com/catalog/datacube-123/thumbnail.png",
+            "type": "image/png",
+            "title": "Thumbnail"
+        }
+    },
+    "links": [
+        {
+            "rel": "self",
+            "href": "http://cool-sat.com/catalog/datacube-123/example-item.json"
+        }
+    ]
+}

--- a/tests/data-files/sar/sentinel-1.json
+++ b/tests/data-files/sar/sentinel-1.json
@@ -1,0 +1,107 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0-rc.1",
+    "stac_extensions": [
+        "https://stac-extensions.github.io/sar/v1.0.0/schema.json"
+    ],
+    "id": "sentinel-1-example",
+    "properties": {
+        "datetime": "2018-11-03T23:58:55.617217Z",
+        "start_datetime": "2018-11-03T23:58:55.121559Z",
+        "end_datetime": "2018-11-03T23:59:55.112875Z",
+        "platform": "sentinel-1a",
+        "constellation": "sentinel-1",
+        "instruments": [
+            "c-sar"
+        ],
+        "sar:instrument_mode": "EW",
+        "sar:polarizations": [
+            "HH"
+        ],
+        "sar:resolution_range": 50,
+        "sar:resolution_azimuth": 50,
+        "sar:pixel_spacing_range": 25,
+        "sar:pixel_spacing_azimuth": 25,
+        "sar:looks_range": 3,
+        "sar:looks_azimuth": 1,
+        "sar:looks_equivalent_number": 2.7,
+        "sar:frequency_band": "C",
+        "sar:center_frequency": 5.405,
+        "sar:product_type": "GRD"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -67.071648,
+                    -64.72924
+                ],
+                [
+                    -65.087479,
+                    -56.674374
+                ],
+                [
+                    -68.033211,
+                    -51.105831
+                ],
+                [
+                    -70.275032,
+                    -59.805672
+                ],
+                [
+                    -67.071648,
+                    -64.72924
+                ]
+            ]
+        ]
+    },
+    "links": [
+        {
+            "rel": "root",
+            "href": "../../catalog.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "parent",
+            "href": "../collection.json",
+            "type": "application/json"
+        }
+    ],
+    "assets": {
+        "noises": {
+            "href": "https://example.com/collections/sentinel-1/items/annotation/calibration/noise-s1a-ew-grd-hh-20181103t235855-20181103t235955-024430-02ad5d-001.xml",
+            "type": "text/xml",
+            "title": "Calibration Schema"
+        },
+        "calibrations": {
+            "href": "https://example.com/collections/sentinel-1/items/annotation/calibration/calibration-s1a-ew-grd-hh-20181103t235855-20181103t235955-024430-02ad5d-001.xml",
+            "type": "text/xml",
+            "title": "Noise Schema"
+        },
+        "products": {
+            "href": "https://example.com/collections/sentinel-1/items/annotation/s1a-ew-grd-hh-20181103t235855-20181103t235955-024430-02ad5d-001.xml",
+            "type": "text/xml",
+            "title": "Product Schema"
+        },
+        "measurement": {
+            "href": "https://example.com/collections/sentinel-1/items/measurement/s1a-ew-grd-hh-20181103t235855-20181103t235955-024430-02ad5d-001.tiff",
+            "type": "image/tiff",
+            "title": "Measurements",
+            "sar:polarizations": [
+                "HH"
+            ]
+        },
+        "thumbnail": {
+            "href": "https://example.com/collections/sentinel-1/items/preview/quick-look.png",
+            "type": "image/png",
+            "title": "Thumbnail"
+        }
+    },
+    "bbox": [
+        -70.275032,
+        -64.72924,
+        -65.087479,
+        -51.105831
+    ]
+}

--- a/tests/data-files/sat/sentinel-1.json
+++ b/tests/data-files/sat/sentinel-1.json
@@ -1,0 +1,126 @@
+{
+    "stac_version": "1.0.0-rc.1",
+    "stac_extensions": [
+        "https://stac-extensions.github.io/sar/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
+    ],
+    "id": "S1A_IW_SLC__1SDV_20150305T051937_20150305T052005_004892_006196_ABBB",
+    "type": "Feature",
+    "bbox": [
+        9.768469,
+        40.479584,
+        13.182633,
+        42.516747
+    ],
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    12.756503,
+                    40.479584
+                ],
+                [
+                    9.768469,
+                    40.877575
+                ],
+                [
+                    10.115331,
+                    42.516747
+                ],
+                [
+                    13.182633,
+                    42.119347
+                ],
+                [
+                    12.756503,
+                    40.479584
+                ]
+            ]
+        ]
+    },
+    "properties": {
+        "title": "Sentinel-1A SLC IW SDV T95 2015-03-05T05:19:37/2015-03-05T05:20:05",
+        "datetime": "2015-03-05T05:19:37.9237880Z",
+        "start_datetime": "2015-03-05T05:19:37.9237880Z",
+        "end_datetime": "2015-03-05T05:20:05.2359650Z",
+        "platform": "sentinel-1a",
+        "constellation": "sentinel-1",
+        "instruments": [
+            "c-sar"
+        ],
+        "sat:platform_international_designator": "2014-016A",
+        "sat:orbit_state": "descending",
+        "sat:absolute_orbit": 4892,
+        "sat:relative_orbit": 95,
+        "sat:anx_datetime": "2015-03-05T04:41:46.5788740Z",
+        "sar:instrument_mode": "IW",
+        "sar:polarizations": [
+            "VV",
+            "VH"
+        ],
+        "sar:resolution_range": 3.5,
+        "sar:resolution_azimuth": 22,
+        "sar:pixel_spacing_range": 2.3,
+        "sar:pixel_spacing_azimuth": 14.1,
+        "sar:looks_range": 1,
+        "sar:looks_azimuth": 1,
+        "sar:looks_equivalent_number": 1,
+        "sar:frequency_band": "C",
+        "sar:center_frequency": 5.405,
+        "sar:product_type": "SLC"
+    },
+    "assets": {
+        "noises_iw1_vh": {
+            "href": "./annotation/calibration/noise-s1a-iw1-slc-vh-20150305t051939-20150305t052005-004892-006196-001.xml",
+            "title": "Calibration Schema",
+            "type": "text/xml",
+            "sar:polarizations": [
+                "VH"
+            ]
+        },
+        "calibrations_iw1_vh": {
+            "href": "./annotation/calibration/calibration-s1a-iw1-slc-vh-20150305t051939-20150305t052005-004892-006196-001.xml",
+            "title": "Noise Schema",
+            "type": "text/xml",
+            "sar:polarizations": [
+                "VH"
+            ]
+        },
+        "products_iw1_vh": {
+            "href": "./annotation/s1a-iw1-slc-vh-20150305t051939-20150305t052005-004892-006196-001.xml",
+            "title": "Product Schema",
+            "type": "text/xml",
+            "sar:polarizations": [
+                "VH"
+            ]
+        },
+        "measurement_iw1_vh": {
+            "href": "./measurement/s1a-iw1-slc-vh-20150305t051939-20150305t052005-004892-006196-001.tiff",
+            "title": "Measurements",
+            "type": "image/tiff",
+            "sar:polarizations": [
+                "VH"
+            ]
+        },
+        "thumbnail": {
+            "href": "./preview/quick-look.png",
+            "title": "Thumbnail",
+            "type": "image/png"
+        }
+    },
+    "links": [
+        {
+            "rel": "self",
+            "href": "https://example.com/collections/sentinel-1/items/S1A_EW_GRDM_1SSH_20181103T235855_20181103T235955_024430_02AD5D_5616"
+        },
+        {
+            "rel": "parent",
+            "href": "https://example.com/collections/sentinel-1"
+        },
+        {
+            "rel": "root",
+            "href": "https://example.com/collections"
+        }
+    ]
+}

--- a/tests/data-files/scientific/collection.json
+++ b/tests/data-files/scientific/collection.json
@@ -1,0 +1,63 @@
+{
+    "stac_version": "1.0.0-rc.1",
+    "stac_extensions": [
+        "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
+    ],
+    "id": "MERRAclim",
+    "title": "MERRAclim, a high-resolution global dataset of remotely sensed bioclimatic variables for ecological modelling.",
+    "description": "Species Distribution Models (SDMs) combine information on the geographic occurrence of species with environmental layers to estimate distributional ranges and have been extensively implemented to answer a wide array of applied ecological questions. Unfortunately, most global datasets available to parameterize SDMs consist of spatially interpolated climate surfaces obtained from ground weather station data and have omitted the Antarctic continent, a landmass covering c. 20% of the Southern Hemisphere and increasingly showing biological effects of global change. Here we introduce MERRAclim, a global set of satellite-based bioclimatic variables including Antarctica for the first time. MERRAclim consists of three datasets of 19 bioclimatic variables that have been built for each of the last three decades (1980s, 1990s and 2000s) using hourly data of 2 m temperature and specific humidity. We provide MERRAclim at three spatial resolutions (10 arc-minutes, 5 arc-minutes and 2.5 arc-minutes). These reanalysed data are comparable to widely used datasets based on ground station interpolations, but allow extending their geographical reach and SDM building in previously uncovered regions of the globe.",
+    "type": "Collection",
+    "keywords": [
+        "bioclimatic",
+        "MERRAclim",
+        "macroecology",
+        "biogeography"
+    ],
+    "license": "CC0-1.0",
+    "extent": {
+        "spatial": {
+            "bbox": [
+                [
+                    -180,
+                    -90,
+                    180,
+                    90
+                ]
+            ]
+        },
+        "temporal": {
+            "interval": [
+                [
+                    "1980-01-01T00:00:00Z",
+                    "2009-12-31T23:59:59Z"
+                ]
+            ]
+        }
+    },
+    "sci:doi": "10.5061/dryad.s2v81.2",
+    "sci:citation": "Vega GC, Pertierra LR, Olalla-Tárraga MÁ (2017) Data from: MERRAclim, a high-resolution global dataset of remotely sensed bioclimatic variables for ecological modelling. Dryad Digital Repository.",
+    "sci:publications": [
+        {
+            "doi": "10.1038/sdata.2017.78",
+            "citation": "Vega GC, Pertierra LR, Olalla-Tárraga MÁ (2017) MERRAclim, a high-resolution global dataset of remotely sensed bioclimatic variables for ecological modelling. Scientific Data 4: 170078."
+        }
+    ],
+    "links": [
+        {
+            "rel": "self",
+            "href": "https://datadryad.org/resource/doi:10.5061/dryad.s2v81/collection.json"
+        },
+        {
+            "rel": "item",
+            "href": "https://datadryad.org/resource/doi:10.5061/dryad.s2v81/item.json"
+        },
+        {
+            "rel": "root",
+            "href": "https://datadryad.org/resource/doi:10.5061/dryad.s2v81/collection.json"
+        },
+        {
+            "rel": "cite-as",
+            "href": "https://doi.org/10.5061/dryad.s2v81.2"
+        }
+    ]
+}

--- a/tests/data-files/scientific/item.json
+++ b/tests/data-files/scientific/item.json
@@ -1,0 +1,80 @@
+{
+    "stac_version": "1.0.0-rc.1",
+    "stac_extensions": [
+        "https://stac-extensions.github.io/scientific/v1.0.0/schema.json"
+    ],
+    "id": "MERRAclim.2_5m_min_80s",
+    "type": "Feature",
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -180,
+                    -90
+                ],
+                [
+                    180,
+                    -90
+                ],
+                [
+                    180,
+                    90
+                ],
+                [
+                    -180,
+                    90
+                ],
+                [
+                    -180,
+                    -90
+                ]
+            ]
+        ]
+    },
+    "bbox": [
+        -180,
+        -90,
+        180,
+        90
+    ],
+    "properties": {
+        "title": "MERRAclim. 2_5m_min_80s",
+        "description": "MERRAclim Dataset. 19 global bioclimatic variables from the 1980s decade at 2.5 arcminutes resolution in GEOtiff format. The humidity version used is the min. The variables have been built using the same protocol as WorldClim with data from MERRA. Temperature layers (BIO1-BIO11) are in degree Celsius multiplied by 10, humidity layers (BIO12-BIO19) are in kg of water/kg of air multiplied by 100000.",
+        "datetime": "1985-07-01T00:00:00Z",
+        "start_datetime": "1980-01-01T00:00:00Z",
+        "end_datetime": "1989-12-31T23:59:59Z",
+        "sci:doi": "10.5061/dryad.s2v81.2/27.2",
+        "sci:publications": [
+            {
+                "doi": "10.5061/dryad.s2v81.2",
+                "citation": "Vega GC, Pertierra LR, Olalla-Tárraga MÁ (2017) Data from: MERRAclim, a high-resolution global dataset of remotely sensed bioclimatic variables for ecological modelling. Dryad Digital Repository."
+            },
+            {
+                "doi": "10.1038/sdata.2017.78",
+                "citation": "Vega GC, Pertierra LR, Olalla-Tárraga MÁ (2017) MERRAclim, a high-resolution global dataset of remotely sensed bioclimatic variables for ecological modelling. Scientific Data 4: 170078."
+            }
+        ]
+    },
+    "links": [
+        {
+            "rel": "self",
+            "href": "https://datadryad.org/resource/doi:10.5061/dryad.s2v81/item.json"
+        },
+        {
+            "rel": "root",
+            "href": "https://datadryad.org/resource/doi:10.5061/dryad.s2v81/catalog.json"
+        },
+        {
+            "rel": "cite-as",
+            "href": "https://doi.org/10.5061/dryad.s2v81.2/27.2"
+        }
+    ],
+    "assets": {
+        "primary": {
+            "href": "https://datadryad.org/stash/downloads/file_stream/100467",
+            "type": "application/zip",
+            "title": "MERRAclim. 2_5m_min_80s"
+        }
+    }
+}

--- a/tests/data-files/version/collection.json
+++ b/tests/data-files/version/collection.json
@@ -1,0 +1,51 @@
+{
+    "stac_version": "1.0.0-rc.1",
+    "stac_extensions": [
+        "https://stac-extensions.github.io/version/v1.0.0/schema.json"
+    ],
+    "id": "merraclim",
+    "type": "Collection",
+    "title": "MERRAclim",
+    "description": "A high-resolution global dataset of remotely sensed bioclimatic variables for ecological modelling.",
+    "license": "CC0-1.0",
+    "version": "1",
+    "deprecated": true,
+    "extent": {
+        "spatial": {
+            "bbox": [
+                [
+                    -180,
+                    -90,
+                    180,
+                    90
+                ]
+            ]
+        },
+        "temporal": {
+            "interval": [
+                [
+                    "1980-01-01T00:00:00Z",
+                    "2009-12-31T23:59:59Z"
+                ]
+            ]
+        }
+    },
+    "links": [
+        {
+            "rel": "self",
+            "href": "https://datadryad.org/resource/doi:10.5061/dryad.s2v81/v1/collection.json"
+        },
+        {
+            "rel": "item",
+            "href": "https://datadryad.org/resource/doi:10.5061/dryad.s2v81/v1/item.json"
+        },
+        {
+            "rel": "root",
+            "href": "https://datadryad.org/resource/doi:10.5061/dryad.s2v81/catalog.json"
+        },
+        {
+            "rel": "latest-version",
+            "href": "https://datadryad.org/resource/doi:10.5061/dryad.s2v81/v2/collection.json"
+        }
+    ]
+}

--- a/tests/data-files/version/item.json
+++ b/tests/data-files/version/item.json
@@ -1,0 +1,77 @@
+{
+    "stac_version": "1.0.0-rc.1",
+    "stac_extensions": [
+        "https://stac-extensions.github.io/version/v1.0.0/schema.json"
+    ],
+    "id": "MERRAclim.2_5m_min_80s",
+    "type": "Feature",
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -180,
+                    -90
+                ],
+                [
+                    180,
+                    -90
+                ],
+                [
+                    180,
+                    90
+                ],
+                [
+                    -180,
+                    90
+                ],
+                [
+                    -180,
+                    -90
+                ]
+            ]
+        ]
+    },
+    "bbox": [
+        -180,
+        -90,
+        180,
+        90
+    ],
+    "properties": {
+        "version": "1",
+        "title": "MERRAclim. 2_5m_min_80s",
+        "description": "MERRAclim Dataset. 19 global bioclimatic variables from the 1980s decade at 2.5 arcminutes resolution in GEOtiff format. The humidity version used is the min. The variables have been built using the same protocol as WorldClim with data from MERRA. Temperature layers (BIO1-BIO11) are in degree Celsius multiplied by 10, humidity layers (BIO12-BIO19) are in kg of water/kg of air multiplied by 100000.",
+        "datetime": "1985-07-01T00:00:00Z"
+    },
+    "collection": "merraclim",
+    "links": [
+        {
+            "rel": "self",
+            "href": "https://datadryad.org/resource/doi:10.5061/dryad.s2v81/v1/item.json"
+        },
+        {
+            "rel": "collection",
+            "href": "https://datadryad.org/resource/doi:10.5061/dryad.s2v81/v1/collection.json"
+        },
+        {
+            "rel": "parent",
+            "href": "https://datadryad.org/resource/doi:10.5061/dryad.s2v81/v1/collection.json"
+        },
+        {
+            "rel": "root",
+            "href": "https://datadryad.org/resource/doi:10.5061/dryad.s2v81/catalog.json"
+        },
+        {
+            "rel": "latest-version",
+            "href": "https://datadryad.org/resource/doi:10.5061/dryad.s2v81/v2/item.json"
+        }
+    ],
+    "assets": {
+        "primary": {
+            "href": "https://datadryad.org/stash/downloads/file_stream/100467",
+            "type": "application/zip",
+            "title": "MERRAclim. 2_5m_min_80s"
+        }
+    }
+}

--- a/tests/extensions/test_datacube.py
+++ b/tests/extensions/test_datacube.py
@@ -1,0 +1,55 @@
+import json
+import unittest
+import pystac
+from pystac.extensions.datacube import DatacubeExtension
+
+from tests.utils import TestCases, assert_to_from_dict
+
+
+class DatacubeTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.maxDiff = None
+        self.example_uri = TestCases.get_path(
+            "data-files/datacube/item.json"
+        )
+    
+    def test_validate_datacube(self) -> None:
+        item = pystac.Item.from_file(self.example_uri)
+        item.validate()
+
+    def test_extension_not_implemented(self) -> None:
+        # Should raise exception if Item does not include extension URI
+        item = pystac.Item.from_file(self.example_uri)
+        item.stac_extensions.remove(DatacubeExtension.get_schema_uri())
+
+        with self.assertRaises(pystac.ExtensionNotImplemented):
+            _ = DatacubeExtension.ext(item)
+
+        # Should raise exception if owning Item does not include extension URI
+        asset = item.assets["data"]
+
+        with self.assertRaises(pystac.ExtensionNotImplemented):
+            _ = DatacubeExtension.ext(asset)
+
+        # Should succeed if Asset has no owner
+        ownerless_asset = pystac.Asset.from_dict(asset.to_dict())
+        _ = DatacubeExtension.ext(ownerless_asset)
+
+    def test_item_ext_add_to(self) -> None:
+        item = pystac.Item.from_file(self.example_uri)
+        item.stac_extensions.remove(DatacubeExtension.get_schema_uri())
+        self.assertNotIn(DatacubeExtension.get_schema_uri(), item.stac_extensions)
+
+        _ = DatacubeExtension.ext(item, add_if_missing=True)
+
+        self.assertIn(DatacubeExtension.get_schema_uri(), item.stac_extensions)
+
+    def test_asset_ext_add_to(self) -> None:
+        item = pystac.Item.from_file(self.example_uri)
+        item.stac_extensions.remove(DatacubeExtension.get_schema_uri())
+        self.assertNotIn(DatacubeExtension.get_schema_uri(), item.stac_extensions)
+        asset = item.assets["data"]
+
+        _ = DatacubeExtension.ext(asset, add_if_missing=True)
+
+        self.assertIn(DatacubeExtension.get_schema_uri(), item.stac_extensions)

--- a/tests/extensions/test_datacube.py
+++ b/tests/extensions/test_datacube.py
@@ -1,18 +1,15 @@
-import json
 import unittest
 import pystac
 from pystac.extensions.datacube import DatacubeExtension
 
-from tests.utils import TestCases, assert_to_from_dict
+from tests.utils import TestCases
 
 
 class DatacubeTest(unittest.TestCase):
     def setUp(self) -> None:
         self.maxDiff = None
-        self.example_uri = TestCases.get_path(
-            "data-files/datacube/item.json"
-        )
-    
+        self.example_uri = TestCases.get_path("data-files/datacube/item.json")
+
     def test_validate_datacube(self) -> None:
         item = pystac.Item.from_file(self.example_uri)
         item.validate()

--- a/tests/extensions/test_eo.py
+++ b/tests/extensions/test_eo.py
@@ -264,3 +264,23 @@ class EOTest(unittest.TestCase):
 
         with self.assertRaises(pystac.ExtensionTypeError):
             EOExtension.ext(link)  # type: ignore
+
+    def test_extension_not_implemented(self) -> None:
+        # Should raise exception if Item does not include extension URI
+        item = pystac.Item.from_file(self.PLAIN_ITEM)
+
+        with self.assertRaises(pystac.ExtensionNotImplemented):
+            _ = EOExtension.ext(item)
+
+        # Should raise exception if owning Item does not include extension URI
+        asset = item.assets["thumbnail"]
+
+        with self.assertRaises(pystac.ExtensionNotImplemented):
+            _ = EOExtension.ext(asset)
+
+        # Should succeed if Asset has no owner
+        stac_io = pystac.StacIO.default()
+        item_dict = stac_io.read_json(self.LANDSAT_EXAMPLE_URI)
+        asset_dict = item_dict["assets"]["B11"]
+        ownerless_asset = pystac.Asset.from_dict(asset_dict)
+        _ = EOExtension.ext(ownerless_asset)

--- a/tests/extensions/test_eo.py
+++ b/tests/extensions/test_eo.py
@@ -281,3 +281,20 @@ class EOTest(unittest.TestCase):
         # Should succeed if Asset has no owner
         ownerless_asset = pystac.Asset.from_dict(asset.to_dict())
         _ = EOExtension.ext(ownerless_asset)
+
+    def test_item_ext_add_to(self) -> None:
+        item = pystac.Item.from_file(self.PLAIN_ITEM)
+        self.assertNotIn(EOExtension.get_schema_uri(), item.stac_extensions)
+
+        _ = EOExtension.ext(item, add_if_missing=True)
+
+        self.assertIn(EOExtension.get_schema_uri(), item.stac_extensions)
+
+    def test_asset_ext_add_to(self) -> None:
+        item = pystac.Item.from_file(self.PLAIN_ITEM)
+        self.assertNotIn(EOExtension.get_schema_uri(), item.stac_extensions)
+        asset = item.assets["thumbnail"]
+
+        _ = EOExtension.ext(asset, add_if_missing=True)
+
+        self.assertIn(EOExtension.get_schema_uri(), item.stac_extensions)

--- a/tests/extensions/test_eo.py
+++ b/tests/extensions/test_eo.py
@@ -279,8 +279,5 @@ class EOTest(unittest.TestCase):
             _ = EOExtension.ext(asset)
 
         # Should succeed if Asset has no owner
-        stac_io = pystac.StacIO.default()
-        item_dict = stac_io.read_json(self.LANDSAT_EXAMPLE_URI)
-        asset_dict = item_dict["assets"]["B11"]
-        ownerless_asset = pystac.Asset.from_dict(asset_dict)
+        ownerless_asset = pystac.Asset.from_dict(asset.to_dict())
         _ = EOExtension.ext(ownerless_asset)

--- a/tests/extensions/test_file.py
+++ b/tests/extensions/test_file.py
@@ -50,6 +50,7 @@ class MappingObjectTest(unittest.TestCase):
 class FileTest(unittest.TestCase):
     FILE_ITEM_EXAMPLE_URI = TestCases.get_path("data-files/file/item.json")
     FILE_COLLECTION_EXAMPLE_URI = TestCases.get_path("data-files/file/collection.json")
+    PLAIN_ITEM = TestCases.get_path("data-files/item/sample-item.json")
 
     def setUp(self) -> None:
         self.maxDiff = None
@@ -188,3 +189,25 @@ class FileTest(unittest.TestCase):
             FileExtension.ext(item.assets["noises"]).checksum,
             "90e40210a30d1711e81a4b11ef67b28744321659",
         )
+
+    def test_extension_type_error(self) -> None:
+        item = pystac.Item.from_file(self.FILE_ITEM_EXAMPLE_URI)
+
+        with self.assertRaises(pystac.ExtensionTypeError):
+            _ = FileExtension.ext(item)  # type: ignore
+
+    def test_extension_not_implemented(self) -> None:
+        # Should raise exception if Item does not include extension URI
+        item = pystac.Item.from_file(self.PLAIN_ITEM)
+        asset = item.assets["thumbnail"]
+
+        with self.assertRaises(pystac.ExtensionNotImplemented):
+            _ = FileExtension.ext(asset)
+
+        # Should succeed if Asset has no owner
+        stac_io = pystac.StacIO.default()
+        item_dict = stac_io.read_json(self.FILE_ITEM_EXAMPLE_URI)
+        asset_dict = item_dict["assets"]["measurement"]
+        ownerless_asset = pystac.Asset.from_dict(asset_dict)
+
+        _ = FileExtension.ext(ownerless_asset)

--- a/tests/extensions/test_file.py
+++ b/tests/extensions/test_file.py
@@ -208,3 +208,13 @@ class FileTest(unittest.TestCase):
         ownerless_asset = pystac.Asset.from_dict(asset.to_dict())
 
         _ = FileExtension.ext(ownerless_asset)
+
+    def test_ext_add_to(self) -> None:
+        item = pystac.Item.from_file(self.PLAIN_ITEM)
+        asset = item.assets["thumbnail"]
+
+        self.assertNotIn(FileExtension.get_schema_uri(), item.stac_extensions)
+
+        _ = FileExtension.ext(asset, add_if_missing=True)
+
+        self.assertIn(FileExtension.get_schema_uri(), item.stac_extensions)

--- a/tests/extensions/test_file.py
+++ b/tests/extensions/test_file.py
@@ -205,9 +205,6 @@ class FileTest(unittest.TestCase):
             _ = FileExtension.ext(asset)
 
         # Should succeed if Asset has no owner
-        stac_io = pystac.StacIO.default()
-        item_dict = stac_io.read_json(self.FILE_ITEM_EXAMPLE_URI)
-        asset_dict = item_dict["assets"]["measurement"]
-        ownerless_asset = pystac.Asset.from_dict(asset_dict)
+        ownerless_asset = pystac.Asset.from_dict(asset.to_dict())
 
         _ = FileExtension.ext(ownerless_asset)

--- a/tests/extensions/test_label.py
+++ b/tests/extensions/test_label.py
@@ -376,3 +376,12 @@ class LabelTest(unittest.TestCase):
 
         with self.assertRaises(pystac.ExtensionNotImplemented):
             _ = LabelExtension.ext(item)
+
+    def test_ext_add_to(self) -> None:
+        item = pystac.Item.from_file(self.label_example_1_uri)
+        item.stac_extensions.remove(LabelExtension.get_schema_uri())
+        self.assertNotIn(LabelExtension.get_schema_uri(), item.stac_extensions)
+
+        _ = LabelExtension.ext(item, add_if_missing=True)
+
+        self.assertIn(LabelExtension.get_schema_uri(), item.stac_extensions)

--- a/tests/extensions/test_label.py
+++ b/tests/extensions/test_label.py
@@ -361,3 +361,18 @@ class LabelTest(unittest.TestCase):
 
         with self.assertRaises(AssertionError):
             _ = overview_1.merge_counts(overview_2)
+
+    def test_extension_type_error(self) -> None:
+        collection = pystac.Collection.from_file(
+            TestCases.get_path("data-files/collections/with-assets.json")
+        )
+        with self.assertRaises(pystac.ExtensionTypeError):
+            _ = LabelExtension.ext(collection)  # type: ignore
+
+    def test_extension_not_implemented(self) -> None:
+        # Should raise exception if Item does not include extension URI
+        item = pystac.Item.from_file(self.label_example_1_uri)
+        item.stac_extensions.remove(LabelExtension.get_schema_uri())
+
+        with self.assertRaises(pystac.ExtensionNotImplemented):
+            _ = LabelExtension.ext(item)

--- a/tests/extensions/test_pointcloud.py
+++ b/tests/extensions/test_pointcloud.py
@@ -311,3 +311,22 @@ class PointcloudTest(unittest.TestCase):
         # Should succeed if Asset has no owner
         ownerless_asset = pystac.Asset.from_dict(asset.to_dict())
         _ = PointcloudExtension.ext(ownerless_asset)
+
+    def test_item_ext_add_to(self) -> None:
+        plain_item_uri = TestCases.get_path("data-files/item/sample-item.json")
+        item = pystac.Item.from_file(plain_item_uri)
+        self.assertNotIn(PointcloudExtension.get_schema_uri(), item.stac_extensions)
+
+        _ = PointcloudExtension.ext(item, add_if_missing=True)
+
+        self.assertIn(PointcloudExtension.get_schema_uri(), item.stac_extensions)
+
+    def test_asset_ext_add_to(self) -> None:
+        plain_item_uri = TestCases.get_path("data-files/item/sample-item.json")
+        item = pystac.Item.from_file(plain_item_uri)
+        self.assertNotIn(PointcloudExtension.get_schema_uri(), item.stac_extensions)
+        asset = item.assets["thumbnail"]
+
+        _ = PointcloudExtension.ext(asset, add_if_missing=True)
+
+        self.assertIn(PointcloudExtension.get_schema_uri(), item.stac_extensions)

--- a/tests/extensions/test_pointcloud.py
+++ b/tests/extensions/test_pointcloud.py
@@ -293,3 +293,21 @@ class PointcloudTest(unittest.TestCase):
 
         with self.assertRaises(ExtensionTypeError):
             PointcloudExtension.ext(RandomObject())  # type: ignore
+
+    def test_extension_not_implemented(self) -> None:
+        # Should raise exception if Item does not include extension URI
+        plain_item_uri = TestCases.get_path("data-files/item/sample-item.json")
+        item = pystac.Item.from_file(plain_item_uri)
+
+        with self.assertRaises(pystac.ExtensionNotImplemented):
+            _ = PointcloudExtension.ext(item)
+
+        # Should raise exception if owning Item does not include extension URI
+        asset = item.assets["thumbnail"]
+
+        with self.assertRaises(pystac.ExtensionNotImplemented):
+            _ = PointcloudExtension.ext(asset)
+
+        # Should succeed if Asset has no owner
+        ownerless_asset = pystac.Asset.from_dict(asset.to_dict())
+        _ = PointcloudExtension.ext(ownerless_asset)

--- a/tests/extensions/test_projection.py
+++ b/tests/extensions/test_projection.py
@@ -406,6 +406,24 @@ class ProjectionTest(unittest.TestCase):
         # Validate
         proj_item.validate()
 
+    def test_extension_not_implemented(self) -> None:
+        # Should raise exception if Item does not include extension URI
+        item = pystac.Item.from_file(self.example_uri)
+        item.stac_extensions.remove(ProjectionExtension.get_schema_uri())
+
+        with self.assertRaises(pystac.ExtensionNotImplemented):
+            _ = ProjectionExtension.ext(item)
+
+        # Should raise exception if owning Item does not include extension URI
+        asset = item.assets["B8"]
+
+        with self.assertRaises(pystac.ExtensionNotImplemented):
+            _ = ProjectionExtension.ext(asset)
+
+        # Should succeed if Asset has no owner
+        ownerless_asset = pystac.Asset.from_dict(asset.to_dict())
+        _ = ProjectionExtension.ext(ownerless_asset)
+
 
 class ProjectionSummariesTest(unittest.TestCase):
     def setUp(self) -> None:

--- a/tests/extensions/test_projection.py
+++ b/tests/extensions/test_projection.py
@@ -424,6 +424,25 @@ class ProjectionTest(unittest.TestCase):
         ownerless_asset = pystac.Asset.from_dict(asset.to_dict())
         _ = ProjectionExtension.ext(ownerless_asset)
 
+    def test_item_ext_add_to(self) -> None:
+        item = pystac.Item.from_file(self.example_uri)
+        item.stac_extensions.remove(ProjectionExtension.get_schema_uri())
+        self.assertNotIn(ProjectionExtension.get_schema_uri(), item.stac_extensions)
+
+        _ = ProjectionExtension.ext(item, add_if_missing=True)
+
+        self.assertIn(ProjectionExtension.get_schema_uri(), item.stac_extensions)
+
+    def test_asset_ext_add_to(self) -> None:
+        item = pystac.Item.from_file(self.example_uri)
+        item.stac_extensions.remove(ProjectionExtension.get_schema_uri())
+        self.assertNotIn(ProjectionExtension.get_schema_uri(), item.stac_extensions)
+        asset = item.assets["B8"]
+
+        _ = ProjectionExtension.ext(asset, add_if_missing=True)
+
+        self.assertIn(ProjectionExtension.get_schema_uri(), item.stac_extensions)
+
 
 class ProjectionSummariesTest(unittest.TestCase):
     def setUp(self) -> None:

--- a/tests/extensions/test_raster.py
+++ b/tests/extensions/test_raster.py
@@ -213,3 +213,12 @@ class RasterTest(unittest.TestCase):
         # Should succeed if Asset has no owner
         ownerless_asset = pystac.Asset.from_dict(asset.to_dict())
         _ = RasterExtension.ext(ownerless_asset)
+
+    def test_ext_add_to(self) -> None:
+        item = pystac.Item.from_file(self.PLANET_EXAMPLE_URI)
+        item.stac_extensions.remove(RasterExtension.get_schema_uri())
+        asset = item.assets["data"]
+
+        _ = RasterExtension.ext(asset, add_if_missing=True)
+
+        self.assertIn(RasterExtension.get_schema_uri(), item.stac_extensions)

--- a/tests/extensions/test_raster.py
+++ b/tests/extensions/test_raster.py
@@ -198,3 +198,18 @@ class RasterTest(unittest.TestCase):
             item.assets["test"].properties["raster:bands"][0]["statistics"]["minimum"],
             1,
         )
+
+    def test_extension_not_implemented(self) -> None:
+        # Should raise exception if Item does not include extension URI
+        item = pystac.Item.from_file(self.PLANET_EXAMPLE_URI)
+        item.stac_extensions.remove(RasterExtension.get_schema_uri())
+
+        # Should raise exception if owning Item does not include extension URI
+        asset = item.assets["data"]
+
+        with self.assertRaises(pystac.ExtensionNotImplemented):
+            _ = RasterExtension.ext(asset)
+
+        # Should succeed if Asset has no owner
+        ownerless_asset = pystac.Asset.from_dict(asset.to_dict())
+        _ = RasterExtension.ext(ownerless_asset)

--- a/tests/extensions/test_sar.py
+++ b/tests/extensions/test_sar.py
@@ -7,6 +7,7 @@ import unittest
 import pystac
 from pystac.extensions import sar
 from pystac.extensions.sar import SarExtension
+from tests.utils import TestCases
 
 
 def make_item() -> pystac.Item:
@@ -24,6 +25,7 @@ class SarItemExtTest(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
         self.item = make_item()
+        self.sentinel_example_uri = TestCases.get_path("data-files/sar/sentinel-1.json")
 
     def test_stac_extensions(self) -> None:
         self.assertTrue(SarExtension.has_extension(self.item))
@@ -140,6 +142,24 @@ class SarItemExtTest(unittest.TestCase):
                 polarizations,  # type:ignore
                 product_type,
             )
+
+    def test_extension_not_implemented(self) -> None:
+        # Should raise exception if Item does not include extension URI
+        item = pystac.Item.from_file(self.sentinel_example_uri)
+        item.stac_extensions.remove(SarExtension.get_schema_uri())
+
+        with self.assertRaises(pystac.ExtensionNotImplemented):
+            _ = SarExtension.ext(item)
+
+        # Should raise exception if owning Item does not include extension URI
+        asset = item.assets["measurement"]
+
+        with self.assertRaises(pystac.ExtensionNotImplemented):
+            _ = SarExtension.ext(asset)
+
+        # Should succeed if Asset has no owner
+        ownerless_asset = pystac.Asset.from_dict(asset.to_dict())
+        _ = SarExtension.ext(ownerless_asset)
 
 
 if __name__ == "__main__":

--- a/tests/extensions/test_sar.py
+++ b/tests/extensions/test_sar.py
@@ -161,6 +161,25 @@ class SarItemExtTest(unittest.TestCase):
         ownerless_asset = pystac.Asset.from_dict(asset.to_dict())
         _ = SarExtension.ext(ownerless_asset)
 
+    def test_item_ext_add_to(self) -> None:
+        item = pystac.Item.from_file(self.sentinel_example_uri)
+        item.stac_extensions.remove(SarExtension.get_schema_uri())
+        self.assertNotIn(SarExtension.get_schema_uri(), item.stac_extensions)
+
+        _ = SarExtension.ext(item, add_if_missing=True)
+
+        self.assertIn(SarExtension.get_schema_uri(), item.stac_extensions)
+
+    def test_asset_ext_add_to(self) -> None:
+        item = pystac.Item.from_file(self.sentinel_example_uri)
+        item.stac_extensions.remove(SarExtension.get_schema_uri())
+        self.assertNotIn(SarExtension.get_schema_uri(), item.stac_extensions)
+        asset = item.assets["measurement"]
+
+        _ = SarExtension.ext(asset, add_if_missing=True)
+
+        self.assertIn(SarExtension.get_schema_uri(), item.stac_extensions)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/extensions/test_sat.py
+++ b/tests/extensions/test_sat.py
@@ -141,3 +141,22 @@ class SatTest(unittest.TestCase):
         # Should succeed if Asset has no owner
         ownerless_asset = pystac.Asset.from_dict(asset.to_dict())
         _ = SatExtension.ext(ownerless_asset)
+
+    def test_item_ext_add_to(self) -> None:
+        item = pystac.Item.from_file(self.sentinel_example_uri)
+        item.stac_extensions.remove(SatExtension.get_schema_uri())
+        self.assertNotIn(SatExtension.get_schema_uri(), item.stac_extensions)
+
+        _ = SatExtension.ext(item, add_if_missing=True)
+
+        self.assertIn(SatExtension.get_schema_uri(), item.stac_extensions)
+
+    def test_asset_ext_add_to(self) -> None:
+        item = pystac.Item.from_file(self.sentinel_example_uri)
+        item.stac_extensions.remove(SatExtension.get_schema_uri())
+        self.assertNotIn(SatExtension.get_schema_uri(), item.stac_extensions)
+        asset = item.assets["measurement_iw1_vh"]
+
+        _ = SatExtension.ext(asset, add_if_missing=True)
+
+        self.assertIn(SatExtension.get_schema_uri(), item.stac_extensions)

--- a/tests/extensions/test_sat.py
+++ b/tests/extensions/test_sat.py
@@ -7,6 +7,7 @@ import unittest
 import pystac
 from pystac.extensions import sat
 from pystac.extensions.sat import SatExtension
+from tests.utils import TestCases
 
 
 def make_item() -> pystac.Item:
@@ -25,6 +26,7 @@ class SatTest(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
         self.item = make_item()
+        self.sentinel_example_uri = TestCases.get_path("data-files/sat/sentinel-1.json")
 
     def test_stac_extensions(self) -> None:
         self.assertTrue(SatExtension.has_extension(self.item))
@@ -90,7 +92,7 @@ class SatTest(unittest.TestCase):
             "geometry": None,
             "links": [],
             "assets": {},
-            "stac_extensions": ["sat"],
+            "stac_extensions": [SatExtension.get_schema_uri()],
         }
         item = pystac.Item.from_dict(d)
         self.assertEqual(orbit_state, SatExtension.ext(item).orbit_state)
@@ -121,3 +123,21 @@ class SatTest(unittest.TestCase):
         SatExtension.ext(self.item).relative_orbit = None
         self.assertIsNone(SatExtension.ext(self.item).relative_orbit)
         self.item.validate()
+
+    def test_extension_not_implemented(self) -> None:
+        # Should raise exception if Item does not include extension URI
+        item = pystac.Item.from_file(self.sentinel_example_uri)
+        item.stac_extensions.remove(SatExtension.get_schema_uri())
+
+        with self.assertRaises(pystac.ExtensionNotImplemented):
+            _ = SatExtension.ext(item)
+
+        # Should raise exception if owning Item does not include extension URI
+        asset = item.assets["measurement_iw1_vh"]
+
+        with self.assertRaises(pystac.ExtensionNotImplemented):
+            _ = SatExtension.ext(asset)
+
+        # Should succeed if Asset has no owner
+        ownerless_asset = pystac.Asset.from_dict(asset.to_dict())
+        _ = SatExtension.ext(ownerless_asset)

--- a/tests/extensions/test_scientific.py
+++ b/tests/extensions/test_scientific.py
@@ -216,6 +216,15 @@ class ItemScientificExtensionTest(unittest.TestCase):
         with self.assertRaises(pystac.ExtensionNotImplemented):
             _ = ScientificExtension.ext(item)
 
+    def test_ext_add_to(self) -> None:
+        item = pystac.Item.from_file(self.example_item_uri)
+        item.stac_extensions.remove(ScientificExtension.get_schema_uri())
+        self.assertNotIn(ScientificExtension.get_schema_uri(), item.stac_extensions)
+
+        _ = ScientificExtension.ext(item, add_if_missing=True)
+
+        self.assertIn(ScientificExtension.get_schema_uri(), item.stac_extensions)
+
 
 def make_collection() -> pystac.Collection:
     asset_id = "my/thing"

--- a/tests/extensions/test_scientific.py
+++ b/tests/extensions/test_scientific.py
@@ -379,7 +379,7 @@ class CollectionScientificExtensionTest(unittest.TestCase):
         self.collection.validate()
 
     def test_extension_not_implemented(self) -> None:
-        # Should raise exception if Item does not include extension URI
+        # Should raise exception if Collection does not include extension URI
         collection = pystac.Collection.from_file(self.example_collection_uri)
         collection.stac_extensions.remove(ScientificExtension.get_schema_uri())
 

--- a/tests/extensions/test_scientific.py
+++ b/tests/extensions/test_scientific.py
@@ -395,6 +395,17 @@ class CollectionScientificExtensionTest(unittest.TestCase):
         with self.assertRaises(pystac.ExtensionNotImplemented):
             _ = ScientificExtension.ext(collection)
 
+    def test_ext_add_to(self) -> None:
+        collection = pystac.Collection.from_file(self.example_collection_uri)
+        collection.stac_extensions.remove(ScientificExtension.get_schema_uri())
+        self.assertNotIn(
+            ScientificExtension.get_schema_uri(), collection.stac_extensions
+        )
+
+        _ = ScientificExtension.ext(collection, add_if_missing=True)
+
+        self.assertIn(ScientificExtension.get_schema_uri(), collection.stac_extensions)
+
 
 class SummariesScientificTest(unittest.TestCase):
     def setUp(self) -> None:

--- a/tests/extensions/test_scientific.py
+++ b/tests/extensions/test_scientific.py
@@ -14,6 +14,7 @@ from pystac.extensions.scientific import (
     ScientificRelType,
     remove_link,
 )
+from tests.utils import TestCases
 
 URL_TEMPLATE = "http://example.com/catalog/%s.json"
 
@@ -73,6 +74,7 @@ class ItemScientificExtensionTest(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
         self.item = make_item()
+        self.example_item_uri = TestCases.get_path("data-files/scientific/item.json")
 
     def test_stac_extensions(self) -> None:
         self.assertTrue(ScientificExtension.has_extension(self.item))
@@ -206,6 +208,14 @@ class ItemScientificExtensionTest(unittest.TestCase):
         self.assertEqual(DOI_URL, links[0].target)
         self.item.validate()
 
+    def test_extension_not_implemented(self) -> None:
+        # Should raise exception if Item does not include extension URI
+        item = pystac.Item.from_file(self.example_item_uri)
+        item.stac_extensions.remove(ScientificExtension.get_schema_uri())
+
+        with self.assertRaises(pystac.ExtensionNotImplemented):
+            _ = ScientificExtension.ext(item)
+
 
 def make_collection() -> pystac.Collection:
     asset_id = "my/thing"
@@ -227,6 +237,9 @@ class CollectionScientificExtensionTest(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
         self.collection = make_collection()
+        self.example_collection_uri = TestCases.get_path(
+            "data-files/scientific/collection.json"
+        )
 
     def test_stac_extensions(self) -> None:
         self.assertTrue(ScientificExtension.has_extension(self.collection))
@@ -364,6 +377,14 @@ class CollectionScientificExtensionTest(unittest.TestCase):
         self.assertEqual(1, len(links))
         self.assertEqual(DOI_URL, links[0].target)
         self.collection.validate()
+
+    def test_extension_not_implemented(self) -> None:
+        # Should raise exception if Item does not include extension URI
+        collection = pystac.Collection.from_file(self.example_collection_uri)
+        collection.stac_extensions.remove(ScientificExtension.get_schema_uri())
+
+        with self.assertRaises(pystac.ExtensionNotImplemented):
+            _ = ScientificExtension.ext(collection)
 
 
 class SummariesScientificTest(unittest.TestCase):

--- a/tests/extensions/test_timestamps.py
+++ b/tests/extensions/test_timestamps.py
@@ -203,3 +203,22 @@ class TimestampsTest(unittest.TestCase):
         # Should succeed if Asset has no owner
         ownerless_asset = pystac.Asset.from_dict(asset.to_dict())
         _ = TimestampsExtension.ext(ownerless_asset)
+
+    def test_item_ext_add_to(self) -> None:
+        item = pystac.Item.from_file(self.example_uri)
+        item.stac_extensions.remove(TimestampsExtension.get_schema_uri())
+        self.assertNotIn(TimestampsExtension.get_schema_uri(), item.stac_extensions)
+
+        _ = TimestampsExtension.ext(item, add_if_missing=True)
+
+        self.assertIn(TimestampsExtension.get_schema_uri(), item.stac_extensions)
+
+    def test_asset_ext_add_to(self) -> None:
+        item = pystac.Item.from_file(self.example_uri)
+        item.stac_extensions.remove(TimestampsExtension.get_schema_uri())
+        self.assertNotIn(TimestampsExtension.get_schema_uri(), item.stac_extensions)
+        asset = item.assets["blue"]
+
+        _ = TimestampsExtension.ext(asset, add_if_missing=True)
+
+        self.assertIn(TimestampsExtension.get_schema_uri(), item.stac_extensions)

--- a/tests/extensions/test_timestamps.py
+++ b/tests/extensions/test_timestamps.py
@@ -185,3 +185,21 @@ class TimestampsTest(unittest.TestCase):
 
         # Validate
         timestamps_item.validate()
+
+    def test_extension_not_implemented(self) -> None:
+        # Should raise exception if Item does not include extension URI
+        item = pystac.Item.from_file(self.example_uri)
+        item.stac_extensions.remove(TimestampsExtension.get_schema_uri())
+
+        with self.assertRaises(pystac.ExtensionNotImplemented):
+            _ = TimestampsExtension.ext(item)
+
+        # Should raise exception if owning Item does not include extension URI
+        asset = item.assets["blue"]
+
+        with self.assertRaises(pystac.ExtensionNotImplemented):
+            _ = TimestampsExtension.ext(asset)
+
+        # Should succeed if Asset has no owner
+        ownerless_asset = pystac.Asset.from_dict(asset.to_dict())
+        _ = TimestampsExtension.ext(ownerless_asset)

--- a/tests/extensions/test_version.py
+++ b/tests/extensions/test_version.py
@@ -452,6 +452,15 @@ class CollectionVersionExtensionTest(unittest.TestCase):
         with self.assertRaises(pystac.ExtensionNotImplemented):
             _ = VersionExtension.ext(collection)
 
+    def test_ext_add_to(self) -> None:
+        collection = pystac.Collection.from_file(self.example_collection_uri)
+        collection.stac_extensions.remove(VersionExtension.get_schema_uri())
+        self.assertNotIn(VersionExtension.get_schema_uri(), collection.stac_extensions)
+
+        _ = VersionExtension.ext(collection, add_if_missing=True)
+
+        self.assertIn(VersionExtension.get_schema_uri(), collection.stac_extensions)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/extensions/test_version.py
+++ b/tests/extensions/test_version.py
@@ -227,6 +227,15 @@ class ItemVersionExtensionTest(unittest.TestCase):
         with self.assertRaises(pystac.ExtensionNotImplemented):
             _ = VersionExtension.ext(item)
 
+    def test_ext_add_to(self) -> None:
+        item = pystac.Item.from_file(self.example_item_uri)
+        item.stac_extensions.remove(VersionExtension.get_schema_uri())
+        self.assertNotIn(VersionExtension.get_schema_uri(), item.stac_extensions)
+
+        _ = VersionExtension.ext(item, add_if_missing=True)
+
+        self.assertIn(VersionExtension.get_schema_uri(), item.stac_extensions)
+
 
 def make_collection(year: int) -> pystac.Collection:
     asset_id = f"my/collection/of/things/{year}"

--- a/tests/extensions/test_version.py
+++ b/tests/extensions/test_version.py
@@ -33,6 +33,7 @@ class ItemVersionExtensionTest(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
         self.item = make_item(2011)
+        self.example_item_uri = TestCases.get_path("data-files/version/item.json")
 
     def test_rel_types(self) -> None:
         self.assertEqual(str(VersionRelType.LATEST), "latest-version")
@@ -218,6 +219,14 @@ class ItemVersionExtensionTest(unittest.TestCase):
         self.assertEqual(1, len(links))
         self.assertEqual(expected_href, links[0].get_href())
 
+    def test_extension_not_implemented(self) -> None:
+        # Should raise exception if Item does not include extension URI
+        item = pystac.Item.from_file(self.example_item_uri)
+        item.stac_extensions.remove(VersionExtension.get_schema_uri())
+
+        with self.assertRaises(pystac.ExtensionNotImplemented):
+            _ = VersionExtension.ext(item)
+
 
 def make_collection(year: int) -> pystac.Collection:
     asset_id = f"my/collection/of/things/{year}"
@@ -243,6 +252,9 @@ class CollectionVersionExtensionTest(unittest.TestCase):
     def setUp(self) -> None:
         super().setUp()
         self.collection = make_collection(2011)
+        self.example_collection_uri = TestCases.get_path(
+            "data-files/version/collection.json"
+        )
 
     def test_stac_extensions(self) -> None:
         self.assertTrue(VersionExtension.has_extension(self.collection))
@@ -422,6 +434,14 @@ class CollectionVersionExtensionTest(unittest.TestCase):
         links = self.collection.get_links(VersionRelType.SUCCESSOR)
         self.assertEqual(1, len(links))
         self.assertEqual(expected_href, links[0].get_href())
+
+    def test_extension_not_implemented(self) -> None:
+        # Should raise exception if Collection does not include extension URI
+        collection = pystac.Collection.from_file(self.example_collection_uri)
+        collection.stac_extensions.remove(VersionExtension.get_schema_uri())
+
+        with self.assertRaises(pystac.ExtensionNotImplemented):
+            _ = VersionExtension.ext(collection)
 
 
 if __name__ == "__main__":

--- a/tests/extensions/test_view.py
+++ b/tests/extensions/test_view.py
@@ -238,6 +238,25 @@ class ViewTest(unittest.TestCase):
         ownerless_asset = pystac.Asset.from_dict(asset.to_dict())
         _ = ViewExtension.ext(ownerless_asset)
 
+    def test_item_ext_add_to(self) -> None:
+        item = pystac.Item.from_file(self.example_uri)
+        item.stac_extensions.remove(ViewExtension.get_schema_uri())
+        self.assertNotIn(ViewExtension.get_schema_uri(), item.stac_extensions)
+
+        _ = ViewExtension.ext(item, add_if_missing=True)
+
+        self.assertIn(ViewExtension.get_schema_uri(), item.stac_extensions)
+
+    def test_asset_ext_add_to(self) -> None:
+        item = pystac.Item.from_file(self.example_uri)
+        item.stac_extensions.remove(ViewExtension.get_schema_uri())
+        self.assertNotIn(ViewExtension.get_schema_uri(), item.stac_extensions)
+        asset = item.assets["blue"]
+
+        _ = ViewExtension.ext(asset, add_if_missing=True)
+
+        self.assertIn(ViewExtension.get_schema_uri(), item.stac_extensions)
+
 
 class ViewSummariestest(unittest.TestCase):
     def setUp(self) -> None:

--- a/tests/extensions/test_view.py
+++ b/tests/extensions/test_view.py
@@ -220,6 +220,24 @@ class ViewTest(unittest.TestCase):
         # Validate
         view_item.validate()
 
+    def test_extension_not_implemented(self) -> None:
+        # Should raise exception if Item does not include extension URI
+        item = pystac.Item.from_file(self.example_uri)
+        item.stac_extensions.remove(ViewExtension.get_schema_uri())
+
+        with self.assertRaises(pystac.ExtensionNotImplemented):
+            _ = ViewExtension.ext(item)
+
+        # Should raise exception if owning Item does not include extension URI
+        asset = item.assets["blue"]
+
+        with self.assertRaises(pystac.ExtensionNotImplemented):
+            _ = ViewExtension.ext(asset)
+
+        # Should succeed if Asset has no owner
+        ownerless_asset = pystac.Asset.from_dict(asset.to_dict())
+        _ = ViewExtension.ext(ownerless_asset)
+
 
 class ViewSummariestest(unittest.TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
**Related Issue(s):**

* #370 

**Description:**

Introduces a new `ExceptionNotImplemented` exception type and raises this when attempting to extend an object that does not include that extension's schema URI in `stac_extensions`. See the corresponding issue for discussion of how Assets without an owner are handled.

Also adds an `add_if_missing` boolean option to the `*Extension.ext` methods that will add the schema URI to the object's `stac_extension` list if it is missing (see [this PR comment](https://github.com/stac-utils/stactools/pull/113#discussion_r639867195) for original suggestion).

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.