### PR TITLE
REF: Use descriptors for properties

### DIFF
--- a/pystac/extensions/datacube.py
+++ b/pystac/extensions/datacube.py
@@ -2,15 +2,14 @@
 
 https://github.com/stac-extensions/datacube
 """
-
 from abc import ABC
+import sys
 from typing import (
     Any,
     Dict,
     Generic,
     List,
     Optional,
-    Protocol,
     Set,
     TypeVar,
     Union,
@@ -24,6 +23,11 @@ from pystac.extensions.base import (
 )
 from pystac.extensions.hooks import ExtensionHooks
 from pystac.utils import get_required, map_opt
+
+if sys.version_info >= (3, 8):
+    from typing import Protocol
+else:
+    from typing_extensions import Protocol
 
 T = TypeVar("T", pystac.Collection, pystac.Item, pystac.Asset)
 

--- a/tests/extensions/test_datacube.py
+++ b/tests/extensions/test_datacube.py
@@ -1,7 +1,11 @@
 from typing import cast
 import unittest
 import pystac
-from pystac.extensions.datacube import AdditionalDimension, DatacubeExtension
+from pystac.extensions.datacube import (
+    AdditionalDimension,
+    DatacubeExtension,
+    VerticalSpatialDimension,
+)
 
 from tests.utils import TestCases
 
@@ -21,12 +25,12 @@ class DatacubeTest(unittest.TestCase):
         ext = DatacubeExtension.ext(item)
         dim = ext.dimensions["x"]
 
-        assert dim.dim_type == "spatial"
+        self.assertEqual(dim.dim_type, "spatial")
 
         spectral = ext.dimensions["spectral"]
         spectral = cast(AdditionalDimension, spectral)
 
-        assert spectral.values == ["red", "green", "blue"]
+        self.assertEqual(spectral.values, ["red", "green", "blue"])
 
         del dim.properties["type"]
 
@@ -36,9 +40,9 @@ class DatacubeTest(unittest.TestCase):
         dim.dim_type = "spatial"
         dim.description = None
 
-        assert "description" not in dim.properties
+        self.assertNotIn("description", dim.properties)
         dim.dim_type = None  # type: ignore
-        assert "type" in dim.properties
+        self.assertIn("type", dim.properties)
 
     def test_extension_not_implemented(self) -> None:
         # Should raise exception if Item does not include extension URI
@@ -81,10 +85,11 @@ class DatacubeTest(unittest.TestCase):
         item = pystac.Item.from_file(self.example_uri)
         ext = DatacubeExtension.ext(item)
         dim = ext.dimensions["pressure_levels"]
-        assert isinstance(dim, AdditionalDimension)
+        self.assertIsInstance(dim, VerticalSpatialDimension)
 
-        assert dim.step == 100
+        dim = cast(VerticalSpatialDimension, dim)
+        self.assertEqual(dim.step, 100)
         dim.step = None
-        assert "step" in dim.properties
+        self.assertIn("step", dim.properties)
         dim.clear_step()
-        assert "step" not in dim.properties
+        self.assertNotIn("step", dim.properties)


### PR DESCRIPTION
**Related Issue(s):** #

#367

**Description:**

A proof of concept for using a descriptor to reduce the boilerplate for defining getters and setters for the attributes on an extension. This cuts down on the lines of code, and should help keep the behavior of getters and setters consistent, since they're using the same implementation.

If we're happy with this, we can expand it to other places in the library. There will be some tradeoff between the complexity of the `__get__` and `__set__` methods and how widely it can be used. Right now it's tailored to the `Datacube` extension.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [ ] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.