### PR TITLE
Verify empty observation direction property

### DIFF
--- a/pystac/extensions/sar.py
+++ b/pystac/extensions/sar.py
@@ -318,7 +318,7 @@ class SarExtension(
             return cast(SarExtension[T], AssetSarExtension(obj))
         else:
             raise pystac.ExtensionTypeError(
-                f"SAR extension does not apply to type {type(obj)}"
+                f"SAR extension does not apply to type '{type(obj).__name__}'"
             )
 
 

--- a/pystac/extensions/view.py
+++ b/pystac/extensions/view.py
@@ -167,7 +167,7 @@ class ViewExtension(
             return cast(ViewExtension[T], AssetViewExtension(obj))
         else:
             raise pystac.ExtensionTypeError(
-                f"View extension does not apply to type {type(obj)}"
+                f"View extension does not apply to type '{type(obj).__name__}'"
             )
 
     @staticmethod

--- a/tests/extensions/test_sar.py
+++ b/tests/extensions/test_sar.py
@@ -8,6 +8,7 @@ import unittest
 from string import ascii_letters
 
 import pystac
+from pystac import ExtensionTypeError
 from pystac.extensions import sar
 from pystac.extensions.sar import SarExtension
 from tests.utils import TestCases
@@ -192,6 +193,16 @@ class SarItemExtTest(unittest.TestCase):
             choice(ascii_letters),
         )
         self.assertIsNone(extension.observation_direction)
+
+    def test_should_raise_exception_when_passing_invalid_extension_object(
+        self,
+    ) -> None:
+        self.assertRaisesRegex(
+            ExtensionTypeError,
+            r"^SAR extension does not apply to type 'object'$",
+            SarExtension.ext,
+            object(),
+        )
 
 
 if __name__ == "__main__":

--- a/tests/extensions/test_sar.py
+++ b/tests/extensions/test_sar.py
@@ -1,8 +1,11 @@
 """Tests for pystac.extensions.sar."""
 
 import datetime
+from random import choice
 from typing import List
 import unittest
+
+from string import ascii_letters
 
 import pystac
 from pystac.extensions import sar
@@ -179,6 +182,16 @@ class SarItemExtTest(unittest.TestCase):
         _ = SarExtension.ext(asset, add_if_missing=True)
 
         self.assertIn(SarExtension.get_schema_uri(), item.stac_extensions)
+
+    def test_should_return_none_when_observation_direction_is_not_set(self) -> None:
+        extension = SarExtension.ext(self.item)
+        extension.apply(
+            choice(ascii_letters),
+            choice(list(sar.FrequencyBand)),
+            [],
+            choice(ascii_letters),
+        )
+        self.assertIsNone(extension.observation_direction)
 
 
 if __name__ == "__main__":

--- a/tests/extensions/test_view.py
+++ b/tests/extensions/test_view.py
@@ -1,4 +1,6 @@
 import json
+
+from pystac import ExtensionTypeError
 from pystac.collection import Collection
 import unittest
 
@@ -256,6 +258,16 @@ class ViewTest(unittest.TestCase):
         _ = ViewExtension.ext(asset, add_if_missing=True)
 
         self.assertIn(ViewExtension.get_schema_uri(), item.stac_extensions)
+
+    def test_should_raise_exception_when_passing_invalid_extension_object(
+        self,
+    ) -> None:
+        self.assertRaisesRegex(
+            ExtensionTypeError,
+            r"^View extension does not apply to type 'object'$",
+            ViewExtension.ext,
+            object(),
+        )
 
 
 class ViewSummariestest(unittest.TestCase):


### PR DESCRIPTION
**Related Issue(s):** #466


**Description:**


**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.