### PR TITLE
Upload coverage for release branches

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+      - "0.3"
+      - "0.4"
+      - "0.5"
+      - "1.0"
   pull_request:
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,9 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "*"
+  release:
+    types:
+      - created
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   release:
     name: release
     runs-on: ubuntu-latest
-    if: ${{ env.GITHUB_REPOSITORY }} == 'stac-utils/pystac'
+    if: ${{ github.repository }} == 'stac-utils/pystac'
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
**Description:**

* Updates the CI to upload coverage to Codecov.io on pushes to the release branches. This fixes an issue where the coverage report for PRs against those branches found no base coverage to compare against.
    ![Screen Shot 2021-06-17 at 10 15 21 PM](https://user-images.githubusercontent.com/6878073/122496311-8740c380-cfb9-11eb-88d3-8088727558cf.png)
* Fixes GitHub repo check in `release` workflow
* Publishes to PyPi on release creation instead of tag push


**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.