### PR TITLE
Avoid calling deepcopy in from_dict methods when unnecessary

### DIFF
--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -906,6 +906,7 @@ class Catalog(STACObject):
         href: Optional[str] = None,
         root: Optional["Catalog"] = None,
         migrate: bool = False,
+        preserve_dict: bool = True,
     ) -> "Catalog":
         if migrate:
             info = identify_stac_object(d)
@@ -916,7 +917,8 @@ class Catalog(STACObject):
 
         catalog_type = CatalogType.determine_type(d)
 
-        d = deepcopy(d)
+        if preserve_dict:
+            d = deepcopy(d)
 
         id = d.pop("id")
         description = d.pop("description")

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -587,6 +587,7 @@ class Collection(Catalog):
         href: Optional[str] = None,
         root: Optional[Catalog] = None,
         migrate: bool = False,
+        preserve_dict: bool = True,
     ) -> "Collection":
         if migrate:
             info = identify_stac_object(d)
@@ -597,7 +598,9 @@ class Collection(Catalog):
 
         catalog_type = CatalogType.determine_type(d)
 
-        d = deepcopy(d)
+        if preserve_dict:
+            d = deepcopy(d)
+
         id = d.pop("id")
         description = d.pop("description")
         license = d.pop("license")

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -915,6 +915,7 @@ class Item(STACObject):
         href: Optional[str] = None,
         root: Optional[Catalog] = None,
         migrate: bool = False,
+        preserve_dict: bool = True,
     ) -> "Item":
         if migrate:
             info = identify_stac_object(d)
@@ -925,7 +926,9 @@ class Item(STACObject):
                 f"{d} does not represent a {cls.__name__} instance"
             )
 
-        d = deepcopy(d)
+        if preserve_dict:
+            d = deepcopy(d)
+
         id = d.pop("id")
         geometry = d.pop("geometry")
         properties = d.pop("properties")

--- a/pystac/stac_io.py
+++ b/pystac/stac_io.py
@@ -99,6 +99,7 @@ class StacIO(ABC):
         d: Dict[str, Any],
         href: Optional[str] = None,
         root: Optional["Catalog_Type"] = None,
+        preserve_dict: bool = True,
     ) -> "STACObject_Type":
         if identify_stac_object_type(d) == pystac.STACObjectType.ITEM:
             collection_cache = None
@@ -114,15 +115,21 @@ class StacIO(ABC):
         d = migrate_to_latest(d, info)
 
         if info.object_type == pystac.STACObjectType.CATALOG:
-            result = pystac.Catalog.from_dict(d, href=href, root=root, migrate=False)
+            result = pystac.Catalog.from_dict(
+                d, href=href, root=root, migrate=False, preserve_dict=preserve_dict
+            )
             result._stac_io = self
             return result
 
         if info.object_type == pystac.STACObjectType.COLLECTION:
-            return pystac.Collection.from_dict(d, href=href, root=root, migrate=False)
+            return pystac.Collection.from_dict(
+                d, href=href, root=root, migrate=False, preserve_dict=preserve_dict
+            )
 
         if info.object_type == pystac.STACObjectType.ITEM:
-            return pystac.Item.from_dict(d, href=href, root=root, migrate=False)
+            return pystac.Item.from_dict(
+                d, href=href, root=root, migrate=False, preserve_dict=preserve_dict
+            )
 
         raise ValueError(f"Unknown STAC object type {info.object_type}")
 
@@ -164,7 +171,7 @@ class StacIO(ABC):
         """
         d = self.read_json(source)
         href = source if isinstance(source, str) else source.get_absolute_href()
-        return self.stac_object_from_dict(d, href=href, root=root)
+        return self.stac_object_from_dict(d, href=href, root=root, preserve_dict=False)
 
     def save_json(
         self, dest: Union[str, "Link_Type"], json_dict: Dict[str, Any]

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -495,6 +495,7 @@ class STACObject(ABC):
         href: Optional[str] = None,
         root: Optional["Catalog_Type"] = None,
         migrate: bool = False,
+        preserve_dict: bool = True,
     ) -> "STACObject":
         """Parses this STACObject from the passed in dictionary.
 
@@ -507,6 +508,11 @@ class STACObject(ABC):
                 previously resolved instances of the STAC object.
             migrate: Use True if this dict represents JSON from an older STAC object,
                 so that migrations are run against it.
+            preserve_dict: If False, the dict parameter ``d`` may be modified
+                during this method call. Otherwise the dict is not mutated.
+                Defaults to True, which results results in a deepcopy of the
+                parameter. Set to False when possible to avoid the performance
+                hit of a deepcopy. Defaults to True.
 
         Returns:
             STACObject: The STACObject parsed from this dict.

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -473,7 +473,7 @@ class STACObject(ABC):
             href = make_absolute_href(href)
 
         d = stac_io.read_json(href)
-        o = cls.from_dict(d, href=href, migrate=True)
+        o = cls.from_dict(d, href=href, migrate=True, preserve_dict=False)
 
         # Set the self HREF, if it's not already set to something else.
         if o.get_self_href() is None:

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -512,7 +512,7 @@ class STACObject(ABC):
                 during this method call. Otherwise the dict is not mutated.
                 Defaults to True, which results results in a deepcopy of the
                 parameter. Set to False when possible to avoid the performance
-                hit of a deepcopy. Defaults to True.
+                hit of a deepcopy.
 
         Returns:
             STACObject: The STACObject parsed from this dict.

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import os
 import json
 import tempfile
@@ -84,6 +85,19 @@ class CatalogTest(unittest.TestCase):
             items = read_catalog.get_all_items()
 
             self.assertEqual(len(list(items)), 8)
+
+    def test_from_dict_preserves_dict(self) -> None:
+        catalog_dict = TestCases.test_case_1().to_dict()
+        param_dict = deepcopy(catalog_dict)
+
+        # test that the parameter is preserved
+        _ = Catalog.from_dict(param_dict)
+        self.assertEqual(param_dict, catalog_dict)
+
+        # assert that the parameter is not preserved with
+        # non-default parameter
+        _ = Catalog.from_dict(param_dict, preserve_dict=False)
+        self.assertNotEqual(param_dict, catalog_dict)
 
     def test_read_remote(self) -> None:
         # TODO: Move this URL to the main stac-spec repo once the example JSON is fixed.

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import unittest
 import os
 import json
@@ -181,6 +182,21 @@ class CollectionTest(unittest.TestCase):
             data = json.load(f)
         collection = pystac.Collection.from_dict(data)
         collection.validate()
+
+    def test_to_dict_preserves_dict(self) -> None:
+        path = TestCases.get_path("data-files/collections/with-assets.json")
+        with open(path) as f:
+            collection_dict = json.load(f)
+        param_dict = deepcopy(collection_dict)
+
+        # test that the parameter is preserved
+        _ = Collection.from_dict(param_dict)
+        self.assertEqual(param_dict, collection_dict)
+
+        # assert that the parameter is not preserved with
+        # non-default parameter
+        _ = Collection.from_dict(param_dict, preserve_dict=False)
+        self.assertNotEqual(param_dict, collection_dict)
 
     def test_schema_summary(self) -> None:
         collection = pystac.Collection.from_file(

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import os
 from datetime import datetime
 import json
@@ -25,9 +26,10 @@ class ItemTest(unittest.TestCase):
         self.maxDiff = None
 
         item_dict = self.get_example_item_dict()
+        param_dict = deepcopy(item_dict)
 
-        assert_to_from_dict(self, Item, item_dict)
-        item = Item.from_dict(item_dict)
+        assert_to_from_dict(self, Item, param_dict)
+        item = Item.from_dict(param_dict)
         self.assertEqual(item.id, "CS3-20160503_132131_05")
 
         # test asset creation additional field(s)
@@ -36,6 +38,14 @@ class ItemTest(unittest.TestCase):
             "http://cool-sat.com/catalog/products/analytic.json",
         )
         self.assertEqual(len(item.assets["thumbnail"].properties), 0)
+
+        # test that the parameter is preserved
+        self.assertEqual(param_dict, item_dict)
+
+        # assert that the parameter is not preserved with
+        # non-default parameter
+        _ = Item.from_dict(param_dict, preserve_dict=False)
+        self.assertNotEqual(param_dict, item_dict)
 
     def test_set_self_href_does_not_break_asset_hrefs(self) -> None:
         cat = TestCases.test_case_2()


### PR DESCRIPTION
**Related Issue(s):** #453 


**Description:**
This PR adds a parameter to the `STACObject.from_dict` method and implementations named `preserve_dict`. If this is True, the dict that is passed in as a parameter will not be mutated during the operation - which is achieved by making a deep copy of dict parameter in the implementing methods. If preserve_dict is False, the incoming dict is mutated and a deepcopy is avoided. The default of this parameter is True, so that users can avoid a situation where their parameters are mutated unsuspectedly. In situations where the dict is a transient encoding of the STAC object, users should use preserve_dict=False to avoid incurring the performance cost of the deepcopy.

`preserve_dict` is set to False for methods that read a STAC object from a file, as there's no need to avoid mutating the dict in those cases.

This should help address some of the performance issues in described in https://github.com/stac-utils/pystac-client/issues/49, as pystac-client will be able to use preserve_dict=False in the [ItemCollection.from_dict method](https://github.com/stac-utils/pystac-client/blob/9e66bb5b46951988f5be23a09579e512e0fd425f/pystac_client/item_collection.py#L59)

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [ ] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.