### PR TITLE
refactor: Use stricter mypy configuration

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -2,6 +2,7 @@
 disallow_any_generics = True
 disallow_incomplete_defs = True
 disallow_subclassing_any = True
+disallow_untyped_calls = True
 disallow_untyped_defs = True
 ignore_missing_imports = True
 no_implicit_optional = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,6 +3,7 @@ disallow_any_generics = True
 disallow_incomplete_defs = True
 disallow_subclassing_any = True
 disallow_untyped_calls = True
+disallow_untyped_decorators = True
 disallow_untyped_defs = True
 ignore_missing_imports = True
 no_implicit_optional = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,6 +1,7 @@
 [mypy]
 disallow_any_generics = True
 disallow_incomplete_defs = True
+disallow_subclassing_any = True
 disallow_untyped_defs = True
 ignore_missing_imports = True
 no_implicit_optional = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,6 @@
 [mypy]
 disallow_any_generics = True
+disallow_incomplete_defs = True
 disallow_untyped_defs = True
 ignore_missing_imports = True
 no_implicit_optional = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -11,4 +11,5 @@ show_error_codes = True
 strict_equality = True
 warn_redundant_casts = True
 warn_return_any = True
+warn_unused_configs = True
 warn_unused_ignores = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,5 @@
 [mypy]
+check_untyped_defs = True
 disallow_any_generics = True
 disallow_incomplete_defs = True
 disallow_subclassing_any = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,7 +6,6 @@ disallow_subclassing_any = True
 disallow_untyped_calls = True
 disallow_untyped_decorators = True
 disallow_untyped_defs = True
-ignore_missing_imports = True
 no_implicit_optional = True
 show_error_codes = True
 strict_equality = True
@@ -14,3 +13,9 @@ warn_redundant_casts = True
 warn_return_any = True
 warn_unused_configs = True
 warn_unused_ignores = True
+
+[mypy-jsonschema.*]
+ignore_missing_imports = True
+
+[mypy-setuptools.*]
+ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -8,6 +8,7 @@ disallow_untyped_defs = True
 ignore_missing_imports = True
 no_implicit_optional = True
 show_error_codes = True
+strict_equality = True
 warn_redundant_casts = True
 warn_return_any = True
 warn_unused_ignores = True


### PR DESCRIPTION
**Related Issue(s):** #332 


**Description:** This is almost as strict as `strict = True`, which can replace every strictness setting already in place once we fulfill `no_implicit_reexport = True`, which I'll try to do in a separate PR since we need to resolve import cycles to do it.


**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.