### PR TITLE
Allow extra fields in Provider and Extent 

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -86,6 +86,14 @@ TemporalExtent
    :members:
    :undoc-members:
 
+ProviderRole
+~~~~~~~~~~~~
+
+.. autoclass:: pystac.ProviderRole
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Provider
 ~~~~~~~~
 

--- a/pystac/__init__.py
+++ b/pystac/__init__.py
@@ -32,6 +32,7 @@ from pystac.collection import (
     SpatialExtent,
     TemporalExtent,
     Provider,
+    ProviderRole,
     Summaries,
 )
 from pystac.summaries import RangeSummary

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -372,17 +372,30 @@ class Provider:
             licensor, producer, processor or host.
         url : Optional homepage on which the provider describes the dataset
             and publishes contact information.
-
-    Attributes:
-        name : The name of the organization or the individual.
-        description : Optional multi-line description to add further provider
-            information such as processing details for processors and producers,
-            hosting details for hosts or basic contact information.
-        roles : Optional roles of the provider. Any of
-            licensor, producer, processor or host.
-        url : Optional homepage on which the provider describes the dataset
-            and publishes contact information.
+        extra_fields : Optional dictionary containing additional top-level fields
+            defined on the Provider object.
+    object.
     """
+
+    name: str
+    """The name of the organization or the individual."""
+
+    description: Optional[str]
+    """Optional multi-line description to add further provider
+    information such as processing details for processors and producers,
+    hosting details for hosts or basic contact information."""
+
+    roles: Optional[List[str]]
+    """Optional roles of the provider. Any of
+    licensor, producer, processor or host."""
+
+    url: Optional[str]
+    """Optional homepage on which the provider describes the dataset
+    and publishes contact information."""
+
+    extra_fields: Dict[str, Any]
+    """Dictionary containing additional top-level fields defined on the Provider
+    object."""
 
     def __init__(
         self,
@@ -390,11 +403,13 @@ class Provider:
         description: Optional[str] = None,
         roles: Optional[List[str]] = None,
         url: Optional[str] = None,
+        extra_fields: Optional[Dict[str, Any]] = None,
     ):
         self.name = name
         self.description = description
         self.roles = roles
         self.url = url
+        self.extra_fields = extra_fields or {}
 
     def to_dict(self) -> Dict[str, Any]:
         """Generate a dictionary representing the JSON of this Provider.
@@ -410,6 +425,8 @@ class Provider:
         if self.url is not None:
             d["url"] = self.url
 
+        d.update(self.extra_fields)
+
         return d
 
     @staticmethod
@@ -417,13 +434,20 @@ class Provider:
         """Constructs an Provider from a dict.
 
         Returns:
-            TemporalExtent: The Provider deserialized from the JSON dict.
+            Provider: The Provider deserialized from the JSON dict.
         """
         return Provider(
             name=d["name"],
             description=d.get("description"),
-            roles=d.get("roles"),
+            roles=d.get(
+                "roles",
+            ),
             url=d.get("url"),
+            extra_fields={
+                k: v
+                for k, v in d.items()
+                if k not in {"name", "description", "roles", "url"}
+            },
         )
 
 

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -117,7 +117,7 @@ class SpatialExtent:
         Args:
             coordinates : Coordinates to derive the bbox from.
             extra_fields : Dictionary containing additional top-level fields defined on
-                the Spatial Extent object.
+                the SpatialExtent object.
 
         Returns:
             SpatialExtent: A SpatialExtent with a single bbox that covers the
@@ -438,7 +438,6 @@ class Provider:
             and publishes contact information.
         extra_fields : Optional dictionary containing additional top-level fields
             defined on the Provider object.
-    object.
     """
 
     name: str

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -1,4 +1,4 @@
-from copy import copy, deepcopy
+from copy import deepcopy
 from datetime import datetime as Datetime
 from pystac.errors import STACTypeError
 from typing import (
@@ -318,8 +318,8 @@ class Extent:
             Extent: The clone of this extent.
         """
         return Extent(
-            spatial=copy(self.spatial),
-            temporal=copy(self.temporal),
+            spatial=self.spatial.clone(),
+            temporal=self.temporal.clone(),
             extra_fields=deepcopy(self.extra_fields),
         )
 

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 from datetime import datetime as Datetime
+from enum import Enum
 from pystac.errors import STACTypeError
 from typing import (
     Any,
@@ -408,6 +409,18 @@ class Extent:
         return Extent(spatial=spatial, temporal=temporal, extra_fields=extra_fields)
 
 
+class ProviderRole(str, Enum):
+    """Enumerates the allows values of the Provider "role" field."""
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+    LICENSOR = "licensor"
+    PRODUCER = "producer"
+    PROCESSOR = "processor"
+    HOST = "host"
+
+
 class Provider:
     """Provides information about a provider of STAC data. A provider is any of the
     organizations that captured or processed the content of the collection and therefore
@@ -436,7 +449,7 @@ class Provider:
     information such as processing details for processors and producers,
     hosting details for hosts or basic contact information."""
 
-    roles: Optional[List[str]]
+    roles: Optional[List[ProviderRole]]
     """Optional roles of the provider. Any of
     licensor, producer, processor or host."""
 
@@ -452,7 +465,7 @@ class Provider:
         self,
         name: str,
         description: Optional[str] = None,
-        roles: Optional[List[str]] = None,
+        roles: Optional[List[ProviderRole]] = None,
         url: Optional[str] = None,
         extra_fields: Optional[Dict[str, Any]] = None,
     ):

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -46,14 +46,25 @@ class SpatialExtent:
             array must be 2*n where n is the number of dimensions. For example, a
             2D Collection with only one bbox would be [[xmin, ymin, xmax, ymax]]
 
-    Attributes:
-        bboxes : A list of bboxes that represent the spatial
-            extent of the collection. Each bbox can be 2D or 3D. The length of the bbox
-            array must be 2*n where n is the number of dimensions. For example, a
-            2D Collection with only one bbox would be [[xmin, ymin, xmax, ymax]]
+        extra_fields : Dictionary containing additional top-level fields defined on the
+            Spatial Extent object.
     """
 
-    def __init__(self, bboxes: Union[List[List[float]], List[float]]) -> None:
+    bboxes: List[List[float]]
+    """A list of bboxes that represent the spatial
+    extent of the collection. Each bbox can be 2D or 3D. The length of the bbox
+    array must be 2*n where n is the number of dimensions. For example, a
+    2D Collection with only one bbox would be [[xmin, ymin, xmax, ymax]]"""
+
+    extra_fields: Dict[str, Any]
+    """Dictionary containing additional top-level fields defined on the Spatial
+    Extent object."""
+
+    def __init__(
+        self,
+        bboxes: Union[List[List[float]], List[float]],
+        extra_fields: Optional[Dict[str, Any]] = None,
+    ) -> None:
         # A common mistake is to pass in a single bbox instead of a list of bboxes.
         # Account for this by transforming the input in that case.
         if isinstance(bboxes, list) and isinstance(bboxes[0], float):
@@ -61,13 +72,15 @@ class SpatialExtent:
         else:
             self.bboxes = cast(List[List[float]], bboxes)
 
+        self.extra_fields = extra_fields or {}
+
     def to_dict(self) -> Dict[str, Any]:
         """Generate a dictionary representing the JSON of this SpatialExtent.
 
         Returns:
             dict: A serialization of the SpatialExtent that can be written out as JSON.
         """
-        d = {"bbox": self.bboxes}
+        d = {"bbox": self.bboxes, **self.extra_fields}
         return d
 
     def clone(self) -> "SpatialExtent":
@@ -76,19 +89,25 @@ class SpatialExtent:
         Returns:
             SpatialExtent: The clone of this object.
         """
-        return SpatialExtent(deepcopy(self.bboxes))
+        return SpatialExtent(
+            bboxes=deepcopy(self.bboxes), extra_fields=deepcopy(self.extra_fields)
+        )
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "SpatialExtent":
-        """Constructs an SpatialExtent from a dict.
+        """Constructs a SpatialExtent from a dict.
 
         Returns:
             SpatialExtent: The SpatialExtent deserialized from the JSON dict.
         """
-        return SpatialExtent(bboxes=d["bbox"])
+        return SpatialExtent(
+            bboxes=d["bbox"], extra_fields={k: v for k, v in d.items() if k != "bbox"}
+        )
 
     @staticmethod
-    def from_coordinates(coordinates: List[Any]) -> "SpatialExtent":
+    def from_coordinates(
+        coordinates: List[Any], extra_fields: Optional[Dict[str, Any]] = None
+    ) -> "SpatialExtent":
         """Constructs a SpatialExtent from a set of coordinates.
 
         This method will only produce a single bbox that covers all points
@@ -96,6 +115,8 @@ class SpatialExtent:
 
         Args:
             coordinates : Coordinates to derive the bbox from.
+            extra_fields : Dictionary containing additional top-level fields defined on
+                the Spatial Extent object.
 
         Returns:
             SpatialExtent: A SpatialExtent with a single bbox that covers the
@@ -133,7 +154,9 @@ class SpatialExtent:
                 f"Could not determine bounds from coordinate sequence {coordinates}"
             )
 
-        return SpatialExtent([[xmin, ymin, xmax, ymax]])
+        return SpatialExtent(
+            bboxes=[[xmin, ymin, xmax, ymax]], extra_fields=extra_fields
+        )
 
 
 class TemporalExtent:
@@ -141,23 +164,30 @@ class TemporalExtent:
 
     Args:
         intervals :  A list of two datetimes wrapped in a list,
-        representing the temporal extent of a Collection. Open date ranges are supported
-        by setting either the start (the first element of the interval) or the end (the
-        second element of the interval) to None.
+            representing the temporal extent of a Collection. Open date ranges are
+            supported by setting either the start (the first element of the interval)
+            or the end (the second element of the interval) to None.
 
-
-    Attributes:
-        intervals :  A list of two datetimes wrapped in a list,
-        representing the temporal extent of a Collection. Open date ranges are
-        represented by either the start (the first element of the interval) or the
-        end (the second element of the interval) being None.
-
+        extra_fields : Dictionary containing additional top-level fields defined on the
+            Temporal Extent object.
     Note:
         Datetimes are required to be in UTC.
     """
 
+    intervals: List[List[Optional[Datetime]]]
+    """A list of two datetimes wrapped in a list,
+    representing the temporal extent of a Collection. Open date ranges are
+    represented by either the start (the first element of the interval) or the
+    end (the second element of the interval) being None."""
+
+    extra_fields: Dict[str, Any]
+    """Dictionary containing additional top-level fields defined on the Temporal
+    Extent object."""
+
     def __init__(
-        self, intervals: Union[List[List[Optional[Datetime]]], List[Optional[Datetime]]]
+        self,
+        intervals: Union[List[List[Optional[Datetime]]], List[Optional[Datetime]]],
+        extra_fields: Optional[Dict[str, Any]] = None,
     ):
         # A common mistake is to pass in a single interval instead of a
         # list of intervals. Account for this by transforming the input
@@ -166,6 +196,8 @@ class TemporalExtent:
             self.intervals = [cast(List[Optional[Datetime]], intervals)]
         else:
             self.intervals = cast(List[List[Optional[Datetime]]], intervals)
+
+        self.extra_fields = extra_fields or {}
 
     def to_dict(self) -> Dict[str, Any]:
         """Generate a dictionary representing the JSON of this TemporalExtent.
@@ -186,7 +218,7 @@ class TemporalExtent:
 
             encoded_intervals.append([start, end])
 
-        d = {"interval": encoded_intervals}
+        d = {"interval": encoded_intervals, **self.extra_fields}
         return d
 
     def clone(self) -> "TemporalExtent":
@@ -195,7 +227,9 @@ class TemporalExtent:
         Returns:
             TemporalExtent: The clone of this object.
         """
-        return TemporalExtent(intervals=deepcopy(self.intervals))
+        return TemporalExtent(
+            intervals=deepcopy(self.intervals), extra_fields=deepcopy(self.extra_fields)
+        )
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "TemporalExtent":
@@ -215,7 +249,10 @@ class TemporalExtent:
                 end = dateutil.parser.parse(i[1])
             parsed_intervals.append([start, end])
 
-        return TemporalExtent(intervals=parsed_intervals)
+        return TemporalExtent(
+            intervals=parsed_intervals,
+            extra_fields={k: v for k, v in d.items() if k != "interval"},
+        )
 
     @staticmethod
     def from_now() -> "TemporalExtent":
@@ -236,15 +273,29 @@ class Extent:
     Args:
         spatial : Potential spatial extent covered by the collection.
         temporal : Potential temporal extent covered by the collection.
-
-    Attributes:
-        spatial : Potential spatial extent covered by the collection.
-        temporal : Potential temporal extent covered by the collection.
+        extra_fields : Dictionary containing additional top-level fields defined on the
+            Extent object.
     """
 
-    def __init__(self, spatial: SpatialExtent, temporal: TemporalExtent):
+    spatial: SpatialExtent
+    """Potential spatial extent covered by the collection."""
+
+    temporal: TemporalExtent
+    """Potential temporal extent covered by the collection."""
+
+    extra_fields: Dict[str, Any]
+    """Dictionary containing additional top-level fields defined on the Extent
+    object."""
+
+    def __init__(
+        self,
+        spatial: SpatialExtent,
+        temporal: TemporalExtent,
+        extra_fields: Optional[Dict[str, Any]] = None,
+    ):
         self.spatial = spatial
         self.temporal = temporal
+        self.extra_fields = extra_fields or {}
 
     def to_dict(self) -> Dict[str, Any]:
         """Generate a dictionary representing the JSON of this Extent.
@@ -252,7 +303,11 @@ class Extent:
         Returns:
             dict: A serialization of the Extent that can be written out as JSON.
         """
-        d = {"spatial": self.spatial.to_dict(), "temporal": self.temporal.to_dict()}
+        d = {
+            "spatial": self.spatial.to_dict(),
+            "temporal": self.temporal.to_dict(),
+            **self.extra_fields,
+        }
 
         return d
 
@@ -262,7 +317,11 @@ class Extent:
         Returns:
             Extent: The clone of this extent.
         """
-        return Extent(spatial=copy(self.spatial), temporal=copy(self.temporal))
+        return Extent(
+            spatial=copy(self.spatial),
+            temporal=copy(self.temporal),
+            extra_fields=deepcopy(self.extra_fields),
+        )
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "Extent":
@@ -287,16 +346,23 @@ class Extent:
             temporal_extent_dict = temporal_extent
 
         return Extent(
-            SpatialExtent.from_dict(spatial_extent_dict),
-            TemporalExtent.from_dict(temporal_extent_dict),
+            spatial=SpatialExtent.from_dict(spatial_extent_dict),
+            temporal=TemporalExtent.from_dict(temporal_extent_dict),
+            extra_fields={
+                k: v for k, v in d.items() if k not in {"spatial", "temporal"}
+            },
         )
 
     @staticmethod
-    def from_items(items: Iterable["Item_Type"]) -> "Extent":
+    def from_items(
+        items: Iterable["Item_Type"], extra_fields: Optional[Dict[str, Any]] = None
+    ) -> "Extent":
         """Create an Extent based on the datetimes and bboxes of a list of items.
 
         Args:
             items : A list of items to derive the extent from.
+            extra_fields : Optional dictionary containing additional top-level fields
+                defined on the Extent object.
 
         Returns:
             Extent: An Extent that spatially and temporally covers all of the
@@ -354,7 +420,7 @@ class Extent:
         )
         temporal = TemporalExtent([[start_timestamp, end_timestamp]])
 
-        return Extent(spatial, temporal)
+        return Extent(spatial=spatial, temporal=temporal, extra_fields=extra_fields)
 
 
 class Provider:

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -330,24 +330,9 @@ class Extent:
         Returns:
             Extent: The Extent deserialized from the JSON dict.
         """
-
-        # Handle pre-0.8 spatial extents
-        spatial_extent = d["spatial"]
-        if isinstance(spatial_extent, list):
-            spatial_extent_dict: Dict[str, Any] = {"bbox": [spatial_extent]}
-        else:
-            spatial_extent_dict = spatial_extent
-
-        # Handle pre-0.8 temporal extents
-        temporal_extent = d["temporal"]
-        if isinstance(temporal_extent, list):
-            temporal_extent_dict: Dict[str, Any] = {"interval": [temporal_extent]}
-        else:
-            temporal_extent_dict = temporal_extent
-
         return Extent(
-            spatial=SpatialExtent.from_dict(spatial_extent_dict),
-            temporal=TemporalExtent.from_dict(temporal_extent_dict),
+            spatial=SpatialExtent.from_dict(d["spatial"]),
+            temporal=TemporalExtent.from_dict(d["temporal"]),
             extra_fields={
                 k: v for k, v in d.items() if k not in {"spatial", "temporal"}
             },

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -9,11 +9,41 @@ import tempfile
 import pystac
 from pystac.extensions.eo import EOExtension
 from pystac.validation import validate_dict
-from pystac import Collection, Item, Extent, SpatialExtent, TemporalExtent, CatalogType
+from pystac import (
+    Collection,
+    Item,
+    Extent,
+    SpatialExtent,
+    TemporalExtent,
+    CatalogType,
+    Provider,
+)
 from pystac.utils import datetime_to_str, get_required
 from tests.utils import TestCases, ARBITRARY_GEOM, ARBITRARY_BBOX
 
 TEST_DATETIME = datetime(2020, 3, 14, 16, 32)
+
+
+class ProviderTest(unittest.TestCase):
+    def test_to_from_dict(self) -> None:
+        provider_dict = {
+            "name": "Remote Data, Inc",
+            "description": "Producers of awesome spatiotemporal assets",
+            "roles": ["producer", "processor"],
+            "url": "http://remotedata.io",
+            "extension:field": "some value",
+        }
+        expected_extra_fields = {"extension:field": provider_dict["extension:field"]}
+
+        provider = Provider.from_dict(provider_dict)
+
+        self.assertEqual(provider_dict["name"], provider.name)
+        self.assertEqual(provider_dict["description"], provider.description)
+        self.assertEqual(provider_dict["roles"], provider.roles)
+        self.assertEqual(provider_dict["url"], provider.url)
+        self.assertDictEqual(expected_extra_fields, provider.extra_fields)
+
+        self.assertDictEqual(provider_dict, provider.to_dict())
 
 
 class CollectionTest(unittest.TestCase):

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -252,6 +252,9 @@ class CollectionTest(unittest.TestCase):
 
 
 class ExtentTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.maxDiff = None
+
     def test_spatial_allows_single_bbox(self) -> None:
         temporal_extent = TemporalExtent(intervals=[[TEST_DATETIME, None]])
 
@@ -318,6 +321,49 @@ class ExtentTest(unittest.TestCase):
 
         self.assertEqual(interval[0], datetime(2000, 1, 1, 12, 0, 0, 0, tzinfo=tz.UTC))
         self.assertEqual(interval[1], datetime(2001, 1, 1, 12, 0, 0, 0, tzinfo=tz.UTC))
+
+    def test_to_from_dict(self) -> None:
+        spatial_dict = {
+            "bbox": [
+                [
+                    172.91173669923782,
+                    1.3438851951615003,
+                    172.95469614953714,
+                    1.3690476620161975,
+                ]
+            ],
+            "extension:field": "spatial value",
+        }
+        temporal_dict = {
+            "interval": [
+                ["2020-12-11T22:38:32.125000Z", "2020-12-14T18:02:31.437000Z"]
+            ],
+            "extension:field": "temporal value",
+        }
+        extent_dict = {
+            "spatial": spatial_dict,
+            "temporal": temporal_dict,
+            "extension:field": "extent value",
+        }
+        expected_extent_extra_fields = {
+            "extension:field": extent_dict["extension:field"],
+        }
+        expected_spatial_extra_fields = {
+            "extension:field": spatial_dict["extension:field"],
+        }
+        expected_temporal_extra_fields = {
+            "extension:field": temporal_dict["extension:field"],
+        }
+
+        extent = Extent.from_dict(extent_dict)
+
+        self.assertDictEqual(expected_extent_extra_fields, extent.extra_fields)
+        self.assertDictEqual(expected_spatial_extra_fields, extent.spatial.extra_fields)
+        self.assertDictEqual(
+            expected_temporal_extra_fields, extent.temporal.extra_fields
+        )
+
+        self.assertDictEqual(extent_dict, extent.to_dict())
 
 
 class CollectionSubClassTest(unittest.TestCase):

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List
 import unittest
 
 import pystac
-from pystac import Asset, Item, Provider
+from pystac import Asset, Item, Provider, ProviderRole
 from pystac.validation import validate_dict
 import pystac.serialization.common_properties
 from pystac.item import CommonMetadata
@@ -532,7 +532,7 @@ class CommonMetadataTest(unittest.TestCase):
             pystac.Provider(
                 name="USGS",
                 url="https://landsat.usgs.gov/",
-                roles=["producer", "licensor"],
+                roles=[ProviderRole.PRODUCER, ProviderRole.LICENSOR],
             )
         ]
 
@@ -546,7 +546,9 @@ class CommonMetadataTest(unittest.TestCase):
         # Set
         set_value = [
             pystac.Provider(
-                name="John Snow", url="https://cholera.com/", roles=["producer"]
+                name="John Snow",
+                url="https://cholera.com/",
+                roles=[ProviderRole.PRODUCER],
             )
         ]
         cm.set_providers(set_value, item.assets["analytic"])


### PR DESCRIPTION
**Related Issue(s):** #

* #479

**Description:**

* Handles additional top-level fields in `Provider`, `Extent`, `SpatialExtent`, and `TemporalExtent` classes. These additional fields are stored in an `extra_fields` dict on the instance. 
* Uses `SpatialExtent.clone` and `TemporalExtent.clone` in `Extent.clone` instead of using `copy`
* Adds `ProviderRole` enum for use in the Provider `"roles"` attribute
* Removes support for pre-0.8 extents

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [ ] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.