### PR TITLE
Run test script with/without coverage

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -97,11 +97,14 @@ jobs:
           pip install -e ".[validation]"
       
       - name: Execute test suite
-        # --fail-under=0 ensures we publish the coverage regardless of whether it meets
-        # the minimum so we can use Codecov to evaluate gaps
-        run: |
-          coverage run --source=pystac/ -m unittest discover tests/
-          coverage xml --fail-under=0
+        run: ./scripts/test
+        env:
+          CHECK_COVERAGE: true
+
+      - name: Prepare ./coverage.xml
+        # Ignore the configured fail-under to ensure we upload the coverage report. We
+        # will trigger a failure for coverage drops in a later job
+        run: coverage xml --fail-under 0
       
       - name: Upload All coverage to Codecov
         uses: codecov/codecov-action@v1
@@ -110,6 +113,11 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
           fail_ci_if_error: false 
+
+      - name: Check for coverage drop
+        # This will use the configured fail-under, causing this job to fail if the
+        # coverage drops.
+        run: coverage report
 
   lint:
     runs-on: ubuntu-latest

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -39,6 +39,10 @@ or the entire project using:
 
     ./scripts/test
 
+The last command will also check test coverage. To view the coverage report, you can run
+`coverage report` (to view the report in the terminal) or `coverage html` (to generate
+an HTML report that can be opened in a browser).
+
 More details on using ``unittest`` are `here
 <https://docs.python.org/3/library/unittest.html>`_.
 

--- a/scripts/test
+++ b/scripts/test
@@ -5,11 +5,15 @@ set -e
 if [[ -z ${CI} ]]; then
     pre-commit run --all-files
 fi
-
-echo
-echo " -- RUNNING UNIT TESTS --"
 echo
 
-# Test suite with coverage enabled
-coverage run -m unittest discover tests
-coverage xml
+if [[ -z ${CI} || -n ${CHECK_COVERAGE} ]]; then
+    echo " -- RUNNING UNIT TESTS (WITH COVERAGE) --"
+    # Test suite with coverage enabled
+    coverage run -m unittest discover tests
+else
+    echo " -- RUNNING UNIT TESTS (WITHOUT COVERAGE) --"
+    python -m unittest discover tests
+fi
+
+echo


### PR DESCRIPTION
**Related Issue(s):** #

* #466 (specifically [this comment](https://github.com/stac-utils/pystac/pull/466#issuecomment-868982522))

**Description:**

Adds ability to run `scripts/test` with or without coverage (default outside of CI is still to run with coverage). 

Also moves generation of `coverage.xml` out of `scripts/test`. The XML file is mostly used when uploading coverage to Codecov.io. Generating this file would cause all `test` jobs in the matrix to fail if the coverage dropped, which is misleading. Instead, this PR updates the `coverage` CI job to first upload the coverage report to Codecov.io so we can use it for debugging, then generates the report again using the configured `fail-under` value, which will cause `coverage` job to fail if coverage drops. This should make the source of the workflow failure a bit more obvious to developers.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.