### PR TITLE
refactor: Change some `set()` calls into literals

### DIFF
--- a/pystac/extensions/datacube.py
+++ b/pystac/extensions/datacube.py
@@ -4,7 +4,7 @@ https://github.com/stac-extensions/datacube
 """
 
 from abc import ABC
-from typing import Any, Dict, Generic, List, Optional, Set, TypeVar, Union, cast
+from typing import Any, Dict, Generic, List, Optional, TypeVar, Union, cast
 
 import pystac
 from pystac.extensions.base import (
@@ -403,10 +403,11 @@ class AssetDatacubeExtension(DatacubeExtension[pystac.Asset]):
 
 class DatacubeExtensionHooks(ExtensionHooks):
     schema_uri: str = SCHEMA_URI
-    prev_extension_ids: Set[str] = set(["datacube"])
-    stac_object_types: Set[pystac.STACObjectType] = set(
-        [pystac.STACObjectType.COLLECTION, pystac.STACObjectType.ITEM]
-    )
+    prev_extension_ids = {"datacube"}
+    stac_object_types = {
+        pystac.STACObjectType.COLLECTION,
+        pystac.STACObjectType.ITEM,
+    }
 
 
 DATACUBE_EXTENSION_HOOKS: ExtensionHooks = DatacubeExtensionHooks()

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -10,7 +10,6 @@ from typing import (
     Iterable,
     List,
     Optional,
-    Set,
     Tuple,
     TypeVar,
     cast,
@@ -498,8 +497,8 @@ class SummariesEOExtension(SummariesExtension):
 
 class EOExtensionHooks(ExtensionHooks):
     schema_uri: str = SCHEMA_URI
-    prev_extension_ids: Set[str] = set(["eo"])
-    stac_object_types: Set[pystac.STACObjectType] = set([pystac.STACObjectType.ITEM])
+    prev_extension_ids = {"eo"}
+    stac_object_types = {pystac.STACObjectType.ITEM}
 
     def migrate(
         self, obj: Dict[str, Any], version: STACVersionID, info: STACJSONDescription

--- a/pystac/extensions/file.py
+++ b/pystac/extensions/file.py
@@ -4,7 +4,7 @@ https://github.com/stac-extensions/file
 """
 
 from enum import Enum
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional
 
 import pystac
 from pystac.extensions.base import ExtensionManagementMixin, PropertiesExtension
@@ -212,8 +212,8 @@ class FileExtension(PropertiesExtension, ExtensionManagementMixin[pystac.Item]):
 
 class FileExtensionHooks(ExtensionHooks):
     schema_uri: str = SCHEMA_URI
-    prev_extension_ids: Set[str] = set(["file"])
-    stac_object_types: Set[pystac.STACObjectType] = set([pystac.STACObjectType.ITEM])
+    prev_extension_ids = {"file"}
+    stac_object_types = {pystac.STACObjectType.ITEM}
 
     def migrate(
         self, obj: Dict[str, Any], version: STACVersionID, info: STACJSONDescription

--- a/pystac/extensions/item_assets.py
+++ b/pystac/extensions/item_assets.py
@@ -3,7 +3,7 @@
 https://github.com/stac-extensions/item-assets
 """
 
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional
 
 import pystac
 from pystac.extensions.base import ExtensionManagementMixin
@@ -80,14 +80,12 @@ class AssetDefinition:
                 k: v
                 for k, v in self.properties.items()
                 if k
-                not in set(
-                    [
-                        ASSET_TITLE_PROP,
-                        ASSET_DESC_PROP,
-                        ASSET_TYPE_PROP,
-                        ASSET_ROLES_PROP,
-                    ]
-                )
+                not in {
+                    ASSET_TITLE_PROP,
+                    ASSET_DESC_PROP,
+                    ASSET_TYPE_PROP,
+                    ASSET_ROLES_PROP,
+                }
             },
         )
 
@@ -132,10 +130,8 @@ class ItemAssetsExtension(ExtensionManagementMixin[pystac.Collection]):
 
 class ItemAssetsExtensionHooks(ExtensionHooks):
     schema_uri: str = SCHEMA_URI
-    prev_extension_ids: Set[str] = set(["asset", "item-assets"])
-    stac_object_types: Set[pystac.STACObjectType] = set(
-        [pystac.STACObjectType.COLLECTION]
-    )
+    prev_extension_ids = {"asset", "item-assets"}
+    stac_object_types = {pystac.STACObjectType.COLLECTION}
 
     def migrate(
         self, obj: Dict[str, Any], version: STACVersionID, info: STACJSONDescription

--- a/pystac/extensions/label.py
+++ b/pystac/extensions/label.py
@@ -5,7 +5,7 @@ https://github.com/stac-extensions/label
 
 from enum import Enum
 from pystac.extensions.base import ExtensionManagementMixin, SummariesExtension
-from typing import Any, Dict, Iterable, List, Optional, Set, Union, cast
+from typing import Any, Dict, Iterable, List, Optional, Union, cast
 
 import pystac
 from pystac.serialization.identify import STACJSONDescription, STACVersionID
@@ -793,8 +793,8 @@ class SummariesLabelExtension(SummariesExtension):
 
 class LabelExtensionHooks(ExtensionHooks):
     schema_uri: str = SCHEMA_URI
-    prev_extension_ids: Set[str] = set(["label"])
-    stac_object_types: Set[pystac.STACObjectType] = set([pystac.STACObjectType.ITEM])
+    prev_extension_ids = {"label"}
+    stac_object_types = {pystac.STACObjectType.ITEM}
 
     def get_object_links(
         self, so: pystac.STACObject

--- a/pystac/extensions/pointcloud.py
+++ b/pystac/extensions/pointcloud.py
@@ -3,7 +3,7 @@
 https://github.com/stac-extensions/pointcloud
 """
 
-from typing import Any, Dict, Generic, List, Optional, Set, TypeVar, cast
+from typing import Any, Dict, Generic, List, Optional, TypeVar, cast
 
 import pystac
 from pystac.extensions.base import (
@@ -565,8 +565,8 @@ class AssetPointcloudExtension(PointcloudExtension[pystac.Asset]):
 
 class PointcloudExtensionHooks(ExtensionHooks):
     schema_uri: str = SCHEMA_URI
-    prev_extension_ids: Set[str] = set(["pointcloud"])
-    stac_object_types: Set[pystac.STACObjectType] = set([pystac.STACObjectType.ITEM])
+    prev_extension_ids = {"pointcloud"}
+    stac_object_types = {pystac.STACObjectType.ITEM}
 
 
 POINTCLOUD_EXTENSION_HOOKS: ExtensionHooks = PointcloudExtensionHooks()

--- a/pystac/extensions/projection.py
+++ b/pystac/extensions/projection.py
@@ -3,7 +3,7 @@
 https://github.com/stac-extensions/projection
 """
 
-from typing import Any, Dict, Generic, Iterable, List, Optional, Set, TypeVar, cast
+from typing import Any, Dict, Generic, Iterable, List, Optional, TypeVar, cast
 
 import pystac
 from pystac.extensions.hooks import ExtensionHooks
@@ -342,8 +342,8 @@ class SummariesProjectionExtension(SummariesExtension):
 
 class ProjectionExtensionHooks(ExtensionHooks):
     schema_uri: str = SCHEMA_URI
-    prev_extension_ids: Set[str] = set(["proj", "projection"])
-    stac_object_types: Set[pystac.STACObjectType] = set([pystac.STACObjectType.ITEM])
+    prev_extension_ids = {"proj", "projection"}
+    stac_object_types = {pystac.STACObjectType.ITEM}
 
 
 PROJECTION_EXTENSION_HOOKS: ExtensionHooks = ProjectionExtensionHooks()

--- a/pystac/extensions/sar.py
+++ b/pystac/extensions/sar.py
@@ -4,7 +4,7 @@ https://github.com/stac-extensions/sar
 """
 
 import enum
-from typing import Any, Dict, Generic, List, Optional, Set, TypeVar, cast
+from typing import Any, Dict, Generic, List, Optional, TypeVar, cast
 
 import pystac
 from pystac.serialization.identify import STACJSONDescription, STACVersionID
@@ -344,8 +344,8 @@ class AssetSarExtension(SarExtension[pystac.Asset]):
 
 class SarExtensionHooks(ExtensionHooks):
     schema_uri = SCHEMA_URI
-    prev_extension_ids: Set[str] = set(["sar"])
-    stac_object_types: Set[pystac.STACObjectType] = set([pystac.STACObjectType.ITEM])
+    prev_extension_ids = {"sar"}
+    stac_object_types = {pystac.STACObjectType.ITEM}
 
     def migrate(
         self, obj: Dict[str, Any], version: STACVersionID, info: STACJSONDescription

--- a/pystac/extensions/sat.py
+++ b/pystac/extensions/sat.py
@@ -6,7 +6,7 @@ https://github.com/stac-extensions/sat
 import enum
 from datetime import datetime as Datetime
 from pystac.summaries import RangeSummary
-from typing import Dict, Any, List, Generic, Iterable, Optional, Set, TypeVar, cast
+from typing import Dict, Any, List, Iterable, Generic, Optional, TypeVar, cast
 
 import pystac
 from pystac.extensions.base import (
@@ -292,8 +292,8 @@ class SummariesSatExtension(SummariesExtension):
 
 class SatExtensionHooks(ExtensionHooks):
     schema_uri: str = SCHEMA_URI
-    prev_extension_ids: Set[str] = set(["sat"])
-    stac_object_types: Set[pystac.STACObjectType] = set([pystac.STACObjectType.ITEM])
+    prev_extension_ids = {"sat"}
+    stac_object_types = {pystac.STACObjectType.ITEM}
 
 
 SAT_EXTENSION_HOOKS: ExtensionHooks = SatExtensionHooks()

--- a/pystac/extensions/scientific.py
+++ b/pystac/extensions/scientific.py
@@ -9,7 +9,7 @@ https://doi.org/10.1000/182
 
 import copy
 from enum import Enum
-from typing import Any, Dict, Generic, List, Optional, Set, TypeVar, Union, cast
+from typing import Any, Dict, Generic, List, Optional, TypeVar, Union, cast
 from urllib import parse
 
 import pystac
@@ -350,10 +350,8 @@ class SummariesScientificExtension(SummariesExtension):
 
 class ScientificExtensionHooks(ExtensionHooks):
     schema_uri: str = SCHEMA_URI
-    prev_extension_ids: Set[str] = set(["scientific"])
-    stac_object_types: Set[pystac.STACObjectType] = set(
-        [pystac.STACObjectType.COLLECTION, pystac.STACObjectType.ITEM]
-    )
+    prev_extension_ids = {"scientific"}
+    stac_object_types = {pystac.STACObjectType.COLLECTION, pystac.STACObjectType.ITEM}
 
 
 SCIENTIFIC_EXTENSION_HOOKS: ExtensionHooks = ScientificExtensionHooks()

--- a/pystac/extensions/timestamps.py
+++ b/pystac/extensions/timestamps.py
@@ -5,7 +5,7 @@ https://github.com/stac-extensions/timestamps
 
 from datetime import datetime as Datetime
 from pystac.summaries import RangeSummary
-from typing import Dict, Any, Generic, Iterable, Optional, Set, TypeVar, cast
+from typing import Dict, Any, Iterable, Generic, Optional, TypeVar, cast
 
 import pystac
 from pystac.extensions.base import (
@@ -283,8 +283,8 @@ class SummariesTimestampsExtension(SummariesExtension):
 
 class TimestampsExtensionHooks(ExtensionHooks):
     schema_uri: str = SCHEMA_URI
-    prev_extension_ids: Set[str] = set(["timestamps"])
-    stac_object_types: Set[pystac.STACObjectType] = set([pystac.STACObjectType.ITEM])
+    prev_extension_ids = {"timestamps"}
+    stac_object_types = {pystac.STACObjectType.ITEM}
 
 
 TIMESTAMPS_EXTENSION_HOOKS: ExtensionHooks = TimestampsExtensionHooks()

--- a/pystac/extensions/version.py
+++ b/pystac/extensions/version.py
@@ -4,7 +4,7 @@ https://github.com/stac-extensions/version
 """
 from enum import Enum
 from pystac.utils import get_required, map_opt
-from typing import Generic, List, Optional, Set, TypeVar, Union, cast
+from typing import Generic, List, Optional, TypeVar, Union, cast
 
 import pystac
 from pystac.extensions.base import (
@@ -264,10 +264,8 @@ class ItemVersionExtension(VersionExtension[pystac.Item]):
 
 class VersionExtensionHooks(ExtensionHooks):
     schema_uri = SCHEMA_URI
-    prev_extension_ids: Set[str] = set(["version"])
-    stac_object_types: Set[pystac.STACObjectType] = set(
-        [pystac.STACObjectType.COLLECTION, pystac.STACObjectType.ITEM]
-    )
+    prev_extension_ids = {"version"}
+    stac_object_types = {pystac.STACObjectType.COLLECTION, pystac.STACObjectType.ITEM}
 
     def get_object_links(self, so: pystac.STACObject) -> Optional[List[str]]:
         if isinstance(so, pystac.Collection) or isinstance(so, pystac.Item):

--- a/pystac/extensions/view.py
+++ b/pystac/extensions/view.py
@@ -3,7 +3,7 @@
 https://github.com/stac-extensions/view
 """
 
-from typing import Any, Dict, Generic, Iterable, Optional, Set, TypeVar, cast
+from typing import Any, Dict, Generic, Iterable, Optional, TypeVar, cast
 
 import pystac
 from pystac.summaries import RangeSummary
@@ -292,8 +292,8 @@ class SummariesViewExtension(SummariesExtension):
 
 class ViewExtensionHooks(ExtensionHooks):
     schema_uri = SCHEMA_URI
-    prev_extension_ids: Set[str] = set(["view"])
-    stac_object_types: Set[pystac.STACObjectType] = set([pystac.STACObjectType.ITEM])
+    prev_extension_ids = {"view"}
+    stac_object_types = {pystac.STACObjectType.ITEM}
 
 
 VIEW_EXTENSION_HOOKS: ExtensionHooks = ViewExtensionHooks()

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -409,9 +409,10 @@ class STACObject(ABC):
 
         This method mutates the entire catalog tree.
         """
-        link_rels = set(self._object_links()) | set(
-            [pystac.RelType.ROOT, pystac.RelType.PARENT]
-        )
+        link_rels = set(self._object_links()) | {
+            pystac.RelType.ROOT,
+            pystac.RelType.PARENT,
+        }
 
         for link in self.links:
             if link.rel in link_rels:


### PR DESCRIPTION
Also removed their type annotations since they were inferred by mypy.

**Related Issue(s):** #


**Description:**


**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.