### PR TITLE
chore: Remove unused `__str__` methods

### DIFF
--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -37,9 +37,6 @@ if TYPE_CHECKING:
 
 
 class CatalogType(str, Enum):
-    def __str__(self) -> str:
-        return str(self.value)
-
     SELF_CONTAINED = "SELF_CONTAINED"
     """A 'self-contained catalog' is one that is designed for portability.
     Users may want to download an online catalog from and be able to use it on their

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -412,9 +412,6 @@ class Extent:
 class ProviderRole(str, Enum):
     """Enumerates the allows values of the Provider "role" field."""
 
-    def __str__(self) -> str:
-        return str(self.value)
-
     LICENSOR = "licensor"
     PRODUCER = "producer"
     PROCESSOR = "processor"

--- a/pystac/extensions/file.py
+++ b/pystac/extensions/file.py
@@ -30,9 +30,6 @@ class ByteOrder(str, Enum):
     """List of allows values for the ``"file:byte_order"`` field defined by the
     :stac-ext:`File Info Extension <file>`."""
 
-    def __str__(self) -> str:
-        return str(self.value)
-
     LITTLE_ENDIAN = "little-endian"
     BIG_ENDIAN = "big-endian"
 

--- a/pystac/extensions/label.py
+++ b/pystac/extensions/label.py
@@ -32,18 +32,12 @@ class LabelRelType(str, Enum):
     documentation for details.
     """
 
-    def __str__(self) -> str:
-        return str(self.value)
-
     SOURCE = "source"
     """Used to indicate a link to the source item to which a label item applies."""
 
 
 class LabelType(str, Enum):
     """Enumerates valid label types ("raster" or "vector")."""
-
-    def __str__(self) -> str:
-        return str(self.value)
 
     VECTOR = "vector"
     RASTER = "raster"
@@ -55,9 +49,6 @@ class LabelType(str, Enum):
 class LabelTask(str, Enum):
     """Enumerates recommended values for "label:tasks" field."""
 
-    def __str__(self) -> str:
-        return str(self.value)
-
     REGRESSION = "regression"
     CLASSIFICATION = "classification"
     DETECTION = "detection"
@@ -66,9 +57,6 @@ class LabelTask(str, Enum):
 
 class LabelMethod(str, Enum):
     """Enumerates recommended values for "label:methods" field."""
-
-    def __str__(self) -> str:
-        return str(self.value)
 
     AUTOMATED = "automated"
     MANUAL = "manual"

--- a/pystac/extensions/raster.py
+++ b/pystac/extensions/raster.py
@@ -20,17 +20,11 @@ BANDS_PROP = "raster:bands"
 
 
 class Sampling(str, enum.Enum):
-    def __str__(self) -> str:
-        return str(self.value)
-
     AREA = "area"
     POINT = "point"
 
 
 class DataType(str, enum.Enum):
-    def __str__(self) -> str:
-        return str(self.value)
-
     INT8 = "int8"
     INT16 = "int16"
     INT32 = "int32"

--- a/pystac/extensions/scientific.py
+++ b/pystac/extensions/scientific.py
@@ -42,9 +42,6 @@ class ScientificRelType(str, Enum):
     <scientific#relation-types>` documentation for details.
     """
 
-    def __str__(self) -> str:
-        return str(self.value)
-
     CITE_AS = "cite-as"
     """Used to indicate a link to the publication referenced by the ``sci:doi``
     field."""

--- a/pystac/extensions/version.py
+++ b/pystac/extensions/version.py
@@ -30,9 +30,6 @@ class VersionRelType(str, Enum):
     <https://github.com/stac-extensions/version#relation-types>`__ documentation
     for details."""
 
-    def __str__(self) -> str:
-        return str(self.value)
-
     LATEST = "latest-version"
     """Indicates a link pointing to a resource containing the latest version."""
 

--- a/pystac/media_type.py
+++ b/pystac/media_type.py
@@ -4,9 +4,6 @@ from enum import Enum
 class MediaType(str, Enum):
     """A list of common media types that can be used in STAC Asset and Link metadata."""
 
-    def __str__(self) -> str:
-        return str(self.value)
-
     COG = "image/tiff; application=geotiff; profile=cloud-optimized"
     GEOJSON = "application/geo+json"
     GEOPACKAGE = "application/geopackage+sqlite3"

--- a/pystac/rel_type.py
+++ b/pystac/rel_type.py
@@ -12,9 +12,6 @@ class RelType(str, Enum):
     specific to those STAC objects.
     """
 
-    def __str__(self) -> str:
-        return str(self.value)
-
     ALTERNATE = "alternate"
     CANONICAL = "canonical"
     CHILD = "child"

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -12,9 +12,6 @@ if TYPE_CHECKING:
 
 
 class STACObjectType(str, Enum):
-    def __str__(self) -> str:
-        return str(self.value)
-
     CATALOG = "Catalog"
     COLLECTION = "Collection"
     ITEM = "Feature"

--- a/pystac/utils.py
+++ b/pystac/utils.py
@@ -40,9 +40,6 @@ def safe_urlparse(href: str) -> URLParseResult:
 class JoinType(str, Enum):
     """Allowed join types for the :func:`_join` function."""
 
-    def __str__(self) -> str:
-        return str(self.value)
-
     @staticmethod
     def from_parsed_uri(parsed_uri: URLParseResult) -> "JoinType":
         """Determines the appropriate join type based on the scheme of the parsed

--- a/tests/extensions/test_file.py
+++ b/tests/extensions/test_file.py
@@ -9,8 +9,8 @@ from pystac.extensions.file import FileExtension, ByteOrder, MappingObject
 
 class ByteOrderTest(unittest.TestCase):
     def test_to_str(self) -> None:
-        self.assertEqual(str(ByteOrder.LITTLE_ENDIAN), "little-endian")
-        self.assertEqual(str(ByteOrder.BIG_ENDIAN), "big-endian")
+        self.assertEqual(ByteOrder.LITTLE_ENDIAN.value, "little-endian")
+        self.assertEqual(ByteOrder.BIG_ENDIAN.value, "big-endian")
 
 
 class MappingObjectTest(unittest.TestCase):

--- a/tests/extensions/test_label.py
+++ b/tests/extensions/test_label.py
@@ -24,21 +24,21 @@ from tests.utils import TestCases, assert_to_from_dict
 
 class LabelTypeTest(unittest.TestCase):
     def test_to_str(self) -> None:
-        self.assertEqual(str(LabelType.VECTOR), "vector")
-        self.assertEqual(str(LabelType.RASTER), "raster")
+        self.assertEqual(LabelType.VECTOR.value, "vector")
+        self.assertEqual(LabelType.RASTER.value, "raster")
 
 
 class LabelRelTypeTest(unittest.TestCase):
     def test_rel_types(self) -> None:
-        self.assertEqual(str(LabelRelType.SOURCE), "source")
+        self.assertEqual(LabelRelType.SOURCE.value, "source")
 
 
 class LabelTaskTest(unittest.TestCase):
     def test_rel_types(self) -> None:
-        self.assertEqual(str(LabelTask.REGRESSION), "regression")
-        self.assertEqual(str(LabelTask.CLASSIFICATION), "classification")
-        self.assertEqual(str(LabelTask.DETECTION), "detection")
-        self.assertEqual(str(LabelTask.SEGMENTATION), "segmentation")
+        self.assertEqual(LabelTask.REGRESSION.value, "regression")
+        self.assertEqual(LabelTask.CLASSIFICATION.value, "classification")
+        self.assertEqual(LabelTask.DETECTION.value, "detection")
+        self.assertEqual(LabelTask.SEGMENTATION.value, "segmentation")
 
 
 class LabelCountTest(unittest.TestCase):

--- a/tests/extensions/test_version.py
+++ b/tests/extensions/test_version.py
@@ -49,9 +49,9 @@ class ItemVersionExtensionTest(unittest.TestCase):
         self.example_item_uri = TestCases.get_path("data-files/version/item.json")
 
     def test_rel_types(self) -> None:
-        self.assertEqual(str(VersionRelType.LATEST), "latest-version")
-        self.assertEqual(str(VersionRelType.PREDECESSOR), "predecessor-version")
-        self.assertEqual(str(VersionRelType.SUCCESSOR), "successor-version")
+        self.assertEqual(VersionRelType.LATEST.value, "latest-version")
+        self.assertEqual(VersionRelType.PREDECESSOR.value, "predecessor-version")
+        self.assertEqual(VersionRelType.SUCCESSOR.value, "successor-version")
 
     def test_stac_extensions(self) -> None:
         self.assertTrue(VersionExtension.has_extension(self.item))


### PR DESCRIPTION
They were only accessed by tests.

**Related Issue(s):** #505


**Description:**


**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.