### PR TITLE
Fix STACObject inheritance

### DIFF
--- a/pystac/__init__.py
+++ b/pystac/__init__.py
@@ -76,10 +76,11 @@ EXTENSION_HOOKS = pystac.extensions.hooks.RegisteredExtensionHooks(
 def read_file(href: str) -> STACObject:
     """Reads a STAC object from a file.
 
-    This method will return either a Catalog, a Collection, or an Item based on what the
-    file contains.
+    This method will return either a Catalog, a Collection, or an Item based on what
+    the file contains.
 
-    This is a convenience method for :meth:`STACObject.from_file <pystac.STACObject.from_file>`
+    This is a convenience method for :meth:`StacIO.read_stac_object
+    <pystac.StacIO.read_stac_object>`
 
     Args:
         href : The HREF to read the object from.
@@ -90,22 +91,12 @@ def read_file(href: str) -> STACObject:
 
     Raises:
         STACTypeError : If the file at ``href`` does not represent a valid
-            :class:`~pystac.STACObject`. Note that an :class:`~pystac.ItemCollection` is not
-            a :class:`~pystac.STACObject` and must be read using
+            :class:`~pystac.STACObject`. Note that an :class:`~pystac.ItemCollection`
+            is not a :class:`~pystac.STACObject` and must be read using
             :meth:`ItemCollection.from_file <pystac.ItemCollection.from_file>`
     """
     stac_io = StacIO.default()
-    d = stac_io.read_json(href)
-    typ = pystac.serialization.identify.identify_stac_object_type(d)
-
-    if typ == STACObjectType.CATALOG:
-        return Catalog.from_file(href)
-    elif typ == STACObjectType.COLLECTION:
-        return Collection.from_file(href)
-    elif typ == STACObjectType.ITEM:
-        return Item.from_file(href)
-    else:
-        raise STACTypeError(f"Cannot read file of type {typ}")
+    return stac_io.read_stac_object(href)
 
 
 def write_file(
@@ -148,7 +139,7 @@ def read_dict(
     or :class`~Item` based on the contents of the dict.
 
     This is a convenience method for either
-    :meth:`stac_io.stac_object_from_dict <stac_io.stac_object_from_dict>`.
+    :meth:`StacIO.stac_object_from_dict <pystac.StacIO.stac_object_from_dict>`.
 
     Args:
         d : The dict to parse.
@@ -162,8 +153,8 @@ def read_dict(
 
     Raises:
         STACTypeError : If the ``d`` dictionary does not represent a valid
-            :class:`~pystac.STACObject`. Note that an :class:`~pystac.ItemCollection` is not
-            a :class:`~pystac.STACObject` and must be read using
+            :class:`~pystac.STACObject`. Note that an :class:`~pystac.ItemCollection`
+            is not a :class:`~pystac.STACObject` and must be read using
             :meth:`ItemCollection.from_dict <pystac.ItemCollection.from_dict>`
     """
     if stac_io is None:

--- a/pystac/__init__.py
+++ b/pystac/__init__.py
@@ -73,7 +73,7 @@ EXTENSION_HOOKS = pystac.extensions.hooks.RegisteredExtensionHooks(
 )
 
 
-def read_file(href: str) -> STACObject:
+def read_file(href: str, stac_io: Optional[StacIO] = None) -> STACObject:
     """Reads a STAC object from a file.
 
     This method will return either a Catalog, a Collection, or an Item based on what
@@ -84,6 +84,8 @@ def read_file(href: str) -> STACObject:
 
     Args:
         href : The HREF to read the object from.
+        stac_io: Optional :class:`~StacIO` instance to use for I/O operations. If not
+            provided, will use :meth:`StacIO.default` to create an instance.
 
     Returns:
         The specific STACObject implementation class that is represented
@@ -95,7 +97,8 @@ def read_file(href: str) -> STACObject:
             is not a :class:`~pystac.STACObject` and must be read using
             :meth:`ItemCollection.from_file <pystac.ItemCollection.from_file>`
     """
-    stac_io = StacIO.default()
+    if stac_io is None:
+        stac_io = StacIO.default()
     return stac_io.read_stac_object(href)
 
 
@@ -103,6 +106,7 @@ def write_file(
     obj: STACObject,
     include_self_link: bool = True,
     dest_href: Optional[str] = None,
+    stac_io: Optional[StacIO] = None,
 ) -> None:
     """Writes a STACObject to a file.
 
@@ -122,8 +126,14 @@ def write_file(
             Otherwise, leave out the self link.
         dest_href : Optional HREF to save the file to. If ``None``, the object will be
             saved to the object's ``"self"`` href.
+        stac_io: Optional :class:`~StacIO` instance to use for I/O operations. If not
+            provided, will use :meth:`StacIO.default` to create an instance.
     """
-    obj.save_object(include_self_link=include_self_link, dest_href=dest_href)
+    if stac_io is None:
+        stac_io = StacIO.default()
+    obj.save_object(
+        include_self_link=include_self_link, dest_href=dest_href, stac_io=stac_io
+    )
 
 
 def read_dict(

--- a/pystac/__init__.py
+++ b/pystac/__init__.py
@@ -94,7 +94,18 @@ def read_file(href: str) -> STACObject:
             a :class:`~pystac.STACObject` and must be read using
             :meth:`ItemCollection.from_file <pystac.ItemCollection.from_file>`
     """
-    return STACObject.from_file(href)
+    stac_io = StacIO.default()
+    d = stac_io.read_json(href)
+    typ = pystac.serialization.identify.identify_stac_object_type(d)
+
+    if typ == STACObjectType.CATALOG:
+        return Catalog.from_file(href)
+    elif typ == STACObjectType.COLLECTION:
+        return Collection.from_file(href)
+    elif typ == STACObjectType.ITEM:
+        return Item.from_file(href)
+    else:
+        raise STACTypeError(f"Cannot read file of type {typ}")
 
 
 def write_file(

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -904,7 +904,7 @@ class Catalog(STACObject):
         if migrate:
             result = pystac.read_dict(d, href=href, root=root)
             if not isinstance(result, Catalog):
-                raise pystac.STACError(f"{result} is not a Catalog")
+                raise pystac.STACTypeError(f"{result} is not a Catalog")
             return result
 
         catalog_type = CatalogType.determine_type(d)
@@ -919,7 +919,7 @@ class Catalog(STACObject):
 
         d.pop("stac_version")
 
-        cat = Catalog(
+        cat = cls(
             id=id,
             description=description,
             title=title,

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -946,7 +946,12 @@ class Catalog(STACObject):
 
     @classmethod
     def from_file(cls, href: str, stac_io: Optional[pystac.StacIO] = None) -> "Catalog":
+        if stac_io is None:
+            stac_io = pystac.StacIO.default()
+
         result = super().from_file(href, stac_io)
         if not isinstance(result, Catalog):
             raise pystac.STACTypeError(f"{result} is not a {Catalog}.")
+        result._stac_io = stac_io
+
         return result

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -1,6 +1,7 @@
 import os
 from copy import deepcopy
 from enum import Enum
+from pystac.errors import STACTypeError
 from typing import (
     Any,
     Callable,
@@ -15,7 +16,7 @@ from typing import (
 )
 
 import pystac
-from pystac.stac_object import STACObject
+from pystac.stac_object import STACObject, STACObjectType
 from pystac.layout import (
     BestPracticesLayoutStrategy,
     HrefLayoutStrategy,
@@ -23,6 +24,11 @@ from pystac.layout import (
 )
 from pystac.link import Link
 from pystac.cache import ResolvedObjectCache
+from pystac.serialization import (
+    identify_stac_object_type,
+    identify_stac_object,
+    migrate_to_latest,
+)
 from pystac.utils import is_absolute_href, make_absolute_href
 
 if TYPE_CHECKING:
@@ -902,10 +908,11 @@ class Catalog(STACObject):
         migrate: bool = False,
     ) -> "Catalog":
         if migrate:
-            result = pystac.read_dict(d, href=href, root=root)
-            if not isinstance(result, Catalog):
-                raise pystac.STACTypeError(f"{result} is not a Catalog")
-            return result
+            info = identify_stac_object(d)
+            d = migrate_to_latest(d, info)
+
+        if not cls.identify_dict(d):
+            raise STACTypeError(f"{d} does not represent a {cls.__name__} instance")
 
         catalog_type = CatalogType.determine_type(d)
 
@@ -955,3 +962,7 @@ class Catalog(STACObject):
         result._stac_io = stac_io
 
         return result
+
+    @classmethod
+    def identify_dict(cls, d: Dict[str, Any]) -> bool:
+        return identify_stac_object_type(d) == STACObjectType.CATALOG

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -911,7 +911,7 @@ class Catalog(STACObject):
             info = identify_stac_object(d)
             d = migrate_to_latest(d, info)
 
-        if not cls.identify_dict(d):
+        if not cls.dict_matches_object_type(d):
             raise STACTypeError(f"{d} does not represent a {cls.__name__} instance")
 
         catalog_type = CatalogType.determine_type(d)
@@ -964,5 +964,5 @@ class Catalog(STACObject):
         return result
 
     @classmethod
-    def identify_dict(cls, d: Dict[str, Any]) -> bool:
+    def dict_matches_object_type(cls, d: Dict[str, Any]) -> bool:
         return identify_stac_object_type(d) == STACObjectType.CATALOG

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -911,7 +911,7 @@ class Catalog(STACObject):
             info = identify_stac_object(d)
             d = migrate_to_latest(d, info)
 
-        if not cls.dict_matches_object_type(d):
+        if not cls.matches_object_type(d):
             raise STACTypeError(f"{d} does not represent a {cls.__name__} instance")
 
         catalog_type = CatalogType.determine_type(d)
@@ -964,5 +964,5 @@ class Catalog(STACObject):
         return result
 
     @classmethod
-    def dict_matches_object_type(cls, d: Dict[str, Any]) -> bool:
+    def matches_object_type(cls, d: Dict[str, Any]) -> bool:
         return identify_stac_object_type(d) == STACObjectType.CATALOG

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -592,7 +592,7 @@ class Collection(Catalog):
             info = identify_stac_object(d)
             d = migrate_to_latest(d, info)
 
-        if not cls.identify_dict(d):
+        if not cls.dict_matches_object_type(d):
             raise STACTypeError(f"{d} does not represent a {cls.__name__} instance")
 
         catalog_type = CatalogType.determine_type(d)
@@ -685,5 +685,5 @@ class Collection(Catalog):
         return result
 
     @classmethod
-    def identify_dict(cls, d: Dict[str, Any]) -> bool:
+    def dict_matches_object_type(cls, d: Dict[str, Any]) -> bool:
         return identify_stac_object_type(d) == STACObjectType.COLLECTION

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -592,7 +592,7 @@ class Collection(Catalog):
             info = identify_stac_object(d)
             d = migrate_to_latest(d, info)
 
-        if not cls.dict_matches_object_type(d):
+        if not cls.matches_object_type(d):
             raise STACTypeError(f"{d} does not represent a {cls.__name__} instance")
 
         catalog_type = CatalogType.determine_type(d)
@@ -685,5 +685,5 @@ class Collection(Catalog):
         return result
 
     @classmethod
-    def dict_matches_object_type(cls, d: Dict[str, Any]) -> bool:
+    def matches_object_type(cls, d: Dict[str, Any]) -> bool:
         return identify_stac_object_type(d) == STACObjectType.COLLECTION

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -610,7 +610,7 @@ class Collection(Catalog):
 
         d.pop("stac_version")
 
-        collection = Collection(
+        collection = cls(
             id=id,
             description=description,
             extent=extent,

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -1,5 +1,6 @@
 from copy import copy, deepcopy
 from datetime import datetime as Datetime
+from pystac.errors import STACTypeError
 from typing import (
     Any,
     Dict,
@@ -23,6 +24,11 @@ from pystac.catalog import Catalog
 from pystac.layout import HrefLayoutStrategy
 from pystac.link import Link
 from pystac.utils import datetime_to_str
+from pystac.serialization import (
+    identify_stac_object_type,
+    identify_stac_object,
+    migrate_to_latest,
+)
 from pystac.summaries import Summaries
 
 if TYPE_CHECKING:
@@ -583,10 +589,11 @@ class Collection(Catalog):
         migrate: bool = False,
     ) -> "Collection":
         if migrate:
-            result = pystac.read_dict(d, href=href, root=root)
-            if not isinstance(result, Collection):
-                raise pystac.STACError(f"{result} is not a Catalog")
-            return result
+            info = identify_stac_object(d)
+            d = migrate_to_latest(d, info)
+
+        if not cls.identify_dict(d):
+            raise STACTypeError(f"{d} does not represent a {cls.__name__} instance")
 
         catalog_type = CatalogType.determine_type(d)
 
@@ -676,3 +683,7 @@ class Collection(Catalog):
         if not isinstance(result, Collection):
             raise pystac.STACTypeError(f"{result} is not a {Collection}.")
         return result
+
+    @classmethod
+    def identify_dict(cls, d: Dict[str, Any]) -> bool:
+        return identify_stac_object_type(d) == STACObjectType.COLLECTION

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -920,7 +920,7 @@ class Item(STACObject):
             info = identify_stac_object(d)
             d = migrate_to_latest(d, info)
 
-        if not cls.dict_matches_object_type(d):
+        if not cls.matches_object_type(d):
             raise pystac.STACTypeError(
                 f"{d} does not represent a {cls.__name__} instance"
             )
@@ -990,5 +990,5 @@ class Item(STACObject):
         return result
 
     @classmethod
-    def dict_matches_object_type(cls, d: Dict[str, Any]) -> bool:
+    def matches_object_type(cls, d: Dict[str, Any]) -> bool:
         return identify_stac_object_type(d) == STACObjectType.ITEM

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -920,7 +920,7 @@ class Item(STACObject):
             info = identify_stac_object(d)
             d = migrate_to_latest(d, info)
 
-        if not cls.identify_dict(d):
+        if not cls.dict_matches_object_type(d):
             raise pystac.STACTypeError(
                 f"{d} does not represent a {cls.__name__} instance"
             )
@@ -990,5 +990,5 @@ class Item(STACObject):
         return result
 
     @classmethod
-    def identify_dict(cls, d: Dict[str, Any]) -> bool:
+    def dict_matches_object_type(cls, d: Dict[str, Any]) -> bool:
         return identify_stac_object_type(d) == STACObjectType.ITEM

--- a/pystac/serialization/__init__.py
+++ b/pystac/serialization/__init__.py
@@ -1,7 +1,4 @@
 # flake8: noqa
-from typing import Any, Dict, Optional, TYPE_CHECKING
-
-import pystac
 from pystac.serialization.identify import (
     STACVersionRange,
     identify_stac_object,
@@ -9,46 +6,3 @@ from pystac.serialization.identify import (
 )
 from pystac.serialization.common_properties import merge_common_properties
 from pystac.serialization.migrate import migrate_to_latest
-
-if TYPE_CHECKING:
-    from pystac.stac_object import STACObject
-    from pystac.catalog import Catalog
-
-
-def stac_object_from_dict(
-    d: Dict[str, Any], href: Optional[str] = None, root: Optional["Catalog"] = None
-) -> "STACObject":
-    """Determines how to deserialize a dictionary into a STAC object.
-
-    Args:
-        d : The dict to parse.
-        href : Optional href that is the file location of the object being
-            parsed.
-        root : Optional root of the catalog for this object.
-            If provided, the root's resolved object cache can be used to search for
-            previously resolved instances of the STAC object.
-
-    Note: This is used internally in StacIO instances to deserialize STAC Objects.
-    """
-    if identify_stac_object_type(d) == pystac.STACObjectType.ITEM:
-        collection_cache = None
-        if root is not None:
-            collection_cache = root._resolved_objects.as_collection_cache()
-
-        # Merge common properties in case this is an older STAC object.
-        merge_common_properties(d, json_href=href, collection_cache=collection_cache)
-
-    info = identify_stac_object(d)
-
-    d = migrate_to_latest(d, info)
-
-    if info.object_type == pystac.STACObjectType.CATALOG:
-        return pystac.Catalog.from_dict(d, href=href, root=root, migrate=False)
-
-    if info.object_type == pystac.STACObjectType.COLLECTION:
-        return pystac.Collection.from_dict(d, href=href, root=root, migrate=False)
-
-    if info.object_type == pystac.STACObjectType.ITEM:
-        return pystac.Item.from_dict(d, href=href, root=root, migrate=False)
-
-    raise pystac.STACTypeError(f"Unknown STAC object type {info.object_type}")

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -515,7 +515,7 @@ class STACObject(ABC):
 
     @classmethod
     @abstractmethod
-    def identify_dict(cls, d: Dict[str, Any]) -> bool:
+    def dict_matches_object_type(cls, d: Dict[str, Any]) -> bool:
         """Returns a boolean indicating whether the given dictionary represents a valid
         instance of this :class:`~STACObject` sub-class.
 

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -6,6 +6,8 @@ import pystac
 from pystac import STACError
 from pystac.link import Link
 from pystac.utils import is_absolute_href, make_absolute_href
+from pystac import serialization
+from pystac.serialization.identify import identify_stac_object
 
 if TYPE_CHECKING:
     from pystac.catalog import Catalog as Catalog_Type
@@ -469,7 +471,10 @@ class STACObject(ABC):
         if not is_absolute_href(href):
             href = make_absolute_href(href)
 
-        o = stac_io.read_stac_object(href)
+        d = stac_io.read_json(href)
+        info = identify_stac_object(d)
+        d = serialization.migrate.migrate_to_latest(d, info)
+        o = cls.from_dict(d, href=href)
 
         # Set the self HREF, if it's not already set to something else.
         if o.get_self_href() is None:

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -515,7 +515,7 @@ class STACObject(ABC):
 
     @classmethod
     @abstractmethod
-    def dict_matches_object_type(cls, d: Dict[str, Any]) -> bool:
+    def matches_object_type(cls, d: Dict[str, Any]) -> bool:
         """Returns a boolean indicating whether the given dictionary represents a valid
         instance of this :class:`~STACObject` sub-class.
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1107,3 +1107,22 @@ class FullCopyTest(unittest.TestCase):
             ].get_absolute_href()
             assert href is not None
             self.assertTrue(os.path.exists(href))
+
+
+class CatalogSubClassTest(unittest.TestCase):
+    """This tests cases related to creating classes inheriting from pystac.Catalog to
+    ensure that inheritance, class methods, etc. function as expected."""
+
+    TEST_CASE_1 = TestCases.get_path("data-files/catalogs/test-case-1/catalog.json")
+
+    class BasicCustomCatalog(pystac.Catalog):
+        pass
+
+    def setUp(self) -> None:
+        self.stac_io = pystac.StacIO.default()
+
+    def test_from_dict_returns_subclass(self) -> None:
+
+        catalog_dict = self.stac_io.read_json(self.TEST_CASE_1)
+        custom_catalog = self.BasicCustomCatalog.from_dict(catalog_dict)
+        self.assertIsInstance(custom_catalog, self.BasicCustomCatalog)

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -974,6 +974,14 @@ class CatalogTest(unittest.TestCase):
         # cached only by HREF
         self.assertEqual(len(cache.id_keys_to_objects), 0)
 
+    def testfrom_invalid_dict_raises_exception(self) -> None:
+        stac_io = pystac.StacIO.default()
+        collection_dict = stac_io.read_json(
+            TestCases.get_path("data-files/collections/multi-extent.json")
+        )
+        with self.assertRaises(pystac.STACTypeError):
+            _ = pystac.Catalog.from_dict(collection_dict)
+
 
 class FullCopyTest(unittest.TestCase):
     def check_link(self, link: pystac.Link, tag: str) -> None:

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1122,7 +1122,12 @@ class CatalogSubClassTest(unittest.TestCase):
         self.stac_io = pystac.StacIO.default()
 
     def test_from_dict_returns_subclass(self) -> None:
-
         catalog_dict = self.stac_io.read_json(self.TEST_CASE_1)
         custom_catalog = self.BasicCustomCatalog.from_dict(catalog_dict)
+
+        self.assertIsInstance(custom_catalog, self.BasicCustomCatalog)
+
+    def test_from_file_returns_subclass(self) -> None:
+        custom_catalog = self.BasicCustomCatalog.from_file(self.TEST_CASE_1)
+
         self.assertIsInstance(custom_catalog, self.BasicCustomCatalog)

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -264,3 +264,22 @@ class ExtentTest(unittest.TestCase):
 
         self.assertEqual(interval[0], datetime(2000, 1, 1, 12, 0, 0, 0, tzinfo=tz.UTC))
         self.assertEqual(interval[1], datetime(2001, 1, 1, 12, 0, 0, 0, tzinfo=tz.UTC))
+
+
+class CollectionSubClassTest(unittest.TestCase):
+    """This tests cases related to creating classes inheriting from pystac.Catalog to
+    ensure that inheritance, class methods, etc. function as expected."""
+
+    MULTI_EXTENT = TestCases.get_path("data-files/collections/multi-extent.json")
+
+    class BasicCustomCollection(pystac.Collection):
+        pass
+
+    def setUp(self) -> None:
+        self.stac_io = pystac.StacIO.default()
+
+    def test_from_dict_returns_subclass(self) -> None:
+
+        collection_dict = self.stac_io.read_json(self.MULTI_EXTENT)
+        custom_collection = self.BasicCustomCollection.from_dict(collection_dict)
+        self.assertIsInstance(custom_collection, self.BasicCustomCollection)

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -279,7 +279,12 @@ class CollectionSubClassTest(unittest.TestCase):
         self.stac_io = pystac.StacIO.default()
 
     def test_from_dict_returns_subclass(self) -> None:
-
         collection_dict = self.stac_io.read_json(self.MULTI_EXTENT)
         custom_collection = self.BasicCustomCollection.from_dict(collection_dict)
+
+        self.assertIsInstance(custom_collection, self.BasicCustomCollection)
+
+    def test_from_file_returns_subclass(self) -> None:
+        custom_collection = self.BasicCustomCollection.from_file(self.MULTI_EXTENT)
+
         self.assertIsInstance(custom_collection, self.BasicCustomCollection)

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -196,6 +196,14 @@ class CollectionTest(unittest.TestCase):
 
         self.assertIsInstance(instruments_schema, dict)
 
+    def test_from_invalid_dict_raises_exception(self) -> None:
+        stac_io = pystac.StacIO.default()
+        catalog_dict = stac_io.read_json(
+            TestCases.get_path("data-files/catalogs/test-case-1/catalog.json")
+        )
+        with self.assertRaises(pystac.STACTypeError):
+            _ = pystac.Collection.from_dict(catalog_dict)
+
 
 class ExtentTest(unittest.TestCase):
     def test_spatial_allows_single_bbox(self) -> None:

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -216,6 +216,14 @@ class ItemTest(unittest.TestCase):
         item.make_asset_hrefs_relative()
         self.assertEqual(asset.get_absolute_href(), original_href)
 
+    def test_from_invalid_dict_raises_exception(self) -> None:
+        stac_io = pystac.StacIO.default()
+        catalog_dict = stac_io.read_json(
+            TestCases.get_path("data-files/catalogs/test-case-1/catalog.json")
+        )
+        with self.assertRaises(pystac.STACTypeError):
+            _ = pystac.Item.from_dict(catalog_dict)
+
 
 class CommonMetadataTest(unittest.TestCase):
     def setUp(self) -> None:

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -698,3 +698,22 @@ class CommonMetadataTest(unittest.TestCase):
         new_a1_value = cm.get_updated(item.assets["analytic"])
         self.assertEqual(new_a1_value, set_value)
         self.assertEqual(cm.updated, item_value)
+
+
+class ItemSubClassTest(unittest.TestCase):
+    """This tests cases related to creating classes inheriting from pystac.Catalog to
+    ensure that inheritance, class methods, etc. function as expected."""
+
+    SAMPLE_ITEM = TestCases.get_path("data-files/item/sample-item.json")
+
+    class BasicCustomItem(pystac.Item):
+        pass
+
+    def setUp(self) -> None:
+        self.stac_io = pystac.StacIO.default()
+
+    def test_from_dict_returns_subclass(self) -> None:
+
+        item_dict = self.stac_io.read_json(self.SAMPLE_ITEM)
+        custom_item = self.BasicCustomItem.from_dict(item_dict)
+        self.assertIsInstance(custom_item, self.BasicCustomItem)

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -713,7 +713,12 @@ class ItemSubClassTest(unittest.TestCase):
         self.stac_io = pystac.StacIO.default()
 
     def test_from_dict_returns_subclass(self) -> None:
-
         item_dict = self.stac_io.read_json(self.SAMPLE_ITEM)
         custom_item = self.BasicCustomItem.from_dict(item_dict)
+
+        self.assertIsInstance(custom_item, self.BasicCustomItem)
+
+    def test_from_file_returns_subclass(self) -> None:
+        custom_item = self.BasicCustomItem.from_file(self.SAMPLE_ITEM)
+
         self.assertIsInstance(custom_item, self.BasicCustomItem)

--- a/tests/test_stac_io.py
+++ b/tests/test_stac_io.py
@@ -4,11 +4,14 @@ import warnings
 import tempfile
 
 import pystac
-from pystac.stac_io import STAC_IO
+from pystac.stac_io import STAC_IO, StacIO
 from tests.utils import TestCases
 
 
 class StacIOTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.stac_io = StacIO.default()
+
     def test_stac_io_issues_warnings(self) -> None:
         with warnings.catch_warnings(record=True) as w:
             # Cause all warnings to always be triggered.
@@ -87,3 +90,30 @@ class StacIOTest(unittest.TestCase):
                     "data-files/item-collection/sample-item-collection.json"
                 )
             )
+
+    def test_read_item_dict(self) -> None:
+        item_dict = self.stac_io.read_json(
+            TestCases.get_path("data-files/item/sample-item.json")
+        )
+        item = pystac.read_dict(item_dict)
+        self.assertIsInstance(item, pystac.Item)
+
+    def test_read_collection_dict(self) -> None:
+        collection_dict = self.stac_io.read_json(
+            TestCases.get_path("data-files/collections/multi-extent.json")
+        )
+        collection = pystac.read_dict(collection_dict)
+        self.assertIsInstance(collection, pystac.Collection)
+
+    def test_read_catalog_dict(self) -> None:
+        catalog_dict = self.stac_io.read_json(
+            TestCases.get_path("data-files/catalogs/test-case-1/catalog.json")
+        )
+        catalog = pystac.read_dict(catalog_dict)
+        self.assertIsInstance(catalog, pystac.Catalog)
+
+    def test_read_from_stac_object(self) -> None:
+        catalog = pystac.STACObject.from_file(
+            TestCases.get_path("data-files/catalogs/test-case-1/catalog.json")
+        )
+        self.assertIsInstance(catalog, pystac.Catalog)

--- a/tests/test_writing.py
+++ b/tests/test_writing.py
@@ -72,7 +72,9 @@ class STACWritingTest(unittest.TestCase):
             href: str, link_type: str, should_include_self: bool
         ) -> None:
             cat_dict = pystac.StacIO.default().read_json(href)
-            cat = pystac.Catalog.from_file(href)
+            cat = pystac.read_file(href)
+            if not isinstance(cat, pystac.Catalog):
+                raise pystac.STACTypeError(f"File at {href} is not a Catalog.")
 
             rels = set([link["rel"] for link in cat_dict["links"]])
             self.assertEqual("self" in rels, should_include_self)

--- a/tests/test_writing.py
+++ b/tests/test_writing.py
@@ -74,7 +74,7 @@ class STACWritingTest(unittest.TestCase):
             cat_dict = pystac.StacIO.default().read_json(href)
             cat = pystac.read_file(href)
             if not isinstance(cat, pystac.Catalog):
-                raise pystac.STACTypeError(f"File at {href} is not a Catalog.")
+                raise pystac.STACTypeError(f"File at {href} is a {cat.STAC_OBJECT_TYPE} not a Catalog.")
 
             rels = set([link["rel"] for link in cat_dict["links"]])
             self.assertEqual("self" in rels, should_include_self)

--- a/tests/test_writing.py
+++ b/tests/test_writing.py
@@ -74,7 +74,9 @@ class STACWritingTest(unittest.TestCase):
             cat_dict = pystac.StacIO.default().read_json(href)
             cat = pystac.read_file(href)
             if not isinstance(cat, pystac.Catalog):
-                raise pystac.STACTypeError(f"File at {href} is a {cat.STAC_OBJECT_TYPE} not a Catalog.")
+                raise pystac.STACTypeError(
+                    f"File at {href} is a {cat.STAC_OBJECT_TYPE} not a Catalog."
+                )
 
             rels = set([link["rel"] for link in cat_dict["links"]])
             self.assertEqual("self" in rels, should_include_self)


### PR DESCRIPTION
**Related Issue(s):** #

* #410 

**Description:**

Updates `from_dict` and `from_file` methods for `STACObject` and all sub-classes so that any classes inheriting from them will be returned by those methods. This makes it easier for downstream libraries like pystac-client to create custom sub-classes. See [these tests](https://github.com/duckontheweb/pystac/blob/6e0785b45960c178c7b73039220589ac6f4723ac/tests/test_catalog.py#L1112-L1133) for an example.

Also moves the logic from `serialization.stac_object_from_dict` into `stac_io` to simplify the chain of functions that is called. If it seems like downstream libraries are using this function directly we can go through a deprecation process, but it seemed unlikely. Once `STAC_IO` is removed in 1.0.0 this code will only be used in one place in the `StacIO` class, so it seemed to be simpler to just move it in there.

Supersedes #443 

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [ ] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.