### PR TITLE
refactor: Avoid implicit reexport in tests

### DIFF
--- a/tests/data-files/change_stac_version.py
+++ b/tests/data-files/change_stac_version.py
@@ -7,9 +7,10 @@ import re
 import argparse
 import json
 
-import pystac
+from pystac import read_dict
+from pystac.version import get_stac_version
 
-TARGET_VERSION = pystac.get_stac_version()
+TARGET_VERSION = get_stac_version()
 
 
 def migrate(path: str) -> None:
@@ -28,7 +29,7 @@ def migrate(path: str) -> None:
                     path, cur_ver, TARGET_VERSION
                 )
             )
-            obj = pystac.read_dict(stac_json, href=path)
+            obj = read_dict(stac_json, href=path)
             migrated = obj.to_dict(include_self_link=False)
             with open(path, "w") as f:
                 json.dump(migrated, f, indent=2)

--- a/tests/data-files/get_examples.py
+++ b/tests/data-files/get_examples.py
@@ -10,8 +10,10 @@ import tempfile
 from typing import Any, Dict, List, Optional
 from urllib.error import HTTPError
 
-import pystac
-from pystac.serialization import identify_stac_object
+from pystac.version import get_stac_version
+from pystac.stac_object import STACObjectType
+from pystac.stac_io import StacIO
+from pystac.serialization.identify import identify_stac_object
 
 
 def remove_bad_collection(js: Dict[str, Any]) -> Dict[str, Any]:
@@ -23,7 +25,7 @@ def remove_bad_collection(js: Dict[str, Any]) -> Dict[str, Any]:
             if rel is not None and rel == "collection":
                 href: str = link["href"]
                 try:
-                    json.loads(pystac.StacIO.default().read_text(href))
+                    json.loads(StacIO.default().read_text(href))
                     filtered_links.append(link)
                 except (HTTPError, FileNotFoundError, json.decoder.JSONDecodeError):
                     print("===REMOVING UNREADABLE COLLECTION AT {}".format(href))
@@ -46,7 +48,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     stac_repo = "https://github.com/radiantearth/stac-spec"
-    stac_spec_tag = "v{}".format(pystac.get_stac_version())
+    stac_spec_tag = "v{}".format(get_stac_version())
 
     examples_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "examples"))
 
@@ -87,7 +89,7 @@ if __name__ == "__main__":
                             and example_version > args.previous_version
                         ):
                             relpath = "{}/{}".format(
-                                pystac.get_stac_version(),
+                                get_stac_version(),
                                 path.replace("{}/".format(tmp_dir), ""),
                             )
                             target_path = os.path.join(examples_dir, relpath)
@@ -98,7 +100,7 @@ if __name__ == "__main__":
 
                             # Handle the case where there are collection links that
                             # don't exist.
-                            if info.object_type == pystac.STACObjectType.ITEM:
+                            if info.object_type == STACObjectType.ITEM:
                                 js = remove_bad_collection(js)
 
                             d = os.path.dirname(target_path)

--- a/tests/extensions/test_datacube.py
+++ b/tests/extensions/test_datacube.py
@@ -1,9 +1,10 @@
 import unittest
-import pystac
-from pystac import ExtensionTypeError
+from pystac.asset import Asset
+from pystac.errors import ExtensionNotImplemented, ExtensionTypeError
+from pystac.item import Item
 from pystac.extensions.datacube import DatacubeExtension
 
-from tests.utils import TestCases
+from tests.utils.test_cases import TestCases
 
 
 class DatacubeTest(unittest.TestCase):
@@ -12,29 +13,29 @@ class DatacubeTest(unittest.TestCase):
         self.example_uri = TestCases.get_path("data-files/datacube/item.json")
 
     def test_validate_datacube(self) -> None:
-        item = pystac.Item.from_file(self.example_uri)
+        item = Item.from_file(self.example_uri)
         item.validate()
 
     def test_extension_not_implemented(self) -> None:
         # Should raise exception if Item does not include extension URI
-        item = pystac.Item.from_file(self.example_uri)
+        item = Item.from_file(self.example_uri)
         item.stac_extensions.remove(DatacubeExtension.get_schema_uri())
 
-        with self.assertRaises(pystac.ExtensionNotImplemented):
+        with self.assertRaises(ExtensionNotImplemented):
             _ = DatacubeExtension.ext(item)
 
         # Should raise exception if owning Item does not include extension URI
         asset = item.assets["data"]
 
-        with self.assertRaises(pystac.ExtensionNotImplemented):
+        with self.assertRaises(ExtensionNotImplemented):
             _ = DatacubeExtension.ext(asset)
 
         # Should succeed if Asset has no owner
-        ownerless_asset = pystac.Asset.from_dict(asset.to_dict())
+        ownerless_asset = Asset.from_dict(asset.to_dict())
         _ = DatacubeExtension.ext(ownerless_asset)
 
     def test_item_ext_add_to(self) -> None:
-        item = pystac.Item.from_file(self.example_uri)
+        item = Item.from_file(self.example_uri)
         item.stac_extensions.remove(DatacubeExtension.get_schema_uri())
         self.assertNotIn(DatacubeExtension.get_schema_uri(), item.stac_extensions)
 
@@ -43,7 +44,7 @@ class DatacubeTest(unittest.TestCase):
         self.assertIn(DatacubeExtension.get_schema_uri(), item.stac_extensions)
 
     def test_asset_ext_add_to(self) -> None:
-        item = pystac.Item.from_file(self.example_uri)
+        item = Item.from_file(self.example_uri)
         item.stac_extensions.remove(DatacubeExtension.get_schema_uri())
         self.assertNotIn(DatacubeExtension.get_schema_uri(), item.stac_extensions)
         asset = item.assets["data"]

--- a/tests/extensions/test_file.py
+++ b/tests/extensions/test_file.py
@@ -1,9 +1,12 @@
 import json
 import unittest
 
-import pystac
-from pystac import ExtensionTypeError
-from tests.utils import TestCases, assert_to_from_dict
+from pystac.asset import Asset
+from pystac.collection import Collection
+from pystac.errors import ExtensionNotImplemented, ExtensionTypeError
+from pystac.item import Item
+from tests.utils import assert_to_from_dict
+from tests.utils.test_cases import TestCases
 from pystac.extensions.file import FileExtension, ByteOrder, MappingObject
 
 
@@ -59,18 +62,18 @@ class FileTest(unittest.TestCase):
     def test_to_from_dict(self) -> None:
         with open(self.FILE_ITEM_EXAMPLE_URI) as f:
             item_dict = json.load(f)
-        assert_to_from_dict(self, pystac.Item, item_dict)
+        assert_to_from_dict(self, Item, item_dict)
 
     def test_validate_item(self) -> None:
-        item = pystac.Item.from_file(self.FILE_ITEM_EXAMPLE_URI)
+        item = Item.from_file(self.FILE_ITEM_EXAMPLE_URI)
         item.validate()
 
     def test_validate_collection(self) -> None:
-        collection = pystac.Collection.from_file(self.FILE_COLLECTION_EXAMPLE_URI)
+        collection = Collection.from_file(self.FILE_COLLECTION_EXAMPLE_URI)
         collection.validate()
 
     def test_item_asset_size(self) -> None:
-        item = pystac.Item.from_file(self.FILE_ITEM_EXAMPLE_URI)
+        item = Item.from_file(self.FILE_ITEM_EXAMPLE_URI)
         asset = item.assets["thumbnail"]
 
         # Get
@@ -83,7 +86,7 @@ class FileTest(unittest.TestCase):
         item.validate()
 
     def test_item_asset_header_size(self) -> None:
-        item = pystac.Item.from_file(self.FILE_ITEM_EXAMPLE_URI)
+        item = Item.from_file(self.FILE_ITEM_EXAMPLE_URI)
         asset = item.assets["measurement"]
 
         # Get
@@ -96,7 +99,7 @@ class FileTest(unittest.TestCase):
         item.validate()
 
     def test_item_asset_checksum(self) -> None:
-        item = pystac.Item.from_file(self.FILE_ITEM_EXAMPLE_URI)
+        item = Item.from_file(self.FILE_ITEM_EXAMPLE_URI)
         asset = item.assets["thumbnail"]
 
         # Get
@@ -113,7 +116,7 @@ class FileTest(unittest.TestCase):
 
     def test_item_asset_byte_order(self) -> None:
         # Get
-        item = pystac.Item.from_file(self.FILE_ITEM_EXAMPLE_URI)
+        item = Item.from_file(self.FILE_ITEM_EXAMPLE_URI)
         asset = item.assets["thumbnail"]
         file_ext = FileExtension.ext(asset)
 
@@ -129,7 +132,7 @@ class FileTest(unittest.TestCase):
 
     def test_item_asset_values(self) -> None:
         # Set/get
-        item = pystac.Item.from_file(self.FILE_ITEM_EXAMPLE_URI)
+        item = Item.from_file(self.FILE_ITEM_EXAMPLE_URI)
         asset = item.assets["thumbnail"]
         file_ext = FileExtension.ext(asset)
         values = [MappingObject.create([0], summary="clouds")]
@@ -139,7 +142,7 @@ class FileTest(unittest.TestCase):
         self.assertEqual(file_ext.values, values)
 
     def test_item_asset_apply(self) -> None:
-        item = pystac.Item.from_file(self.FILE_ITEM_EXAMPLE_URI)
+        item = Item.from_file(self.FILE_ITEM_EXAMPLE_URI)
         asset = item.assets["thumbnail"]
         file_ext = FileExtension.ext(asset)
 
@@ -170,7 +173,7 @@ class FileTest(unittest.TestCase):
         self.assertEqual(file_ext.byte_order, new_byte_order)
 
     def test_repr(self) -> None:
-        item = pystac.Item.from_file(self.FILE_ITEM_EXAMPLE_URI)
+        item = Item.from_file(self.FILE_ITEM_EXAMPLE_URI)
         asset = item.assets["thumbnail"]
         file_ext = FileExtension.ext(asset)
 
@@ -183,7 +186,7 @@ class FileTest(unittest.TestCase):
             "data-files/examples/1.0.0-beta.2/"
             "extensions/checksum/examples/sentinel1.json"
         )
-        item = pystac.Item.from_file(example_path)
+        item = Item.from_file(example_path)
 
         self.assertTrue(FileExtension.has_extension(item))
         self.assertEqual(
@@ -192,26 +195,26 @@ class FileTest(unittest.TestCase):
         )
 
     def test_extension_type_error(self) -> None:
-        item = pystac.Item.from_file(self.FILE_ITEM_EXAMPLE_URI)
+        item = Item.from_file(self.FILE_ITEM_EXAMPLE_URI)
 
-        with self.assertRaises(pystac.ExtensionTypeError):
+        with self.assertRaises(ExtensionTypeError):
             _ = FileExtension.ext(item)  # type: ignore
 
     def test_extension_not_implemented(self) -> None:
         # Should raise exception if Item does not include extension URI
-        item = pystac.Item.from_file(self.PLAIN_ITEM)
+        item = Item.from_file(self.PLAIN_ITEM)
         asset = item.assets["thumbnail"]
 
-        with self.assertRaises(pystac.ExtensionNotImplemented):
+        with self.assertRaises(ExtensionNotImplemented):
             _ = FileExtension.ext(asset)
 
         # Should succeed if Asset has no owner
-        ownerless_asset = pystac.Asset.from_dict(asset.to_dict())
+        ownerless_asset = Asset.from_dict(asset.to_dict())
 
         _ = FileExtension.ext(ownerless_asset)
 
     def test_ext_add_to(self) -> None:
-        item = pystac.Item.from_file(self.PLAIN_ITEM)
+        item = Item.from_file(self.PLAIN_ITEM)
         asset = item.assets["thumbnail"]
 
         self.assertNotIn(FileExtension.get_schema_uri(), item.stac_extensions)

--- a/tests/extensions/test_sat.py
+++ b/tests/extensions/test_sat.py
@@ -1,25 +1,29 @@
 """Tests for pystac.extensions.sat."""
 
 import datetime
-from pystac.summaries import RangeSummary
 from typing import Any, Dict
 import unittest
 
-import pystac
+from pystac.asset import Asset
+from pystac.collection import Collection
+from pystac.errors import (
+    ExtensionNotImplemented,
+    ExtensionTypeError,
+    STACValidationError,
+)
+from pystac.item import Item
+from pystac.summaries import RangeSummary
 from pystac.utils import str_to_datetime, datetime_to_str
-from pystac import ExtensionTypeError
 from pystac.extensions import sat
 from pystac.extensions.sat import OrbitState, SatExtension
-from tests.utils import TestCases
+from tests.utils.test_cases import TestCases
 
 
-def make_item() -> pystac.Item:
+def make_item() -> Item:
     """Create basic test items that are only slightly different."""
     asset_id = "an/asset"
     start = datetime.datetime(2018, 1, 2)
-    item = pystac.Item(
-        id=asset_id, geometry=None, bbox=None, datetime=start, properties={}
-    )
+    item = Item(id=asset_id, geometry=None, bbox=None, datetime=start, properties={})
 
     SatExtension.add_to(item)
     return item
@@ -41,7 +45,7 @@ class SatTest(unittest.TestCase):
         )
 
     def test_asset_repr(self) -> None:
-        item = pystac.Item.from_file(self.sentinel_example_uri)
+        item = Item.from_file(self.sentinel_example_uri)
         asset = item.assets["measurement_iw1_vh"]
         sat_asset_ext = SatExtension.ext(asset)
 
@@ -51,7 +55,7 @@ class SatTest(unittest.TestCase):
 
     def test_no_args_fails(self) -> None:
         SatExtension.ext(self.item).apply()
-        with self.assertRaises(pystac.STACValidationError):
+        with self.assertRaises(STACValidationError):
             self.item.validate()
 
     def test_orbit_state(self) -> None:
@@ -102,7 +106,7 @@ class SatTest(unittest.TestCase):
     def test_relative_orbit_no_negative(self) -> None:
         negative_relative_orbit = -2
         SatExtension.ext(self.item).apply(None, negative_relative_orbit)
-        with self.assertRaises(pystac.STACValidationError):
+        with self.assertRaises(STACValidationError):
             self.item.validate()
 
     def test_both(self) -> None:
@@ -141,7 +145,7 @@ class SatTest(unittest.TestCase):
             "assets": {},
             "stac_extensions": [SatExtension.get_schema_uri()],
         }
-        item = pystac.Item.from_dict(d)
+        item = Item.from_dict(d)
         self.assertEqual(orbit_state, SatExtension.ext(item).orbit_state)
         self.assertEqual(relative_orbit, SatExtension.ext(item).relative_orbit)
 
@@ -153,7 +157,7 @@ class SatTest(unittest.TestCase):
         self.assertEqual(orbit_state.value, d["properties"][sat.ORBIT_STATE_PROP])
         self.assertEqual(relative_orbit, d["properties"][sat.RELATIVE_ORBIT_PROP])
 
-        item = pystac.Item.from_dict(d)
+        item = Item.from_dict(d)
         self.assertEqual(orbit_state, SatExtension.ext(item).orbit_state)
         self.assertEqual(relative_orbit, SatExtension.ext(item).relative_orbit)
 
@@ -173,24 +177,24 @@ class SatTest(unittest.TestCase):
 
     def test_extension_not_implemented(self) -> None:
         # Should raise exception if Item does not include extension URI
-        item = pystac.Item.from_file(self.sentinel_example_uri)
+        item = Item.from_file(self.sentinel_example_uri)
         item.stac_extensions.remove(SatExtension.get_schema_uri())
 
-        with self.assertRaises(pystac.ExtensionNotImplemented):
+        with self.assertRaises(ExtensionNotImplemented):
             _ = SatExtension.ext(item)
 
         # Should raise exception if owning Item does not include extension URI
         asset = item.assets["measurement_iw1_vh"]
 
-        with self.assertRaises(pystac.ExtensionNotImplemented):
+        with self.assertRaises(ExtensionNotImplemented):
             _ = SatExtension.ext(asset)
 
         # Should succeed if Asset has no owner
-        ownerless_asset = pystac.Asset.from_dict(asset.to_dict())
+        ownerless_asset = Asset.from_dict(asset.to_dict())
         _ = SatExtension.ext(ownerless_asset)
 
     def test_item_ext_add_to(self) -> None:
-        item = pystac.Item.from_file(self.sentinel_example_uri)
+        item = Item.from_file(self.sentinel_example_uri)
         item.stac_extensions.remove(SatExtension.get_schema_uri())
         self.assertNotIn(SatExtension.get_schema_uri(), item.stac_extensions)
 
@@ -199,7 +203,7 @@ class SatTest(unittest.TestCase):
         self.assertIn(SatExtension.get_schema_uri(), item.stac_extensions)
 
     def test_asset_ext_add_to(self) -> None:
-        item = pystac.Item.from_file(self.sentinel_example_uri)
+        item = Item.from_file(self.sentinel_example_uri)
         item.stac_extensions.remove(SatExtension.get_schema_uri())
         self.assertNotIn(SatExtension.get_schema_uri(), item.stac_extensions)
         asset = item.assets["measurement_iw1_vh"]
@@ -224,8 +228,8 @@ class SatSummariesTest(unittest.TestCase):
         self.maxDiff = None
 
     @staticmethod
-    def collection() -> pystac.Collection:
-        return pystac.Collection.from_file(
+    def collection() -> Collection:
+        return Collection.from_file(
             TestCases.get_path("data-files/collections/multi-extent.json")
         )
 
@@ -334,7 +338,7 @@ class SatSummariesTest(unittest.TestCase):
         col = self.collection()
         col.stac_extensions = []
         self.assertRaisesRegex(
-            pystac.ExtensionNotImplemented,
+            ExtensionNotImplemented,
             r"Could not find extension schema URI.*",
             SatExtension.summaries,
             col,

--- a/tests/extensions/test_view.py
+++ b/tests/extensions/test_view.py
@@ -1,13 +1,15 @@
 import json
 
-from pystac import ExtensionTypeError
-from pystac.collection import Collection
 import unittest
 
-import pystac
+from pystac.asset import Asset
+from pystac.collection import Collection
+from pystac.errors import ExtensionNotImplemented, ExtensionTypeError
+from pystac.item import Item
 from pystac.summaries import RangeSummary
 from pystac.extensions.view import ViewExtension
-from tests.utils import TestCases, assert_to_from_dict
+from tests.utils import assert_to_from_dict
+from tests.utils.test_cases import TestCases
 
 
 class ViewTest(unittest.TestCase):
@@ -18,7 +20,7 @@ class ViewTest(unittest.TestCase):
     def test_to_from_dict(self) -> None:
         with open(self.example_uri) as f:
             d = json.load(f)
-        assert_to_from_dict(self, pystac.Item, d)
+        assert_to_from_dict(self, Item, d)
 
     def test_apply(self) -> None:
         item = next(iter(TestCases.test_case_2().get_all_items()))
@@ -40,12 +42,12 @@ class ViewTest(unittest.TestCase):
         self.assertEqual(ViewExtension.ext(item).sun_elevation, 5.0)
 
     def test_validate_view(self) -> None:
-        item = pystac.Item.from_file(self.example_uri)
+        item = Item.from_file(self.example_uri)
         self.assertTrue(ViewExtension.has_extension(item))
         item.validate()
 
     def test_off_nadir(self) -> None:
-        view_item = pystac.Item.from_file(self.example_uri)
+        view_item = Item.from_file(self.example_uri)
 
         # Get
         self.assertIn("view:off_nadir", view_item.properties)
@@ -79,7 +81,7 @@ class ViewTest(unittest.TestCase):
         view_item.validate()
 
     def test_incidence_angle(self) -> None:
-        view_item = pystac.Item.from_file(self.example_uri)
+        view_item = Item.from_file(self.example_uri)
 
         # Get
         self.assertIn("view:incidence_angle", view_item.properties)
@@ -117,7 +119,7 @@ class ViewTest(unittest.TestCase):
         view_item.validate()
 
     def test_azimuth(self) -> None:
-        view_item = pystac.Item.from_file(self.example_uri)
+        view_item = Item.from_file(self.example_uri)
 
         # Get
         self.assertIn("view:azimuth", view_item.properties)
@@ -151,7 +153,7 @@ class ViewTest(unittest.TestCase):
         view_item.validate()
 
     def test_sun_azimuth(self) -> None:
-        view_item = pystac.Item.from_file(self.example_uri)
+        view_item = Item.from_file(self.example_uri)
 
         # Get
         self.assertIn("view:sun_azimuth", view_item.properties)
@@ -187,7 +189,7 @@ class ViewTest(unittest.TestCase):
         view_item.validate()
 
     def test_sun_elevation(self) -> None:
-        view_item = pystac.Item.from_file(self.example_uri)
+        view_item = Item.from_file(self.example_uri)
 
         # Get
         self.assertIn("view:sun_elevation", view_item.properties)
@@ -224,24 +226,24 @@ class ViewTest(unittest.TestCase):
 
     def test_extension_not_implemented(self) -> None:
         # Should raise exception if Item does not include extension URI
-        item = pystac.Item.from_file(self.example_uri)
+        item = Item.from_file(self.example_uri)
         item.stac_extensions.remove(ViewExtension.get_schema_uri())
 
-        with self.assertRaises(pystac.ExtensionNotImplemented):
+        with self.assertRaises(ExtensionNotImplemented):
             _ = ViewExtension.ext(item)
 
         # Should raise exception if owning Item does not include extension URI
         asset = item.assets["blue"]
 
-        with self.assertRaises(pystac.ExtensionNotImplemented):
+        with self.assertRaises(ExtensionNotImplemented):
             _ = ViewExtension.ext(asset)
 
         # Should succeed if Asset has no owner
-        ownerless_asset = pystac.Asset.from_dict(asset.to_dict())
+        ownerless_asset = Asset.from_dict(asset.to_dict())
         _ = ViewExtension.ext(ownerless_asset)
 
     def test_item_ext_add_to(self) -> None:
-        item = pystac.Item.from_file(self.example_uri)
+        item = Item.from_file(self.example_uri)
         item.stac_extensions.remove(ViewExtension.get_schema_uri())
         self.assertNotIn(ViewExtension.get_schema_uri(), item.stac_extensions)
 
@@ -250,7 +252,7 @@ class ViewTest(unittest.TestCase):
         self.assertIn(ViewExtension.get_schema_uri(), item.stac_extensions)
 
     def test_asset_ext_add_to(self) -> None:
-        item = pystac.Item.from_file(self.example_uri)
+        item = Item.from_file(self.example_uri)
         item.stac_extensions.remove(ViewExtension.get_schema_uri())
         self.assertNotIn(ViewExtension.get_schema_uri(), item.stac_extensions)
         asset = item.assets["blue"]
@@ -362,7 +364,7 @@ class ViewSummariesTest(unittest.TestCase):
         collection = self.collection.clone()
         collection.stac_extensions = []
         self.assertRaisesRegex(
-            pystac.ExtensionNotImplemented,
+            ExtensionNotImplemented,
             r"Could not find extension schema URI.*",
             ViewExtension.summaries,
             collection,

--- a/tests/serialization/test_identify.py
+++ b/tests/serialization/test_identify.py
@@ -1,15 +1,18 @@
 import unittest
 
-import pystac
+from pystac.stac_object import STACObjectType
+from pystac.errors import STACTypeError
+from pystac.stac_io import StacIO
 from pystac.cache import CollectionCache
-from pystac.serialization import (
+from pystac.serialization.common_properties import merge_common_properties
+from pystac.serialization.identify import (
+    STACVersionRange,
+    STACVersionID,
     identify_stac_object,
     identify_stac_object_type,
-    merge_common_properties,
 )
-from pystac.serialization.identify import STACVersionRange, STACVersionID
 
-from tests.utils import TestCases
+from tests.utils.test_cases import TestCases
 
 
 class IdentifyTest(unittest.TestCase):
@@ -21,8 +24,8 @@ class IdentifyTest(unittest.TestCase):
         for example in self.examples:
             with self.subTest(example.path):
                 path = example.path
-                d = pystac.StacIO.default().read_json(path)
-                if identify_stac_object_type(d) == pystac.STACObjectType.ITEM:
+                d = StacIO.default().read_json(path)
+                if identify_stac_object_type(d) == STACObjectType.ITEM:
                     merge_common_properties(
                         d, json_href=path, collection_cache=collection_cache
                     )
@@ -72,7 +75,7 @@ class IdentifyTest(unittest.TestCase):
             "stac_version": "1.0.0",
         }
 
-        with self.assertRaises(pystac.STACTypeError) as ctx:
+        with self.assertRaises(STACTypeError) as ctx:
             identify_stac_object(invalid_dict)
 
         self.assertIn("JSON does not represent a STAC object", str(ctx.exception))
@@ -84,7 +87,7 @@ class IdentifyTest(unittest.TestCase):
             "geometry": {"type": "Point", "coordinates": [0, 0]},
         }
 
-        with self.assertRaises(pystac.STACTypeError) as ctx:
+        with self.assertRaises(STACTypeError) as ctx:
             identify_stac_object(plain_feature_dict)
 
         self.assertIn("JSON does not represent a STAC object", str(ctx.exception))

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,14 +1,15 @@
 from typing import Any, Dict
+
+from pystac.catalog import Catalog
 from pystac.utils import get_opt
 import unittest
 
-import pystac
 from pystac.cache import ResolvedObjectCache, ResolvedObjectCollectionCache
-from tests.utils import TestCases
+from tests.utils.test_cases import TestCases
 
 
-def create_catalog(suffix: Any, include_href: bool = True) -> pystac.Catalog:
-    return pystac.Catalog(
+def create_catalog(suffix: Any, include_href: bool = True) -> Catalog:
+    return Catalog(
         id="test {}".format(suffix),
         description="test desc {}".format(suffix),
         href=(

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1154,8 +1154,9 @@ class FullCopyTest(unittest.TestCase):
 
 
 class CatalogSubClassTest(unittest.TestCase):
-    """This tests cases related to creating classes inheriting from pystac.Catalog to
-    ensure that inheritance, class methods, etc. function as expected."""
+    """This tests cases related to creating classes inheriting from
+    pystac.catalog.Catalog to ensure that inheritance, class methods, etc. function as
+    expected."""
 
     TEST_CASE_1 = TestCases.get_path("data-files/catalogs/test-case-1/catalog.json")
 

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -375,8 +375,9 @@ class ExtentTest(unittest.TestCase):
 
 
 class CollectionSubClassTest(unittest.TestCase):
-    """This tests cases related to creating classes inheriting from pystac.Catalog to
-    ensure that inheritance, class methods, etc. function as expected."""
+    """This tests cases related to creating classes inheriting from
+    pystac.catalog.Catalog to ensure that inheritance, class methods, etc. function as
+    expected."""
 
     MULTI_EXTENT = TestCases.get_path("data-files/collections/multi-extent.json")
 

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -724,8 +724,9 @@ class CommonMetadataTest(unittest.TestCase):
 
 
 class ItemSubClassTest(unittest.TestCase):
-    """This tests cases related to creating classes inheriting from pystac.Catalog to
-    ensure that inheritance, class methods, etc. function as expected."""
+    """This tests cases related to creating classes inheriting from
+    pystac.catalog.Catalog to ensure that inheritance, class methods, etc. function as
+    expected."""
 
     SAMPLE_ITEM = TestCases.get_path("data-files/item/sample-item.json")
 

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -2,17 +2,20 @@ import datetime
 import unittest
 from typing import Any, Dict, List
 
-import pystac
+from pystac.link import Link
+from pystac.collection import Collection
+from pystac.item import Item
+from pystac.catalog import Catalog
 from tests.utils.test_cases import ARBITRARY_EXTENT
 
 TEST_DATETIME: datetime.datetime = datetime.datetime(2020, 3, 14, 16, 32)
 
 
 class LinkTest(unittest.TestCase):
-    item: pystac.Item
+    item: Item
 
     def setUp(self) -> None:
-        self.item = pystac.Item(
+        self.item = Item(
             id="test-item",
             geometry=None,
             bbox=None,
@@ -23,7 +26,7 @@ class LinkTest(unittest.TestCase):
     def test_minimal(self) -> None:
         rel = "my rel"
         target = "https://example.com/a/b"
-        link = pystac.Link(rel, target)
+        link = Link(rel, target)
         self.assertEqual(target, link.get_href())
         self.assertEqual(target, link.get_absolute_href())
 
@@ -58,7 +61,7 @@ class LinkTest(unittest.TestCase):
         rel = "my rel"
         target = "../elsewhere"
         mime_type = "example/stac_thing"
-        link = pystac.Link(rel, target, mime_type, "a title", extra_fields={"a": "b"})
+        link = Link(rel, target, mime_type, "a title", extra_fields={"a": "b"})
         expected_dict = {
             "rel": rel,
             "href": target,
@@ -70,7 +73,7 @@ class LinkTest(unittest.TestCase):
 
     def test_link_does_not_fail_if_href_is_none(self) -> None:
         """Test to ensure get_href does not fail when the href is None."""
-        catalog = pystac.Catalog(id="test", description="test desc")
+        catalog = Catalog(id="test", description="test desc")
         catalog.add_item(self.item)
         catalog.set_self_href("/some/href")
 
@@ -79,13 +82,13 @@ class LinkTest(unittest.TestCase):
         self.assertIsNone(link.get_href())
 
     def test_resolve_stac_object_no_root_and_target_is_item(self) -> None:
-        link = pystac.Link("my rel", target=self.item)
+        link = Link("my rel", target=self.item)
         link.resolve_stac_object()
 
 
 class StaticLinkTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.item = pystac.Item(
+        self.item = Item(
             id="test-item",
             geometry=None,
             bbox=None,
@@ -93,9 +96,7 @@ class StaticLinkTest(unittest.TestCase):
             properties={},
         )
 
-        self.collection = pystac.Collection(
-            "collection id", "desc", extent=ARBITRARY_EXTENT
-        )
+        self.collection = Collection("collection id", "desc", extent=ARBITRARY_EXTENT)
 
     def test_from_dict_round_trip(self) -> None:
         test_cases: List[Dict[str, Any]] = [
@@ -107,32 +108,32 @@ class StaticLinkTest(unittest.TestCase):
             {"rel": "self", "href": "t"},
         ]
         for d in test_cases:
-            d2 = pystac.Link.from_dict(d).to_dict()
+            d2 = Link.from_dict(d).to_dict()
             self.assertEqual(d, d2)
 
     def test_from_dict_failures(self) -> None:
         dicts: List[Dict[str, Any]] = [{}, {"href": "t"}, {"rel": "r"}]
         for d in dicts:
             with self.assertRaises(KeyError):
-                pystac.Link.from_dict(d)
+                Link.from_dict(d)
 
     def test_collection(self) -> None:
-        link = pystac.Link.collection(self.collection)
+        link = Link.collection(self.collection)
         expected = {"rel": "collection", "href": None, "type": "application/json"}
         self.assertEqual(expected, link.to_dict())
 
     def test_child(self) -> None:
-        link = pystac.Link.child(self.collection)
+        link = Link.child(self.collection)
         expected = {"rel": "child", "href": None, "type": "application/json"}
         self.assertEqual(expected, link.to_dict())
 
     def test_canonical_item(self) -> None:
-        link = pystac.Link.canonical(self.item)
+        link = Link.canonical(self.item)
         expected = {"rel": "canonical", "href": None, "type": "application/json"}
         self.assertEqual(expected, link.to_dict())
 
     def test_canonical_collection(self) -> None:
-        link = pystac.Link.canonical(self.collection)
+        link = Link.canonical(self.collection)
         expected = {"rel": "canonical", "href": None, "type": "application/json"}
         self.assertEqual(expected, link.to_dict())
 
@@ -140,10 +141,8 @@ class StaticLinkTest(unittest.TestCase):
 class LinkInheritanceTest(unittest.TestCase):
     def setUp(self) -> None:
         self.maxDiff = None
-        self.collection = pystac.Collection(
-            "collection id", "desc", extent=ARBITRARY_EXTENT
-        )
-        self.item = pystac.Item(
+        self.collection = Collection("collection id", "desc", extent=ARBITRARY_EXTENT)
+        self.item = Item(
             id="test-item",
             geometry=None,
             bbox=None,
@@ -151,7 +150,7 @@ class LinkInheritanceTest(unittest.TestCase):
             properties={},
         )
 
-    class CustomLink(pystac.Link):
+    class CustomLink(Link):
         pass
 
     def test_from_dict(self) -> None:

--- a/tests/test_summaries.py
+++ b/tests/test_summaries.py
@@ -3,7 +3,7 @@ from typing import Any
 import unittest
 
 from pystac.summaries import RangeSummary, Summarizer, Summaries
-from tests.utils import TestCases
+from tests.utils.test_cases import TestCases
 
 
 class SummariesTest(unittest.TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone, timedelta
 from pystac import utils
 
 from pystac.utils import make_relative_href, make_absolute_href, is_absolute_href
-from tests.utils import TestCases
+from tests.utils.test_cases import TestCases
 
 
 class UtilsTest(unittest.TestCase):

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,13 +2,13 @@ import os
 import unittest
 from unittest.mock import patch
 
-import pystac
-from tests.utils import TestCases
+from pystac.version import STACVersion, set_stac_version
+from tests.utils.test_cases import TestCases
 
 
 class VersionTest(unittest.TestCase):
     def setUp(self) -> None:
-        pystac.version.STACVersion._override_version = None
+        STACVersion._override_version = None
 
     def test_override_stac_version_with_environ(self) -> None:
         override_version = "1.0.0-gamma.2"
@@ -19,7 +19,7 @@ class VersionTest(unittest.TestCase):
 
     def test_override_stac_version_with_call(self) -> None:
         override_version = "1.0.0-delta.2"
-        pystac.set_stac_version(override_version)
+        set_stac_version(override_version)
         cat = TestCases.test_case_1()
         d = cat.to_dict()
         self.assertEqual(d["stac_version"], override_version)

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict, TYPE_CHECKING, Type
 import unittest
+
+from pystac.stac_object import STACObject
 from tests.utils.test_cases import (
     TestCases,
     ARBITRARY_GEOM,
@@ -11,13 +13,12 @@ from copy import deepcopy
 from datetime import datetime
 from dateutil.parser import parse
 
-import pystac
 from tests.utils.stac_io_mock import MockStacIO
 
 
 def assert_to_from_dict(
     test_class: unittest.TestCase,
-    stac_object_class: Type[pystac.STACObject],
+    stac_object_class: Type[STACObject],
     d: Dict[str, Any],
 ) -> None:
     def _parse_times(a_dict: Dict[str, Any]) -> None:

--- a/tests/utils/stac_io_mock.py
+++ b/tests/utils/stac_io_mock.py
@@ -1,10 +1,11 @@
 from typing import Any, Union
 from unittest.mock import Mock
 
-import pystac
+from pystac.link import Link
+from pystac.stac_io import StacIO
 
 
-class MockStacIO(pystac.StacIO):
+class MockStacIO(StacIO):
     """Creates a mock that records StacIO calls for testing and allows
     clients to replace StacIO functionality, all within a context scope.
     """
@@ -12,14 +13,12 @@ class MockStacIO(pystac.StacIO):
     def __init__(self) -> None:
         self.mock = Mock()
 
-    def read_text(
-        self, source: Union[str, pystac.Link], *args: Any, **kwargs: Any
-    ) -> str:
+    def read_text(self, source: Union[str, Link], *args: Any, **kwargs: Any) -> str:
         self.mock.read_text(source)
-        return pystac.StacIO.default().read_text(source)
+        return StacIO.default().read_text(source)
 
     def write_text(
-        self, dest: Union[str, pystac.Link], txt: str, *args: Any, **kwargs: Any
+        self, dest: Union[str, Link], txt: str, *args: Any, **kwargs: Any
     ) -> None:
         self.mock.write_text(dest, txt)
-        pystac.StacIO.default().write_text(dest, txt)
+        StacIO.default().write_text(dest, txt)

--- a/tests/utils/test_cases.py
+++ b/tests/utils/test_cases.py
@@ -3,17 +3,13 @@ from datetime import datetime
 import csv
 from typing import Any, Dict, List
 
-import pystac
-from pystac import (
-    Catalog,
-    Collection,
-    Item,
-    Asset,
-    Extent,
-    TemporalExtent,
-    SpatialExtent,
-    MediaType,
-)
+from pystac.media_type import MediaType
+from pystac.asset import Asset
+from pystac.stac_object import STACObjectType
+from pystac.collection import Collection, Extent, TemporalExtent
+from pystac.item import Item
+from pystac.catalog import Catalog
+from pystac.collection import SpatialExtent
 from pystac.extensions.label import (
     LabelExtension,
     LabelOverview,
@@ -79,7 +75,7 @@ class ExampleInfo:
     def __init__(
         self,
         path: str,
-        object_type: pystac.STACObjectType,
+        object_type: STACObjectType,
         stac_version: str,
         extensions: List[str],
         valid: bool,
@@ -119,7 +115,7 @@ class TestCases:
                 examples.append(
                     ExampleInfo(
                         path=path,
-                        object_type=pystac.STACObjectType(object_type),
+                        object_type=STACObjectType(object_type),
                         stac_version=stac_version,
                         extensions=extensions,
                         valid=valid,

--- a/tests/validation/test_schema_uri_map.py
+++ b/tests/validation/test_schema_uri_map.py
@@ -1,13 +1,13 @@
 import unittest
 
-import pystac
+from pystac.stac_object import STACObjectType
 from pystac.validation.schema_uri_map import DefaultSchemaUriMap
 
 
 class SchemaUriMapTest(unittest.TestCase):
     def test_gets_schema_uri_for_old_version(self) -> None:
         d = DefaultSchemaUriMap()
-        uri = d.get_object_schema_uri(pystac.STACObjectType.ITEM, "0.8.0")
+        uri = d.get_object_schema_uri(STACObjectType.ITEM, "0.8.0")
 
         self.assertEqual(
             uri,


### PR DESCRIPTION
**Related Issue(s):** #332 


**Description:** First step towards `strict = True` mypy setting.


**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.