### PR TITLE
Updates to CI and README

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,5 +8,6 @@
 
 - [ ] Code is formatted (run `pre-commit run --all-files`)
 - [ ] Tests pass (run `scripts/test`)
+- [ ] Documentation has been updated to reflect changes, if applicable
 - [ ] This PR maintains or improves overall codebase code coverage.
 - [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           path: ~/.cache/pip
           # Cache based on OS, Python version, and dependency hash
-          key: test-${{ runner.os }}-python${{ matrix.python-version }}-${{ hashFiles('requirements-test.txt') }}
+          key: pip-test-${{ runner.os }}-python${{ matrix.python-version }}-${{ hashFiles('requirements-test.txt') }}
       
       - name: Cache dependencies (macOS)
         if: startsWith(runner.os, 'macOS')
@@ -46,7 +46,7 @@ jobs:
         with:
           path: ~/Library/Caches/pip
           # Cache based on OS, Python version, and dependency hash
-          key: test-${{ runner.os }}-python${{ matrix.python-version }}-${{ hashFiles('requirements-test.txt') }}
+          key: pip-test-${{ runner.os }}-python${{ matrix.python-version }}-${{ hashFiles('requirements-test.txt') }}
           
       - name: Cache dependencies (Windows)
         if: startsWith(runner.os, 'Windows')
@@ -54,7 +54,7 @@ jobs:
         with:
           path: ~\AppData\Local\pip\Cache
           # Cache based on OS, Python version, and dependency hash
-          key: pip-${{ runner.os }}-python${{ matrix.python-version }}-${{ hashFiles('requirements-test.txt') }}
+          key: pip-test-${{ runner.os }}-python${{ matrix.python-version }}-${{ hashFiles('requirements-test.txt') }}
 
       - name: Install dependencies
         run: |
@@ -67,15 +67,46 @@ jobs:
         shell: bash
         env:
           TMPDIR: "${{ matrix.os == 'windows-latest' && 'D:\\a\\_temp' || '' }}"
+
+  coverage:
+    name: coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          # Cache based on OS, Python version, and dependency hash
+          key: pip-test-${{ runner.os }}-python3.8-${{ hashFiles('requirements-test.txt') }}
+      
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements-test.txt
+          pip install -e ".[validation]"
+      
+      - name: Execute test suite
+        # --fail-under=0 ensures we publish the coverage regardless of whether it meets
+        # the minimum so we can use Codecov to evaluate gaps
+        run: |
+          coverage run --source=pystac/ -m unittest discover tests/
+          coverage xml --fail-under=0
       
       - name: Upload All coverage to Codecov
         uses: codecov/codecov-action@v1
-        # Only upload this once...
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.8'}}
+        if: ${{ env.GITHUB_REPOSITORY }} == 'stac-utils/pystac'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
           fail_ci_if_error: false 
+
   lint:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
   release:
     name: release
     runs-on: ubuntu-latest
+    if: ${{ env.GITHUB_REPOSITORY }} == 'stac-utils/pystac'
     steps:
       - uses: actions/checkout@v2
 

--- a/README.md
+++ b/README.md
@@ -1,27 +1,37 @@
 ## PySTAC
-![Build Status](https://github.com/stac-utils/pystac/workflows/CI/badge.svg?branch=develop)
+![Build Status](https://github.com/stac-utils/pystac/workflows/CI/badge.svg?branch=main)
 [![PyPI version](https://badge.fury.io/py/pystac.svg)](https://badge.fury.io/py/pystac)
 [![Documentation](https://readthedocs.org/projects/pystac/badge/?version=latest)](https://pystac.readthedocs.io/en/latest/)
 [![codecov](https://codecov.io/gh/stac-utils/pystac/branch/main/graph/badge.svg)](https://codecov.io/gh/stac-utils/pystac)
-[![Gitter chat](https://badges.gitter.im/azavea/pystac.svg)](https://gitter.im/azavea/pystac)
+
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 PySTAC is a library for working with [SpatialTemporal Asset Catalog](https://stacspec.org) in Python 3.
 
 ## Installation
 
-PySTAC has a single dependency (`python-dateutil`).
+PySTAC has a single required dependency (`python-dateutil`).
 PySTAC can be installed from pip or the source repository.
 
 ```bash
 > pip install pystac
 ```
 
-if you'd like to enable the validation feature utilizing the [jsonschema](https://pypi.org/project/jsonschema/) project, install with the optional `validation` requirements:
+If you would like to enable the validation feature utilizing the
+[jsonschema](https://pypi.org/project/jsonschema/) project, install with the optional
+`validation` requirements: 
 
 
 ```bash
 > pip install pystac[validation]
+```
+
+If you would like to use the [`orjson`](https://pypi.org/project/orjson/) instead of the
+standard `json` library for JSON serialization/deserialization, install with the
+optional `orjson` requirements:
+
+```bash
+> pip install pystac[orjson]
 ```
 
 From source repository:
@@ -34,20 +44,23 @@ From source repository:
 
 
 #### Versions
-To install a specific versions of STAC, install the matching version of pystac.
+To install a version of PySTAC that works with a specific versions of the STAC
+specification, install the matching version of PySTAC from the following table.
 
-```bash
-> pip install pystac==0.5.*
-```
-
-The table below shows the corresponding versions between pystac and STAC:
-
-| pystac | STAC  |
+| PySTAC | STAC  |
 | ------ | ----- |
 | 1.x    | 1.0.x |
 | 0.5.x  | 1.0.0-beta.* |
 | 0.4.x  | 0.9.x |
 | 0.3.x  | 0.8.x |
+
+For instance, to work with STAC v0.9.x:
+
+```bash
+pip install pystac==0.4.0
+```
+
+STAC spec versions below 0.8 are not supported by PySTAC.
 
 ## Documentation
 
@@ -55,7 +68,7 @@ See the [documentation page](https://pystac.readthedocs.io/en/latest/) for the l
 
 ## Developing
 
-See [contributing docs](docs/contributing.rst)
+See [contributing docs](docs/contributing.rst) for details on contributing to this project.
 
 ## Running the quickstart and tutorials
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![PyPI version](https://badge.fury.io/py/pystac.svg)](https://badge.fury.io/py/pystac)
 [![Documentation](https://readthedocs.org/projects/pystac/badge/?version=latest)](https://pystac.readthedocs.io/en/latest/)
 [![codecov](https://codecov.io/gh/stac-utils/pystac/branch/main/graph/badge.svg)](https://codecov.io/gh/stac-utils/pystac)
-
+[![Gitter](https://badges.gitter.im/SpatioTemporal-Asset-Catalog/python.svg)](https://gitter.im/SpatioTemporal-Asset-Catalog/python?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 PySTAC is a library for working with [SpatialTemporal Asset Catalog](https://stacspec.org) in Python 3.


### PR DESCRIPTION
**Description:**

* Removes Gitter badge since that channel is mostly unused
* Adds `orjson` extra install instructions
* Minor clarifications around versions
* Only run release build for this repo (I was seeing failed builds in my fork when I updated tags)
* Move coverage reporting into separate job
    Since we added the minimum coverage requirement, the `test` job fails before uploading coverage to Codecov.io. When I was working on removing support for pre-0.8 STAC versions I found myself wishing I could use that UI to figure out where the coverage had dropped. This change means the CI workflow will still fail overall, but we will still get a coverage report we can look at if we drop below the minimum threshhold.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.