### PR TITLE
Update Timestamps Extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 -  `LabelMethod` enum in `pystac.extensions.label` with recommended values for
   `"label:methods"` field ([#484](https://github.com/stac-utils/pystac/pull/484))
 - Label Extension summaries ([#484](https://github.com/stac-utils/pystac/pull/484))
+- Timestamps Extension summaries ([#513](https://github.com/stac-utils/pystac/pull/513))
+- Define equality and `__repr__` of `RangeSummary` instances based on `to_dict`
+  representation ([#513](https://github.com/stac-utils/pystac/pull/513))
 
 ### Changed
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -536,17 +536,29 @@ ItemScientificExtension
 Timestamps Extension
 --------------------
 
-Implements the :stac-ext:`Timestamps Extension <timestamps>`.
+These classes are representations of the :stac-ext:`Timestamps Extension Spec
+<timestamps>`.
 
-TimestampsItemExt
-~~~~~~~~~~~~~~~~~
+TimestampsExtension
+~~~~~~~~~~~~~~~~~~~
 
-**TEMPORARILY REMOVED**
+.. autoclass:: pystac.extensions.timestamps.TimestampsExtension
+   :members:
+   :show-inheritance:
 
-.. .. autoclass:: pystac.extensions.timestamps.TimestampsItemExt
-..    :members:
-..    :undoc-members:
-..    :show-inheritance:
+ItemTimestampsExtension
+~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: pystac.extensions.timestamps.ItemTimestampsExtension
+   :members:
+   :show-inheritance:
+
+AssetTimestampsExtension
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: pystac.extensions.timestamps.AssetTimestampsExtension
+   :members:
+   :show-inheritance:
 
 SAR Extension
 -------------

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -278,10 +278,11 @@ class EOExtension(
     Generic[T], PropertiesExtension, ExtensionManagementMixin[pystac.Item]
 ):
     """An abstract class that can be used to extend the properties of an
-    :class:`~pystac.Item` or :class:`~pystac.Collection` with properties from the
+    :class:`~pystac.Item` or :class:`~pystac.Asset` with properties from the
     :stac-ext:`Electro-Optical Extension <eo>`. This class is generic over the type of
     STAC Object to be extended (e.g. :class:`~pystac.Item`,
-    :class:`~pystac.Collection`).
+    :class:`~pystac.
+    Asset`).
 
     To create a concrete instance of :class:`EOExtension`, use the
     :meth:`EOExtension.ext` method. For example:

--- a/pystac/extensions/timestamps.py
+++ b/pystac/extensions/timestamps.py
@@ -4,12 +4,14 @@ https://github.com/stac-extensions/timestamps
 """
 
 from datetime import datetime as Datetime
+from pystac.summaries import RangeSummary
 from typing import Dict, Any, Generic, Iterable, Optional, Set, TypeVar, cast
 
 import pystac
 from pystac.extensions.base import (
     ExtensionManagementMixin,
     PropertiesExtension,
+    SummariesExtension,
 )
 from pystac.extensions.hooks import ExtensionHooks
 from pystac.utils import datetime_to_str, map_opt, str_to_datetime
@@ -139,6 +141,11 @@ class TimestampsExtension(
                 f"Timestamps extension does not apply to type '{type(obj).__name__}'"
             )
 
+    @staticmethod
+    def summaries(obj: pystac.Collection) -> "SummariesTimestampsExtension":
+        """Returns the extended summaries object for the given collection."""
+        return SummariesTimestampsExtension(obj)
+
 
 class ItemTimestampsExtension(TimestampsExtension[pystac.Item]):
     """A concrete implementation of :class:`TimestampsExtension` on an
@@ -190,6 +197,88 @@ class AssetTimestampsExtension(TimestampsExtension[pystac.Asset]):
 
     def __repr__(self) -> str:
         return "<AssetTimestampsExtension Asset href={}>".format(self.asset_href)
+
+
+class SummariesTimestampsExtension(SummariesExtension):
+    """A concrete implementation of :class:`~SummariesExtension` that extends
+    the ``summaries`` field of a :class:`~pystac.Collection` to include properties
+    defined in the :stac-ext:`Timestamps Extension <timestamps>`.
+    """
+
+    @property
+    def published(self) -> Optional[RangeSummary[Datetime]]:
+        """Get or sets the summary of :attr:`TimestampsExtension.published` values
+        for this Collection.
+        """
+
+        return map_opt(
+            lambda s: RangeSummary(
+                str_to_datetime(s.minimum), str_to_datetime(s.maximum)
+            ),
+            self.summaries.get_range(PUBLISHED_PROP),
+        )
+
+    @published.setter
+    def published(self, v: Optional[RangeSummary[Datetime]]) -> None:
+        self._set_summary(
+            PUBLISHED_PROP,
+            map_opt(
+                lambda s: RangeSummary(
+                    datetime_to_str(s.minimum), datetime_to_str(s.maximum)
+                ),
+                v,
+            ),
+        )
+
+    @property
+    def expires(self) -> Optional[RangeSummary[Datetime]]:
+        """Get or sets the summary of :attr:`TimestampsExtension.expires` values
+        for this Collection.
+        """
+
+        return map_opt(
+            lambda s: RangeSummary(
+                str_to_datetime(s.minimum), str_to_datetime(s.maximum)
+            ),
+            self.summaries.get_range(EXPIRES_PROP),
+        )
+
+    @expires.setter
+    def expires(self, v: Optional[RangeSummary[Datetime]]) -> None:
+        self._set_summary(
+            EXPIRES_PROP,
+            map_opt(
+                lambda s: RangeSummary(
+                    datetime_to_str(s.minimum), datetime_to_str(s.maximum)
+                ),
+                v,
+            ),
+        )
+
+    @property
+    def unpublished(self) -> Optional[RangeSummary[Datetime]]:
+        """Get or sets the summary of :attr:`TimestampsExtension.unpublished` values
+        for this Collection.
+        """
+
+        return map_opt(
+            lambda s: RangeSummary(
+                str_to_datetime(s.minimum), str_to_datetime(s.maximum)
+            ),
+            self.summaries.get_range(UNPUBLISHED_PROP),
+        )
+
+    @unpublished.setter
+    def unpublished(self, v: Optional[RangeSummary[Datetime]]) -> None:
+        self._set_summary(
+            UNPUBLISHED_PROP,
+            map_opt(
+                lambda s: RangeSummary(
+                    datetime_to_str(s.minimum), datetime_to_str(s.maximum)
+                ),
+                v,
+            ),
+        )
 
 
 class TimestampsExtensionHooks(ExtensionHooks):

--- a/pystac/summaries.py
+++ b/pystac/summaries.py
@@ -59,6 +59,15 @@ class RangeSummary(Generic[T]):
         maximum: T = get_required(d.get("maximum"), "RangeSummary", "maximum")
         return cls(minimum=minimum, maximum=maximum)
 
+    def __eq__(self, o: object) -> bool:
+        if not isinstance(o, RangeSummary):
+            return NotImplemented
+
+        return self.to_dict() == o.to_dict()
+
+    def __repr__(self) -> str:
+        return self.to_dict().__repr__()
+
 
 FIELDS_JSON_URL = (
     "https://cdn.jsdelivr.net/npm/@radiantearth/stac-fields/fields-normalized.json"

--- a/tests/test_summaries.py
+++ b/tests/test_summaries.py
@@ -2,7 +2,7 @@ import socket
 from typing import Any
 import unittest
 
-from pystac.summaries import Summarizer, Summaries
+from pystac.summaries import RangeSummary, Summarizer, Summaries
 from tests.utils import TestCases
 
 
@@ -58,3 +58,21 @@ class SummariesTest(unittest.TestCase):
         coll = TestCases.test_case_5()
         summaries = Summarizer().summarize(coll.get_all_items())
         self.assertFalse(summaries.is_empty())
+
+
+class RangeSummaryTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.maxDiff = None
+
+    def test_repr(self) -> None:
+        rs = RangeSummary(5, 10)
+        self.assertEqual("{'minimum': 5, 'maximum': 10}", rs.__repr__())
+
+    def test_equality(self) -> None:
+        rs_1 = RangeSummary(5, 10)
+        rs_2 = RangeSummary(5, 10)
+        rs_3 = RangeSummary(5, 11)
+
+        self.assertEqual(rs_1, rs_2)
+        self.assertNotEqual(rs_1, rs_3)
+        self.assertNotEqual(rs_1, (5, 10))


### PR DESCRIPTION
**Related Issue(s):**

* #326
* #327

**Description:**

* Update docstring and adds Summaries for Timestamps Extension
* Defines equality and `__repr__` for `RangeSummary` (cherry picked from #509, so there should be no conflict)

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.