### PR TITLE
Use Protocol instead of generics for ExtensionManagementMixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 ### Removed
 
+### Fixed
+
+- Allow `ExtensionManagementMixin` to be added to any object with a `stac_extensions`
+  property. ([#545](https://github.com/stac-utils/pystac/pull/545))
+
 ### Changed
 
 ### Deprecated
@@ -26,7 +31,7 @@
 - Sat Extension summaries ([#509](https://github.com/stac-utils/pystac/pull/509))
 - `Catalog.get_collections` for getting all child
   `Collections` for a catalog, and `Catalog.get_all_collections` for recursively getting
-  all child `Collections` for a catalog and its children ([#511](https://github.com/stac-utils/pystac/pull/))
+  all child `Collections` for a catalog and its children ([#511](https://github.com/stac-utils/pystac/pull/511))
 
 ### Changed
 

--- a/pystac/extensions/base.py
+++ b/pystac/extensions/base.py
@@ -26,7 +26,7 @@ class HasExtensions(Protocol):
 
     @stac_extensions.setter
     def stac_extensions(self, v: List[str]) -> None:
-        pass
+        """Setter for stac_extensions property."""
 
 
 class SummariesExtension:

--- a/pystac/extensions/datacube.py
+++ b/pystac/extensions/datacube.py
@@ -313,7 +313,7 @@ class AdditionalDimension(Dimension):
 class DatacubeExtension(
     Generic[T],
     PropertiesExtension,
-    ExtensionManagementMixin[Union[pystac.Collection, pystac.Item]],
+    ExtensionManagementMixin,
 ):
     def apply(self, dimensions: Dict[str, Dimension]) -> None:
         self.dimensions = dimensions

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -273,9 +273,7 @@ class Band:
         return None
 
 
-class EOExtension(
-    Generic[T], PropertiesExtension, ExtensionManagementMixin[pystac.Item]
-):
+class EOExtension(Generic[T], PropertiesExtension, ExtensionManagementMixin):
     """An abstract class that can be used to extend the properties of an
     :class:`~pystac.Item` or :class:`~pystac.Asset` with properties from the
     :stac-ext:`Electro-Optical Extension <eo>`. This class is generic over the type of

--- a/pystac/extensions/file.py
+++ b/pystac/extensions/file.py
@@ -85,7 +85,7 @@ class MappingObject:
         self.properties["summary"] = v
 
 
-class FileExtension(PropertiesExtension, ExtensionManagementMixin[pystac.Item]):
+class FileExtension(PropertiesExtension, ExtensionManagementMixin):
     """A class that can be used to extend the properties of an :class:`~pystac.Asset`
     with properties from the :stac-ext:`File Info Extension <file>`.
 

--- a/pystac/extensions/item_assets.py
+++ b/pystac/extensions/item_assets.py
@@ -90,7 +90,7 @@ class AssetDefinition:
         )
 
 
-class ItemAssetsExtension(ExtensionManagementMixin[pystac.Collection]):
+class ItemAssetsExtension(ExtensionManagementMixin):
     def __init__(self, collection: pystac.Collection) -> None:
         self.collection = collection
 

--- a/pystac/extensions/label.py
+++ b/pystac/extensions/label.py
@@ -425,7 +425,7 @@ class LabelOverview:
         return self.to_dict() == o
 
 
-class LabelExtension(ExtensionManagementMixin[pystac.Item]):
+class LabelExtension(ExtensionManagementMixin):
     """A class that can be used to extend the properties of an
     :class:`~pystac.Item` with properties from the :stac-ext:`Label Extension <label>`.
 

--- a/pystac/extensions/pointcloud.py
+++ b/pystac/extensions/pointcloud.py
@@ -365,9 +365,7 @@ class PointcloudStatistic:
         return self.properties
 
 
-class PointcloudExtension(
-    Generic[T], PropertiesExtension, ExtensionManagementMixin[pystac.Item]
-):
+class PointcloudExtension(Generic[T], PropertiesExtension, ExtensionManagementMixin):
     """PointcloudItemExt is the extension of an Item in the PointCloud Extension.
     The Pointclout extension adds pointcloud information to STAC Items.
 

--- a/pystac/extensions/projection.py
+++ b/pystac/extensions/projection.py
@@ -29,9 +29,7 @@ SHAPE_PROP: str = PREFIX + "shape"
 TRANSFORM_PROP: str = PREFIX + "transform"
 
 
-class ProjectionExtension(
-    Generic[T], PropertiesExtension, ExtensionManagementMixin[pystac.Item]
-):
+class ProjectionExtension(Generic[T], PropertiesExtension, ExtensionManagementMixin):
     """An abstract class that can be used to extend the properties of an
     :class:`~pystac.Item` with properties from the :stac-ext:`Projection
     Extension <projection>`. This class is generic over the type of STAC Object to be

--- a/pystac/extensions/raster.py
+++ b/pystac/extensions/raster.py
@@ -625,7 +625,7 @@ class RasterBand:
         return self.properties
 
 
-class RasterExtension(PropertiesExtension, ExtensionManagementMixin[pystac.Item]):
+class RasterExtension(PropertiesExtension, ExtensionManagementMixin):
     """An abstract class that can be used to extend the properties of an
     :class:`~pystac.Item` or :class:`~pystac.Asset` with properties from
     the :stac-ext:`Raster Extension <raster>`. This class is generic over

--- a/pystac/extensions/sar.py
+++ b/pystac/extensions/sar.py
@@ -57,9 +57,7 @@ class ObservationDirection(enum.Enum):
     RIGHT = "right"
 
 
-class SarExtension(
-    Generic[T], PropertiesExtension, ExtensionManagementMixin[pystac.Item]
-):
+class SarExtension(Generic[T], PropertiesExtension, ExtensionManagementMixin):
     """SarItemExt extends Item to add sar properties to a STAC Item.
 
     Args:

--- a/pystac/extensions/sat.py
+++ b/pystac/extensions/sat.py
@@ -37,9 +37,7 @@ class OrbitState(str, enum.Enum):
     GEOSTATIONARY = "geostationary"
 
 
-class SatExtension(
-    Generic[T], PropertiesExtension, ExtensionManagementMixin[pystac.Item]
-):
+class SatExtension(Generic[T], PropertiesExtension, ExtensionManagementMixin):
     """An abstract class that can be used to extend the properties of an
     :class:`~pystac.Item` or :class:`~pystac.Asset` with properties from the
     :stac-ext:`Satellite Extension <sat>`. This class is generic over the type of

--- a/pystac/extensions/scientific.py
+++ b/pystac/extensions/scientific.py
@@ -9,7 +9,7 @@ https://doi.org/10.1000/182
 
 import copy
 from enum import Enum
-from typing import Any, Dict, Generic, List, Optional, TypeVar, Union, cast
+from typing import Any, Dict, Generic, List, Optional, TypeVar, cast
 from urllib import parse
 
 import pystac
@@ -98,7 +98,7 @@ def remove_link(links: List[pystac.Link], doi: Optional[str]) -> None:
 class ScientificExtension(
     Generic[T],
     PropertiesExtension,
-    ExtensionManagementMixin[Union[pystac.Collection, pystac.Item]],
+    ExtensionManagementMixin,
 ):
     """An abstract class that can be used to extend the properties of an
     :class:`~pystac.Item` or a :class:`pystac.Collection` with properties from the

--- a/pystac/extensions/timestamps.py
+++ b/pystac/extensions/timestamps.py
@@ -25,9 +25,7 @@ EXPIRES_PROP = "expires"
 UNPUBLISHED_PROP = "unpublished"
 
 
-class TimestampsExtension(
-    Generic[T], PropertiesExtension, ExtensionManagementMixin[pystac.Item]
-):
+class TimestampsExtension(Generic[T], PropertiesExtension, ExtensionManagementMixin):
     """An abstract class that can be used to extend the properties of an
     :class:`~pystac.Item` or :class:`~pystac.Asset` with properties from the
     :stac-ext:`Timestamps Extension <timestamps>`. This class is generic over the type

--- a/pystac/extensions/version.py
+++ b/pystac/extensions/version.py
@@ -4,7 +4,7 @@ https://github.com/stac-extensions/version
 """
 from enum import Enum
 from pystac.utils import get_required, map_opt
-from typing import Generic, List, Optional, TypeVar, Union, cast
+from typing import Generic, List, Optional, TypeVar, cast
 
 import pystac
 from pystac.extensions.base import (
@@ -45,7 +45,7 @@ class VersionRelType(str, Enum):
 class VersionExtension(
     Generic[T],
     PropertiesExtension,
-    ExtensionManagementMixin[Union[pystac.Collection, pystac.Item]],
+    ExtensionManagementMixin,
 ):
     """An abstract class that can be used to extend the properties of an
     :class:`~pystac.Item` or :class:`~pystac.Collection` with properties from the

--- a/pystac/extensions/view.py
+++ b/pystac/extensions/view.py
@@ -26,9 +26,7 @@ SUN_AZIMUTH_PROP: str = PREFIX + "sun_azimuth"
 SUN_ELEVATION_PROP: str = PREFIX + "sun_elevation"
 
 
-class ViewExtension(
-    Generic[T], PropertiesExtension, ExtensionManagementMixin[pystac.Item]
-):
+class ViewExtension(Generic[T], PropertiesExtension, ExtensionManagementMixin):
     """An abstract class that can be used to extend the properties of an
     :class:`~pystac.Item` with properties from the :stac-ext:`View Geometry
     Extension <view>`. This class is generic over the type of STAC Object to be

--- a/tests/extensions/test_custom.py
+++ b/tests/extensions/test_custom.py
@@ -1,7 +1,7 @@
 """Tests creating a custom extension"""
 
 from pystac.summaries import RangeSummary
-from typing import Any, Dict, Generic, List, Optional, Set, TypeVar, Union, cast
+from typing import Any, Dict, Generic, List, Optional, Set, TypeVar, cast
 import unittest
 
 import pystac
@@ -24,7 +24,7 @@ TEST_LINK_REL = "test-link"
 class CustomExtension(
     Generic[T],
     PropertiesExtension,
-    ExtensionManagementMixin[Union[pystac.Catalog, pystac.Collection, pystac.Item]],
+    ExtensionManagementMixin,
 ):
     def __init__(self, obj: Optional[pystac.STACObject]) -> None:
         self.obj = obj


### PR DESCRIPTION
**Related Issue(s):**

- #525


**Description:**

Using a `Protocol` class that defines a `stac_extensions` property means we can now add `ExtensionManagementMixin` to any instance that has a `stac_extensions` property that returns a list of strings.

TODO:

- [ ] Add tests for using `ExtensionManagementMixin.add_to` on a `Collection` instance

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [ ] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.