### PR TITLE
RFC: Drop support for Python 3.6

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -20,7 +20,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.6"
           - "3.7"
           - "3.8"
           - "3.9"
@@ -140,9 +139,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.6"
           - "3.7"
           - "3.8"
+          - "3.9"
+          - "3.10.0-beta.3"
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 - `STAC_IO` class in favor of `StacIO`. This was deprecated in v1.0.0-beta.1 and has
   been removed in this release. ([#490](https://github.com/stac-utils/pystac/pull/490))
+- Support for Python 3.6 ([#500](https://github.com/stac-utils/pystac/pull/500))
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -6,16 +6,17 @@
 [![Gitter](https://badges.gitter.im/SpatioTemporal-Asset-Catalog/python.svg)](https://gitter.im/SpatioTemporal-Asset-Catalog/python?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-PySTAC is a library for working with [SpatialTemporal Asset Catalog](https://stacspec.org) in Python 3.
+PySTAC is a library for working with [SpatioTemporal Asset Catalog](https://stacspec.org) in Python 3.
 
 ## Installation
 
-PySTAC requires Python>=3.7. This project follows the recommendations of
+PySTAC requires Python >= 3.7. This project follows the recommendations of
 [NEP-29](https://numpy.org/neps/nep-0029-deprecation_policy.html) in deprecating support
 for Python versions. This means that users can expect support for Python 3.7 to be
-removed in next major or minor release after Dec 26, 2021.
+removed from the `main` branch after Dec 26, 2021 and therefore from the next release
+after that date.
 
-*Support for Python>=3.10 should be considered experimental
+*Support for Python >= 3.10 should be considered experimental
 until further notice.*
 
 PySTAC has a single required dependency (`python-dateutil`).

--- a/README.md
+++ b/README.md
@@ -10,8 +10,13 @@ PySTAC is a library for working with [SpatialTemporal Asset Catalog](https://sta
 
 ## Installation
 
-PySTAC requires Python>=3.6. Support for Python>=3.10 should be considered experimental
-until further notice.
+PySTAC requires Python>=3.7. This project follows the recommendations of
+[NEP-29](https://numpy.org/neps/nep-0029-deprecation_policy.html) in deprecating support
+for Python versions. This means that users can expect support for Python 3.7 to be
+removed in next major or minor release after Dec 26, 2021.
+
+*Support for Python>=3.10 should be considered experimental
+until further notice.*
 
 PySTAC has a single required dependency (`python-dateutil`).
 PySTAC can be installed from pip or the source repository.

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     packages=find_packages(),
     py_modules=[splitext(basename(path))[0] for path in glob("pystac/*.py")],
     include_package_data=False,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=[
         "python-dateutil>=2.7.0",
         'typing_extensions >= 3.7; python_version < "3.8"',
@@ -38,7 +38,6 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
**Related Issue(s):**

* Closes #474

**Description:**

Drops support for Python 3.6 (both in terms of `python_version` check on install and in CI tests), and adds a note to the README that we follow the NEP-29 guidelines.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.