### PR TITLE
tests: Verify branch coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,10 +1,11 @@
 [report]
-fail_under = 96
+fail_under = 94
 exclude_lines =
     if TYPE_CHECKING:
 
 
 [run]
+branch = true
 source =
     pystac
     tests


### PR DESCRIPTION
Stricter than statement coverage, so I had to take the coverage minimum
down one percentage point.

The coverage library does not yet have support for conditional coverage
<https://github.com/nedbat/coveragepy/issues/660>, which is even
stricter.

Hover over yellow lines in the output of `coverage html` for a good idea of the difference between this and line coverage.


**Related Issue(s):** #331


**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.