### PR TITLE
Updates to StacIO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,17 @@
 
 ### Added
 
-- Add a `preserve_dict` parameter to `ItemCollection.from_dict` and set it to False when using `ItemCollection.from_file`. ([#468](https://github.com/stac-utils/pystac/pull/468))
+- Add a `preserve_dict` parameter to `ItemCollection.from_dict` and set it to False when
+  using `ItemCollection.from_file`.
+  ([#468](https://github.com/stac-utils/pystac/pull/468)) 
+- `StacIO.json_dumps` and `StacIO.json_loads` methods for JSON
+  serialization/deserialization. These were "private" methods, but are now "public" and
+  documented ([#471](https://github.com/stac-utils/pystac/pull/471))
 
 ### Changed
+
+- `pystac.stac_io.DuplicateObjectKeyError` moved to `pystac.DuplicateObjectKeyError`
+  ([#471](https://github.com/stac-utils/pystac/pull/471))
 
 ### Fixed
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -171,6 +171,20 @@ StacIO
    :members:
    :undoc-members:
 
+DefaultStacIO
+~~~~~~~~~~~~~
+
+.. autoclass:: pystac.stac_io.DefaultStacIO
+   :members:
+   :show-inheritance:
+
+DuplicateKeyReportingMixin
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: pystac.stac_io.DuplicateKeyReportingMixin
+   :members:
+   :show-inheritance:
+
 STAC_IO
 ~~~~~~~
 
@@ -213,10 +227,46 @@ STACError
 
 .. autoclass:: pystac.STACError
 
+STACTypeError
+~~~~~~~~~~~~~
+
+.. autoclass:: pystac.STACTypeError
+
+DuplicateObjectKeyError
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: pystac.DuplicateObjectKeyError
+
+ExtensionAlreadyExistsError
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: pystac.ExtensionAlreadyExistsError
+
 ExtensionTypeError
 ~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: pystac.ExtensionTypeError
+
+ExtensionNotImplemented
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: pystac.ExtensionNotImplemented
+
+ExtensionTypeError
+~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: pystac.ExtensionTypeError
+
+RequiredPropertyMissing
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: pystac.RequiredPropertyMissing
+
+STACValidationError
+~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: pystac.STACValidationError
+
 
 Extensions
 ----------

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -269,7 +269,7 @@ for reading from AWS's S3 cloud object storage using `boto3
          if parsed.scheme == "s3":
             bucket = parsed.netloc
             key = parsed.path[1:]
-            
+
             obj = self.s3.Object(bucket, key)
             return obj.get()["Body"].read().decode("utf-8")
          else:
@@ -288,7 +288,7 @@ for reading from AWS's S3 cloud object storage using `boto3
             super().write_text(dest, txt, *args, **kwargs)
 
    StacIO.set_default(CustomStacIO)
-   
+
 
 If you only need to customize read operations you can inherit from
 :class:`~pystac.stac_io.DefaultStacIO` and only overwrite the read method. For example,
@@ -304,7 +304,7 @@ to take advantage of connection pooling using a `requests.Session
    class ConnectionPoolingIO(DefaultStacIO):
       def __init__():
          self.session = requests.Session()
-      
+
       def read_text(
          self, source: Union[str, Link], *args: Any, **kwargs: Any
       ) -> str:
@@ -313,7 +313,7 @@ to take advantage of connection pooling using a `requests.Session
             return self.session.get(uri).text
          else:
             return super().read_text(source, *args, **kwargs)
-   
+
    StacIO.set_default(ConnectionPoolingIO)
 
 Validation

--- a/pystac/__init__.py
+++ b/pystac/__init__.py
@@ -6,6 +6,7 @@ PySTAC is a library for working with SpatioTemporal Asset Catalogs (STACs)
 from pystac.errors import (
     STACError,
     STACTypeError,
+    DuplicateObjectKeyError,
     ExtensionAlreadyExistsError,
     ExtensionNotImplemented,
     ExtensionTypeError,

--- a/pystac/errors.py
+++ b/pystac/errors.py
@@ -19,6 +19,12 @@ class STACTypeError(Exception):
     pass
 
 
+class DuplicateObjectKeyError(Exception):
+    """Raised when deserializing a JSON object containing a duplicate key."""
+
+    pass
+
+
 class ExtensionTypeError(Exception):
     """An ExtensionTypeError is raised when an extension is used against
     an object that the extension does not apply to

--- a/pystac/stac_io.py
+++ b/pystac/stac_io.py
@@ -293,10 +293,6 @@ class DefaultStacIO(StacIO):
             f.write(txt)
 
 
-class DuplicateObjectKeyError(Exception):
-    pass
-
-
 class DuplicateKeyReportingMixin(StacIO):
     """A mixin for StacIO implementations that will report
     on duplicate keys in the JSON being read in.

--- a/pystac/stac_io.py
+++ b/pystac/stac_io.py
@@ -50,7 +50,7 @@ class StacIO(ABC):
         :class:`~pystac.Link`. If it is a string, it must be a URI or local path from
         which to read. Using a :class:`~pystac.Link` enables implementations to use
         additional link information, such as paging information contained in the
-        extended links described in the `STAC API spec 
+        extended links described in the `STAC API spec
         <https://github.com/radiantearth/stac-api-spec/tree/master/item-search#paging>`__.
 
         Args:
@@ -263,12 +263,11 @@ class StacIO(ABC):
 
 
 class DefaultStacIO(StacIO):
-    def read_text(
-        self, source: Union[str, "Link_Type"], *_: Any, **__: Any
-    ) -> str:
-        """A concrete implementation of :meth:`StacIO.read_text <pystac.StacIO.read_text>`. Converts the
-        ``source`` argument to a string (if it is not already) and delegates to
-        :meth:`DefaultStacIO.read_text_from_href` for opening and reading the file."""
+    def read_text(self, source: Union[str, "Link_Type"], *_: Any, **__: Any) -> str:
+        """A concrete implementation of :meth:`StacIO.read_text
+        <pystac.StacIO.read_text>`. Converts the ``source`` argument to a string (if it
+        is not already) and delegates to :meth:`DefaultStacIO.read_text_from_href` for
+        opening and reading the file."""
         href: Optional[str]
         if isinstance(source, str):
             href = source
@@ -305,9 +304,10 @@ class DefaultStacIO(StacIO):
     def write_text(
         self, dest: Union[str, "Link_Type"], txt: str, *_: Any, **__: Any
     ) -> None:
-        """A concrete implementation of :meth:`StacIO.write_text <pystac.StacIO.write_text>`. Converts the
-        ``dest`` argument to a string (if it is not already) and delegates to
-        :meth:`DefaultStacIO.write_text_from_href` for opening and reading the file."""
+        """A concrete implementation of :meth:`StacIO.write_text
+        <pystac.StacIO.write_text>`. Converts the ``dest`` argument to a string (if it
+        is not already) and delegates to :meth:`DefaultStacIO.write_text_from_href` for
+        opening and reading the file."""
         href: Optional[str]
         if isinstance(dest, str):
             href = dest
@@ -317,9 +317,7 @@ class DefaultStacIO(StacIO):
                 raise IOError(f"Could not get an absolute HREF from link {dest}")
         return self.write_text_to_href(href, txt)
 
-    def write_text_to_href(
-        self, href: str, txt: str
-    ) -> None:
+    def write_text_to_href(self, href: str, txt: str) -> None:
         """Writes text to file using UTF-8 encoding.
 
         This implementation uses :func:`open` and therefore can only write to the local


### PR DESCRIPTION
**Related Issue(s):**

* Closes #467 
* Closes #432 
* #313 


**Description:**

* Makes "private"  `StacIO._json_dumps` method  into a "public" `StacIO.json_dumps` and updates the signature to accept arbitrary keyword arguments instead of specifically accepting a `source` argument (see #467).
* Refactors error reporting logic for `DuplicateKeyReportingMixin.read_json` and `DuplicateKeyReportingMixin.json_loads` so that we do not need to pass the `source` into `json_loads`. Also adds test coverage for this class.
* Adds all exception classes to API docs
* Moves `DuplicateObjectKeyError` into `pystac.errors`
* Updates the API docs for the `stac_io` classes as well as the "Using STAC_IO" section in the "Concepts" docs

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.