### PR TITLE
tests: Make tests runnable from anywhere

### DIFF
--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -939,7 +939,7 @@ class CatalogTest(unittest.TestCase):
 
     def test_reading_iterating_and_writing_works_as_expected(self) -> None:
         """Test case to cover issue #88"""
-        stac_uri = "tests/data-files/catalogs/test-case-6/catalog.json"
+        stac_uri = TestCases.get_path("data-files/catalogs/test-case-6/catalog.json")
         cat = Catalog.from_file(stac_uri)
 
         # Iterate over the items. This was causing failure in

--- a/tests/test_item_collection.py
+++ b/tests/test_item_collection.py
@@ -2,6 +2,8 @@ from copy import deepcopy
 import json
 from pystac.item_collection import ItemCollection
 import unittest
+from os.path import relpath
+
 import pystac
 
 from tests.utils import TestCases
@@ -101,7 +103,11 @@ class TestItemCollection(unittest.TestCase):
 
     def test_from_relative_path(self) -> None:
         _ = pystac.ItemCollection.from_file(
-            "./tests/data-files/item-collection/sample-item-collection.json"
+            relpath(
+                TestCases.get_path(
+                    "data-files/item-collection/sample-item-collection.json"
+                )
+            )
         )
 
     def test_from_list_of_dicts(self) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone, timedelta
 from pystac import utils
 
 from pystac.utils import make_relative_href, make_absolute_href, is_absolute_href
+from tests.utils import TestCases
 
 
 class UtilsTest(unittest.TestCase):
@@ -273,7 +274,9 @@ class UtilsTest(unittest.TestCase):
 
     def test_geojson_bbox(self) -> None:
         # Use sample Geojson from https://en.wikipedia.org/wiki/GeoJSON
-        with open("tests/data-files/geojson/sample.geojson") as sample_geojson:
+        with open(
+            TestCases.get_path("data-files/geojson/sample.geojson")
+        ) as sample_geojson:
             all_features = json.load(sample_geojson)
             geom_dicts = [f["geometry"] for f in all_features["features"]]
             for geom in geom_dicts:


### PR DESCRIPTION
By using the current file rather than the root of the project as the
reference, the tests are now runnable for example in an IDE which uses
the "tests" directory as the root.

**Related Issue(s):** #331


**Description:**


**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.