### PR TITLE
chore: Remove unused parameters recursively

### DIFF
--- a/pystac/stac_io.py
+++ b/pystac/stac_io.py
@@ -98,7 +98,7 @@ class StacIO(ABC):
         if orjson is not None:
             result = orjson.loads(txt)
         else:
-            result = json.loads(txt)
+            result = json.loads(txt, *args, **kwargs)
         return result
 
     def json_dumps(self, json_dict: Dict[str, Any], *args: Any, **kwargs: Any) -> str:
@@ -115,9 +115,11 @@ class StacIO(ABC):
             json_dict : The dictionary to serialize
         """
         if orjson is not None:
-            return orjson.dumps(json_dict, option=orjson.OPT_INDENT_2).decode("utf-8")
+            return orjson.dumps(json_dict, option=orjson.OPT_INDENT_2, **kwargs).decode(
+                "utf-8"
+            )
         else:
-            return json.dumps(json_dict, indent=2)
+            return json.dumps(json_dict, *args, indent=2, **kwargs)
 
     def stac_object_from_dict(
         self,


### PR DESCRIPTION
Since `orjson.dumps` and `json.dumps` don't support the same options, we
probably don't want to forward arbitrary arguments to them in any case.

**Related Issue(s):** #331


**Description:**


**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.