### PR TITLE
Update Satellite Extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Timestamps Extension summaries ([#513](https://github.com/stac-utils/pystac/pull/513))
 - Define equality and `__repr__` of `RangeSummary` instances based on `to_dict`
   representation ([#513](https://github.com/stac-utils/pystac/pull/513))
+- Sat Extension summaries ([#509](https://github.com/stac-utils/pystac/pull/509))
 
 ### Changed
 
@@ -24,6 +25,8 @@
 - `Link` constructor classes (e.g. `Link.from_dict`, `Link.canonical`, etc.) now return
   the calling class instead of always returning the `Link` class
   ([#512](https://github.com/stac-utils/pystac/pull/512))
+- Sat extension now includes all fields defined in v1.0.0
+  ([#509](https://github.com/stac-utils/pystac/pull/509))
 
 ### Removed
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -499,6 +499,45 @@ RasterExtension
    :show-inheritance:
    :inherited-members:
 
+Satellite Extension
+-------------------
+
+OrbitState
+~~~~~~~~~~
+
+.. autoclass:: pystac.extensions.sat.OrbitState
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+SatExtension
+~~~~~~~~~~~~
+
+.. autoclass:: pystac.extensions.sat.SatExtension
+   :members:
+   :show-inheritance:
+
+ItemSatExtension
+~~~~~~~~~~~~
+
+.. autoclass:: pystac.extensions.sat.ItemSatExtension
+   :members:
+   :show-inheritance:
+
+AssetSatExtension
+~~~~~~~~~~~~
+
+.. autoclass:: pystac.extensions.sat.AssetSatExtension
+   :members:
+   :show-inheritance:
+
+SummariesSatExtension
+~~~~~~~~~~~~
+
+.. autoclass:: pystac.extensions.sat.SummariesSatExtension
+   :members:
+   :show-inheritance:
+
 Scientific Extension
 --------------------
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -518,21 +518,21 @@ SatExtension
    :show-inheritance:
 
 ItemSatExtension
-~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 .. autoclass:: pystac.extensions.sat.ItemSatExtension
    :members:
    :show-inheritance:
 
 AssetSatExtension
-~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~
 
 .. autoclass:: pystac.extensions.sat.AssetSatExtension
    :members:
    :show-inheritance:
 
 SummariesSatExtension
-~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: pystac.extensions.sat.SummariesSatExtension
    :members:

--- a/pystac/extensions/sat.py
+++ b/pystac/extensions/sat.py
@@ -4,6 +4,7 @@ https://github.com/stac-extensions/sat
 """
 
 import enum
+from datetime import datetime as Datetime
 from typing import Dict, Any, Generic, Iterable, Optional, Set, TypeVar, cast
 
 import pystac
@@ -12,15 +13,20 @@ from pystac.extensions.base import (
     PropertiesExtension,
 )
 from pystac.extensions.hooks import ExtensionHooks
-from pystac.utils import map_opt
+from pystac.utils import str_to_datetime, datetime_to_str, map_opt
 
 T = TypeVar("T", pystac.Item, pystac.Asset)
 
 SCHEMA_URI = "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
 
 PREFIX: str = "sat:"
-ORBIT_STATE: str = PREFIX + "orbit_state"
-RELATIVE_ORBIT: str = PREFIX + "relative_orbit"
+PLATFORM_INTERNATIONAL_DESIGNATOR_PROP: str = (
+    PREFIX + "platform_international_designator"
+)
+ABSOLUTE_ORBIT_PROP: str = PREFIX + "absolute_orbit"
+ORBIT_STATE_PROP: str = PREFIX + "orbit_state"
+RELATIVE_ORBIT_PROP: str = PREFIX + "relative_orbit"
+ANX_DATETIME_PROP: str = PREFIX + "anx_datetime"
 
 
 class OrbitState(str, enum.Enum):
@@ -51,6 +57,9 @@ class SatExtension(
         self,
         orbit_state: Optional[OrbitState] = None,
         relative_orbit: Optional[int] = None,
+        absolute_orbit: Optional[int] = None,
+        platform_international_designator: Optional[str] = None,
+        anx_datetime: Optional[Datetime] = None,
     ) -> None:
         """Applies ext extension properties to the extended :class:`~pystac.Item` or
         class:`~pystac.Asset`.
@@ -66,26 +75,58 @@ class SatExtension(
                 the time of acquisition.
         """
 
+        self.platform_international_designator = platform_international_designator
         self.orbit_state = orbit_state
+        self.absolute_orbit = absolute_orbit
         self.relative_orbit = relative_orbit
+        self.anx_datetime = anx_datetime
+
+    @property
+    def platform_international_designator(self) -> Optional[str]:
+        """Gets or sets the International Designator, also known as COSPAR ID, and
+        NSSDCA ID."""
+        return self._get_property(PLATFORM_INTERNATIONAL_DESIGNATOR_PROP, str)
+
+    @platform_international_designator.setter
+    def platform_international_designator(self, v: Optional[str]) -> None:
+        self._set_property(PLATFORM_INTERNATIONAL_DESIGNATOR_PROP, v)
 
     @property
     def orbit_state(self) -> Optional[OrbitState]:
         """Get or sets an orbit state of the object."""
-        return map_opt(lambda x: OrbitState(x), self._get_property(ORBIT_STATE, str))
+        return map_opt(
+            lambda x: OrbitState(x), self._get_property(ORBIT_STATE_PROP, str)
+        )
 
     @orbit_state.setter
     def orbit_state(self, v: Optional[OrbitState]) -> None:
-        self._set_property(ORBIT_STATE, map_opt(lambda x: x.value, v))
+        self._set_property(ORBIT_STATE_PROP, map_opt(lambda x: x.value, v))
+
+    @property
+    def absolute_orbit(self) -> Optional[int]:
+        """Get or sets a absolute orbit number of the item."""
+        return self._get_property(ABSOLUTE_ORBIT_PROP, int)
+
+    @absolute_orbit.setter
+    def absolute_orbit(self, v: Optional[int]) -> None:
+        self._set_property(ABSOLUTE_ORBIT_PROP, v)
 
     @property
     def relative_orbit(self) -> Optional[int]:
         """Get or sets a relative orbit number of the item."""
-        return self._get_property(RELATIVE_ORBIT, int)
+        return self._get_property(RELATIVE_ORBIT_PROP, int)
 
     @relative_orbit.setter
     def relative_orbit(self, v: Optional[int]) -> None:
-        self._set_property(RELATIVE_ORBIT, v)
+        self._set_property(RELATIVE_ORBIT_PROP, v)
+
+    @property
+    def anx_datetime(self) -> Optional[Datetime]:
+        return map_opt(str_to_datetime, self._get_property(ANX_DATETIME_PROP, str))
+
+    @anx_datetime.setter
+    def anx_datetime(self, v: Optional[Datetime]) -> None:
+        self._set_property(ANX_DATETIME_PROP, map_opt(datetime_to_str, v))
 
     @classmethod
     def get_schema_uri(cls) -> str:

--- a/tests/extensions/test_sat.py
+++ b/tests/extensions/test_sat.py
@@ -223,12 +223,15 @@ class SatSummariesTest(unittest.TestCase):
     def setUp(self) -> None:
         self.maxDiff = None
 
-        self.collection = pystac.Collection.from_file(
+    @staticmethod
+    def collection() -> pystac.Collection:
+        return pystac.Collection.from_file(
             TestCases.get_path("data-files/collections/multi-extent.json")
         )
 
     def test_platform_international_designation(self) -> None:
-        summaries_ext = SatExtension.summaries(self.collection)
+        collection = self.collection()
+        summaries_ext = SatExtension.summaries(collection)
         platform_international_designator_list = ["2018-080A"]
 
         summaries_ext.platform_international_designator = ["2018-080A"]
@@ -238,7 +241,7 @@ class SatSummariesTest(unittest.TestCase):
             platform_international_designator_list,
         )
 
-        summaries_dict = self.collection.to_dict()["summaries"]
+        summaries_dict = collection.to_dict()["summaries"]
 
         self.assertEqual(
             summaries_dict["sat:platform_international_designator"],
@@ -246,7 +249,8 @@ class SatSummariesTest(unittest.TestCase):
         )
 
     def test_orbit_state(self) -> None:
-        summaries_ext = SatExtension.summaries(self.collection)
+        collection = self.collection()
+        summaries_ext = SatExtension.summaries(collection)
         orbit_state_list = [OrbitState.ASCENDING]
 
         summaries_ext.orbit_state = orbit_state_list
@@ -256,7 +260,7 @@ class SatSummariesTest(unittest.TestCase):
             orbit_state_list,
         )
 
-        summaries_dict = self.collection.to_dict()["summaries"]
+        summaries_dict = collection.to_dict()["summaries"]
 
         self.assertEqual(
             summaries_dict["sat:orbit_state"],
@@ -264,7 +268,8 @@ class SatSummariesTest(unittest.TestCase):
         )
 
     def test_absolute_orbit(self) -> None:
-        summaries_ext = SatExtension.summaries(self.collection)
+        collection = self.collection()
+        summaries_ext = SatExtension.summaries(collection)
         absolute_orbit_range = RangeSummary(2000, 3000)
 
         summaries_ext.absolute_orbit = absolute_orbit_range
@@ -274,7 +279,7 @@ class SatSummariesTest(unittest.TestCase):
             absolute_orbit_range,
         )
 
-        summaries_dict = self.collection.to_dict()["summaries"]
+        summaries_dict = collection.to_dict()["summaries"]
 
         self.assertEqual(
             summaries_dict["sat:absolute_orbit"],
@@ -282,7 +287,8 @@ class SatSummariesTest(unittest.TestCase):
         )
 
     def test_relative_orbit(self) -> None:
-        summaries_ext = SatExtension.summaries(self.collection)
+        collection = self.collection()
+        summaries_ext = SatExtension.summaries(collection)
         relative_orbit_range = RangeSummary(50, 100)
 
         summaries_ext.relative_orbit = relative_orbit_range
@@ -292,7 +298,7 @@ class SatSummariesTest(unittest.TestCase):
             relative_orbit_range,
         )
 
-        summaries_dict = self.collection.to_dict()["summaries"]
+        summaries_dict = collection.to_dict()["summaries"]
 
         self.assertEqual(
             summaries_dict["sat:relative_orbit"],
@@ -300,7 +306,8 @@ class SatSummariesTest(unittest.TestCase):
         )
 
     def test_anx_datetime(self) -> None:
-        summaries_ext = SatExtension.summaries(self.collection)
+        collection = self.collection()
+        summaries_ext = SatExtension.summaries(collection)
         anx_datetime_range = RangeSummary(
             str_to_datetime("2020-01-01T00:00:00.000Z"),
             str_to_datetime("2020-01-02T00:00:00.000Z"),
@@ -313,7 +320,7 @@ class SatSummariesTest(unittest.TestCase):
             anx_datetime_range,
         )
 
-        summaries_dict = self.collection.to_dict()["summaries"]
+        summaries_dict = collection.to_dict()["summaries"]
 
         self.assertDictEqual(
             summaries_dict["sat:anx_datetime"],

--- a/tests/extensions/test_sat.py
+++ b/tests/extensions/test_sat.py
@@ -1,14 +1,15 @@
 """Tests for pystac.extensions.sat."""
 
 import datetime
+from pystac.summaries import RangeSummary
 from typing import Any, Dict
 import unittest
 
 import pystac
-from pystac.utils import str_to_datetime
+from pystac.utils import str_to_datetime, datetime_to_str
 from pystac import ExtensionTypeError
 from pystac.extensions import sat
-from pystac.extensions.sat import SatExtension
+from pystac.extensions.sat import OrbitState, SatExtension
 from tests.utils import TestCases
 
 
@@ -215,4 +216,109 @@ class SatTest(unittest.TestCase):
             r"^Satellite extension does not apply to type 'object'$",
             SatExtension.ext,
             object(),
+        )
+
+
+class SatSummariesTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.maxDiff = None
+
+        self.collection = pystac.Collection.from_file(
+            TestCases.get_path("data-files/collections/multi-extent.json")
+        )
+
+    def test_platform_international_designation(self) -> None:
+        summaries_ext = SatExtension.summaries(self.collection)
+        platform_international_designator_list = ["2018-080A"]
+
+        summaries_ext.platform_international_designator = ["2018-080A"]
+
+        self.assertEqual(
+            summaries_ext.platform_international_designator,
+            platform_international_designator_list,
+        )
+
+        summaries_dict = self.collection.to_dict()["summaries"]
+
+        self.assertEqual(
+            summaries_dict["sat:platform_international_designator"],
+            platform_international_designator_list,
+        )
+
+    def test_orbit_state(self) -> None:
+        summaries_ext = SatExtension.summaries(self.collection)
+        orbit_state_list = [OrbitState.ASCENDING]
+
+        summaries_ext.orbit_state = orbit_state_list
+
+        self.assertEqual(
+            summaries_ext.orbit_state,
+            orbit_state_list,
+        )
+
+        summaries_dict = self.collection.to_dict()["summaries"]
+
+        self.assertEqual(
+            summaries_dict["sat:orbit_state"],
+            orbit_state_list,
+        )
+
+    def test_absolute_orbit(self) -> None:
+        summaries_ext = SatExtension.summaries(self.collection)
+        absolute_orbit_range = RangeSummary(2000, 3000)
+
+        summaries_ext.absolute_orbit = absolute_orbit_range
+
+        self.assertEqual(
+            summaries_ext.absolute_orbit,
+            absolute_orbit_range,
+        )
+
+        summaries_dict = self.collection.to_dict()["summaries"]
+
+        self.assertEqual(
+            summaries_dict["sat:absolute_orbit"],
+            absolute_orbit_range.to_dict(),
+        )
+
+    def test_relative_orbit(self) -> None:
+        summaries_ext = SatExtension.summaries(self.collection)
+        relative_orbit_range = RangeSummary(50, 100)
+
+        summaries_ext.relative_orbit = relative_orbit_range
+
+        self.assertEqual(
+            summaries_ext.relative_orbit,
+            relative_orbit_range,
+        )
+
+        summaries_dict = self.collection.to_dict()["summaries"]
+
+        self.assertEqual(
+            summaries_dict["sat:relative_orbit"],
+            relative_orbit_range.to_dict(),
+        )
+
+    def test_anx_datetime(self) -> None:
+        summaries_ext = SatExtension.summaries(self.collection)
+        anx_datetime_range = RangeSummary(
+            str_to_datetime("2020-01-01T00:00:00.000Z"),
+            str_to_datetime("2020-01-02T00:00:00.000Z"),
+        )
+
+        summaries_ext.anx_datetime = anx_datetime_range
+
+        self.assertEqual(
+            summaries_ext.anx_datetime,
+            anx_datetime_range,
+        )
+
+        summaries_dict = self.collection.to_dict()["summaries"]
+
+        self.assertDictEqual(
+            summaries_dict["sat:anx_datetime"],
+            {
+                "minimum": datetime_to_str(anx_datetime_range.minimum),
+                "maximum": datetime_to_str(anx_datetime_range.maximum),
+            },
         )


### PR DESCRIPTION
**Related Issue(s):** #

* Closes #507
* #326
* #327

**Description:**

* Adds missing fields to Satellite Extension
* Implements collection summaries for Satellite Extension
* Defines `__eq__` and `__repr__` for `RangeSummary`
    I found myself wanting to use this when testing summaries

Let me know what you think about the implementation of the RangeSummary for the `sat:anx_datetime` field, which has a  `datetime` type.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.