### PR TITLE
tests: Include tests in coverage metric

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,4 +2,6 @@
 fail_under = 91
 
 [run]
-source = pystac
+source =
+    pystac
+    tests


### PR DESCRIPTION
Missing coverage in tests means unreached (and usually unreachable) test
code, often indicating a test bug.

**Related Issue(s):** #331


**Description:**


**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.