### PR TITLE
Experimental Python 3.10 support

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -39,6 +39,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - uses: actions-rs/toolchain@v1
+        # No wheels exist for orjson on Python 3.10 on MacOS or Windows, and the Linux
+        #  wheels are sometimes not uploaded until after the package is initially
+        # published. This sets up the Rust nightly toolchain so we can build the orjson
+        # wheel.
         if: ${{ startsWith(matrix.python-version, '3.10')}}
         with:
           toolchain: nightly

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,6 +14,7 @@ jobs:
   test:
     name: test
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ startsWith(matrix.python-version, '3.10')}}
     strategy:
       # Allow other matrix jobs to complete if 1 fails
       fail-fast: false
@@ -23,6 +24,7 @@ jobs:
           - "3.7"
           - "3.8"
           - "3.9"
+          - "3.10.0-beta.3"
         os:
           - ubuntu-latest
           - windows-latest

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -38,6 +38,14 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - uses: actions-rs/toolchain@v1
+        if: ${{ startsWith(matrix.python-version, '3.10')}}
+        with:
+          toolchain: nightly
+          override: true
+          default: true
+          profile: minimal
+
       - name: Cache dependencies (Linux)
         if: startsWith(runner.os, 'Linux')
         uses: actions/cache@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- (Experimental) support for Python 3.10 ([#473](https://github.com/stac-utils/pystac/pull/473))
+
 ### Changed
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ PySTAC is a library for working with [SpatialTemporal Asset Catalog](https://sta
 
 ## Installation
 
+PySTAC requires Python>=3.6. Support for Python>=3.10 should be considered experimental
+until further notice.
+
 PySTAC has a single required dependency (`python-dateutil`).
 PySTAC can be installed from pip or the source repository.
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ optional `orjson` requirements:
 > pip install pystac[orjson]
 ```
 
+> *`orjson` wheels are only available for Linux in Python 3.10. If you are using the
+> `orjson` extra with Python 3.10 you will need to have the Rust nightly toolchain
+> installed as your default toolchain in order to build the package wheel.*
+
 From source repository:
 
 ```bash


### PR DESCRIPTION
**Related Issue(s):**

* #331 

**Description:**

Adds Python 3.10 to the test matrix, but allows the CI workflow to succeed even if any Python 3.10 job fails. The main hiccup is that `orjson` does not have Python 3.10 wheels for Windows or MacOS, and needs the Rust nightly toolchain to build. The CI job installs Rust nightly for Python 3.10 jobs, and this PR adds a note in the Installation docs describing this requirements.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.