### PR TITLE
tests: Trust method signature to be accurate

### DIFF
--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -169,9 +169,7 @@ class ItemTest(unittest.TestCase):
         )
 
     def test_read_eo_item_owns_asset(self) -> None:
-        item = next(
-            x for x in TestCases.test_case_1().get_all_items() if isinstance(x, Item)
-        )
+        item = next(iter(TestCases.test_case_1().get_all_items()))
         assert len(item.assets) > 0
         for asset_key in item.assets:
             self.assertEqual(item.assets[asset_key].owner, item)


### PR DESCRIPTION
`Catalog.get_all_items` is contracted to return `Iterable[Item]`, so we
shouldn't have to filter the response.

**Related Issue(s):** #331 


**Description:**


**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.