### PR TITLE
`properties` -> `extra_fields` for Asset and Link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 ### Changed
 
+- Renamed `Asset.properties` -> `Asset.extra_fields` and `Link.properties` ->
+  `Link.extra_fields` for consistency with other STAC objects
+  ([#510](https://github.com/stac-utils/pystac/pull/510))
+
 ### Fixed
 
 - Bug in `pystac.serialization.identify_stac_object_type` where invalid objects with

--- a/pystac/asset.py
+++ b/pystac/asset.py
@@ -27,21 +27,34 @@ class Asset:
         properties : Optional, additional properties for this asset. This is used
             by extensions as a way to serialize and deserialize properties on asset
             object JSON.
-
-    Attributes:
-        href : Link to the asset object. Relative and absolute links are both
-            allowed.
-        title : Optional displayed title for clients and users.
-        description : A description of the Asset providing additional details,
-            such as how it was processed or created. CommonMark 0.29 syntax MAY be
-            used for rich text representation.
-        media_type : Optional description of the media type. Registered Media Types
-            are preferred. See :class:`~pystac.MediaType` for common media types.
-        properties : Optional, additional properties for this asset. This is used
-            by extensions as a way to serialize and deserialize properties on asset
-            object JSON.
-        owner: The Item or Collection this asset belongs to, or None if it has no owner.
     """
+
+    href: str
+    """Link to the asset object. Relative and absolute links are both allowed."""
+
+    title: Optional[str]
+    """Optional displayed title for clients and users."""
+
+    description: Optional[str]
+    """A description of the Asset providing additional details, such as how it was
+    processed or created. CommonMark 0.29 syntax MAY be used for rich text
+    representation."""
+
+    media_type: Optional[str]
+    """Optional description of the media type. Registered Media Types are preferred.
+    See :class:`~pystac.MediaType` for common media types."""
+
+    roles: Optional[List[str]]
+    """Optional, Semantic roles (i.e. thumbnail, overview, data, metadata) of the
+    asset."""
+
+    owner: Optional[Union[pystac.Item, pystac.Collection]]
+    """The :class:`~pystac.Item` or :class:`~pystac.Collection` that this asset belongs
+    to, or ``None`` if it has no owner."""
+
+    properties: Optional[Dict[str, Any]]
+    """Optional, additional properties for this asset. This is used by extensions as a
+    way to serialize and deserialize properties on asset object JSON."""
 
     def __init__(
         self,
@@ -64,7 +77,7 @@ class Asset:
             self.properties = {}
 
         # The Item which owns this Asset.
-        self.owner: Optional[Union[pystac.Item, pystac.Collection]] = None
+        self.owner = None
 
     def set_owner(self, obj: Union["Collection_Type", "Item_Type"]) -> None:
         """Sets the owning item of this Asset.

--- a/pystac/asset.py
+++ b/pystac/asset.py
@@ -1,7 +1,6 @@
 from copy import copy
 from typing import Any, Dict, List, Optional, TYPE_CHECKING, Union
 
-import pystac
 from pystac.utils import is_absolute_href, make_absolute_href
 
 if TYPE_CHECKING:
@@ -24,7 +23,7 @@ class Asset:
             are preferred. See :class:`~pystac.MediaType` for common media types.
         roles : Optional, Semantic roles (i.e. thumbnail, overview,
             data, metadata) of the asset.
-        properties : Optional, additional properties for this asset. This is used
+        extra_fields : Optional, additional fields for this asset. This is used
             by extensions as a way to serialize and deserialize properties on asset
             object JSON.
     """
@@ -48,12 +47,12 @@ class Asset:
     """Optional, Semantic roles (i.e. thumbnail, overview, data, metadata) of the
     asset."""
 
-    owner: Optional[Union[pystac.Item, pystac.Collection]]
+    owner: Optional[Union["Item_Type", "Collection_Type"]]
     """The :class:`~pystac.Item` or :class:`~pystac.Collection` that this asset belongs
     to, or ``None`` if it has no owner."""
 
-    properties: Optional[Dict[str, Any]]
-    """Optional, additional properties for this asset. This is used by extensions as a
+    extra_fields: Dict[str, Any]
+    """Optional, additional fields for this asset. This is used by extensions as a
     way to serialize and deserialize properties on asset object JSON."""
 
     def __init__(
@@ -63,18 +62,14 @@ class Asset:
         description: Optional[str] = None,
         media_type: Optional[str] = None,
         roles: Optional[List[str]] = None,
-        properties: Optional[Dict[str, Any]] = None,
+        extra_fields: Optional[Dict[str, Any]] = None,
     ) -> None:
         self.href = href
         self.title = title
         self.description = description
         self.media_type = media_type
         self.roles = roles
-
-        if properties is not None:
-            self.properties = properties
-        else:
-            self.properties = {}
+        self.extra_fields = extra_fields or {}
 
         # The Item which owns this Asset.
         self.owner = None
@@ -125,8 +120,8 @@ class Asset:
         if self.description is not None:
             d["description"] = self.description
 
-        if self.properties is not None and len(self.properties) > 0:
-            for k, v in self.properties.items():
+        if self.extra_fields is not None and len(self.extra_fields) > 0:
+            for k, v in self.extra_fields.items():
                 d[k] = v
 
         if self.roles is not None:
@@ -146,7 +141,7 @@ class Asset:
             description=self.description,
             media_type=self.media_type,
             roles=self.roles,
-            properties=self.properties,
+            extra_fields=self.extra_fields,
         )
 
     def __repr__(self) -> str:
@@ -175,5 +170,5 @@ class Asset:
             title=title,
             description=description,
             roles=roles,
-            properties=properties,
+            extra_fields=properties,
         )

--- a/pystac/extensions/datacube.py
+++ b/pystac/extensions/datacube.py
@@ -391,7 +391,7 @@ class AssetDatacubeExtension(DatacubeExtension[pystac.Asset]):
 
     def __init__(self, asset: pystac.Asset):
         self.asset_href = asset.href
-        self.properties = asset.properties
+        self.properties = asset.extra_fields
         if asset.owner and isinstance(asset.owner, pystac.Item):
             self.additional_read_properties = [asset.owner.properties]
         else:

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -408,9 +408,9 @@ class ItemEOExtension(EOExtension[pystac.Item]):
         if bands is None:
             asset_bands: List[Dict[str, Any]] = []
             for _, value in self.item.get_assets().items():
-                if BANDS_PROP in value.properties:
+                if BANDS_PROP in value.extra_fields:
                     asset_bands.extend(
-                        cast(List[Dict[str, Any]], value.properties.get(BANDS_PROP))
+                        cast(List[Dict[str, Any]], value.extra_fields.get(BANDS_PROP))
                     )
             if any(asset_bands):
                 bands = asset_bands
@@ -454,7 +454,7 @@ class AssetEOExtension(EOExtension[pystac.Asset]):
 
     def __init__(self, asset: pystac.Asset):
         self.asset_href = asset.href
-        self.properties = asset.properties
+        self.properties = asset.extra_fields
         if asset.owner and isinstance(asset.owner, pystac.Item):
             self.additional_read_properties = [asset.owner.properties]
 

--- a/pystac/extensions/file.py
+++ b/pystac/extensions/file.py
@@ -103,7 +103,7 @@ class FileExtension(PropertiesExtension, ExtensionManagementMixin[pystac.Item]):
 
     def __init__(self, asset: pystac.Asset):
         self.asset_href = asset.href
-        self.properties = asset.properties
+        self.properties = asset.extra_fields
         if asset.owner and isinstance(asset.owner, pystac.Item):
             self.additional_read_properties = [asset.owner.properties]
 

--- a/pystac/extensions/item_assets.py
+++ b/pystac/extensions/item_assets.py
@@ -76,7 +76,7 @@ class AssetDefinition:
             description=self.description,
             media_type=self.media_type,
             roles=self.roles,
-            properties={
+            extra_fields={
                 k: v
                 for k, v in self.properties.items()
                 if k

--- a/pystac/extensions/label.py
+++ b/pystac/extensions/label.py
@@ -619,15 +619,15 @@ class LabelExtension(ExtensionManagementMixin[pystac.Item]):
             assets : Optional list of assets that determine what
                 assets in the source item this label item data applies to.
         """
-        properties = None
+        extra_fields = None
         if assets is not None:
-            properties = {"label:assets": assets}
+            extra_fields = {"label:assets": assets}
         link = pystac.Link(
             "source",
             source_item,
             title=title,
             media_type=pystac.MediaType.JSON,
-            properties=properties,
+            extra_fields=extra_fields,
         )
         self.obj.add_link(link)
 

--- a/pystac/extensions/label.py
+++ b/pystac/extensions/label.py
@@ -665,7 +665,7 @@ class LabelExtension(ExtensionManagementMixin[pystac.Item]):
         self.obj.add_asset(
             "labels",
             pystac.Asset(
-                href=href, title=title, media_type=media_type, properties=properties
+                href=href, title=title, media_type=media_type, extra_fields=properties
             ),
         )
 

--- a/pystac/extensions/pointcloud.py
+++ b/pystac/extensions/pointcloud.py
@@ -552,7 +552,7 @@ class ItemPointcloudExtension(PointcloudExtension[pystac.Item]):
 class AssetPointcloudExtension(PointcloudExtension[pystac.Asset]):
     def __init__(self, asset: pystac.Asset):
         self.asset_href = asset.href
-        self.properties = asset.properties
+        self.properties = asset.extra_fields
         if asset.owner and isinstance(asset.owner, pystac.Item):
             self.additional_read_properties = [asset.owner.properties]
             self.repr_id = f"href={asset.href} item.id={asset.owner.id}"

--- a/pystac/extensions/projection.py
+++ b/pystac/extensions/projection.py
@@ -314,7 +314,7 @@ class AssetProjectionExtension(ProjectionExtension[pystac.Asset]):
 
     def __init__(self, asset: pystac.Asset):
         self.asset_href = asset.href
-        self.properties = asset.properties
+        self.properties = asset.extra_fields
         if asset.owner and isinstance(asset.owner, pystac.Item):
             self.additional_read_properties = [asset.owner.properties]
 

--- a/pystac/extensions/raster.py
+++ b/pystac/extensions/raster.py
@@ -647,7 +647,7 @@ class RasterExtension(PropertiesExtension, ExtensionManagementMixin[pystac.Item]
 
     def __init__(self, asset: pystac.Asset):
         self.asset_href = asset.href
-        self.properties = asset.properties
+        self.properties = asset.extra_fields
         if asset.owner and isinstance(asset.owner, pystac.Item):
             self.additional_read_properties = [asset.owner.properties]
 

--- a/pystac/extensions/sar.py
+++ b/pystac/extensions/sar.py
@@ -334,7 +334,7 @@ class ItemSarExtension(SarExtension[pystac.Item]):
 class AssetSarExtension(SarExtension[pystac.Asset]):
     def __init__(self, asset: pystac.Asset):
         self.asset_href = asset.href
-        self.properties = asset.properties
+        self.properties = asset.extra_fields
         if asset.owner and isinstance(asset.owner, pystac.Item):
             self.additional_read_properties = [asset.owner.properties]
 

--- a/pystac/extensions/sat.py
+++ b/pystac/extensions/sat.py
@@ -125,7 +125,7 @@ class ItemSatExtension(SatExtension[pystac.Item]):
 class AssetSatExtension(SatExtension[pystac.Asset]):
     def __init__(self, asset: pystac.Asset):
         self.asset_href = asset.href
-        self.properties = asset.properties
+        self.properties = asset.extra_fields
         if asset.owner and isinstance(asset.owner, pystac.Item):
             self.additional_read_properties = [asset.owner.properties]
 

--- a/pystac/extensions/timestamps.py
+++ b/pystac/extensions/timestamps.py
@@ -146,7 +146,7 @@ class ItemTimestampsExtension(TimestampsExtension[pystac.Item]):
 class AssetTimestampsExtension(TimestampsExtension[pystac.Asset]):
     def __init__(self, asset: pystac.Asset):
         self.asset_href = asset.href
-        self.properties = asset.properties
+        self.properties = asset.extra_fields
         if asset.owner and isinstance(asset.owner, pystac.Item):
             self.additional_read_properties = [asset.owner.properties]
 

--- a/pystac/extensions/view.py
+++ b/pystac/extensions/view.py
@@ -220,7 +220,7 @@ class AssetViewExtension(ViewExtension[pystac.Asset]):
 
     def __init__(self, asset: pystac.Asset):
         self.asset_href = asset.href
-        self.properties = asset.properties
+        self.properties = asset.extra_fields
         if asset.owner and isinstance(asset.owner, pystac.Item):
             self.additional_read_properties = [asset.owner.properties]
 

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -87,10 +87,10 @@ class CommonMetadata:
         Returns:
             datetime
         """
-        if asset is None or "start_datetime" not in asset.properties:
+        if asset is None or "start_datetime" not in asset.extra_fields:
             start_datetime = self.properties.get("start_datetime")
         else:
-            start_datetime = asset.properties.get("start_datetime")
+            start_datetime = asset.extra_fields.get("start_datetime")
 
         if start_datetime is None:
             return None
@@ -110,7 +110,7 @@ class CommonMetadata:
                 None if start_datetime is None else datetime_to_str(start_datetime)
             )
         else:
-            asset.properties["start_datetime"] = (
+            asset.extra_fields["start_datetime"] = (
                 None if start_datetime is None else datetime_to_str(start_datetime)
             )
 
@@ -138,10 +138,10 @@ class CommonMetadata:
         Returns:
             datetime
         """
-        if asset is None or "end_datetime" not in asset.properties:
+        if asset is None or "end_datetime" not in asset.extra_fields:
             end_datetime = self.properties.get("end_datetime")
         else:
-            end_datetime = asset.properties.get("end_datetime")
+            end_datetime = asset.extra_fields.get("end_datetime")
 
         if end_datetime is None:
             return None
@@ -161,7 +161,7 @@ class CommonMetadata:
                 None if end_datetime is None else datetime_to_str(end_datetime)
             )
         else:
-            asset.properties["end_datetime"] = (
+            asset.extra_fields["end_datetime"] = (
                 None if end_datetime is None else datetime_to_str(end_datetime)
             )
 
@@ -188,10 +188,10 @@ class CommonMetadata:
         Returns:
             str
         """
-        if asset is None or "license" not in asset.properties:
+        if asset is None or "license" not in asset.extra_fields:
             return self.properties.get("license")
         else:
-            return asset.properties.get("license")
+            return asset.extra_fields.get("license")
 
     def set_license(
         self, license: Optional[str], asset: Optional[Asset] = None
@@ -204,7 +204,7 @@ class CommonMetadata:
         if asset is None:
             self.properties["license"] = license
         else:
-            asset.properties["license"] = license
+            asset.extra_fields["license"] = license
 
     # Providers
     @property
@@ -231,10 +231,10 @@ class CommonMetadata:
         Returns:
             List[Provider]
         """
-        if asset is None or "providers" not in asset.properties:
+        if asset is None or "providers" not in asset.extra_fields:
             providers = self.properties.get("providers")
         else:
-            providers = asset.properties.get("providers")
+            providers = asset.extra_fields.get("providers")
 
         if providers is None:
             return None
@@ -257,10 +257,10 @@ class CommonMetadata:
                 self.properties["providers"] = providers_dicts
         else:
             if providers is None:
-                asset.properties.pop("providers", None)
+                asset.extra_fields.pop("providers", None)
             else:
                 providers_dicts = [d.to_dict() for d in providers]
-                asset.properties["providers"] = providers_dicts
+                asset.extra_fields["providers"] = providers_dicts
 
     # Instrument
     @property
@@ -286,10 +286,10 @@ class CommonMetadata:
         Returns:
             str
         """
-        if asset is None or "platform" not in asset.properties:
+        if asset is None or "platform" not in asset.extra_fields:
             return self.properties.get("platform")
         else:
-            return asset.properties.get("platform")
+            return asset.extra_fields.get("platform")
 
     def set_platform(
         self, platform: Optional[str], asset: Optional[Asset] = None
@@ -302,7 +302,7 @@ class CommonMetadata:
         if asset is None:
             self.properties["platform"] = platform
         else:
-            asset.properties["platform"] = platform
+            asset.extra_fields["platform"] = platform
 
     @property
     def instruments(self) -> Optional[List[str]]:
@@ -326,10 +326,10 @@ class CommonMetadata:
         Returns:
             Optional[List[str]]
         """
-        if asset is None or "instruments" not in asset.properties:
+        if asset is None or "instruments" not in asset.extra_fields:
             return self.properties.get("instruments")
         else:
-            return asset.properties.get("instruments")
+            return asset.extra_fields.get("instruments")
 
     def set_instruments(
         self, instruments: Optional[List[str]], asset: Optional[Asset] = None
@@ -342,7 +342,7 @@ class CommonMetadata:
         if asset is None:
             self.properties["instruments"] = instruments
         else:
-            asset.properties["instruments"] = instruments
+            asset.extra_fields["instruments"] = instruments
 
     @property
     def constellation(self) -> Optional[str]:
@@ -366,10 +366,10 @@ class CommonMetadata:
         Returns:
             str
         """
-        if asset is None or "constellation" not in asset.properties:
+        if asset is None or "constellation" not in asset.extra_fields:
             return self.properties.get("constellation")
         else:
-            return asset.properties.get("constellation")
+            return asset.extra_fields.get("constellation")
 
     def set_constellation(
         self, constellation: Optional[str], asset: Optional[Asset] = None
@@ -382,7 +382,7 @@ class CommonMetadata:
         if asset is None:
             self.properties["constellation"] = constellation
         else:
-            asset.properties["constellation"] = constellation
+            asset.extra_fields["constellation"] = constellation
 
     @property
     def mission(self) -> Optional[str]:
@@ -406,10 +406,10 @@ class CommonMetadata:
         Returns:
             str
         """
-        if asset is None or "mission" not in asset.properties:
+        if asset is None or "mission" not in asset.extra_fields:
             return self.properties.get("mission")
         else:
-            return asset.properties.get("mission")
+            return asset.extra_fields.get("mission")
 
     def set_mission(
         self, mission: Optional[str], asset: Optional[Asset] = None
@@ -422,7 +422,7 @@ class CommonMetadata:
         if asset is None:
             self.properties["mission"] = mission
         else:
-            asset.properties["mission"] = mission
+            asset.extra_fields["mission"] = mission
 
     @property
     def gsd(self) -> Optional[float]:
@@ -446,10 +446,10 @@ class CommonMetadata:
         Returns:
             float
         """
-        if asset is None or "gsd" not in asset.properties:
+        if asset is None or "gsd" not in asset.extra_fields:
             return self.properties.get("gsd")
         else:
-            return asset.properties.get("gsd")
+            return asset.extra_fields.get("gsd")
 
     def set_gsd(self, gsd: Optional[float], asset: Optional[Asset] = None) -> None:
         """Set an Item or an Asset gsd.
@@ -460,7 +460,7 @@ class CommonMetadata:
         if asset is None:
             self.properties["gsd"] = gsd
         else:
-            asset.properties["gsd"] = gsd
+            asset.extra_fields["gsd"] = gsd
 
     # Metadata
     @property
@@ -494,10 +494,10 @@ class CommonMetadata:
         Returns:
             datetime
         """
-        if asset is None or "created" not in asset.properties:
+        if asset is None or "created" not in asset.extra_fields:
             created = self.properties.get("created")
         else:
-            created = asset.properties.get("created")
+            created = asset.extra_fields.get("created")
 
         if created is None:
             return None
@@ -517,7 +517,7 @@ class CommonMetadata:
                 None if created is None else datetime_to_str(created)
             )
         else:
-            asset.properties["created"] = (
+            asset.extra_fields["created"] = (
                 None if created is None else datetime_to_str(created)
             )
 
@@ -560,10 +560,10 @@ class CommonMetadata:
         Returns:
             datetime
         """
-        if asset is None or "updated" not in asset.properties:
+        if asset is None or "updated" not in asset.extra_fields:
             updated = self.properties.get("updated")
         else:
-            updated = asset.properties.get("updated")
+            updated = asset.extra_fields.get("updated")
 
         if updated is None:
             return None
@@ -583,7 +583,7 @@ class CommonMetadata:
                 None if updated is None else datetime_to_str(updated)
             )
         else:
-            asset.properties["updated"] = (
+            asset.extra_fields["updated"] = (
                 None if updated is None else datetime_to_str(updated)
             )
 
@@ -731,10 +731,10 @@ class Item(STACObject):
         Returns:
             datetime or None
         """
-        if asset is None or "datetime" not in asset.properties:
+        if asset is None or "datetime" not in asset.extra_fields:
             return self.datetime
         else:
-            asset_dt = asset.properties.get("datetime")
+            asset_dt = asset.extra_fields.get("datetime")
             if asset_dt is None:
                 return None
             else:
@@ -749,7 +749,7 @@ class Item(STACObject):
         if asset is None:
             self.datetime = datetime
         else:
-            asset.properties["datetime"] = datetime_to_str(datetime)
+            asset.extra_fields["datetime"] = datetime_to_str(datetime)
 
     def get_assets(self) -> Dict[str, Asset]:
         """Get this item's assets.

--- a/pystac/link.py
+++ b/pystac/link.py
@@ -46,26 +46,32 @@ class Link:
         properties : Optional, additional properties for this link. This is used
             by extensions as a way to serialize and deserialize properties on link
             object JSON.
-
-    Attributes:
-        rel : The relation of the link (e.g. 'child', 'item'). Registered rel Types
-            are preferred. See :class:`~pystac.RelType` for common media types.
-        target : The target of the link. If the link is
-            unresolved, or the link is to something that is not a STACObject,
-            the target is an HREF. If resolved, the target is a STACObject.
-        media_type : Optional description of the media type.
-            Registered Media Types are preferred. See
-            :class:`~pystac.MediaType` for common media types.
-        title : Optional title for this link.
-        properties : Optional, additional properties for this link.
-            This is used by extensions as a way to serialize and deserialize properties
-            on link object JSON.
-        owner : The owner of this link. The link will use
-            its owner's root catalog
-            :class:`~pystac.resolved_object_cache.ResolvedObjectCache` to resolve
-            objects, and will create absolute HREFs from relative HREFs against
-            the owner's self HREF.
     """
+
+    rel: Union[str, pystac.RelType]
+    """The relation of the link (e.g. 'child', 'item'). Registered rel Types are
+    preferred. See :class:`~pystac.RelType` for common media types."""
+
+    target: Union[str, "STACObject_Type"]
+    """The target of the link. If the link is unresolved, or the link is to something
+    that is not a STACObject, the target is an HREF. If resolved, the target is a
+    STACObject."""
+
+    media_type: Optional[str]
+    """Optional description of the media type. Registered Media Types are preferred.
+    See :class:`~pystac.MediaType` for common media types."""
+
+    title: Optional[str]
+    """Optional title for this link."""
+
+    properties: Optional[Dict[str, Any]]
+    """Optional, additional properties for this link. This is used by extensions as a
+    way to serialize and deserialize properties on link object JSON."""
+
+    owner: Optional["STACObject_Type"]
+    """The owner of this link. The link will use its owner's root catalog
+    :class:`~pystac.resolved_object_cache.ResolvedObjectCache` to resolve objects, and
+    will create absolute HREFs from relative HREFs against the owner's self HREF."""
 
     def __init__(
         self,
@@ -76,11 +82,11 @@ class Link:
         properties: Optional[Dict[str, Any]] = None,
     ) -> None:
         self.rel = rel
-        self.target: Union[str, "STACObject_Type"] = target  # An object or an href
+        self.target = target
         self.media_type = media_type
         self.title = title
         self.properties = properties
-        self.owner: Optional["STACObject_Type"] = None
+        self.owner = None
 
     def set_owner(self, owner: Optional["STACObject_Type"]) -> "Link":
         """Sets the owner of this link.

--- a/pystac/link.py
+++ b/pystac/link.py
@@ -43,7 +43,7 @@ class Link:
         media_type : Optional description of the media type. Registered Media Types
             are preferred. See :class:`~pystac.MediaType` for common media types.
         title : Optional title for this link.
-        properties : Optional, additional properties for this link. This is used
+        extra_fields : Optional, additional fields for this link. This is used
             by extensions as a way to serialize and deserialize properties on link
             object JSON.
     """
@@ -64,8 +64,8 @@ class Link:
     title: Optional[str]
     """Optional title for this link."""
 
-    properties: Optional[Dict[str, Any]]
-    """Optional, additional properties for this link. This is used by extensions as a
+    extra_fields: Dict[str, Any]
+    """Optional, additional fields for this link. This is used by extensions as a
     way to serialize and deserialize properties on link object JSON."""
 
     owner: Optional["STACObject_Type"]
@@ -79,13 +79,13 @@ class Link:
         target: Union[str, "STACObject_Type"],
         media_type: Optional[str] = None,
         title: Optional[str] = None,
-        properties: Optional[Dict[str, Any]] = None,
+        extra_fields: Optional[Dict[str, Any]] = None,
     ) -> None:
         self.rel = rel
         self.target = target
         self.media_type = media_type
         self.title = title
-        self.properties = properties
+        self.extra_fields = extra_fields or {}
         self.owner = None
 
     def set_owner(self, owner: Optional["STACObject_Type"]) -> "Link":
@@ -260,9 +260,8 @@ class Link:
         if self.title is not None:
             d["title"] = self.title
 
-        if self.properties:
-            for k, v in self.properties.items():
-                d[k] = v
+        for k, v in self.extra_fields.items():
+            d[k] = v
 
         return d
 
@@ -299,16 +298,16 @@ class Link:
         media_type = d.pop("type", None)
         title = d.pop("title", None)
 
-        properties = None
+        extra_fields = None
         if any(d):
-            properties = d
+            extra_fields = d
 
         return Link(
             rel=rel,
             target=href,
             media_type=media_type,
             title=title,
-            properties=properties,
+            extra_fields=extra_fields,
         )
 
     @staticmethod

--- a/tests/extensions/test_custom.py
+++ b/tests/extensions/test_custom.py
@@ -94,7 +94,7 @@ class ItemCustomExtension(CustomExtension[pystac.Item]):
 class AssetCustomExtension(CustomExtension[pystac.Asset]):
     def __init__(self, asset: pystac.Asset) -> None:
         self.catalog = asset
-        self.properties = asset.properties
+        self.properties = asset.extra_fields
         if asset.owner:
             if isinstance(asset.owner, pystac.Item):
                 self.additional_read_properties = [asset.owner.properties]

--- a/tests/extensions/test_eo.py
+++ b/tests/extensions/test_eo.py
@@ -161,7 +161,7 @@ class EOTest(unittest.TestCase):
         EOExtension.ext(asset).bands = new_bands
         item.add_asset("test", asset)
 
-        self.assertEqual(len(item.assets["test"].properties["eo:bands"]), 3)
+        self.assertEqual(len(item.assets["test"].extra_fields["eo:bands"]), 3)
 
     def test_cloud_cover(self) -> None:
         item = pystac.Item.from_file(self.LANDSAT_EXAMPLE_URI)

--- a/tests/extensions/test_pointcloud.py
+++ b/tests/extensions/test_pointcloud.py
@@ -270,7 +270,7 @@ class PointcloudTest(unittest.TestCase):
         pc_item.add_asset("data", asset)
         ext = AssetPointcloudExtension(asset)
         self.assertEqual(ext.asset_href, asset.href)
-        self.assertEqual(ext.properties, asset.properties)
+        self.assertEqual(ext.properties, asset.extra_fields)
         self.assertEqual(ext.additional_read_properties, [pc_item.properties])
 
     def test_ext(self) -> None:

--- a/tests/extensions/test_raster.py
+++ b/tests/extensions/test_raster.py
@@ -137,13 +137,15 @@ class RasterTest(unittest.TestCase):
         RasterExtension.ext(asset).bands = new_bands
         item.add_asset("test", asset)
 
-        self.assertEqual(len(item.assets["test"].properties["raster:bands"]), 3)
+        self.assertEqual(len(item.assets["test"].extra_fields["raster:bands"]), 3)
         self.assertEqual(
-            item.assets["test"].properties["raster:bands"][1]["statistics"]["minimum"],
+            item.assets["test"].extra_fields["raster:bands"][1]["statistics"][
+                "minimum"
+            ],
             -1,
         )
         self.assertEqual(
-            item.assets["test"].properties["raster:bands"][1]["histogram"]["min"],
+            item.assets["test"].extra_fields["raster:bands"][1]["histogram"]["min"],
             3848.354901960784,
         )
 
@@ -195,7 +197,9 @@ class RasterTest(unittest.TestCase):
         )
         RasterExtension.ext(item.assets["test"]).apply(new_bands)
         self.assertEqual(
-            item.assets["test"].properties["raster:bands"][0]["statistics"]["minimum"],
+            item.assets["test"].extra_fields["raster:bands"][0]["statistics"][
+                "minimum"
+            ],
             1,
         )
 

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -34,10 +34,10 @@ class ItemTest(unittest.TestCase):
 
         # test asset creation additional field(s)
         self.assertEqual(
-            item.assets["analytic"].properties["product"],
+            item.assets["analytic"].extra_fields["product"],
             "http://cool-sat.com/catalog/products/analytic.json",
         )
-        self.assertEqual(len(item.assets["thumbnail"].properties), 0)
+        self.assertEqual(len(item.assets["thumbnail"].extra_fields), 0)
 
         # test that the parameter is preserved
         self.assertEqual(param_dict, item_dict)

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -58,7 +58,7 @@ class LinkTest(unittest.TestCase):
         rel = "my rel"
         target = "../elsewhere"
         mime_type = "example/stac_thing"
-        link = pystac.Link(rel, target, mime_type, "a title", properties={"a": "b"})
+        link = pystac.Link(rel, target, mime_type, "a title", extra_fields={"a": "b"})
         expected_dict = {
             "rel": rel,
             "href": target,


### PR DESCRIPTION
**Related Issue(s):**

* #479 (see [this comment](https://github.com/stac-utils/pystac/issues/479#issuecomment-869968926))
* #321


**Description:**

Adds type annotations for `Link` and `Asset` attributes and uses these in API documentation. Changes `properties` to `extra_fields` for `Link` and `Asset` classes to use more consistent naming across PySTAC classes. 

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.