### PR TITLE
refactor: Avoid implicit reexport in submodules

### DIFF
--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -16,7 +16,11 @@ from typing import (
     cast,
 )
 
-import pystac
+from pystac.asset import Asset
+from pystac.stac_object import STACObjectType
+from pystac.collection import Collection
+from pystac.errors import ExtensionTypeError
+from pystac.item import Item
 from pystac.summaries import RangeSummary
 from pystac.extensions.base import (
     ExtensionManagementMixin,
@@ -28,7 +32,7 @@ from pystac.extensions import view, projection
 from pystac.serialization.identify import STACJSONDescription, STACVersionID
 from pystac.utils import get_required, map_opt
 
-T = TypeVar("T", pystac.Item, pystac.Asset)
+T = TypeVar("T", Item, Asset)
 
 SCHEMA_URI: str = "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
 PREFIX: str = "eo:"
@@ -277,28 +281,28 @@ class Band:
 class EOExtension(
     Generic[T],
     PropertiesExtension,
-    ExtensionManagementMixin[Union[pystac.Item, pystac.Collection]],
+    ExtensionManagementMixin[Union[Item, Collection]],
 ):
     """An abstract class that can be used to extend the properties of an
-    :class:`~pystac.Item` or :class:`~pystac.Asset` with properties from the
+    :class:`~Item` or :class:`~Asset` with properties from the
     :stac-ext:`Electro-Optical Extension <eo>`. This class is generic over the type of
-    STAC Object to be extended (e.g. :class:`~pystac.Item`,
-    :class:`~pystac.Asset`).
+    STAC Object to be extended (e.g. :class:`~Item`,
+    :class:`~Asset`).
 
     To create a concrete instance of :class:`EOExtension`, use the
     :meth:`EOExtension.ext` method. For example:
 
     .. code-block:: python
 
-       >>> item: pystac.Item = ...
+       >>> item: Item = ...
        >>> eo_ext = EOExtension.ext(item)
     """
 
     def apply(
         self, bands: Optional[List[Band]] = None, cloud_cover: Optional[float] = None
     ) -> None:
-        """Applies label extension properties to the extended :class:`~pystac.Item` or
-        :class:`~pystac.Asset`.
+        """Applies label extension properties to the extended :class:`~Item` or
+        :class:`~Asset`.
 
         Args:
             bands : A list of available bands where each item is a :class:`~Band`
@@ -353,54 +357,54 @@ class EOExtension(
         """Extends the given STAC Object with properties from the :stac-ext:`Electro-Optical
         Extension <eo>`.
 
-        This extension can be applied to instances of :class:`~pystac.Item` or
-        :class:`~pystac.Asset`.
+        This extension can be applied to instances of :class:`~Item` or
+        :class:`~Asset`.
 
         Raises:
 
-            pystac.ExtensionTypeError : If an invalid object type is passed.
+            ExtensionTypeError : If an invalid object type is passed.
         """
-        if isinstance(obj, pystac.Item):
+        if isinstance(obj, Item):
             cls.validate_has_extension(obj, add_if_missing)
             return cast(EOExtension[T], ItemEOExtension(obj))
-        elif isinstance(obj, pystac.Asset):
+        elif isinstance(obj, Asset):
             cls.validate_owner_has_extension(obj, add_if_missing)
             return cast(EOExtension[T], AssetEOExtension(obj))
         else:
-            raise pystac.ExtensionTypeError(
+            raise ExtensionTypeError(
                 f"EO extension does not apply to type '{type(obj).__name__}'"
             )
 
     @classmethod
     def summaries(
-        cls, obj: pystac.Collection, add_if_missing: bool = False
+        cls, obj: Collection, add_if_missing: bool = False
     ) -> "SummariesEOExtension":
         """Returns the extended summaries object for the given collection."""
         cls.validate_has_extension(obj, add_if_missing)
         return SummariesEOExtension(obj)
 
 
-class ItemEOExtension(EOExtension[pystac.Item]):
-    """A concrete implementation of :class:`EOExtension` on an :class:`~pystac.Item`
+class ItemEOExtension(EOExtension[Item]):
+    """A concrete implementation of :class:`EOExtension` on an :class:`~Item`
     that extends the properties of the Item to include properties defined in the
     :stac-ext:`Electro-Optical Extension <eo>`.
 
     This class should generally not be instantiated directly. Instead, call
-    :meth:`EOExtension.ext` on an :class:`~pystac.Item` to extend it.
+    :meth:`EOExtension.ext` on an :class:`~Item` to extend it.
     """
 
-    item: pystac.Item
-    """The :class:`~pystac.Item` being extended."""
+    item: Item
+    """The :class:`~Item` being extended."""
 
     properties: Dict[str, Any]
-    """The :class:`~pystac.Item` properties, including extension properties."""
+    """The :class:`~Item` properties, including extension properties."""
 
-    def __init__(self, item: pystac.Item):
+    def __init__(self, item: Item):
         self.item = item
         self.properties = item.properties
 
     def _get_bands(self) -> Optional[List[Band]]:
-        """Get or sets a list of :class:`~pystac.Band` objects that represent
+        """Get or sets a list of :class:`~Band` objects that represent
         the available bands.
         """
         bands = self._get_property(BANDS_PROP, List[Dict[str, Any]])
@@ -424,24 +428,24 @@ class ItemEOExtension(EOExtension[pystac.Item]):
         return "<ItemEOExtension Item id={}>".format(self.item.id)
 
 
-class AssetEOExtension(EOExtension[pystac.Asset]):
-    """A concrete implementation of :class:`EOExtension` on an :class:`~pystac.Asset`
+class AssetEOExtension(EOExtension[Asset]):
+    """A concrete implementation of :class:`EOExtension` on an :class:`~Asset`
     that extends the Asset fields to include properties defined in the
     :stac-ext:`Electro-Optical Extension <eo>`.
 
     This class should generally not be instantiated directly. Instead, call
-    :meth:`EOExtension.ext` on an :class:`~pystac.Asset` to extend it.
+    :meth:`EOExtension.ext` on an :class:`~Asset` to extend it.
     """
 
     asset_href: str
-    """The ``href`` value of the :class:`~pystac.Asset` being extended."""
+    """The ``href`` value of the :class:`~Asset` being extended."""
 
     properties: Dict[str, Any]
-    """The :class:`~pystac.Asset` fields, including extension properties."""
+    """The :class:`~Asset` fields, including extension properties."""
 
     additional_read_properties: Optional[Iterable[Dict[str, Any]]] = None
     """If present, this will be a list containing 1 dictionary representing the
-    properties of the owning :class:`~pystac.Item`."""
+    properties of the owning :class:`~Item`."""
 
     def _get_bands(self) -> Optional[List[Band]]:
         if BANDS_PROP not in self.properties:
@@ -453,10 +457,10 @@ class AssetEOExtension(EOExtension[pystac.Asset]):
             )
         )
 
-    def __init__(self, asset: pystac.Asset):
+    def __init__(self, asset: Asset):
         self.asset_href = asset.href
         self.properties = asset.extra_fields
-        if asset.owner and isinstance(asset.owner, pystac.Item):
+        if asset.owner and isinstance(asset.owner, Item):
             self.additional_read_properties = [asset.owner.properties]
 
     def __repr__(self) -> str:
@@ -465,7 +469,7 @@ class AssetEOExtension(EOExtension[pystac.Asset]):
 
 class SummariesEOExtension(SummariesExtension):
     """A concrete implementation of :class:`~SummariesExtension` that extends
-    the ``summaries`` field of a :class:`~pystac.Collection` to include properties
+    the ``summaries`` field of a :class:`~Collection` to include properties
     defined in the :stac-ext:`Electro-Optical Extension <eo>`.
     """
 
@@ -499,7 +503,7 @@ class SummariesEOExtension(SummariesExtension):
 class EOExtensionHooks(ExtensionHooks):
     schema_uri: str = SCHEMA_URI
     prev_extension_ids = {"eo"}
-    stac_object_types = {pystac.STACObjectType.ITEM}
+    stac_object_types = {STACObjectType.ITEM}
 
     def migrate(
         self, obj: Dict[str, Any], version: STACVersionID, info: STACJSONDescription
@@ -566,7 +570,7 @@ class EOExtensionHooks(ExtensionHooks):
                 if not any(prop.startswith(PREFIX) for prop in obj["properties"]):
                     obj["stac_extensions"].remove(EOExtension.get_schema_uri())
 
-        if version < "1.0.0-beta.1" and info.object_type == pystac.STACObjectType.ITEM:
+        if version < "1.0.0-beta.1" and info.object_type == STACObjectType.ITEM:
             # gsd moved from eo to common metadata
             if "eo:gsd" in obj["properties"]:
                 obj["properties"]["gsd"] = obj["properties"]["eo:gsd"]

--- a/pystac/extensions/file.py
+++ b/pystac/extensions/file.py
@@ -6,7 +6,11 @@ https://github.com/stac-extensions/file
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
-import pystac
+from pystac.asset import Asset
+from pystac.collection import Collection
+from pystac.stac_object import STACObjectType
+from pystac.errors import ExtensionTypeError
+from pystac.item import Item
 from pystac.extensions.base import ExtensionManagementMixin, PropertiesExtension
 from pystac.extensions.hooks import ExtensionHooks
 from pystac.serialization.identify import (
@@ -86,9 +90,9 @@ class MappingObject:
 
 
 class FileExtension(
-    PropertiesExtension, ExtensionManagementMixin[Union[pystac.Item, pystac.Collection]]
+    PropertiesExtension, ExtensionManagementMixin[Union[Item, Collection]]
 ):
-    """A class that can be used to extend the properties of an :class:`~pystac.Asset`
+    """A class that can be used to extend the properties of an :class:`~Asset`
     with properties from the :stac-ext:`File Info Extension <file>`.
 
     To create an instance of :class:`FileExtension`, use the
@@ -96,14 +100,14 @@ class FileExtension(
 
     .. code-block:: python
 
-       >>> asset: pystac.Asset = ...
+       >>> asset: Asset = ...
        >>> file_ext = FileExtension.ext(asset)
     """
 
-    def __init__(self, asset: pystac.Asset):
+    def __init__(self, asset: Asset):
         self.asset_href = asset.href
         self.properties = asset.extra_fields
-        if asset.owner and isinstance(asset.owner, pystac.Item):
+        if asset.owner and isinstance(asset.owner, Item):
             self.additional_read_properties = [asset.owner.properties]
 
     def __repr__(self) -> str:
@@ -192,17 +196,17 @@ class FileExtension(
         return SCHEMA_URI
 
     @classmethod
-    def ext(cls, obj: pystac.Asset, add_if_missing: bool = False) -> "FileExtension":
+    def ext(cls, obj: Asset, add_if_missing: bool = False) -> "FileExtension":
         """Extends the given STAC Object with properties from the :stac-ext:`File Info
         Extension <file>`.
 
-        This extension can be applied to instances of :class:`~pystac.Asset`.
+        This extension can be applied to instances of :class:`~Asset`.
         """
-        if isinstance(obj, pystac.Asset):
+        if isinstance(obj, Asset):
             cls.validate_owner_has_extension(obj, add_if_missing)
             return cls(obj)
         else:
-            raise pystac.ExtensionTypeError(
+            raise ExtensionTypeError(
                 f"File Info extension does not apply to type '{type(obj).__name__}'"
             )
 
@@ -210,7 +214,7 @@ class FileExtension(
 class FileExtensionHooks(ExtensionHooks):
     schema_uri: str = SCHEMA_URI
     prev_extension_ids = {"file"}
-    stac_object_types = {pystac.STACObjectType.ITEM}
+    stac_object_types = {STACObjectType.ITEM}
 
     def migrate(
         self, obj: Dict[str, Any], version: STACVersionID, info: STACJSONDescription

--- a/pystac/extensions/hooks.py
+++ b/pystac/extensions/hooks.py
@@ -2,7 +2,9 @@ from abc import ABC, abstractmethod
 from functools import lru_cache
 from typing import Any, Dict, Iterable, List, Optional, Set, TYPE_CHECKING, Union
 
-import pystac
+from pystac.rel_type import RelType
+from pystac.stac_object import STACObjectType
+from pystac.errors import ExtensionAlreadyExistsError
 from pystac.serialization.identify import STACJSONDescription, STACVersionID
 
 if TYPE_CHECKING:
@@ -28,7 +30,7 @@ class ExtensionHooks(ABC):
 
     @property
     @abstractmethod
-    def stac_object_types(self) -> Set[pystac.STACObjectType]:
+    def stac_object_types(self) -> Set[STACObjectType]:
         """A set of STACObjectType for which migration logic will be applied."""
         raise NotImplementedError
 
@@ -39,7 +41,7 @@ class ExtensionHooks(ABC):
 
     def get_object_links(
         self, obj: "STACObject_Type"
-    ) -> Optional[List[Union[str, pystac.RelType]]]:
+    ) -> Optional[List[Union[str, RelType]]]:
         return None
 
     def migrate(
@@ -70,7 +72,7 @@ class RegisteredExtensionHooks:
     def add_extension_hooks(self, hooks: ExtensionHooks) -> None:
         e_id = hooks.schema_uri
         if e_id in self.hooks:
-            raise pystac.ExtensionAlreadyExistsError(
+            raise ExtensionAlreadyExistsError(
                 "ExtensionDefinition with id '{}' already exists.".format(e_id)
             )
 
@@ -82,8 +84,8 @@ class RegisteredExtensionHooks:
 
     def get_extended_object_links(
         self, obj: "STACObject_Type"
-    ) -> List[Union[str, pystac.RelType]]:
-        result: Optional[List[Union[str, pystac.RelType]]] = None
+    ) -> List[Union[str, RelType]]:
+        result: Optional[List[Union[str, RelType]]] = None
         for ext in obj.stac_extensions:
             if ext in self.hooks:
                 ext_result = self.hooks[ext].get_object_links(obj)

--- a/pystac/extensions/item_assets.py
+++ b/pystac/extensions/item_assets.py
@@ -5,7 +5,10 @@ https://github.com/stac-extensions/item-assets
 
 from typing import Any, Dict, List, Optional
 
-import pystac
+from pystac.asset import Asset
+from pystac.stac_object import STACObjectType
+from pystac.collection import Collection
+from pystac.errors import ExtensionTypeError
 from pystac.extensions.base import ExtensionManagementMixin
 from pystac.extensions.hooks import ExtensionHooks
 from pystac.serialization.identify import STACJSONDescription, STACVersionID
@@ -69,8 +72,8 @@ class AssetDefinition:
         else:
             self.properties[ASSET_ROLES_PROP] = v
 
-    def create_asset(self, href: str) -> pystac.Asset:
-        return pystac.Asset(
+    def create_asset(self, href: str) -> Asset:
+        return Asset(
             href=href,
             title=self.title,
             description=self.description,
@@ -90,8 +93,8 @@ class AssetDefinition:
         )
 
 
-class ItemAssetsExtension(ExtensionManagementMixin[pystac.Collection]):
-    def __init__(self, collection: pystac.Collection) -> None:
+class ItemAssetsExtension(ExtensionManagementMixin[Collection]):
+    def __init__(self, collection: Collection) -> None:
         self.collection = collection
 
     @property
@@ -116,13 +119,13 @@ class ItemAssetsExtension(ExtensionManagementMixin[pystac.Collection]):
 
     @classmethod
     def ext(
-        cls, obj: pystac.Collection, add_if_missing: bool = False
+        cls, obj: Collection, add_if_missing: bool = False
     ) -> "ItemAssetsExtension":
-        if isinstance(obj, pystac.Collection):
+        if isinstance(obj, Collection):
             cls.validate_has_extension(obj, add_if_missing)
             return cls(obj)
         else:
-            raise pystac.ExtensionTypeError(
+            raise ExtensionTypeError(
                 f"Item Assets extension does not apply to type '{type(obj).__name__}'"
             )
 
@@ -130,7 +133,7 @@ class ItemAssetsExtension(ExtensionManagementMixin[pystac.Collection]):
 class ItemAssetsExtensionHooks(ExtensionHooks):
     schema_uri: str = SCHEMA_URI
     prev_extension_ids = {"asset", "item-assets"}
-    stac_object_types = {pystac.STACObjectType.COLLECTION}
+    stac_object_types = {STACObjectType.COLLECTION}
 
     def migrate(
         self, obj: Dict[str, Any], version: STACVersionID, info: STACJSONDescription

--- a/pystac/extensions/raster.py
+++ b/pystac/extensions/raster.py
@@ -6,7 +6,10 @@ https://github.com/stac-extensions/raster
 import enum
 from typing import Any, Dict, Iterable, List, Optional, Union
 
-import pystac
+from pystac.asset import Asset
+from pystac.collection import Collection
+from pystac.errors import ExtensionTypeError
+from pystac.item import Item
 from pystac.extensions.base import (
     ExtensionManagementMixin,
     PropertiesExtension,
@@ -626,44 +629,44 @@ class RasterBand:
 
 
 class RasterExtension(
-    PropertiesExtension, ExtensionManagementMixin[Union[pystac.Item, pystac.Collection]]
+    PropertiesExtension, ExtensionManagementMixin[Union[Item, Collection]]
 ):
     """An abstract class that can be used to extend the properties of an
-    :class:`~pystac.Item` or :class:`~pystac.Asset` with properties from
+    :class:`~Item` or :class:`~Asset` with properties from
     the :stac-ext:`Raster Extension <raster>`. This class is generic over
-    the type of STAC Object to be extended (e.g. :class:`~pystac.Item`,
-    :class:`~pystac.Asset`).
+    the type of STAC Object to be extended (e.g. :class:`~Item`,
+    :class:`~Asset`).
 
     This class will generally not be used directly. Instead, use the concrete
     implementation associated with the STAC Object you want to extend (e.g.
-    :class:`~ItemRasterExtension` to extend an :class:`~pystac.Item`).
+    :class:`~ItemRasterExtension` to extend an :class:`~Item`).
     """
 
     asset_href: str
-    """The ``href`` value of the :class:`~pystac.Asset` being extended."""
+    """The ``href`` value of the :class:`~Asset` being extended."""
 
     properties: Dict[str, Any]
-    """The :class:`~pystac.Asset` fields, including extension properties."""
+    """The :class:`~Asset` fields, including extension properties."""
 
     additional_read_properties: Optional[Iterable[Dict[str, Any]]] = None
     """If present, this will be a list containing 1 dictionary representing the
-    properties of the owning :class:`~pystac.Item`."""
+    properties of the owning :class:`~Item`."""
 
-    def __init__(self, asset: pystac.Asset):
+    def __init__(self, asset: Asset):
         self.asset_href = asset.href
         self.properties = asset.extra_fields
-        if asset.owner and isinstance(asset.owner, pystac.Item):
+        if asset.owner and isinstance(asset.owner, Item):
             self.additional_read_properties = [asset.owner.properties]
 
     def __repr__(self) -> str:
         return "<AssetRasterExtension Asset href={}>".format(self.asset_href)
 
     def apply(self, bands: List[RasterBand]) -> None:
-        """Applies raster extension properties to the extended :class:`pystac.Item` or
-        :class:`pystac.Asset`.
+        """Applies raster extension properties to the extended :class:`Item` or
+        :class:`Asset`.
 
         Args:
-            bands : a list of :class:`~pystac.RasterBand` objects that represent
+            bands : a list of :class:`~RasterBand` objects that represent
                 the available raster bands.
         """
         self.bands = bands
@@ -693,27 +696,27 @@ class RasterExtension(
         return SCHEMA_URI
 
     @classmethod
-    def ext(cls, obj: pystac.Asset, add_if_missing: bool = False) -> "RasterExtension":
+    def ext(cls, obj: Asset, add_if_missing: bool = False) -> "RasterExtension":
         """Extends the given STAC Object with properties from the :stac-ext:`Raster
         Extension <raster>`.
 
-        This extension can be applied to instances of :class:`~pystac.Asset`.
+        This extension can be applied to instances of :class:`~Asset`.
 
         Raises:
 
-            pystac.ExtensionTypeError : If an invalid object type is passed.
+            ExtensionTypeError : If an invalid object type is passed.
         """
-        if isinstance(obj, pystac.Asset):
+        if isinstance(obj, Asset):
             cls.validate_owner_has_extension(obj, add_if_missing)
             return cls(obj)
         else:
-            raise pystac.ExtensionTypeError(
+            raise ExtensionTypeError(
                 f"Raster extension does not apply to type '{type(obj).__name__}'"
             )
 
     @classmethod
     def summaries(
-        cls, obj: pystac.Collection, add_if_missing: bool = False
+        cls, obj: Collection, add_if_missing: bool = False
     ) -> "SummariesRasterExtension":
         cls.validate_has_extension(obj, add_if_missing)
         return SummariesRasterExtension(obj)
@@ -721,13 +724,13 @@ class RasterExtension(
 
 class SummariesRasterExtension(SummariesExtension):
     """A concrete implementation of :class:`~SummariesExtension` that extends
-    the ``summaries`` field of a :class:`~pystac.Collection` to include properties
+    the ``summaries`` field of a :class:`~Collection` to include properties
     defined in the :stac-ext:`Raster Extension <raster>`.
     """
 
     @property
     def bands(self) -> Optional[List[RasterBand]]:
-        """Get or sets a list of :class:`~pystac.Band` objects that represent
+        """Get or sets a list of :class:`~Band` objects that represent
         the available bands.
         """
         return map_opt(

--- a/pystac/extensions/sar.py
+++ b/pystac/extensions/sar.py
@@ -6,7 +6,11 @@ https://github.com/stac-extensions/sar
 import enum
 from typing import Any, Dict, Generic, Iterable, List, Optional, TypeVar, cast, Union
 
-import pystac
+from pystac.asset import Asset
+from pystac.collection import Collection
+from pystac.stac_object import STACObjectType
+from pystac.errors import ExtensionTypeError, STACError
+from pystac.item import Item
 from pystac.serialization.identify import STACJSONDescription, STACVersionID
 from pystac.summaries import RangeSummary
 from pystac.extensions.base import (
@@ -17,7 +21,7 @@ from pystac.extensions.base import (
 from pystac.extensions.hooks import ExtensionHooks
 from pystac.utils import get_required, map_opt
 
-T = TypeVar("T", pystac.Item, pystac.Asset)
+T = TypeVar("T", Item, Asset)
 
 SCHEMA_URI: str = "https://stac-extensions.github.io/sar/v1.0.0/schema.json"
 PREFIX: str = "sar:"
@@ -66,20 +70,20 @@ class ObservationDirection(str, enum.Enum):
 class SarExtension(
     Generic[T],
     PropertiesExtension,
-    ExtensionManagementMixin[Union[pystac.Item, pystac.Collection]],
+    ExtensionManagementMixin[Union[Item, Collection]],
 ):
     """An abstract class that can be used to extend the properties of an
-    :class:`~pystac.Item` or :class:`~pystac.Asset` with properties from the
+    :class:`~Item` or :class:`~Asset` with properties from the
     :stac-ext:`SAR Extension <sar>`. This class is generic over the type of
-    STAC Object to be extended (e.g. :class:`~pystac.Item`,
-    :class:`~pystac.Asset`).
+    STAC Object to be extended (e.g. :class:`~Item`,
+    :class:`~Asset`).
 
     To create a concrete instance of :class:`SARExtension`, use the
     :meth:`SARExtension.ext` method. For example:
 
     .. code-block:: python
 
-       >>> item: pystac.Item = ...
+       >>> item: Item = ...
        >>> sar_ext = SARExtension.ext(item)
     """
 
@@ -198,7 +202,7 @@ class SarExtension(
     @polarizations.setter
     def polarizations(self, values: List[Polarization]) -> None:
         if not isinstance(values, list):
-            raise pystac.STACError(f'polarizations must be a list. Invalid "{values}"')
+            raise STACError(f'polarizations must be a list. Invalid "{values}"')
         self._set_property(
             POLARIZATIONS_PROP, [v.value for v in values], pop_if_none=False
         )
@@ -307,53 +311,53 @@ class SarExtension(
         """Extends the given STAC Object with properties from the :stac-ext:`SAR
         Extension <sar>`.
 
-        This extension can be applied to instances of :class:`~pystac.Item` or
-        :class:`~pystac.Asset`.
+        This extension can be applied to instances of :class:`~Item` or
+        :class:`~Asset`.
 
         Raises:
 
-            pystac.ExtensionTypeError : If an invalid object type is passed.
+            ExtensionTypeError : If an invalid object type is passed.
         """
-        if isinstance(obj, pystac.Item):
+        if isinstance(obj, Item):
             cls.validate_has_extension(obj, add_if_missing)
             return cast(SarExtension[T], ItemSarExtension(obj))
-        elif isinstance(obj, pystac.Asset):
-            if obj.owner is not None and not isinstance(obj.owner, pystac.Item):
-                raise pystac.ExtensionTypeError(
+        elif isinstance(obj, Asset):
+            if obj.owner is not None and not isinstance(obj.owner, Item):
+                raise ExtensionTypeError(
                     "SAR extension does not apply to Collection Assets."
                 )
             cls.validate_owner_has_extension(obj, add_if_missing)
             return cast(SarExtension[T], AssetSarExtension(obj))
         else:
-            raise pystac.ExtensionTypeError(
+            raise ExtensionTypeError(
                 f"SAR extension does not apply to type '{type(obj).__name__}'"
             )
 
     @classmethod
     def summaries(
-        cls, obj: pystac.Collection, add_if_missing: bool = False
+        cls, obj: Collection, add_if_missing: bool = False
     ) -> "SummariesSarExtension":
         """Returns the extended summaries object for the given collection."""
         cls.validate_has_extension(obj, add_if_missing)
         return SummariesSarExtension(obj)
 
 
-class ItemSarExtension(SarExtension[pystac.Item]):
-    """A concrete implementation of :class:`SARExtension` on an :class:`~pystac.Item`
+class ItemSarExtension(SarExtension[Item]):
+    """A concrete implementation of :class:`SARExtension` on an :class:`~Item`
     that extends the properties of the Item to include properties defined in the
     :stac-ext:`SAR Extension <sar>`.
 
     This class should generally not be instantiated directly. Instead, call
-    :meth:`SARExtension.ext` on an :class:`~pystac.Item` to extend it.
+    :meth:`SARExtension.ext` on an :class:`~Item` to extend it.
     """
 
-    item: pystac.Item
-    """The :class:`~pystac.Item` being extended."""
+    item: Item
+    """The :class:`~Item` being extended."""
 
     properties: Dict[str, Any]
-    """The :class:`~pystac.Item` properties, including extension properties."""
+    """The :class:`~Item` properties, including extension properties."""
 
-    def __init__(self, item: pystac.Item):
+    def __init__(self, item: Item):
         self.item = item
         self.properties = item.properties
 
@@ -361,29 +365,29 @@ class ItemSarExtension(SarExtension[pystac.Item]):
         return "<ItemSarExtension Item id={}>".format(self.item.id)
 
 
-class AssetSarExtension(SarExtension[pystac.Asset]):
-    """A concrete implementation of :class:`SARExtension` on an :class:`~pystac.Asset`
+class AssetSarExtension(SarExtension[Asset]):
+    """A concrete implementation of :class:`SARExtension` on an :class:`~Asset`
     that extends the Asset fields to include properties defined in the
     :stac-ext:`SAR Extension <sar>`.
 
     This class should generally not be instantiated directly. Instead, call
-    :meth:`SARExtension.ext` on an :class:`~pystac.Asset` to extend it.
+    :meth:`SARExtension.ext` on an :class:`~Asset` to extend it.
     """
 
     asset_href: str
-    """The ``href`` value of the :class:`~pystac.Asset` being extended."""
+    """The ``href`` value of the :class:`~Asset` being extended."""
 
     properties: Dict[str, Any]
-    """The :class:`~pystac.Asset` fields, including extension properties."""
+    """The :class:`~Asset` fields, including extension properties."""
 
     additional_read_properties: Optional[Iterable[Dict[str, Any]]] = None
     """If present, this will be a list containing 1 dictionary representing the
-    properties of the owning :class:`~pystac.Item`."""
+    properties of the owning :class:`~Item`."""
 
-    def __init__(self, asset: pystac.Asset):
+    def __init__(self, asset: Asset):
         self.asset_href = asset.href
         self.properties = asset.extra_fields
-        if asset.owner and isinstance(asset.owner, pystac.Item):
+        if asset.owner and isinstance(asset.owner, Item):
             self.additional_read_properties = [asset.owner.properties]
 
     def __repr__(self) -> str:
@@ -392,7 +396,7 @@ class AssetSarExtension(SarExtension[pystac.Asset]):
 
 class SummariesSarExtension(SummariesExtension):
     """A concrete implementation of :class:`~SummariesExtension` that extends
-    the ``summaries`` field of a :class:`~pystac.Collection` to include properties
+    the ``summaries`` field of a :class:`~Collection` to include properties
     defined in the :stac-ext:`SAR Extension <sar>`.
     """
 
@@ -556,7 +560,7 @@ class SummariesSarExtension(SummariesExtension):
 class SarExtensionHooks(ExtensionHooks):
     schema_uri = SCHEMA_URI
     prev_extension_ids = {"sar"}
-    stac_object_types = {pystac.STACObjectType.ITEM}
+    stac_object_types = {STACObjectType.ITEM}
 
     def migrate(
         self, obj: Dict[str, Any], version: STACVersionID, info: STACJSONDescription

--- a/pystac/extensions/sat.py
+++ b/pystac/extensions/sat.py
@@ -8,7 +8,11 @@ from datetime import datetime as Datetime
 from pystac.summaries import RangeSummary
 from typing import Dict, Any, List, Iterable, Generic, Optional, TypeVar, Union, cast
 
-import pystac
+from pystac.asset import Asset
+from pystac.stac_object import STACObjectType
+from pystac.collection import Collection
+from pystac.errors import ExtensionTypeError
+from pystac.item import Item
 from pystac.extensions.base import (
     ExtensionManagementMixin,
     PropertiesExtension,
@@ -17,7 +21,7 @@ from pystac.extensions.base import (
 from pystac.extensions.hooks import ExtensionHooks
 from pystac.utils import str_to_datetime, datetime_to_str, map_opt
 
-T = TypeVar("T", pystac.Item, pystac.Asset)
+T = TypeVar("T", Item, Asset)
 
 SCHEMA_URI = "https://stac-extensions.github.io/sat/v1.0.0/schema.json"
 
@@ -40,20 +44,20 @@ class OrbitState(str, enum.Enum):
 class SatExtension(
     Generic[T],
     PropertiesExtension,
-    ExtensionManagementMixin[Union[pystac.Item, pystac.Collection]],
+    ExtensionManagementMixin[Union[Item, Collection]],
 ):
     """An abstract class that can be used to extend the properties of an
-    :class:`~pystac.Item` or :class:`~pystac.Asset` with properties from the
+    :class:`~Item` or :class:`~Asset` with properties from the
     :stac-ext:`Satellite Extension <sat>`. This class is generic over the type of
-    STAC Object to be extended (e.g. :class:`~pystac.Item`,
-    :class:`~pystac.Collection`).
+    STAC Object to be extended (e.g. :class:`~Item`,
+    :class:`~Collection`).
 
     To create a concrete instance of :class:`SatExtension`, use the
     :meth:`SatExtension.ext` method. For example:
 
     .. code-block:: python
 
-       >>> item: pystac.Item = ...
+       >>> item: Item = ...
        >>> sat_ext = SatExtension.ext(item)
     """
 
@@ -65,8 +69,8 @@ class SatExtension(
         platform_international_designator: Optional[str] = None,
         anx_datetime: Optional[Datetime] = None,
     ) -> None:
-        """Applies ext extension properties to the extended :class:`~pystac.Item` or
-        class:`~pystac.Asset`.
+        """Applies ext extension properties to the extended :class:`~Item` or
+        class:`~Asset`.
 
         Must specify at least one of orbit_state or relative_orbit in order
         for the sat extension to properties to be valid.
@@ -141,50 +145,50 @@ class SatExtension(
         """Extends the given STAC Object with properties from the :stac-ext:`Satellite
         Extension <sat>`.
 
-        This extension can be applied to instances of :class:`~pystac.Item` or
-        :class:`~pystac.Asset`.
+        This extension can be applied to instances of :class:`~Item` or
+        :class:`~Asset`.
 
         Raises:
 
-            pystac.ExtensionTypeError : If an invalid object type is passed.
+            ExtensionTypeError : If an invalid object type is passed.
         """
-        if isinstance(obj, pystac.Item):
+        if isinstance(obj, Item):
             cls.validate_has_extension(obj, add_if_missing)
             return cast(SatExtension[T], ItemSatExtension(obj))
-        elif isinstance(obj, pystac.Asset):
+        elif isinstance(obj, Asset):
             cls.validate_owner_has_extension(obj, add_if_missing)
             return cast(SatExtension[T], AssetSatExtension(obj))
         else:
-            raise pystac.ExtensionTypeError(
+            raise ExtensionTypeError(
                 f"Satellite extension does not apply to type '{type(obj).__name__}'"
             )
 
     @classmethod
     def summaries(
-        cls, obj: pystac.Collection, add_if_missing: bool = False
+        cls, obj: Collection, add_if_missing: bool = False
     ) -> "SummariesSatExtension":
         """Returns the extended summaries object for the given collection."""
         cls.validate_has_extension(obj, add_if_missing)
         return SummariesSatExtension(obj)
 
 
-class ItemSatExtension(SatExtension[pystac.Item]):
-    """A concrete implementation of :class:`SatExtension` on an :class:`~pystac.Item`
+class ItemSatExtension(SatExtension[Item]):
+    """A concrete implementation of :class:`SatExtension` on an :class:`~Item`
     that extends the properties of the Item to include properties defined in the
     :stac-ext:`Satellite Extension <sat>`.
 
     This class should generally not be instantiated directly. Instead, call
-    :meth:`SatExtension.ext` on an :class:`~pystac.Item` to
+    :meth:`SatExtension.ext` on an :class:`~Item` to
     extend it.
     """
 
-    item: pystac.Item
-    """The :class:`~pystac.Item` being extended."""
+    item: Item
+    """The :class:`~Item` being extended."""
 
     properties: Dict[str, Any]
-    """The :class:`~pystac.Item` properties, including extension properties."""
+    """The :class:`~Item` properties, including extension properties."""
 
-    def __init__(self, item: pystac.Item):
+    def __init__(self, item: Item):
         self.item = item
         self.properties = item.properties
 
@@ -192,30 +196,30 @@ class ItemSatExtension(SatExtension[pystac.Item]):
         return "<ItemSatExtension Item id={}>".format(self.item.id)
 
 
-class AssetSatExtension(SatExtension[pystac.Asset]):
-    """A concrete implementation of :class:`SatExtension` on an :class:`~pystac.Asset`
+class AssetSatExtension(SatExtension[Asset]):
+    """A concrete implementation of :class:`SatExtension` on an :class:`~Asset`
     that extends the properties of the Asset to include properties defined in the
     :stac-ext:`Satellite Extension <sat>`.
 
     This class should generally not be instantiated directly. Instead, call
-    :meth:`SatExtension.ext` on an :class:`~pystac.Asset` to
+    :meth:`SatExtension.ext` on an :class:`~Asset` to
     extend it.
     """
 
     asset_href: str
-    """The ``href`` value of the :class:`~pystac.Asset` being extended."""
+    """The ``href`` value of the :class:`~Asset` being extended."""
 
     properties: Dict[str, Any]
-    """The :class:`~pystac.Asset` fields, including extension properties."""
+    """The :class:`~Asset` fields, including extension properties."""
 
     additional_read_properties: Optional[Iterable[Dict[str, Any]]] = None
     """If present, this will be a list containing 1 dictionary representing the
-    properties of the owning :class:`~pystac.Item`."""
+    properties of the owning :class:`~Item`."""
 
-    def __init__(self, asset: pystac.Asset):
+    def __init__(self, asset: Asset):
         self.asset_href = asset.href
         self.properties = asset.extra_fields
-        if asset.owner and isinstance(asset.owner, pystac.Item):
+        if asset.owner and isinstance(asset.owner, Item):
             self.additional_read_properties = [asset.owner.properties]
 
     def __repr__(self) -> str:
@@ -224,7 +228,7 @@ class AssetSatExtension(SatExtension[pystac.Asset]):
 
 class SummariesSatExtension(SummariesExtension):
     """A concrete implementation of :class:`~SummariesExtension` that extends
-    the ``summaries`` field of a :class:`~pystac.Collection` to include properties
+    the ``summaries`` field of a :class:`~Collection` to include properties
     defined in the :stac-ext:`Satellite Extension <sat>`.
     """
 
@@ -294,7 +298,7 @@ class SummariesSatExtension(SummariesExtension):
 class SatExtensionHooks(ExtensionHooks):
     schema_uri: str = SCHEMA_URI
     prev_extension_ids = {"sat"}
-    stac_object_types = {pystac.STACObjectType.ITEM}
+    stac_object_types = {STACObjectType.ITEM}
 
 
 SAT_EXTENSION_HOOKS: ExtensionHooks = SatExtensionHooks()

--- a/pystac/extensions/timestamps.py
+++ b/pystac/extensions/timestamps.py
@@ -7,7 +7,11 @@ from datetime import datetime as datetime
 from pystac.summaries import RangeSummary
 from typing import Dict, Any, Iterable, Generic, Optional, TypeVar, Union, cast
 
-import pystac
+from pystac.asset import Asset
+from pystac.stac_object import STACObjectType
+from pystac.collection import Collection
+from pystac.errors import ExtensionTypeError
+from pystac.item import Item
 from pystac.extensions.base import (
     ExtensionManagementMixin,
     PropertiesExtension,
@@ -16,7 +20,7 @@ from pystac.extensions.base import (
 from pystac.extensions.hooks import ExtensionHooks
 from pystac.utils import datetime_to_str, map_opt, str_to_datetime
 
-T = TypeVar("T", pystac.Item, pystac.Asset)
+T = TypeVar("T", Item, Asset)
 
 SCHEMA_URI = "https://stac-extensions.github.io/timestamps/v1.0.0/schema.json"
 
@@ -28,19 +32,19 @@ UNPUBLISHED_PROP = "unpublished"
 class TimestampsExtension(
     Generic[T],
     PropertiesExtension,
-    ExtensionManagementMixin[Union[pystac.Item, pystac.Collection]],
+    ExtensionManagementMixin[Union[Item, Collection]],
 ):
     """An abstract class that can be used to extend the properties of an
-    :class:`~pystac.Item` or :class:`~pystac.Asset` with properties from the
+    :class:`~Item` or :class:`~Asset` with properties from the
     :stac-ext:`Timestamps Extension <timestamps>`. This class is generic over the type
-    of STAC Object to be extended (e.g. :class:`~pystac.Item`, :class:`~pystac.Asset`).
+    of STAC Object to be extended (e.g. :class:`~Item`, :class:`~Asset`).
 
     To create a concrete instance of :class:`TimestampsExtension`, use the
     :meth:`TimestampsExtension.ext` method. For example:
 
     .. code-block:: python
 
-       >>> item: pystac.Item = ...
+       >>> item: Item = ...
        >>> ts_ext = TimestampsExtension.ext(item)
     """
 
@@ -121,49 +125,49 @@ class TimestampsExtension(
         """Extends the given STAC Object with properties from the :stac-ext:`Timestamps
         Extension <timestamps>`.
 
-        This extension can be applied to instances of :class:`~pystac.Item` or
-        :class:`~pystac.Asset`.
+        This extension can be applied to instances of :class:`~Item` or
+        :class:`~Asset`.
 
         Raises:
 
-            pystac.ExtensionTypeError : If an invalid object type is passed.
+            ExtensionTypeError : If an invalid object type is passed.
         """
-        if isinstance(obj, pystac.Item):
+        if isinstance(obj, Item):
             cls.validate_has_extension(obj, add_if_missing)
             return cast(TimestampsExtension[T], ItemTimestampsExtension(obj))
-        elif isinstance(obj, pystac.Asset):
+        elif isinstance(obj, Asset):
             cls.validate_owner_has_extension(obj, add_if_missing)
             return cast(TimestampsExtension[T], AssetTimestampsExtension(obj))
         else:
-            raise pystac.ExtensionTypeError(
+            raise ExtensionTypeError(
                 f"Timestamps extension does not apply to type '{type(obj).__name__}'"
             )
 
     @classmethod
     def summaries(
-        cls, obj: pystac.Collection, add_if_missing: bool = False
+        cls, obj: Collection, add_if_missing: bool = False
     ) -> "SummariesTimestampsExtension":
         """Returns the extended summaries object for the given collection."""
         cls.validate_has_extension(obj, add_if_missing)
         return SummariesTimestampsExtension(obj)
 
 
-class ItemTimestampsExtension(TimestampsExtension[pystac.Item]):
+class ItemTimestampsExtension(TimestampsExtension[Item]):
     """A concrete implementation of :class:`TimestampsExtension` on an
-    :class:`~pystac.Item` that extends the properties of the Item to include properties
+    :class:`~Item` that extends the properties of the Item to include properties
     defined in the :stac-ext:`Timestamps Extension <timestamps>`.
 
     This class should generally not be instantiated directly. Instead, call
-    :meth:`TimestampsExtension.ext` on an :class:`~pystac.Item` to extend it.
+    :meth:`TimestampsExtension.ext` on an :class:`~Item` to extend it.
     """
 
-    item: pystac.Item
-    """The :class:`~pystac.Item` being extended."""
+    item: Item
+    """The :class:`~Item` being extended."""
 
     properties: Dict[str, Any]
-    """The :class:`~pystac.Item` properties, including extension properties."""
+    """The :class:`~Item` properties, including extension properties."""
 
-    def __init__(self, item: pystac.Item):
+    def __init__(self, item: Item):
         self.item = item
         self.properties = item.properties
 
@@ -171,29 +175,29 @@ class ItemTimestampsExtension(TimestampsExtension[pystac.Item]):
         return "<ItemTimestampsExtension Item id={}>".format(self.item.id)
 
 
-class AssetTimestampsExtension(TimestampsExtension[pystac.Asset]):
+class AssetTimestampsExtension(TimestampsExtension[Asset]):
     """A concrete implementation of :class:`TimestampsExtension` on an
-    :class:`~pystac.Asset` that extends the Asset fields to include properties
+    :class:`~Asset` that extends the Asset fields to include properties
     defined in the :stac-ext:`Timestamps Extension <timestamps>`.
 
     This class should generally not be instantiated directly. Instead, call
-    :meth:`TimestampsExtension.ext` on an :class:`~pystac.Asset` to extend it.
+    :meth:`TimestampsExtension.ext` on an :class:`~Asset` to extend it.
     """
 
     asset_href: str
-    """The ``href`` value of the :class:`~pystac.Asset` being extended."""
+    """The ``href`` value of the :class:`~Asset` being extended."""
 
     properties: Dict[str, Any]
-    """The :class:`~pystac.Asset` fields, including extension properties."""
+    """The :class:`~Asset` fields, including extension properties."""
 
     additional_read_properties: Optional[Iterable[Dict[str, Any]]] = None
     """If present, this will be a list containing 1 dictionary representing the
-    properties of the owning :class:`~pystac.Item`."""
+    properties of the owning :class:`~Item`."""
 
-    def __init__(self, asset: pystac.Asset):
+    def __init__(self, asset: Asset):
         self.asset_href = asset.href
         self.properties = asset.extra_fields
-        if asset.owner and isinstance(asset.owner, pystac.Item):
+        if asset.owner and isinstance(asset.owner, Item):
             self.additional_read_properties = [asset.owner.properties]
 
     def __repr__(self) -> str:
@@ -202,7 +206,7 @@ class AssetTimestampsExtension(TimestampsExtension[pystac.Asset]):
 
 class SummariesTimestampsExtension(SummariesExtension):
     """A concrete implementation of :class:`~SummariesExtension` that extends
-    the ``summaries`` field of a :class:`~pystac.Collection` to include properties
+    the ``summaries`` field of a :class:`~Collection` to include properties
     defined in the :stac-ext:`Timestamps Extension <timestamps>`.
     """
 
@@ -285,7 +289,7 @@ class SummariesTimestampsExtension(SummariesExtension):
 class TimestampsExtensionHooks(ExtensionHooks):
     schema_uri: str = SCHEMA_URI
     prev_extension_ids = {"timestamps"}
-    stac_object_types = {pystac.STACObjectType.ITEM}
+    stac_object_types = {STACObjectType.ITEM}
 
 
 TIMESTAMPS_EXTENSION_HOOKS: ExtensionHooks = TimestampsExtensionHooks()

--- a/pystac/extensions/view.py
+++ b/pystac/extensions/view.py
@@ -5,7 +5,11 @@ https://github.com/stac-extensions/view
 
 from typing import Any, Dict, Generic, Iterable, Optional, TypeVar, Union, cast
 
-import pystac
+from pystac.asset import Asset
+from pystac.stac_object import STACObjectType
+from pystac.collection import Collection
+from pystac.errors import ExtensionTypeError
+from pystac.item import Item
 from pystac.summaries import RangeSummary
 from pystac.extensions.base import (
     ExtensionManagementMixin,
@@ -14,7 +18,7 @@ from pystac.extensions.base import (
 )
 from pystac.extensions.hooks import ExtensionHooks
 
-T = TypeVar("T", pystac.Item, pystac.Asset)
+T = TypeVar("T", Item, Asset)
 
 SCHEMA_URI: str = "https://stac-extensions.github.io/view/v1.0.0/schema.json"
 PREFIX: str = "view:"
@@ -29,19 +33,19 @@ SUN_ELEVATION_PROP: str = PREFIX + "sun_elevation"
 class ViewExtension(
     Generic[T],
     PropertiesExtension,
-    ExtensionManagementMixin[Union[pystac.Item, pystac.Collection]],
+    ExtensionManagementMixin[Union[Item, Collection]],
 ):
     """An abstract class that can be used to extend the properties of an
-    :class:`~pystac.Item` with properties from the :stac-ext:`View Geometry
+    :class:`~Item` with properties from the :stac-ext:`View Geometry
     Extension <view>`. This class is generic over the type of STAC Object to be
-    extended (e.g. :class:`~pystac.Item`, :class:`~pystac.Asset`).
+    extended (e.g. :class:`~Item`, :class:`~Asset`).
 
     To create a concrete instance of :class:`ViewExtension`, use the
     :meth:`ViewExtension.ext` method. For example:
 
     .. code-block:: python
 
-       >>> item: pystac.Item = ...
+       >>> item: Item = ...
        >>> view_ext = ViewExtension.ext(item)
     """
 
@@ -54,7 +58,7 @@ class ViewExtension(
         sun_elevation: Optional[float] = None,
     ) -> None:
         """Applies View Geometry extension properties to the extended
-        :class:`~pystac.Item`.
+        :class:`~Item`.
 
         Args:
             off_nadir : The angle from the sensor between nadir (straight down)
@@ -150,49 +154,49 @@ class ViewExtension(
         """Extends the given STAC Object with properties from the :stac-ext:`View
         Geometry Extension <scientific>`.
 
-        This extension can be applied to instances of :class:`~pystac.Item` or
-        :class:`~pystac.Asset`.
+        This extension can be applied to instances of :class:`~Item` or
+        :class:`~Asset`.
 
         Raises:
 
-            pystac.ExtensionTypeError : If an invalid object type is passed.
+            ExtensionTypeError : If an invalid object type is passed.
         """
-        if isinstance(obj, pystac.Item):
+        if isinstance(obj, Item):
             cls.validate_has_extension(obj, add_if_missing)
             return cast(ViewExtension[T], ItemViewExtension(obj))
-        elif isinstance(obj, pystac.Asset):
+        elif isinstance(obj, Asset):
             cls.validate_owner_has_extension(obj, add_if_missing)
             return cast(ViewExtension[T], AssetViewExtension(obj))
         else:
-            raise pystac.ExtensionTypeError(
+            raise ExtensionTypeError(
                 f"View extension does not apply to type '{type(obj).__name__}'"
             )
 
     @classmethod
     def summaries(
-        cls, obj: pystac.Collection, add_if_missing: bool = False
+        cls, obj: Collection, add_if_missing: bool = False
     ) -> "SummariesViewExtension":
         """Returns the extended summaries object for the given collection."""
         cls.validate_has_extension(obj, add_if_missing)
         return SummariesViewExtension(obj)
 
 
-class ItemViewExtension(ViewExtension[pystac.Item]):
-    """A concrete implementation of :class:`ViewExtension` on an :class:`~pystac.Item`
+class ItemViewExtension(ViewExtension[Item]):
+    """A concrete implementation of :class:`ViewExtension` on an :class:`~Item`
     that extends the properties of the Item to include properties defined in the
     :stac-ext:`View Geometry Extension <view>`.
 
     This class should generally not be instantiated directly. Instead, call
-    :meth:`ViewExtension.ext` on an :class:`~pystac.Item` to extend it.
+    :meth:`ViewExtension.ext` on an :class:`~Item` to extend it.
     """
 
-    item: pystac.Item
-    """The :class:`~pystac.Item` being extended."""
+    item: Item
+    """The :class:`~Item` being extended."""
 
     properties: Dict[str, Any]
-    """The :class:`~pystac.Item` properties, including extension properties."""
+    """The :class:`~Item` properties, including extension properties."""
 
-    def __init__(self, item: pystac.Item):
+    def __init__(self, item: Item):
         self.item = item
         self.properties = item.properties
 
@@ -200,29 +204,29 @@ class ItemViewExtension(ViewExtension[pystac.Item]):
         return "<ItemViewExtension Item id={}>".format(self.item.id)
 
 
-class AssetViewExtension(ViewExtension[pystac.Asset]):
-    """A concrete implementation of :class:`ViewExtension` on an :class:`~pystac.Asset`
+class AssetViewExtension(ViewExtension[Asset]):
+    """A concrete implementation of :class:`ViewExtension` on an :class:`~Asset`
     that extends the Asset fields to include properties defined in the
     :stac-ext:`View Geometry Extension <view>`.
 
     This class should generally not be instantiated directly. Instead, call
-    :meth:`ViewExtension.ext` on an :class:`~pystac.Asset` to extend it.
+    :meth:`ViewExtension.ext` on an :class:`~Asset` to extend it.
     """
 
     asset_href: str
-    """The ``href`` value of the :class:`~pystac.Asset` being extended."""
+    """The ``href`` value of the :class:`~Asset` being extended."""
 
     properties: Dict[str, Any]
-    """The :class:`~pystac.Asset` fields, including extension properties."""
+    """The :class:`~Asset` fields, including extension properties."""
 
     additional_read_properties: Optional[Iterable[Dict[str, Any]]] = None
     """If present, this will be a list containing 1 dictionary representing the
-    properties of the owning :class:`~pystac.Item`."""
+    properties of the owning :class:`~Item`."""
 
-    def __init__(self, asset: pystac.Asset):
+    def __init__(self, asset: Asset):
         self.asset_href = asset.href
         self.properties = asset.extra_fields
-        if asset.owner and isinstance(asset.owner, pystac.Item):
+        if asset.owner and isinstance(asset.owner, Item):
             self.additional_read_properties = [asset.owner.properties]
 
     def __repr__(self) -> str:
@@ -231,7 +235,7 @@ class AssetViewExtension(ViewExtension[pystac.Asset]):
 
 class SummariesViewExtension(SummariesExtension):
     """A concrete implementation of :class:`~SummariesExtension` that extends
-    the ``summaries`` field of a :class:`~pystac.Collection` to include properties
+    the ``summaries`` field of a :class:`~Collection` to include properties
     defined in the :stac-ext:`View Object Extension <view>`.
     """
 
@@ -294,7 +298,7 @@ class SummariesViewExtension(SummariesExtension):
 class ViewExtensionHooks(ExtensionHooks):
     schema_uri = SCHEMA_URI
     prev_extension_ids = {"view"}
-    stac_object_types = {pystac.STACObjectType.ITEM}
+    stac_object_types = {STACObjectType.ITEM}
 
 
 VIEW_EXTENSION_HOOKS: ExtensionHooks = ViewExtensionHooks()

--- a/pystac/validation/__init__.py
+++ b/pystac/validation/__init__.py
@@ -1,6 +1,9 @@
 from typing import Dict, List, Any, Optional, cast, TYPE_CHECKING
 
-import pystac
+from pystac.version import get_stac_version
+from pystac.stac_io import StacIO
+from pystac.rel_type import RelType
+from pystac.stac_object import STACObjectType
 from pystac.serialization.identify import STACVersionID, identify_stac_object
 from pystac.validation.schema_uri_map import OldExtensionSchemaUriMap
 from pystac.utils import make_absolute_href
@@ -31,7 +34,7 @@ def validate(stac_object: "STACObject_Type") -> List[Any]:
     return validate_dict(
         stac_dict=stac_object.to_dict(),
         stac_object_type=stac_object.STAC_OBJECT_TYPE,
-        stac_version=pystac.get_stac_version(),
+        stac_version=get_stac_version(),
         extensions=stac_object.stac_extensions,
         href=stac_object.get_self_href(),
     )
@@ -105,7 +108,7 @@ def validate_dict(
 
 
 def validate_all(
-    stac_dict: Dict[str, Any], href: str, stac_io: Optional[pystac.StacIO] = None
+    stac_dict: Dict[str, Any], href: str, stac_io: Optional[StacIO] = None
 ) -> None:
     """Validate STAC JSON and all contained catalogs, collections and items.
 
@@ -125,7 +128,7 @@ def validate_all(
             contained catalog, collection or item has a validation error.
     """
     if stac_io is None:
-        stac_io = pystac.StacIO.default()
+        stac_io = StacIO.default()
 
     info = identify_stac_object(stac_dict)
 
@@ -138,7 +141,7 @@ def validate_all(
         href=href,
     )
 
-    if info.object_type != pystac.STACObjectType.ITEM:
+    if info.object_type != STACObjectType.ITEM:
         if "links" in stac_dict:
             # Account for 0.6 links
             if isinstance(stac_dict["links"], dict):
@@ -147,7 +150,7 @@ def validate_all(
                 links = cast(List[Dict[str, Any]], stac_dict.get("links"))
             for link in links:
                 rel = link.get("rel")
-                if rel in [pystac.RelType.ITEM, pystac.RelType.CHILD]:
+                if rel in [RelType.ITEM, RelType.CHILD]:
                     link_href = make_absolute_href(
                         cast(str, link.get("href")), start_href=href
                     )

--- a/pystac/validation/schema_uri_map.py
+++ b/pystac/validation/schema_uri_map.py
@@ -3,7 +3,7 @@ from functools import lru_cache
 from pystac.serialization.identify import OldExtensionShortIDs, STACVersionID
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
-import pystac
+from pystac.version import get_stac_version
 from pystac.serialization import STACVersionRange
 from pystac.stac_object import STACObjectType
 
@@ -90,7 +90,7 @@ class DefaultSchemaUriMap(SchemaUriMap):
     def get_object_schema_uri(
         self, object_type: STACObjectType, stac_version: str
     ) -> Optional[str]:
-        is_latest = stac_version == pystac.get_stac_version()
+        is_latest = stac_version == get_stac_version()
 
         if object_type not in self.DEFAULT_SCHEMA_MAP:
             raise KeyError("Unknown STAC object type {}".format(object_type))
@@ -149,13 +149,13 @@ class OldExtensionSchemaUriMap:
         return {
             OldExtensionShortIDs.CHECKSUM.value: (
                 {
-                    pystac.STACObjectType.CATALOG: (
+                    STACObjectType.CATALOG: (
                         "extensions/checksum/json-schema/schema.json"
                     ),
-                    pystac.STACObjectType.COLLECTION: (
+                    STACObjectType.COLLECTION: (
                         "extensions/checksum/json-schema/schema.json"
                     ),
-                    pystac.STACObjectType.ITEM: (
+                    STACObjectType.ITEM: (
                         "extensions/checksum/json-schema/schema.json"
                     ),
                 },
@@ -163,7 +163,7 @@ class OldExtensionSchemaUriMap:
             ),
             OldExtensionShortIDs.COLLECTION_ASSETS.value: (
                 {
-                    pystac.STACObjectType.COLLECTION: (
+                    STACObjectType.COLLECTION: (
                         "extensions/collection-assets/json-schema/schema.json"
                     )
                 },
@@ -171,10 +171,10 @@ class OldExtensionSchemaUriMap:
             ),
             OldExtensionShortIDs.DATACUBE.value: (
                 {
-                    pystac.STACObjectType.COLLECTION: (
+                    STACObjectType.COLLECTION: (
                         "extensions/datacube/json-schema/schema.json"
                     ),
-                    pystac.STACObjectType.ITEM: (
+                    STACObjectType.ITEM: (
                         "extensions/datacube/json-schema/schema.json"
                     ),
                 },
@@ -182,34 +182,30 @@ class OldExtensionSchemaUriMap:
                     (
                         STACVersionRange(min_version="0.5.0", max_version="0.9.0"),
                         {
-                            pystac.STACObjectType.COLLECTION: None,
-                            pystac.STACObjectType.ITEM: None,
+                            STACObjectType.COLLECTION: None,
+                            STACObjectType.ITEM: None,
                         },
                     )
                 ],
             ),
             OldExtensionShortIDs.EO.value: (
-                {pystac.STACObjectType.ITEM: "extensions/eo/json-schema/schema.json"},
+                {STACObjectType.ITEM: "extensions/eo/json-schema/schema.json"},
                 None,
             ),
             OldExtensionShortIDs.ITEM_ASSETS.value: (
                 {
-                    pystac.STACObjectType.COLLECTION: (
+                    STACObjectType.COLLECTION: (
                         "extensions/item-assets/json-schema/schema.json"
                     )
                 },
                 None,
             ),
             OldExtensionShortIDs.LABEL.value: (
-                {
-                    pystac.STACObjectType.ITEM: (
-                        "extensions/label/json-schema/schema.json"
-                    )
-                },
+                {STACObjectType.ITEM: ("extensions/label/json-schema/schema.json")},
                 [
                     (
                         STACVersionRange(min_version="0.8.0-rc1", max_version="0.8.1"),
-                        {pystac.STACObjectType.ITEM: "extensions/label/schema.json"},
+                        {STACObjectType.ITEM: "extensions/label/schema.json"},
                     )
                 ],
             ),
@@ -220,26 +216,26 @@ class OldExtensionSchemaUriMap:
             ),
             OldExtensionShortIDs.PROJECTION.value: (
                 {
-                    pystac.STACObjectType.ITEM: (
+                    STACObjectType.ITEM: (
                         "extensions/projection/json-schema/schema.json"
                     )
                 },
                 None,
             ),
             OldExtensionShortIDs.SAR.value: (
-                {pystac.STACObjectType.ITEM: "extensions/sar/json-schema/schema.json"},
+                {STACObjectType.ITEM: "extensions/sar/json-schema/schema.json"},
                 None,
             ),
             OldExtensionShortIDs.SAT.value: (
-                {pystac.STACObjectType.ITEM: "extensions/sat/json-schema/schema.json"},
+                {STACObjectType.ITEM: "extensions/sat/json-schema/schema.json"},
                 None,
             ),
             OldExtensionShortIDs.SCIENTIFIC.value: (
                 {
-                    pystac.STACObjectType.ITEM: (
+                    STACObjectType.ITEM: (
                         "extensions/scientific/json-schema/schema.json"
                     ),
-                    pystac.STACObjectType.COLLECTION: (
+                    STACObjectType.COLLECTION: (
                         "extensions/scientific/json-schema/schema.json"
                     ),
                 },
@@ -247,7 +243,7 @@ class OldExtensionSchemaUriMap:
             ),
             OldExtensionShortIDs.SINGLE_FILE_STAC.value: (
                 {
-                    pystac.STACObjectType.CATALOG: (
+                    STACObjectType.CATALOG: (
                         "extensions/single-file-stac/json-schema/schema.json"
                     )
                 },
@@ -255,13 +251,13 @@ class OldExtensionSchemaUriMap:
             ),
             OldExtensionShortIDs.TILED_ASSETS.value: (
                 {
-                    pystac.STACObjectType.CATALOG: (
+                    STACObjectType.CATALOG: (
                         "extensions/tiled-assets/json-schema/schema.json"
                     ),
-                    pystac.STACObjectType.COLLECTION: (
+                    STACObjectType.COLLECTION: (
                         "extensions/tiled-assets/json-schema/schema.json"
                     ),
-                    pystac.STACObjectType.ITEM: (
+                    STACObjectType.ITEM: (
                         "extensions/tiled-assets/json-schema/schema.json"
                     ),
                 },
@@ -269,7 +265,7 @@ class OldExtensionSchemaUriMap:
             ),
             OldExtensionShortIDs.TIMESTAMPS.value: (
                 {
-                    pystac.STACObjectType.ITEM: (
+                    STACObjectType.ITEM: (
                         "extensions/timestamps/json-schema/schema.json"
                     )
                 },
@@ -277,17 +273,15 @@ class OldExtensionSchemaUriMap:
             ),
             OldExtensionShortIDs.VERSION.value: (
                 {
-                    pystac.STACObjectType.ITEM: (
-                        "extensions/version/json-schema/schema.json"
-                    ),
-                    pystac.STACObjectType.COLLECTION: (
+                    STACObjectType.ITEM: ("extensions/version/json-schema/schema.json"),
+                    STACObjectType.COLLECTION: (
                         "extensions/version/json-schema/schema.json"
                     ),
                 },
                 None,
             ),
             OldExtensionShortIDs.VIEW.value: (
-                {pystac.STACObjectType.ITEM: "extensions/view/json-schema/schema.json"},
+                {STACObjectType.ITEM: "extensions/view/json-schema/schema.json"},
                 None,
             ),
             # Removed or renamed extensions.
@@ -298,7 +292,7 @@ class OldExtensionSchemaUriMap:
                     (
                         STACVersionRange(min_version="0.8.0-rc1", max_version="0.9.0"),
                         {
-                            pystac.STACObjectType.COLLECTION: (
+                            STACObjectType.COLLECTION: (
                                 "extensions/asset/json-schema/schema.json"
                             )
                         },
@@ -329,7 +323,7 @@ class OldExtensionSchemaUriMap:
     ) -> Optional[str]:
         uri = None
 
-        is_latest = stac_version == pystac.get_stac_version()
+        is_latest = stac_version == get_stac_version()
 
         ext_map = cls.get_schema_map()
         if extension_id in ext_map:

--- a/pystac/validation/stac_validator.py
+++ b/pystac/validation/stac_validator.py
@@ -4,7 +4,8 @@ import json
 from pystac.stac_object import STACObjectType
 from typing import Any, Dict, List, Optional, Tuple
 
-import pystac
+from pystac.stac_io import StacIO
+from pystac.errors import STACValidationError
 from pystac.validation.schema_uri_map import DefaultSchemaUriMap, SchemaUriMap
 
 try:
@@ -144,7 +145,7 @@ class JsonSchemaSTACValidator(STACValidator):
 
     def get_schema_from_uri(self, schema_uri: str) -> Tuple[Dict[str, Any], Any]:
         if schema_uri not in self.schema_cache:
-            s = json.loads(pystac.StacIO.default().read_text(schema_uri))
+            s = json.loads(StacIO.default().read_text(schema_uri))
             self.schema_cache[schema_uri] = s
 
         schema = self.schema_cache[schema_uri]
@@ -217,7 +218,7 @@ class JsonSchemaSTACValidator(STACValidator):
             msg = self._get_error_message(
                 schema_uri, stac_object_type, None, href, stac_dict.get("id")
             )
-            raise pystac.STACValidationError(msg, source=e) from e
+            raise STACValidationError(msg, source=e) from e
 
     def validate_extension(
         self,
@@ -255,7 +256,7 @@ class JsonSchemaSTACValidator(STACValidator):
             msg = self._get_error_message(
                 schema_uri, stac_object_type, extension_id, href, stac_dict.get("id")
             )
-            raise pystac.STACValidationError(msg, source=e) from e
+            raise STACValidationError(msg, source=e) from e
         except Exception as e:
             logger.error(f"Exception while validating {stac_object_type} href: {href}")
             logger.exception(e)


### PR DESCRIPTION
**Related Issue(s):** #332


**Description:** I couldn't do the equivalent changes anywhere in the `serialization` submodule without running into circular imports, so I've postponed that until it's easier to fix.


**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.