### PR TITLE
Add Label Extension summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Added
 
 - (Experimental) support for Python 3.10 ([#473](https://github.com/stac-utils/pystac/pull/473))
+-  `LabelTask` enum in `pystac.extensions.label` with recommended values for
+  `"label:tasks"` field ([#484](https://github.com/stac-utils/pystac/pull/484))
+-  `LabelMethod` enum in `pystac.extensions.label` with recommended values for
+  `"label:methods"` field ([#484](https://github.com/stac-utils/pystac/pull/484))
+- Label Extension summaries ([#484](https://github.com/stac-utils/pystac/pull/484))
 
 ### Changed
 

--- a/pystac/extensions/label.py
+++ b/pystac/extensions/label.py
@@ -133,6 +133,15 @@ class LabelClasses:
             ",".join([str(x) for x in self.classes])
         )
 
+    def __eq__(self, o: object) -> bool:
+        if isinstance(o, LabelClasses):
+            o = o.to_dict()
+
+        if not isinstance(o, dict):
+            return NotImplemented
+
+        return self.to_dict() == o
+
     def to_dict(self) -> Dict[str, Any]:
         """Returns the dictionary representing the JSON of this instance."""
         return self.properties
@@ -192,6 +201,15 @@ class LabelCount:
         """Returns the dictionary representing the JSON of this instance."""
         return self.properties
 
+    def __eq__(self, o: object) -> bool:
+        if isinstance(o, LabelCount):
+            o = o.to_dict()
+
+        if not isinstance(o, dict):
+            return NotImplemented
+
+        return self.to_dict() == o
+
 
 class LabelStatistics:
     """Contains statistics for regression/continuous numeric value data.
@@ -245,6 +263,15 @@ class LabelStatistics:
     def to_dict(self) -> Dict[str, Any]:
         """Returns the dictionary representing the JSON of this LabelStatistics."""
         return self.properties
+
+    def __eq__(self, o: object) -> bool:
+        if isinstance(o, LabelStatistics):
+            o = o.to_dict()
+
+        if not isinstance(o, dict):
+            return NotImplemented
+
+        return self.to_dict() == o
 
 
 class LabelOverview:
@@ -390,6 +417,15 @@ class LabelOverview:
     def to_dict(self) -> Dict[str, Any]:
         """Returns the dictionary representing the JSON of this LabelOverview."""
         return self.properties
+
+    def __eq__(self, o: object) -> bool:
+        if isinstance(o, LabelOverview):
+            o = o.to_dict()
+
+        if not isinstance(o, dict):
+            return NotImplemented
+
+        return self.to_dict() == o
 
 
 class LabelExtension(ExtensionManagementMixin[pystac.Item]):

--- a/pystac/extensions/label.py
+++ b/pystac/extensions/label.py
@@ -52,6 +52,18 @@ class LabelType(str, Enum):
     """Convenience attribute for checking if values are valid label types"""
 
 
+class LabelTask(str, Enum):
+    """Enumerates recommended label tasks."""
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    REGRESSION = "regression"
+    CLASSIFICATION = "classification"
+    DETECTION = "detection"
+    SEGMENTATION = "segmentation"
+
+
 class LabelClasses:
     """Defines the list of possible class names (e.g., tree, building, car, hippo).
 
@@ -403,7 +415,7 @@ class LabelExtension(ExtensionManagementMixin[pystac.Item]):
         label_type: LabelType,
         label_properties: Optional[List[str]] = None,
         label_classes: Optional[List[LabelClasses]] = None,
-        label_tasks: Optional[List[str]] = None,
+        label_tasks: Optional[List[Union[LabelTask, str]]] = None,
         label_methods: Optional[List[str]] = None,
         label_overviews: Optional[List[LabelOverview]] = None,
     ) -> None:
@@ -499,14 +511,14 @@ class LabelExtension(ExtensionManagementMixin[pystac.Item]):
             self.obj.properties[CLASSES_PROP] = classes
 
     @property
-    def label_tasks(self) -> Optional[List[str]]:
+    def label_tasks(self) -> Optional[List[Union[LabelTask, str]]]:
         """Gets or set a list of tasks these labels apply to. Usually a subset of 'regression',
         'classification', 'detection', or 'segmentation', but may be arbitrary
         values."""
         return self.obj.properties.get(TASKS_PROP)
 
     @label_tasks.setter
-    def label_tasks(self, v: Optional[List[str]]) -> None:
+    def label_tasks(self, v: Optional[List[Union[LabelTask, str]]]) -> None:
         if v is None:
             self.obj.properties.pop(TASKS_PROP, None)
         else:

--- a/pystac/extensions/label.py
+++ b/pystac/extensions/label.py
@@ -4,13 +4,13 @@ https://github.com/stac-extensions/label
 """
 
 from enum import Enum
-from pystac.extensions.base import ExtensionManagementMixin
+from pystac.extensions.base import ExtensionManagementMixin, SummariesExtension
 from typing import Any, Dict, Iterable, List, Optional, Set, Union, cast
 
 import pystac
 from pystac.serialization.identify import STACJSONDescription, STACVersionID
 from pystac.extensions.hooks import ExtensionHooks
-from pystac.utils import get_required
+from pystac.utils import get_required, map_opt
 
 SCHEMA_URI = "https://stac-extensions.github.io/label/v1.0.0/schema.json"
 
@@ -702,6 +702,83 @@ class LabelExtension(ExtensionManagementMixin[pystac.Item]):
             raise pystac.ExtensionTypeError(
                 f"Label extension does not apply to type {type(obj)}"
             )
+
+    @staticmethod
+    def summaries(obj: pystac.Collection) -> "SummariesLabelExtension":
+        """Returns the extended summaries object for the given collection."""
+        return SummariesLabelExtension(obj)
+
+
+class SummariesLabelExtension(SummariesExtension):
+    """A concrete implementation of :class:`~SummariesExtension` that extends
+    the ``summaries`` field of a :class:`~pystac.Collection` to include properties
+    defined in the :stac-ext:`Label Extension <label>`.
+    """
+
+    @property
+    def label_properties(self) -> Optional[List[str]]:
+        """Get or sets the summary of :attr:`LabelExtension.label_properties` values
+        for this Collection.
+        """
+
+        return self.summaries.get_list(PROPERTIES_PROP)
+
+    @label_properties.setter
+    def label_properties(self, v: Optional[List[LabelClasses]]) -> None:
+        self._set_summary(PROPERTIES_PROP, v)
+
+    @property
+    def label_classes(self) -> Optional[List[LabelClasses]]:
+        """Get or sets the summary of :attr:`LabelExtension.label_classes` values
+        for this Collection.
+        """
+
+        return map_opt(
+            lambda classes: [LabelClasses(c) for c in classes],
+            self.summaries.get_list(CLASSES_PROP),
+        )
+
+    @label_classes.setter
+    def label_classes(self, v: Optional[List[LabelClasses]]) -> None:
+        self._set_summary(
+            CLASSES_PROP, map_opt(lambda classes: [c.to_dict() for c in classes], v)
+        )
+
+    @property
+    def label_type(self) -> Optional[List[LabelType]]:
+        """Get or sets the summary of :attr:`LabelExtension.label_type` values
+        for this Collection.
+        """
+
+        return self.summaries.get_list(TYPE_PROP)
+
+    @label_type.setter
+    def label_type(self, v: Optional[List[LabelType]]) -> None:
+        self._set_summary(TYPE_PROP, v)
+
+    @property
+    def label_tasks(self) -> Optional[List[Union[LabelTask, str]]]:
+        """Get or sets the summary of :attr:`LabelExtension.label_tasks` values
+        for this Collection.
+        """
+
+        return self.summaries.get_list(TASKS_PROP)
+
+    @label_tasks.setter
+    def label_tasks(self, v: Optional[List[Union[LabelTask, str]]]) -> None:
+        self._set_summary(TASKS_PROP, v)
+
+    @property
+    def label_methods(self) -> Optional[List[str]]:
+        """Get or sets the summary of :attr:`LabelExtension.label_methods` values
+        for this Collection.
+        """
+
+        return self.summaries.get_list(METHODS_PROP)
+
+    @label_methods.setter
+    def label_methods(self, v: Optional[List[str]]) -> None:
+        self._set_summary(METHODS_PROP, v)
 
 
 class LabelExtensionHooks(ExtensionHooks):

--- a/pystac/extensions/label.py
+++ b/pystac/extensions/label.py
@@ -53,7 +53,7 @@ class LabelType(str, Enum):
 
 
 class LabelTask(str, Enum):
-    """Enumerates recommended label tasks."""
+    """Enumerates recommended values for "label:tasks" field."""
 
     def __str__(self) -> str:
         return str(self.value)
@@ -62,6 +62,16 @@ class LabelTask(str, Enum):
     CLASSIFICATION = "classification"
     DETECTION = "detection"
     SEGMENTATION = "segmentation"
+
+
+class LabelMethod(str, Enum):
+    """Enumerates recommended values for "label:methods" field."""
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    AUTOMATED = "automated"
+    MANUAL = "manual"
 
 
 class LabelClasses:
@@ -452,7 +462,7 @@ class LabelExtension(ExtensionManagementMixin[pystac.Item]):
         label_properties: Optional[List[str]] = None,
         label_classes: Optional[List[LabelClasses]] = None,
         label_tasks: Optional[List[Union[LabelTask, str]]] = None,
-        label_methods: Optional[List[str]] = None,
+        label_methods: Optional[List[Union[LabelMethod, str]]] = None,
         label_overviews: Optional[List[LabelOverview]] = None,
     ) -> None:
         """Applies label extension properties to the extended Item.
@@ -561,14 +571,14 @@ class LabelExtension(ExtensionManagementMixin[pystac.Item]):
             self.obj.properties[TASKS_PROP] = v
 
     @property
-    def label_methods(self) -> Optional[List[str]]:
+    def label_methods(self) -> Optional[List[Union[LabelMethod, str]]]:
         """Gets or set a list of methods used for labeling.
 
         Usually a subset of 'automated' or 'manual', but may be arbitrary values."""
         return self.obj.properties.get("label:methods")
 
     @label_methods.setter
-    def label_methods(self, v: Optional[List[str]]) -> None:
+    def label_methods(self, v: Optional[List[Union[LabelMethod, str]]]) -> None:
         if v is None:
             self.obj.properties.pop("label:methods", None)
         else:
@@ -769,7 +779,7 @@ class SummariesLabelExtension(SummariesExtension):
         self._set_summary(TASKS_PROP, v)
 
     @property
-    def label_methods(self) -> Optional[List[str]]:
+    def label_methods(self) -> Optional[List[Union[LabelMethod, str]]]:
         """Get or sets the summary of :attr:`LabelExtension.label_methods` values
         for this Collection.
         """
@@ -777,7 +787,7 @@ class SummariesLabelExtension(SummariesExtension):
         return self.summaries.get_list(METHODS_PROP)
 
     @label_methods.setter
-    def label_methods(self, v: Optional[List[str]]) -> None:
+    def label_methods(self, v: Optional[List[Union[LabelMethod, str]]]) -> None:
         self._set_summary(METHODS_PROP, v)
 
 

--- a/tests/data-files/label/spacenet-roads/roads_collection.json
+++ b/tests/data-files/label/spacenet-roads/roads_collection.json
@@ -1,0 +1,55 @@
+{
+    "stac_version": "1.0.0-rc.1",
+    "type": "Collection",
+    "id": "spacenet-roads-sample",
+    "description": "A sample of the SpaceNet Roads dataset built during STAC Sprint 4. The dataset contains hand-labeled roads.",
+    "keywords": [
+        "spacenet",
+        "roads",
+        "labels"
+    ],
+    "license": "CC-BY-SA-4.0",
+    "providers": [
+        {
+            "name": "SpaceNet",
+            "roles": [
+                "licensor",
+                "host",
+                "producer",
+                "processor"
+            ],
+            "url": "https://spacenet.ai"
+        }
+    ],
+    "extent": {
+        "spatial": {
+            "bbox": [
+                [
+                    2.23379639995,
+                    49.0178709,
+                    2.23730639995,
+                    49.0213809
+                ]
+            ]
+        },
+        "temporal": {
+            "interval": [
+                [
+                    "2016-08-26T22:41:55.000000Z",
+                    null
+                ]
+            ]
+        }
+    },
+    "links": [
+        {
+            "href": "roads_collection.json",
+            "rel": "root",
+            "title": "sample SpaceNet roads label collection"
+        },
+        {
+            "rel": "item",
+            "href": "roads_item.json"
+        }
+    ]
+}

--- a/tests/extensions/test_label.py
+++ b/tests/extensions/test_label.py
@@ -10,6 +10,7 @@ from pystac.extensions.label import (
     LabelExtension,
     LabelClasses,
     LabelCount,
+    LabelMethod,
     LabelOverview,
     LabelStatistics,
     LabelTask,
@@ -522,3 +523,20 @@ class LabelSummariesTest(unittest.TestCase):
         label_tasks_summary_ext = label_ext_summaries.label_tasks
         assert label_tasks_summary_ext is not None
         self.assertListEqual(label_tasks, label_tasks_summary_ext)
+
+    def test_label_methods_summary(self) -> None:
+        label_methods: List[Union[LabelMethod, str]] = [LabelMethod.AUTOMATED]
+        collection = Collection.from_file(self.EXAMPLE_COLLECTION)
+        label_ext_summaries = LabelExtension.summaries(collection)
+
+        label_ext_summaries.label_methods = label_methods
+
+        summaries = collection.summaries
+        assert summaries is not None
+        label_methods_summary = summaries.get_list("label:methods")
+        assert label_methods_summary is not None
+        self.assertListEqual(label_methods, label_methods_summary)
+
+        label_methods_summary_ext = label_ext_summaries.label_methods
+        assert label_methods_summary_ext is not None
+        self.assertListEqual(label_methods, label_methods_summary_ext)

--- a/tests/extensions/test_label.py
+++ b/tests/extensions/test_label.py
@@ -2,6 +2,7 @@ import json
 import os
 import unittest
 import tempfile
+from typing import List, Union
 
 import pystac
 from pystac import Catalog, Item, CatalogType
@@ -28,6 +29,59 @@ class LabelTypeTest(unittest.TestCase):
 class LabelRelTypeTest(unittest.TestCase):
     def test_rel_types(self) -> None:
         self.assertEqual(str(LabelRelType.SOURCE), "source")
+
+
+class LabelTaskTest(unittest.TestCase):
+    def test_rel_types(self) -> None:
+        self.assertEqual(str(LabelTask.REGRESSION), "regression")
+        self.assertEqual(str(LabelTask.CLASSIFICATION), "classification")
+        self.assertEqual(str(LabelTask.DETECTION), "detection")
+        self.assertEqual(str(LabelTask.SEGMENTATION), "segmentation")
+
+
+class LabelCountTest(unittest.TestCase):
+    def test_label_count_equality(self) -> None:
+        count1 = LabelCount.create(name="prop", count=1)
+        count2 = LabelCount.create(name="prop", count=1)
+        count3 = LabelCount.create(name="other", count=1)
+        count4 = LabelCount.create(name="prop", count=2)
+
+        self.assertEqual(count1, count2)
+        self.assertNotEqual(count1, count3)
+        self.assertNotEqual(count1, count4)
+        self.assertNotEqual(count1, 42)
+
+
+class LabelOverviewTest(unittest.TestCase):
+    def test_label_count_equality(self) -> None:
+        stats1 = LabelStatistics.create(name="prop", value=42.3)
+        count1 = LabelCount.create(name="prop", count=1)
+
+        overview1 = LabelOverview.create(
+            property_key="first", counts=[count1], statistics=[stats1]
+        )
+        overview2 = LabelOverview.create(
+            property_key="first", counts=[count1], statistics=[stats1]
+        )
+        overview3 = LabelOverview.create(property_key="first", counts=[count1])
+        overview4 = LabelOverview.create(property_key="first", statistics=[stats1])
+        self.assertEqual(overview1, overview2)
+        self.assertNotEqual(overview1, overview3)
+        self.assertNotEqual(overview1, overview4)
+        self.assertNotEqual(overview1, 42)
+
+
+class LabelStatisticsTest(unittest.TestCase):
+    def test_label_statistics_equality(self) -> None:
+        stats1 = LabelStatistics.create(name="prop", value=42.3)
+        stats2 = LabelStatistics.create(name="prop", value=42.3)
+        stats3 = LabelStatistics.create(name="other", value=42.3)
+        stats4 = LabelStatistics.create(name="prop", value=73.4)
+
+        self.assertEqual(stats1, stats2)
+        self.assertNotEqual(stats1, stats3)
+        self.assertNotEqual(stats1, stats4)
+        self.assertNotEqual(stats1, 42)
 
 
 class LabelTest(unittest.TestCase):

--- a/tests/extensions/test_label.py
+++ b/tests/extensions/test_label.py
@@ -5,13 +5,14 @@ import tempfile
 from typing import List, Union
 
 import pystac
-from pystac import Catalog, Item, CatalogType
+from pystac import Catalog, Collection, Item, CatalogType
 from pystac.extensions.label import (
     LabelExtension,
     LabelClasses,
     LabelCount,
     LabelOverview,
     LabelStatistics,
+    LabelTask,
     LabelType,
     LabelRelType,
 )
@@ -439,3 +440,85 @@ class LabelTest(unittest.TestCase):
         _ = LabelExtension.ext(item, add_if_missing=True)
 
         self.assertIn(LabelExtension.get_schema_uri(), item.stac_extensions)
+
+
+class LabelSummariesTest(unittest.TestCase):
+    EXAMPLE_COLLECTION = TestCases.get_path(
+        "data-files/label/spacenet-roads/roads_collection.json"
+    )
+
+    def test_label_properties_summary(self) -> None:
+        label_properties = ["road_type", "lane_number", "paved"]
+        collection = Collection.from_file(self.EXAMPLE_COLLECTION)
+        label_ext_summaries = LabelExtension.summaries(collection)
+
+        label_ext_summaries.label_properties = label_properties
+
+        summaries = collection.summaries
+        assert summaries is not None
+        label_properties_summary = summaries.get_list("label:properties")
+        assert label_properties_summary is not None
+        self.assertListEqual(label_properties, label_properties_summary)
+
+        label_properties_summary_ext = label_ext_summaries.label_properties
+        assert label_properties_summary_ext is not None
+        self.assertListEqual(label_properties, label_properties_summary_ext)
+
+    def test_label_classes_summary(self) -> None:
+        label_classes = [
+            LabelClasses(
+                {"name": "road_type", "classes": ["1", "2", "3", "4", "5", "6"]}
+            ),
+            LabelClasses({"name": "lane_number", "classes": ["1", "2", "3", "4", "5"]}),
+            LabelClasses({"name": "paved", "classes": ["0", "1"]}),
+        ]
+        collection = Collection.from_file(self.EXAMPLE_COLLECTION)
+        label_ext_summaries = LabelExtension.summaries(collection)
+
+        label_ext_summaries.label_classes = label_classes
+
+        summaries = collection.summaries
+        assert summaries is not None
+        label_classes_summary = summaries.get_list("label:classes")
+        assert label_classes_summary is not None
+        self.assertListEqual(
+            [lc.to_dict() for lc in label_classes], label_classes_summary
+        )
+
+        label_classes_summary_ext = label_ext_summaries.label_classes
+        assert label_classes_summary_ext is not None
+        self.assertListEqual(label_classes, label_classes_summary_ext)
+
+    def test_label_type_summary(self) -> None:
+        label_types = [LabelType.VECTOR]
+        collection = Collection.from_file(self.EXAMPLE_COLLECTION)
+        label_ext_summaries = LabelExtension.summaries(collection)
+
+        label_ext_summaries.label_type = label_types
+
+        summaries = collection.summaries
+        assert summaries is not None
+        label_type_summary = summaries.get_list("label:type")
+        assert label_type_summary is not None
+        self.assertListEqual(label_types, label_type_summary)
+
+        label_type_summary_ext = label_ext_summaries.label_type
+        assert label_type_summary_ext is not None
+        self.assertListEqual(label_types, label_type_summary_ext)
+
+    def test_label_task_summary(self) -> None:
+        label_tasks: List[Union[LabelTask, str]] = [LabelTask.REGRESSION]
+        collection = Collection.from_file(self.EXAMPLE_COLLECTION)
+        label_ext_summaries = LabelExtension.summaries(collection)
+
+        label_ext_summaries.label_tasks = label_tasks
+
+        summaries = collection.summaries
+        assert summaries is not None
+        label_tasks_summary = summaries.get_list("label:tasks")
+        assert label_tasks_summary is not None
+        self.assertListEqual(label_tasks, label_tasks_summary)
+
+        label_tasks_summary_ext = label_ext_summaries.label_tasks
+        assert label_tasks_summary_ext is not None
+        self.assertListEqual(label_tasks, label_tasks_summary_ext)


### PR DESCRIPTION
**Related Issue(s):**

* #327

**Description:**

* Defines equality for component classes in the Label Extension (e.g. `LabelClasses`, `LabelProperties`, etc.)
* Adds summaries for fields defined in `stac-fields`
* Uses `Enum` for `"label:tasks"`, but continues to allow free string input (following pattern for `RelType`).


**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [ ] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.