### PR TITLE
feat: Introduce isort

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,3 @@
+[settings]
+case_sensitive = true
+profile = black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,6 +33,13 @@ repos:
         stages: [commit]
         types: [python]
 
+      - id: isort
+        name: isort
+        entry: isort
+        language: system
+        stages: [commit]
+        types: [python]
+
       - id: mypy
         name: mypy
         entry: mypy

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,13 +13,13 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
-import sys
 import subprocess
+import sys
 from typing import Any, Dict
 
 sys.path.insert(0, os.path.abspath("."))
 sys.path.insert(0, os.path.abspath("../"))
-from pystac.version import __version__, STACVersion  # noqa:E402
+from pystac.version import STACVersion, __version__  # noqa:E402
 
 git_branch = (
     subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"])

--- a/pystac/__init__.py
+++ b/pystac/__init__.py
@@ -2,48 +2,12 @@
 PySTAC is a library for working with SpatioTemporal Asset Catalogs (STACs)
 """
 
-from pystac.errors import (
-    STACError,
-    STACTypeError,
-    DuplicateObjectKeyError,
-    ExtensionAlreadyExistsError,
-    ExtensionNotImplemented,
-    ExtensionTypeError,
-    RequiredPropertyMissing,
-    STACValidationError,
-)
-
 from typing import Any, Dict, Optional
-from pystac.version import (
-    __version__,
-    get_stac_version,
-    set_stac_version,
-)
-from pystac.media_type import MediaType
-from pystac.rel_type import RelType
-from pystac.stac_io import StacIO
-from pystac.stac_object import STACObject, STACObjectType
-from pystac.link import Link, HIERARCHICAL_LINKS
-from pystac.catalog import Catalog, CatalogType
-from pystac.collection import (
-    Collection,
-    Extent,
-    SpatialExtent,
-    TemporalExtent,
-    Provider,
-    ProviderRole,
-    Summaries,
-)
-from pystac.summaries import RangeSummary
-from pystac.item import Item, Asset, CommonMetadata
-from pystac.item_collection import ItemCollection
 
-import pystac.validation
-
-import pystac.extensions.hooks
 import pystac.extensions.datacube
 import pystac.extensions.eo
 import pystac.extensions.file
+import pystac.extensions.hooks
 import pystac.extensions.item_assets
 import pystac.extensions.label
 import pystac.extensions.pointcloud
@@ -54,6 +18,36 @@ import pystac.extensions.scientific
 import pystac.extensions.timestamps
 import pystac.extensions.version
 import pystac.extensions.view
+import pystac.validation
+from pystac.catalog import Catalog, CatalogType
+from pystac.collection import (
+    Collection,
+    Extent,
+    Provider,
+    ProviderRole,
+    SpatialExtent,
+    Summaries,
+    TemporalExtent,
+)
+from pystac.errors import (
+    DuplicateObjectKeyError,
+    ExtensionAlreadyExistsError,
+    ExtensionNotImplemented,
+    ExtensionTypeError,
+    RequiredPropertyMissing,
+    STACError,
+    STACTypeError,
+    STACValidationError,
+)
+from pystac.item import Asset, CommonMetadata, Item
+from pystac.item_collection import ItemCollection
+from pystac.link import HIERARCHICAL_LINKS, Link
+from pystac.media_type import MediaType
+from pystac.rel_type import RelType
+from pystac.stac_io import StacIO
+from pystac.stac_object import STACObject, STACObjectType
+from pystac.summaries import RangeSummary
+from pystac.version import __version__, get_stac_version, set_stac_version
 
 EXTENSION_HOOKS = pystac.extensions.hooks.RegisteredExtensionHooks(
     [

--- a/pystac/asset.py
+++ b/pystac/asset.py
@@ -1,5 +1,5 @@
 from copy import copy
-from typing import Any, Dict, List, Optional, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from pystac.utils import is_absolute_href, make_absolute_href
 

--- a/pystac/cache.py
+++ b/pystac/cache.py
@@ -1,12 +1,12 @@
 from collections import ChainMap
 from copy import copy
-from typing import Any, Dict, List, Optional, TYPE_CHECKING, Tuple, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, cast
 
 import pystac
 
 if TYPE_CHECKING:
-    from pystac.stac_object import STACObject as STACObject_Type
     from pystac.collection import Collection as Collection_Type
+    from pystac.stac_object import STACObject as STACObject_Type
 
 
 def get_cache_key(stac_object: "STACObject_Type") -> Tuple[str, bool]:

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -1,39 +1,40 @@
 import os
 from copy import deepcopy
 from enum import Enum
-from pystac.errors import STACTypeError
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
     Iterable,
     List,
     Optional,
-    TYPE_CHECKING,
     Tuple,
     Union,
     cast,
 )
 
 import pystac
-from pystac.stac_object import STACObject, STACObjectType
+from pystac.cache import ResolvedObjectCache
+from pystac.errors import STACTypeError
 from pystac.layout import (
     BestPracticesLayoutStrategy,
     HrefLayoutStrategy,
     LayoutTemplate,
 )
 from pystac.link import Link
-from pystac.cache import ResolvedObjectCache
 from pystac.serialization import (
-    identify_stac_object_type,
     identify_stac_object,
+    identify_stac_object_type,
     migrate_to_latest,
 )
+from pystac.stac_object import STACObject, STACObjectType
 from pystac.utils import is_absolute_href, make_absolute_href
 
 if TYPE_CHECKING:
-    from pystac.item import Asset as Asset_Type, Item as Item_Type
     from pystac.collection import Collection as Collection_Type
+    from pystac.item import Asset as Asset_Type
+    from pystac.item import Item as Item_Type
 
 
 class CatalogType(str, Enum):

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -1,14 +1,13 @@
 from copy import deepcopy
 from datetime import datetime
 from enum import Enum
-from pystac.errors import STACTypeError
 from typing import (
+    TYPE_CHECKING,
     Any,
     Dict,
     Iterable,
     List,
     Optional,
-    TYPE_CHECKING,
     Tuple,
     TypeVar,
     Union,
@@ -19,18 +18,19 @@ import dateutil.parser
 from dateutil import tz
 
 import pystac
-from pystac import STACObjectType, CatalogType
+from pystac import CatalogType, STACObjectType
 from pystac.asset import Asset
 from pystac.catalog import Catalog
+from pystac.errors import STACTypeError
 from pystac.layout import HrefLayoutStrategy
 from pystac.link import Link
-from pystac.utils import datetime_to_str
 from pystac.serialization import (
-    identify_stac_object_type,
     identify_stac_object,
+    identify_stac_object_type,
     migrate_to_latest,
 )
 from pystac.summaries import Summaries
+from pystac.utils import datetime_to_str
 
 if TYPE_CHECKING:
     from pystac.item import Item as Item_Type

--- a/pystac/extensions/base.py
+++ b/pystac/extensions/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Generic, Iterable, List, Optional, Dict, Any, Type, TypeVar, Union
+from typing import Any, Dict, Generic, Iterable, List, Optional, Type, TypeVar, Union
 
 import pystac
 

--- a/pystac/extensions/datacube.py
+++ b/pystac/extensions/datacube.py
@@ -7,10 +7,7 @@ from abc import ABC
 from typing import Any, Dict, Generic, List, Optional, TypeVar, Union, cast
 
 import pystac
-from pystac.extensions.base import (
-    ExtensionManagementMixin,
-    PropertiesExtension,
-)
+from pystac.extensions.base import ExtensionManagementMixin, PropertiesExtension
 from pystac.extensions.hooks import ExtensionHooks
 from pystac.utils import get_required, map_opt
 

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -3,28 +3,18 @@
 https://github.com/stac-extensions/eo
 """
 
-from typing import (
-    Any,
-    Dict,
-    Generic,
-    Iterable,
-    List,
-    Optional,
-    Tuple,
-    TypeVar,
-    cast,
-)
+from typing import Any, Dict, Generic, Iterable, List, Optional, Tuple, TypeVar, cast
 
 import pystac
-from pystac.summaries import RangeSummary
+from pystac.extensions import view
 from pystac.extensions.base import (
     ExtensionManagementMixin,
     PropertiesExtension,
     SummariesExtension,
 )
 from pystac.extensions.hooks import ExtensionHooks
-from pystac.extensions import view
 from pystac.serialization.identify import STACJSONDescription, STACVersionID
+from pystac.summaries import RangeSummary
 from pystac.utils import get_required, map_opt
 
 T = TypeVar("T", pystac.Item, pystac.Asset)

--- a/pystac/extensions/hooks.py
+++ b/pystac/extensions/hooks.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from functools import lru_cache
-from typing import Any, Dict, Iterable, List, Optional, Set, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Set, Union
 
 import pystac
 from pystac.serialization.identify import STACJSONDescription, STACVersionID

--- a/pystac/extensions/label.py
+++ b/pystac/extensions/label.py
@@ -4,12 +4,12 @@ https://github.com/stac-extensions/label
 """
 
 from enum import Enum
-from pystac.extensions.base import ExtensionManagementMixin, SummariesExtension
 from typing import Any, Dict, Iterable, List, Optional, Union, cast
 
 import pystac
-from pystac.serialization.identify import STACJSONDescription, STACVersionID
+from pystac.extensions.base import ExtensionManagementMixin, SummariesExtension
 from pystac.extensions.hooks import ExtensionHooks
+from pystac.serialization.identify import STACJSONDescription, STACVersionID
 from pystac.utils import get_required, map_opt
 
 SCHEMA_URI = "https://stac-extensions.github.io/label/v1.0.0/schema.json"

--- a/pystac/extensions/pointcloud.py
+++ b/pystac/extensions/pointcloud.py
@@ -6,10 +6,7 @@ https://github.com/stac-extensions/pointcloud
 from typing import Any, Dict, Generic, List, Optional, TypeVar, cast
 
 import pystac
-from pystac.extensions.base import (
-    ExtensionManagementMixin,
-    PropertiesExtension,
-)
+from pystac.extensions.base import ExtensionManagementMixin, PropertiesExtension
 from pystac.extensions.hooks import ExtensionHooks
 from pystac.utils import map_opt
 

--- a/pystac/extensions/projection.py
+++ b/pystac/extensions/projection.py
@@ -6,12 +6,12 @@ https://github.com/stac-extensions/projection
 from typing import Any, Dict, Generic, Iterable, List, Optional, TypeVar, cast
 
 import pystac
-from pystac.extensions.hooks import ExtensionHooks
 from pystac.extensions.base import (
     ExtensionManagementMixin,
     PropertiesExtension,
     SummariesExtension,
 )
+from pystac.extensions.hooks import ExtensionHooks
 
 T = TypeVar("T", pystac.Item, pystac.Asset)
 

--- a/pystac/extensions/sar.py
+++ b/pystac/extensions/sar.py
@@ -7,9 +7,9 @@ import enum
 from typing import Any, Dict, Generic, List, Optional, TypeVar, cast
 
 import pystac
-from pystac.serialization.identify import STACJSONDescription, STACVersionID
 from pystac.extensions.base import ExtensionManagementMixin, PropertiesExtension
 from pystac.extensions.hooks import ExtensionHooks
+from pystac.serialization.identify import STACJSONDescription, STACVersionID
 from pystac.utils import get_required, map_opt
 
 T = TypeVar("T", pystac.Item, pystac.Asset)

--- a/pystac/extensions/sat.py
+++ b/pystac/extensions/sat.py
@@ -5,8 +5,7 @@ https://github.com/stac-extensions/sat
 
 import enum
 from datetime import datetime as Datetime
-from pystac.summaries import RangeSummary
-from typing import Dict, Any, List, Iterable, Generic, Optional, TypeVar, cast
+from typing import Any, Dict, Generic, Iterable, List, Optional, TypeVar, cast
 
 import pystac
 from pystac.extensions.base import (
@@ -15,7 +14,8 @@ from pystac.extensions.base import (
     SummariesExtension,
 )
 from pystac.extensions.hooks import ExtensionHooks
-from pystac.utils import str_to_datetime, datetime_to_str, map_opt
+from pystac.summaries import RangeSummary
+from pystac.utils import datetime_to_str, map_opt, str_to_datetime
 
 T = TypeVar("T", pystac.Item, pystac.Asset)
 

--- a/pystac/extensions/timestamps.py
+++ b/pystac/extensions/timestamps.py
@@ -4,8 +4,7 @@ https://github.com/stac-extensions/timestamps
 """
 
 from datetime import datetime as datetime
-from pystac.summaries import RangeSummary
-from typing import Dict, Any, Iterable, Generic, Optional, TypeVar, cast
+from typing import Any, Dict, Generic, Iterable, Optional, TypeVar, cast
 
 import pystac
 from pystac.extensions.base import (
@@ -14,6 +13,7 @@ from pystac.extensions.base import (
     SummariesExtension,
 )
 from pystac.extensions.hooks import ExtensionHooks
+from pystac.summaries import RangeSummary
 from pystac.utils import datetime_to_str, map_opt, str_to_datetime
 
 T = TypeVar("T", pystac.Item, pystac.Asset)

--- a/pystac/extensions/version.py
+++ b/pystac/extensions/version.py
@@ -3,15 +3,12 @@
 https://github.com/stac-extensions/version
 """
 from enum import Enum
-from pystac.utils import get_required, map_opt
 from typing import Generic, List, Optional, TypeVar, Union, cast
 
 import pystac
-from pystac.extensions.base import (
-    ExtensionManagementMixin,
-    PropertiesExtension,
-)
+from pystac.extensions.base import ExtensionManagementMixin, PropertiesExtension
 from pystac.extensions.hooks import ExtensionHooks
+from pystac.utils import get_required, map_opt
 
 T = TypeVar("T", pystac.Collection, pystac.Item)
 

--- a/pystac/extensions/view.py
+++ b/pystac/extensions/view.py
@@ -6,13 +6,13 @@ https://github.com/stac-extensions/view
 from typing import Any, Dict, Generic, Iterable, Optional, TypeVar, cast
 
 import pystac
-from pystac.summaries import RangeSummary
 from pystac.extensions.base import (
     ExtensionManagementMixin,
     PropertiesExtension,
     SummariesExtension,
 )
 from pystac.extensions.hooks import ExtensionHooks
+from pystac.summaries import RangeSummary
 
 T = TypeVar("T", pystac.Item, pystac.Asset)
 

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -1,6 +1,5 @@
 from copy import copy, deepcopy
 from datetime import datetime as Datetime
-from pystac.catalog import Catalog
 from typing import Any, Dict, List, Optional, Union, cast
 
 import dateutil.parser
@@ -8,21 +7,22 @@ import dateutil.parser
 import pystac
 from pystac import STACError, STACObjectType
 from pystac.asset import Asset
+from pystac.catalog import Catalog
+from pystac.collection import Collection, Provider
 from pystac.link import Link
 from pystac.serialization import (
-    identify_stac_object_type,
     identify_stac_object,
+    identify_stac_object_type,
     migrate_to_latest,
 )
 from pystac.stac_object import STACObject
 from pystac.utils import (
+    datetime_to_str,
     is_absolute_href,
     make_absolute_href,
     make_relative_href,
-    datetime_to_str,
     str_to_datetime,
 )
-from pystac.collection import Collection, Provider
 
 
 class CommonMetadata:

--- a/pystac/item_collection.py
+++ b/pystac/item_collection.py
@@ -1,11 +1,10 @@
 from copy import deepcopy
-from pystac.errors import STACTypeError
-from typing import Any, Dict, Iterator, List, Optional, Collection, Iterable, Union
+from typing import Any, Collection, Dict, Iterable, Iterator, List, Optional, Union
 
 import pystac
-from pystac.utils import make_absolute_href, is_absolute_href
+from pystac.errors import STACTypeError
 from pystac.serialization.identify import identify_stac_object_type
-
+from pystac.utils import is_absolute_href, make_absolute_href
 
 ItemLike = Union[pystac.Item, Dict[str, Any]]
 

--- a/pystac/layout.py
+++ b/pystac/layout.py
@@ -1,16 +1,16 @@
-from abc import abstractmethod, ABC
+from abc import ABC, abstractmethod
 from collections import OrderedDict
 from string import Formatter
-from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 import pystac
-from pystac.utils import safe_urlparse, join_path_or_url, JoinType
+from pystac.utils import JoinType, join_path_or_url, safe_urlparse
 
 if TYPE_CHECKING:
-    from pystac.stac_object import STACObject as STACObject_Type
     from pystac.catalog import Catalog as Catalog_Type
     from pystac.collection import Collection as Collection_Type
     from pystac.item import Item as Item_Type
+    from pystac.stac_object import STACObject as STACObject_Type
 
 
 class TemplateError(Exception):

--- a/pystac/link.py
+++ b/pystac/link.py
@@ -1,14 +1,14 @@
 from copy import copy
-from typing import Any, Dict, Optional, TYPE_CHECKING, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union, cast
 
 import pystac
-from pystac.utils import make_absolute_href, make_relative_href, is_absolute_href
+from pystac.utils import is_absolute_href, make_absolute_href, make_relative_href
 
 if TYPE_CHECKING:
-    from pystac.stac_object import STACObject as STACObject_Type
-    from pystac.item import Item as Item_Type
     from pystac.catalog import Catalog as Catalog_Type
     from pystac.collection import Collection as Collection_Type
+    from pystac.item import Item as Item_Type
+    from pystac.stac_object import STACObject as STACObject_Type
 
 HIERARCHICAL_LINKS = [
     pystac.RelType.ROOT,

--- a/pystac/serialization/__init__.py
+++ b/pystac/serialization/__init__.py
@@ -1,7 +1,7 @@
+from pystac.serialization.common_properties import merge_common_properties
 from pystac.serialization.identify import (
     STACVersionRange,
     identify_stac_object,
     identify_stac_object_type,
 )
-from pystac.serialization.common_properties import merge_common_properties
 from pystac.serialization.migrate import migrate_to_latest

--- a/pystac/serialization/identify.py
+++ b/pystac/serialization/identify.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from functools import total_ordering
-from typing import Any, Dict, Optional, Set, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Set, Union
 
 import pystac
 from pystac.version import STACVersion

--- a/pystac/serialization/migrate.py
+++ b/pystac/serialization/migrate.py
@@ -1,13 +1,13 @@
 from copy import deepcopy
-from typing import Any, Callable, Dict, List, Optional, Set, TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple
 
 import pystac
-from pystac.version import STACVersion
 from pystac.serialization.identify import (
     OldExtensionShortIDs,
     STACJSONDescription,
     STACVersionID,
 )
+from pystac.version import STACVersion
 
 if TYPE_CHECKING:
     from pystac import STACObjectType as STACObjectType_Type

--- a/pystac/stac_io.py
+++ b/pystac/stac_io.py
@@ -1,28 +1,18 @@
-from abc import ABC, abstractmethod
-import os
 import json
-from typing import (
-    Any,
-    Dict,
-    List,
-    Optional,
-    TYPE_CHECKING,
-    Tuple,
-    Type,
-    Union,
-)
-
-from urllib.request import urlopen
+import os
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
 from urllib.error import HTTPError
+from urllib.request import urlopen
 
 import pystac
-from pystac.utils import safe_urlparse
 from pystac.serialization import (
-    merge_common_properties,
-    identify_stac_object_type,
     identify_stac_object,
+    identify_stac_object_type,
+    merge_common_properties,
     migrate_to_latest,
 )
+from pystac.utils import safe_urlparse
 
 # Use orjson if available
 try:
@@ -31,9 +21,9 @@ except ImportError:
     orjson = None  # type: ignore[assignment]
 
 if TYPE_CHECKING:
-    from pystac.stac_object import STACObject as STACObject_Type
     from pystac.catalog import Catalog as Catalog_Type
     from pystac.link import Link as Link_Type
+    from pystac.stac_object import STACObject as STACObject_Type
 
 
 class StacIO(ABC):

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from enum import Enum
-from typing import Any, Dict, Iterable, List, Optional, Type, cast, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Type, Union, cast
 
 import pystac
 from pystac import STACError

--- a/pystac/summaries.py
+++ b/pystac/summaries.py
@@ -1,22 +1,21 @@
-import sys
 import numbers
+import sys
 from enum import Enum
 from functools import lru_cache
-
-import pystac
-from pystac.utils import get_required
-
 from typing import (
+    TYPE_CHECKING,
     Any,
     Dict,
     Generic,
+    Iterable,
     List,
     Optional,
-    Union,
     TypeVar,
-    Iterable,
-    TYPE_CHECKING,
+    Union,
 )
+
+import pystac
+from pystac.utils import get_required
 
 if sys.version_info >= (3, 8):
     from typing import Protocol

--- a/pystac/utils.py
+++ b/pystac/utils.py
@@ -1,11 +1,14 @@
 import os
 import posixpath
-from enum import Enum
-from pystac.errors import RequiredPropertyMissing
-from typing import Any, Callable, Dict, List, Optional, TypeVar, Union
-from urllib.parse import urljoin, urlparse, urlunparse, ParseResult as URLParseResult
 from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Callable, Dict, List, Optional, TypeVar, Union
+from urllib.parse import ParseResult as URLParseResult
+from urllib.parse import urljoin, urlparse, urlunparse
+
 import dateutil.parser
+
+from pystac.errors import RequiredPropertyMissing
 
 # Allow for modifying the path library for testability
 # (i.e. testing Windows path manipulation on non-Windows systems)

--- a/pystac/validation/__init__.py
+++ b/pystac/validation/__init__.py
@@ -1,9 +1,9 @@
-from typing import Dict, List, Any, Optional, cast, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
 
 import pystac
 from pystac.serialization.identify import STACVersionID, identify_stac_object
-from pystac.validation.schema_uri_map import OldExtensionSchemaUriMap
 from pystac.utils import make_absolute_href
+from pystac.validation.schema_uri_map import OldExtensionSchemaUriMap
 
 if TYPE_CHECKING:
     from pystac.stac_object import STACObject as STACObject_Type
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 
 # Import after above class definition
-from pystac.validation.stac_validator import STACValidator, JsonSchemaSTACValidator
+from pystac.validation.stac_validator import JsonSchemaSTACValidator, STACValidator
 
 
 def validate(stac_object: "STACObject_Type") -> List[Any]:

--- a/pystac/validation/schema_uri_map.py
+++ b/pystac/validation/schema_uri_map.py
@@ -1,10 +1,10 @@
 from abc import ABC, abstractmethod
 from functools import lru_cache
-from pystac.serialization.identify import OldExtensionShortIDs, STACVersionID
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import pystac
 from pystac.serialization import STACVersionRange
+from pystac.serialization.identify import OldExtensionShortIDs, STACVersionID
 from pystac.stac_object import STACObjectType
 
 

--- a/pystac/validation/stac_validator.py
+++ b/pystac/validation/stac_validator.py
@@ -1,16 +1,16 @@
-from abc import ABC, abstractmethod
-import logging
 import json
-from pystac.stac_object import STACObjectType
+import logging
+from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Tuple
 
 import pystac
+from pystac.stac_object import STACObjectType
 from pystac.validation.schema_uri_map import DefaultSchemaUriMap, SchemaUriMap
 
 try:
     import jsonschema
-    import jsonschema.validators
     import jsonschema.exceptions
+    import jsonschema.validators
 except ImportError:
     jsonschema = None
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,7 @@
 mypy==0.910
 flake8==3.9.2
 black==21.6b0
+isort==5.9.1
 
 codespell==2.1.0
 

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 import os
-from setuptools import setup, find_packages
 from glob import glob
-
 from os.path import basename, splitext
+
+from setuptools import find_packages, setup
 
 here = os.path.abspath(os.path.dirname(__file__))
 

--- a/tests/data-files/change_stac_version.py
+++ b/tests/data-files/change_stac_version.py
@@ -2,10 +2,10 @@
 Script to change the version property of the test files for PySTAC.
 This is used when upgrading to a new version of STAC.
 """
-import os
-import re
 import argparse
 import json
+import os
+import re
 
 import pystac
 

--- a/tests/data-files/get_examples.py
+++ b/tests/data-files/get_examples.py
@@ -2,11 +2,11 @@
 Script to download the examples from the stac-spec repository.
 This is used when upgrading to a new version of STAC.
 """
-import os
 import argparse
 import json
-from subprocess import call
+import os
 import tempfile
+from subprocess import call
 from typing import Any, Dict, List, Optional
 from urllib.error import HTTPError
 

--- a/tests/extensions/test_custom.py
+++ b/tests/extensions/test_custom.py
@@ -1,17 +1,17 @@
 """Tests creating a custom extension"""
 
-from pystac.summaries import RangeSummary
-from typing import Any, Dict, Generic, List, Optional, Set, TypeVar, Union, cast
 import unittest
+from typing import Any, Dict, Generic, List, Optional, Set, TypeVar, Union, cast
 
 import pystac
-from pystac.serialization.identify import STACJSONDescription, STACVersionID
 from pystac.extensions.base import (
     ExtensionManagementMixin,
     PropertiesExtension,
     SummariesExtension,
 )
 from pystac.extensions.hooks import ExtensionHooks
+from pystac.serialization.identify import STACJSONDescription, STACVersionID
+from pystac.summaries import RangeSummary
 
 T = TypeVar("T", pystac.Catalog, pystac.Collection, pystac.Item, pystac.Asset)
 

--- a/tests/extensions/test_datacube.py
+++ b/tests/extensions/test_datacube.py
@@ -1,8 +1,8 @@
 import unittest
+
 import pystac
 from pystac import ExtensionTypeError
 from pystac.extensions.datacube import DatacubeExtension
-
 from tests.utils import TestCases
 
 

--- a/tests/extensions/test_eo.py
+++ b/tests/extensions/test_eo.py
@@ -3,9 +3,9 @@ import unittest
 
 import pystac
 from pystac import ExtensionTypeError, Item
+from pystac.extensions.eo import Band, EOExtension
 from pystac.summaries import RangeSummary
 from pystac.utils import get_opt
-from pystac.extensions.eo import EOExtension, Band
 from tests.utils import TestCases, assert_to_from_dict
 
 

--- a/tests/extensions/test_file.py
+++ b/tests/extensions/test_file.py
@@ -3,8 +3,8 @@ import unittest
 
 import pystac
 from pystac import ExtensionTypeError
+from pystac.extensions.file import ByteOrder, FileExtension, MappingObject
 from tests.utils import TestCases, assert_to_from_dict
-from pystac.extensions.file import FileExtension, ByteOrder, MappingObject
 
 
 class ByteOrderTest(unittest.TestCase):

--- a/tests/extensions/test_label.py
+++ b/tests/extensions/test_label.py
@@ -1,23 +1,23 @@
 import json
 import os
-import unittest
 import tempfile
+import unittest
 from typing import List, Union
 
 import pystac
-from pystac import Catalog, Collection, ExtensionTypeError, Item, CatalogType
+import pystac.validation
+from pystac import Catalog, CatalogType, Collection, ExtensionTypeError, Item
 from pystac.extensions.label import (
-    LabelExtension,
     LabelClasses,
     LabelCount,
+    LabelExtension,
     LabelMethod,
     LabelOverview,
+    LabelRelType,
     LabelStatistics,
     LabelTask,
     LabelType,
-    LabelRelType,
 )
-import pystac.validation
 from pystac.utils import get_opt
 from tests.utils import TestCases, assert_to_from_dict
 

--- a/tests/extensions/test_pointcloud.py
+++ b/tests/extensions/test_pointcloud.py
@@ -1,8 +1,6 @@
 import json
-from typing import Any, Dict
 import unittest
-
-# from copy import deepcopy
+from typing import Any, Dict
 
 import pystac
 from pystac.asset import Asset
@@ -14,6 +12,8 @@ from pystac.extensions.pointcloud import (
     PointcloudStatistic,
 )
 from tests.utils import TestCases, assert_to_from_dict
+
+# from copy import deepcopy
 
 
 class PointcloudTest(unittest.TestCase):

--- a/tests/extensions/test_projection.py
+++ b/tests/extensions/test_projection.py
@@ -1,7 +1,7 @@
 import json
-from typing import Any, Dict
 import unittest
 from copy import deepcopy
+from typing import Any, Dict
 
 import pystac
 from pystac import ExtensionTypeError

--- a/tests/extensions/test_raster.py
+++ b/tests/extensions/test_raster.py
@@ -3,15 +3,15 @@ import unittest
 
 import pystac
 from pystac import ExtensionTypeError, Item
-from pystac.utils import get_opt
 from pystac.extensions.raster import (
-    Histogram,
-    RasterExtension,
-    RasterBand,
-    Sampling,
     DataType,
+    Histogram,
+    RasterBand,
+    RasterExtension,
+    Sampling,
     Statistics,
 )
+from pystac.utils import get_opt
 from tests.utils import TestCases, assert_to_from_dict
 
 

--- a/tests/extensions/test_sar.py
+++ b/tests/extensions/test_sar.py
@@ -1,11 +1,10 @@
 """Tests for pystac.extensions.sar."""
 
 import datetime
-from random import choice
-from typing import List
 import unittest
-
+from random import choice
 from string import ascii_letters
+from typing import List
 
 import pystac
 from pystac import ExtensionTypeError

--- a/tests/extensions/test_sat.py
+++ b/tests/extensions/test_sat.py
@@ -1,15 +1,15 @@
 """Tests for pystac.extensions.sat."""
 
 import datetime
-from pystac.summaries import RangeSummary
-from typing import Any, Dict
 import unittest
+from typing import Any, Dict
 
 import pystac
-from pystac.utils import str_to_datetime, datetime_to_str
 from pystac import ExtensionTypeError
 from pystac.extensions import sat
 from pystac.extensions.sat import OrbitState, SatExtension
+from pystac.summaries import RangeSummary
+from pystac.utils import datetime_to_str, str_to_datetime
 from tests.utils import TestCases
 
 

--- a/tests/extensions/test_scientific.py
+++ b/tests/extensions/test_scientific.py
@@ -1,14 +1,12 @@
 """Tests for pystac.tests.extensions.scientific."""
 
 import datetime
-
-from pystac import ExtensionTypeError
-from pystac.link import Link
-from pystac.collection import Summaries
 import unittest
 from typing import List, Optional
 
 import pystac
+from pystac import ExtensionTypeError
+from pystac.collection import Summaries
 from pystac.extensions import scientific
 from pystac.extensions.scientific import (
     Publication,
@@ -16,6 +14,7 @@ from pystac.extensions.scientific import (
     ScientificRelType,
     remove_link,
 )
+from pystac.link import Link
 from tests.utils import TestCases
 
 URL_TEMPLATE = "http://example.com/catalog/%s.json"

--- a/tests/extensions/test_timestamps.py
+++ b/tests/extensions/test_timestamps.py
@@ -4,9 +4,9 @@ from datetime import datetime
 
 import pystac
 from pystac import ExtensionTypeError
-from pystac.summaries import RangeSummary
 from pystac.extensions.timestamps import TimestampsExtension
-from pystac.utils import get_opt, str_to_datetime, datetime_to_str
+from pystac.summaries import RangeSummary
+from pystac.utils import datetime_to_str, get_opt, str_to_datetime
 from tests.utils import TestCases, assert_to_from_dict
 
 

--- a/tests/extensions/test_view.py
+++ b/tests/extensions/test_view.py
@@ -1,12 +1,11 @@
 import json
-
-from pystac import ExtensionTypeError
-from pystac.collection import Collection
 import unittest
 
 import pystac
-from pystac.summaries import RangeSummary
+from pystac import ExtensionTypeError
+from pystac.collection import Collection
 from pystac.extensions.view import ViewExtension
+from pystac.summaries import RangeSummary
 from tests.utils import TestCases, assert_to_from_dict
 
 

--- a/tests/serialization/test_identify.py
+++ b/tests/serialization/test_identify.py
@@ -7,8 +7,7 @@ from pystac.serialization import (
     identify_stac_object_type,
     merge_common_properties,
 )
-from pystac.serialization.identify import STACVersionRange, STACVersionID
-
+from pystac.serialization.identify import STACVersionID, STACVersionRange
 from tests.utils import TestCases
 
 

--- a/tests/serialization/test_migrate.py
+++ b/tests/serialization/test_migrate.py
@@ -1,18 +1,17 @@
-from pystac import ExtensionTypeError
-from pystac.extensions.item_assets import ItemAssetsExtension
-from pystac.extensions.view import ViewExtension
 import unittest
 
 import pystac
+from pystac import ExtensionTypeError
 from pystac.cache import CollectionCache
+from pystac.extensions.item_assets import ItemAssetsExtension
+from pystac.extensions.view import ViewExtension
 from pystac.serialization import (
     identify_stac_object,
     identify_stac_object_type,
     merge_common_properties,
     migrate_to_latest,
 )
-from pystac.utils import str_to_datetime, get_required
-
+from pystac.utils import get_required, str_to_datetime
 from tests.utils import TestCases
 
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,9 +1,9 @@
-from typing import Any, Dict
-from pystac.utils import get_opt
 import unittest
+from typing import Any, Dict
 
 import pystac
 from pystac.cache import ResolvedObjectCache, ResolvedObjectCollectionCache
+from pystac.utils import get_opt
 from tests.utils import TestCases
 
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,30 +1,25 @@
-from copy import deepcopy
-import os
 import json
+import os
 import tempfile
-from typing import Any, Dict, List, Tuple, Union, cast
 import unittest
-from datetime import datetime
 from collections import defaultdict
+from copy import deepcopy
+from datetime import datetime
+from typing import Any, Dict, List, Tuple, Union, cast
 
 import pystac
 from pystac import (
-    Catalog,
-    Collection,
-    CatalogType,
-    Item,
-    Asset,
-    MediaType,
     HIERARCHICAL_LINKS,
+    Asset,
+    Catalog,
+    CatalogType,
+    Collection,
+    Item,
+    MediaType,
 )
 from pystac.extensions.label import LabelClasses, LabelExtension, LabelType
-from pystac.utils import is_absolute_href, join_path_or_url, JoinType
-from tests.utils import (
-    TestCases,
-    ARBITRARY_GEOM,
-    ARBITRARY_BBOX,
-    MockStacIO,
-)
+from pystac.utils import JoinType, is_absolute_href, join_path_or_url
+from tests.utils import ARBITRARY_BBOX, ARBITRARY_GEOM, MockStacIO, TestCases
 
 
 class CatalogTypeTest(unittest.TestCase):

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -1,25 +1,26 @@
-from copy import deepcopy
-import unittest
-import os
 import json
-from datetime import datetime
-from dateutil import tz
+import os
 import tempfile
+import unittest
+from copy import deepcopy
+from datetime import datetime
+
+from dateutil import tz
 
 import pystac
-from pystac.extensions.eo import EOExtension
-from pystac.validation import validate_dict
 from pystac import (
+    CatalogType,
     Collection,
-    Item,
     Extent,
+    Item,
+    Provider,
     SpatialExtent,
     TemporalExtent,
-    CatalogType,
-    Provider,
 )
+from pystac.extensions.eo import EOExtension
 from pystac.utils import datetime_to_str, get_required
-from tests.utils import TestCases, ARBITRARY_GEOM, ARBITRARY_BBOX
+from pystac.validation import validate_dict
+from tests.utils import ARBITRARY_BBOX, ARBITRARY_GEOM, TestCases
 
 TEST_DATETIME = datetime(2020, 3, 14, 16, 32)
 

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -1,17 +1,17 @@
-from copy import deepcopy
-import os
-from datetime import datetime
 import json
+import os
 import tempfile
-from typing import Any, Dict, List
 import unittest
+from copy import deepcopy
+from datetime import datetime
+from typing import Any, Dict, List
 
 import pystac
-from pystac import Asset, Item, Provider, ProviderRole
-from pystac.validation import validate_dict
 import pystac.serialization.common_properties
+from pystac import Asset, Item, Provider, ProviderRole
 from pystac.item import CommonMetadata
-from pystac.utils import datetime_to_str, get_opt, str_to_datetime, is_absolute_href
+from pystac.utils import datetime_to_str, get_opt, is_absolute_href, str_to_datetime
+from pystac.validation import validate_dict
 from tests.utils import TestCases, assert_to_from_dict
 
 

--- a/tests/test_item_collection.py
+++ b/tests/test_item_collection.py
@@ -1,11 +1,10 @@
-from copy import deepcopy
 import json
-from pystac.item_collection import ItemCollection
 import unittest
+from copy import deepcopy
 from os.path import relpath
 
 import pystac
-
+from pystac.item_collection import ItemCollection
 from tests.utils import TestCases
 
 

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1,18 +1,18 @@
+import unittest
 from datetime import datetime, timedelta
 from typing import Callable
-from pystac.collection import Collection
-import unittest
 
 import pystac
-from pystac.utils import join_path_or_url, JoinType
+from pystac.collection import Collection
 from pystac.layout import (
-    LayoutTemplate,
-    CustomLayoutStrategy,
-    TemplateLayoutStrategy,
     BestPracticesLayoutStrategy,
+    CustomLayoutStrategy,
+    LayoutTemplate,
     TemplateError,
+    TemplateLayoutStrategy,
 )
-from tests.utils import TestCases, ARBITRARY_GEOM, ARBITRARY_BBOX
+from pystac.utils import JoinType, join_path_or_url
+from tests.utils import ARBITRARY_BBOX, ARBITRARY_GEOM, TestCases
 
 
 class LayoutTemplateTest(unittest.TestCase):

--- a/tests/test_stac_io.py
+++ b/tests/test_stac_io.py
@@ -1,9 +1,9 @@
 import os
-import unittest
 import tempfile
+import unittest
 
 import pystac
-from pystac.stac_io import StacIO, DefaultStacIO, DuplicateKeyReportingMixin
+from pystac.stac_io import DefaultStacIO, DuplicateKeyReportingMixin, StacIO
 from tests.utils import TestCases
 
 

--- a/tests/test_summaries.py
+++ b/tests/test_summaries.py
@@ -1,8 +1,8 @@
 import socket
-from typing import Any
 import unittest
+from typing import Any
 
-from pystac.summaries import RangeSummary, Summarizer, Summaries
+from pystac.summaries import RangeSummary, Summaries, Summarizer
 from tests.utils import TestCases
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,13 +1,12 @@
-import unittest
-import os
 import json
 import ntpath
+import os
 import sys
-from datetime import datetime, timezone, timedelta
+import unittest
+from datetime import datetime, timedelta, timezone
 
 from pystac import utils
-
-from pystac.utils import make_relative_href, make_absolute_href, is_absolute_href
+from pystac.utils import is_absolute_href, make_absolute_href, make_relative_href
 from tests.utils import TestCases
 
 

--- a/tests/test_writing.py
+++ b/tests/test_writing.py
@@ -1,12 +1,11 @@
-import unittest
 import tempfile
+import unittest
 from typing import Any, List
 
 import pystac
-from pystac import Collection, CatalogType, HIERARCHICAL_LINKS
+from pystac import HIERARCHICAL_LINKS, CatalogType, Collection
 from pystac.utils import is_absolute_href, make_absolute_href
 from pystac.validation import validate_dict
-
 from tests.utils import TestCases
 
 

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,18 +1,18 @@
-from typing import Any, Dict, TYPE_CHECKING, Type
 import unittest
-from tests.utils.test_cases import (
-    TestCases,
-    ARBITRARY_GEOM,
-    ARBITRARY_BBOX,
-    ARBITRARY_EXTENT,
-)
-
 from copy import deepcopy
 from datetime import datetime
+from typing import TYPE_CHECKING, Any, Dict, Type
+
 from dateutil.parser import parse
 
 import pystac
 from tests.utils.stac_io_mock import MockStacIO
+from tests.utils.test_cases import (
+    ARBITRARY_BBOX,
+    ARBITRARY_EXTENT,
+    ARBITRARY_GEOM,
+    TestCases,
+)
 
 
 def assert_to_from_dict(

--- a/tests/utils/test_cases.py
+++ b/tests/utils/test_cases.py
@@ -1,24 +1,24 @@
+import csv
 import os
 from datetime import datetime
-import csv
 from typing import Any, Dict, List
 
 import pystac
 from pystac import (
+    Asset,
     Catalog,
     Collection,
-    Item,
-    Asset,
     Extent,
-    TemporalExtent,
-    SpatialExtent,
+    Item,
     MediaType,
+    SpatialExtent,
+    TemporalExtent,
 )
 from pystac.extensions.label import (
-    LabelExtension,
-    LabelOverview,
     LabelClasses,
     LabelCount,
+    LabelExtension,
+    LabelOverview,
     LabelType,
 )
 

--- a/tests/validation/test_validate.py
+++ b/tests/validation/test_validate.py
@@ -1,11 +1,10 @@
-from datetime import datetime
 import json
 import os
-from typing import Any, Dict
-from pystac.utils import get_opt
 import shutil
-import unittest
 import tempfile
+import unittest
+from datetime import datetime
+from typing import Any, Dict
 
 import jsonschema
 
@@ -13,6 +12,7 @@ import pystac
 import pystac.validation
 from pystac.cache import CollectionCache
 from pystac.serialization.common_properties import merge_common_properties
+from pystac.utils import get_opt
 from tests.utils import TestCases
 
 


### PR DESCRIPTION
Sorts and groups imports automatically. Interestingly, this has surfaced at least one circular import, which I might remove in another PR.

**Related Issue(s):** Closes #533


**Description:**


**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.