### PR TITLE
refactor: Reintroduce linting to `__init__` files

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,4 @@
 [flake8]
 max-line-length = 88
 extend-ignore = E203, W503, E731, E722
+per-file-ignores = __init__.py:F401

--- a/pystac/__init__.py
+++ b/pystac/__init__.py
@@ -2,7 +2,6 @@
 PySTAC is a library for working with SpatioTemporal Asset Catalogs (STACs)
 """
 
-# flake8: noqa
 from pystac.errors import (
     STACError,
     STACTypeError,
@@ -113,12 +112,12 @@ def write_file(
     """Writes a STACObject to a file.
 
     This will write only the Catalog, Collection or Item ``obj``. It will not attempt
-    to write any other objects that are linked to ``obj``; if you'd like functionality to
-    save off catalogs recursively see :meth:`Catalog.save <pystac.Catalog.save>`.
+    to write any other objects that are linked to ``obj``; if you'd like functionality
+    to save off catalogs recursively see :meth:`Catalog.save <pystac.Catalog.save>`.
 
-    This method will write the JSON of the object to the object's assigned "self" link or
-    to the dest_href if provided. To set the self link, see :meth:`STACObject.set_self_href
-    <pystac.STACObject.set_self_href>`.
+    This method will write the JSON of the object to the object's assigned "self" link
+    or to the dest_href if provided. To set the self link, see
+    :meth:`STACObject.set_self_href <pystac.STACObject.set_self_href>`.
 
     Convenience method for :meth:`STACObject.from_file <pystac.STACObject.from_file>`
 

--- a/pystac/serialization/__init__.py
+++ b/pystac/serialization/__init__.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 from pystac.serialization.identify import (
     STACVersionRange,
     identify_stac_object,

--- a/pystac/validation/__init__.py
+++ b/pystac/validation/__init__.py
@@ -1,4 +1,3 @@
-# flake8: noqa
 from typing import Dict, List, Any, Optional, cast, TYPE_CHECKING
 
 import pystac
@@ -47,8 +46,9 @@ def validate_dict(
 ) -> List[Any]:
     """Validate a stac object serialized as JSON into a dict.
 
-    This method delegates to the call to :meth:`pystac.validation.STACValidator.validate`
-    for the STACValidator registered via :meth:`~pystac.validation.set_validator` or
+    This method delegates to the call to
+    :meth:`pystac.validation.STACValidator.validate` for the STACValidator registered
+    via :meth:`~pystac.validation.set_validator` or
     :class:`~pystac.validation.JsonSchemaSTACValidator` by default.
 
     Args:
@@ -56,8 +56,9 @@ def validate_dict(
         stac_object_type : The stac object type of the object encoded in stac_dict.
             One of :class:`~pystac.STACObjectType`. If not supplied, this will use
             PySTAC's identification logic to identify the object type.
-        stac_version : The version of STAC to validate the object against. If not supplied,
-            this will use PySTAC's identification logic to identify the stac version
+        stac_version : The version of STAC to validate the object against. If not
+            supplied, this will use PySTAC's identification logic to identify the stac
+            version
         extensions : Extension IDs for this stac object. If not supplied,
             PySTAC's identification logic to identify the extensions.
         href : Optional HREF of the STAC object being validated.
@@ -120,8 +121,8 @@ def validate_all(
             the StacIO.default() instance is used.
 
     Raises:
-        STACValidationError: This will raise a STACValidationError if this or any contained
-            catalog, collection or item has a validation error.
+        STACValidationError: This will raise a STACValidationError if this or any
+            contained catalog, collection or item has a validation error.
     """
     if stac_io is None:
         stac_io = pystac.StacIO.default()
@@ -165,9 +166,10 @@ class RegisteredValidator:
                 import jsonschema
             except ImportError:
                 raise Exception(
-                    'Cannot validate with default validator because package "jsonschema" '
-                    "is not installed. Install pystac with the validation optional requirements "
-                    "(e.g. pip install pystac[validation]) to install jsonschema"
+                    "Cannot validate with default validator because package"
+                    ' "jsonschema" is not installed. Install pystac with the validation'
+                    " optional requirements (e.g. pip install pystac[validation]) to"
+                    " install jsonschema"
                 )
             cls._validator = JsonSchemaSTACValidator()
 

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,5 +1,3 @@
-# flake8: noqa
-
 from typing import Any, Dict, TYPE_CHECKING, Type
 import unittest
 from tests.utils.test_cases import (


### PR DESCRIPTION
By only ignoring error 401 ("imported but unused") we can lint these
files for any other issues.

**Related Issue(s):**


**Description:**


**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.