### PR TITLE
Add collection to ExtensionManagementMixin type params where appropriate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### Changed
 
+### Fixed
+
+- Added `Collections` as a type that can be extended for extensions whose fields can appear in collection summaries ([#547](https://github.com/stac-utils/pystac/pull/547))
+
 ### Deprecated
 
 ## [v1.0.0-rc.3]

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -376,9 +376,15 @@ class EOExtension(
                 f"EO extension does not apply to type '{type(obj).__name__}'"
             )
 
-    @staticmethod
-    def summaries(obj: pystac.Collection) -> "SummariesEOExtension":
+    @classmethod
+    def summaries(
+        cls, obj: pystac.Collection, add_if_missing: bool = False
+    ) -> "SummariesEOExtension":
         """Returns the extended summaries object for the given collection."""
+        if not add_if_missing:
+            cls.validate_has_extension(obj)
+        else:
+            cls.add_to(obj)
         return SummariesEOExtension(obj)
 
 
@@ -470,10 +476,6 @@ class SummariesEOExtension(SummariesExtension):
     the ``summaries`` field of a :class:`~pystac.Collection` to include properties
     defined in the :stac-ext:`Electro-Optical Extension <eo>`.
     """
-
-    def __init__(self, collection: pystac.Collection):
-        EOExtension.add_to(collection)
-        super().__init__(collection)
 
     @property
     def bands(self) -> Optional[List[Band]]:

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -28,7 +28,7 @@ from pystac.extensions import view
 from pystac.serialization.identify import STACJSONDescription, STACVersionID
 from pystac.utils import get_required, map_opt
 
-T = TypeVar("T", pystac.Item, pystac.Asset, pystac.Collection)
+T = TypeVar("T", pystac.Item, pystac.Asset)
 
 SCHEMA_URI: str = "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
 PREFIX: str = "eo:"

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -471,6 +471,10 @@ class SummariesEOExtension(SummariesExtension):
     defined in the :stac-ext:`Electro-Optical Extension <eo>`.
     """
 
+    def __init__(self, collection: pystac.Collection):
+        EOExtension.add_to(collection)
+        super().__init__(collection)
+
     @property
     def bands(self) -> Optional[List[Band]]:
         """Get or sets the summary of :attr:`EOExtension.bands` values

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -12,6 +12,7 @@ from typing import (
     Optional,
     Tuple,
     TypeVar,
+    Union,
     cast,
 )
 
@@ -276,7 +277,7 @@ class Band:
 class EOExtension(
     Generic[T],
     PropertiesExtension,
-    ExtensionManagementMixin[T],
+    ExtensionManagementMixin[Union[pystac.Item, pystac.Collection]],
 ):
     """An abstract class that can be used to extend the properties of an
     :class:`~pystac.Item` or :class:`~pystac.Asset` with properties from the

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -274,7 +274,9 @@ class Band:
 
 
 class EOExtension(
-    Generic[T], PropertiesExtension, ExtensionManagementMixin[pystac.Item]
+    Generic[T],
+    PropertiesExtension,
+    ExtensionManagementMixin[pystac.Item, pystac.Collection, pystac.Asset],
 ):
     """An abstract class that can be used to extend the properties of an
     :class:`~pystac.Item` or :class:`~pystac.Asset` with properties from the
@@ -296,7 +298,7 @@ class EOExtension(
         self, bands: Optional[List[Band]] = None, cloud_cover: Optional[float] = None
     ) -> None:
         """Applies label extension properties to the extended :class:`~pystac.Item` or
-        :class:`~pystac.Collection`.
+        :class:`~pystac.Asset`.
 
         Args:
             bands : A list of available bands where each item is a :class:`~Band`

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -27,7 +27,7 @@ from pystac.extensions import view
 from pystac.serialization.identify import STACJSONDescription, STACVersionID
 from pystac.utils import get_required, map_opt
 
-T = TypeVar("T", pystac.Item, pystac.Asset)
+T = TypeVar("T", pystac.Item, pystac.Asset, pystac.Collection)
 
 SCHEMA_URI: str = "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
 PREFIX: str = "eo:"
@@ -276,7 +276,7 @@ class Band:
 class EOExtension(
     Generic[T],
     PropertiesExtension,
-    ExtensionManagementMixin[pystac.Item, pystac.Collection, pystac.Asset],
+    ExtensionManagementMixin[T],
 ):
     """An abstract class that can be used to extend the properties of an
     :class:`~pystac.Item` or :class:`~pystac.Asset` with properties from the

--- a/pystac/extensions/label.py
+++ b/pystac/extensions/label.py
@@ -425,7 +425,7 @@ class LabelOverview:
         return self.to_dict() == o
 
 
-class LabelExtension(ExtensionManagementMixin[pystac.Item, pystac.Collection]):
+class LabelExtension(ExtensionManagementMixin[Union[pystac.Item, pystac.Collection]]):
     """A class that can be used to extend the properties of an
     :class:`~pystac.Item` with properties from the :stac-ext:`Label Extension <label>`.
 

--- a/pystac/extensions/label.py
+++ b/pystac/extensions/label.py
@@ -425,7 +425,7 @@ class LabelOverview:
         return self.to_dict() == o
 
 
-class LabelExtension(ExtensionManagementMixin[pystac.Item]):
+class LabelExtension(ExtensionManagementMixin[pystac.Item, pystac.Collection]):
     """A class that can be used to extend the properties of an
     :class:`~pystac.Item` with properties from the :stac-ext:`Label Extension <label>`.
 

--- a/pystac/extensions/label.py
+++ b/pystac/extensions/label.py
@@ -712,6 +712,10 @@ class SummariesLabelExtension(SummariesExtension):
     defined in the :stac-ext:`Label Extension <label>`.
     """
 
+    def __init__(self, collection: pystac.Collection) -> None:
+        LabelExtension.add_to(collection)
+        super().__init__(collection)
+
     @property
     def label_properties(self) -> Optional[List[str]]:
         """Get or sets the summary of :attr:`LabelExtension.label_properties` values

--- a/pystac/extensions/label.py
+++ b/pystac/extensions/label.py
@@ -712,10 +712,6 @@ class SummariesLabelExtension(SummariesExtension):
     defined in the :stac-ext:`Label Extension <label>`.
     """
 
-    def __init__(self, collection: pystac.Collection) -> None:
-        LabelExtension.add_to(collection)
-        super().__init__(collection)
-
     @property
     def label_properties(self) -> Optional[List[str]]:
         """Get or sets the summary of :attr:`LabelExtension.label_properties` values

--- a/pystac/extensions/label.py
+++ b/pystac/extensions/label.py
@@ -700,9 +700,15 @@ class LabelExtension(ExtensionManagementMixin[Union[pystac.Item, pystac.Collecti
                 f"Label extension does not apply to type '{type(obj).__name__}'"
             )
 
-    @staticmethod
-    def summaries(obj: pystac.Collection) -> "SummariesLabelExtension":
+    @classmethod
+    def summaries(
+        cls, obj: pystac.Collection, add_if_missing: bool = False
+    ) -> "SummariesLabelExtension":
         """Returns the extended summaries object for the given collection."""
+        if not add_if_missing:
+            cls.validate_has_extension(obj)
+        else:
+            cls.add_to(obj)
         return SummariesLabelExtension(obj)
 
 

--- a/pystac/extensions/projection.py
+++ b/pystac/extensions/projection.py
@@ -328,6 +328,10 @@ class SummariesProjectionExtension(SummariesExtension):
     defined in the :stac-ext:`Projection Extension <projection>`.
     """
 
+    def __init__(self, collection: pystac.Collection) -> None:
+        ProjectionExtension.add_to(collection)
+        super().__init__(collection)
+
     @property
     def epsg(self) -> Optional[List[int]]:
         """Get or sets the summary of :attr:`ProjectionExtension.epsg` values

--- a/pystac/extensions/projection.py
+++ b/pystac/extensions/projection.py
@@ -3,7 +3,7 @@
 https://github.com/stac-extensions/projection
 """
 
-from typing import Any, Dict, Generic, Iterable, List, Optional, TypeVar, cast
+from typing import Any, Dict, Generic, Iterable, List, Optional, TypeVar, Union, cast
 
 import pystac
 from pystac.extensions.hooks import ExtensionHooks
@@ -32,7 +32,7 @@ TRANSFORM_PROP: str = PREFIX + "transform"
 class ProjectionExtension(
     Generic[T],
     PropertiesExtension,
-    ExtensionManagementMixin[pystac.Item, pystac.Collection],
+    ExtensionManagementMixin[Union[pystac.Item, pystac.Collection]],
 ):
     """An abstract class that can be used to extend the properties of an
     :class:`~pystac.Item` with properties from the :stac-ext:`Projection

--- a/pystac/extensions/projection.py
+++ b/pystac/extensions/projection.py
@@ -350,10 +350,6 @@ class SummariesProjectionExtension(SummariesExtension):
     defined in the :stac-ext:`Projection Extension <projection>`.
     """
 
-    def __init__(self, collection: pystac.Collection) -> None:
-        ProjectionExtension.add_to(collection)
-        super().__init__(collection)
-
     @property
     def epsg(self) -> Optional[List[int]]:
         """Get or sets the summary of :attr:`ProjectionExtension.epsg` values

--- a/pystac/extensions/projection.py
+++ b/pystac/extensions/projection.py
@@ -30,7 +30,9 @@ TRANSFORM_PROP: str = PREFIX + "transform"
 
 
 class ProjectionExtension(
-    Generic[T], PropertiesExtension, ExtensionManagementMixin[pystac.Item]
+    Generic[T],
+    PropertiesExtension,
+    ExtensionManagementMixin[pystac.Item, pystac.Collection],
 ):
     """An abstract class that can be used to extend the properties of an
     :class:`~pystac.Item` with properties from the :stac-ext:`Projection

--- a/pystac/extensions/projection.py
+++ b/pystac/extensions/projection.py
@@ -286,9 +286,15 @@ class ProjectionExtension(
                 f"Projection extension does not apply to type '{type(obj).__name__}'"
             )
 
-    @staticmethod
-    def summaries(obj: pystac.Collection) -> "SummariesProjectionExtension":
+    @classmethod
+    def summaries(
+        cls, obj: pystac.Collection, add_if_missing: bool = False
+    ) -> "SummariesProjectionExtension":
         """Returns the extended summaries object for the given collection."""
+        if not add_if_missing:
+            cls.validate_has_extension(obj)
+        else:
+            cls.add_to(obj)
         return SummariesProjectionExtension(obj)
 
 

--- a/pystac/extensions/raster.py
+++ b/pystac/extensions/raster.py
@@ -625,7 +625,9 @@ class RasterBand:
         return self.properties
 
 
-class RasterExtension(PropertiesExtension, ExtensionManagementMixin[pystac.Item]):
+class RasterExtension(
+    PropertiesExtension, ExtensionManagementMixin[pystac.Item, pystac.Collection]
+):
     """An abstract class that can be used to extend the properties of an
     :class:`~pystac.Item` or :class:`~pystac.Asset` with properties from
     the :stac-ext:`Raster Extension <raster>`. This class is generic over

--- a/pystac/extensions/raster.py
+++ b/pystac/extensions/raster.py
@@ -724,6 +724,10 @@ class SummariesRasterExtension(SummariesExtension):
     defined in the :stac-ext:`Raster Extension <raster>`.
     """
 
+    def __init__(self, collection: pystac.Collection) -> None:
+        RasterExtension.add_to(collection)
+        super().__init__(collection)
+
     @property
     def bands(self) -> Optional[List[RasterBand]]:
         """Get or sets a list of :class:`~pystac.Band` objects that represent

--- a/pystac/extensions/raster.py
+++ b/pystac/extensions/raster.py
@@ -724,10 +724,6 @@ class SummariesRasterExtension(SummariesExtension):
     defined in the :stac-ext:`Raster Extension <raster>`.
     """
 
-    def __init__(self, collection: pystac.Collection) -> None:
-        RasterExtension.add_to(collection)
-        super().__init__(collection)
-
     @property
     def bands(self) -> Optional[List[RasterBand]]:
         """Get or sets a list of :class:`~pystac.Band` objects that represent

--- a/pystac/extensions/raster.py
+++ b/pystac/extensions/raster.py
@@ -713,8 +713,14 @@ class RasterExtension(
                 f"Raster extension does not apply to type '{type(obj).__name__}'"
             )
 
-    @staticmethod
-    def summaries(obj: pystac.Collection) -> "SummariesRasterExtension":
+    @classmethod
+    def summaries(
+        cls, obj: pystac.Collection, add_if_missing: bool = False
+    ) -> "SummariesRasterExtension":
+        if not add_if_missing:
+            cls.validate_has_extension(obj)
+        else:
+            cls.add_to(obj)
         return SummariesRasterExtension(obj)
 
 

--- a/pystac/extensions/raster.py
+++ b/pystac/extensions/raster.py
@@ -4,7 +4,7 @@ https://github.com/stac-extensions/raster
 """
 
 import enum
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Union
 
 import pystac
 from pystac.extensions.base import (
@@ -626,7 +626,7 @@ class RasterBand:
 
 
 class RasterExtension(
-    PropertiesExtension, ExtensionManagementMixin[pystac.Item, pystac.Collection]
+    PropertiesExtension, ExtensionManagementMixin[Union[pystac.Item, pystac.Collection]]
 ):
     """An abstract class that can be used to extend the properties of an
     :class:`~pystac.Item` or :class:`~pystac.Asset` with properties from

--- a/pystac/extensions/sat.py
+++ b/pystac/extensions/sat.py
@@ -6,7 +6,7 @@ https://github.com/stac-extensions/sat
 import enum
 from datetime import datetime as Datetime
 from pystac.summaries import RangeSummary
-from typing import Dict, Any, List, Iterable, Generic, Optional, TypeVar, cast
+from typing import Dict, Any, List, Iterable, Generic, Optional, TypeVar, Union, cast
 
 import pystac
 from pystac.extensions.base import (
@@ -40,7 +40,7 @@ class OrbitState(str, enum.Enum):
 class SatExtension(
     Generic[T],
     PropertiesExtension,
-    ExtensionManagementMixin[pystac.Item, pystac.Collection],
+    ExtensionManagementMixin[Union[pystac.Item, pystac.Collection]],
 ):
     """An abstract class that can be used to extend the properties of an
     :class:`~pystac.Item` or :class:`~pystac.Asset` with properties from the

--- a/pystac/extensions/sat.py
+++ b/pystac/extensions/sat.py
@@ -163,9 +163,15 @@ class SatExtension(
                 f"Satellite extension does not apply to type '{type(obj).__name__}'"
             )
 
-    @staticmethod
-    def summaries(obj: pystac.Collection) -> "SummariesSatExtension":
+    @classmethod
+    def summaries(
+        cls, obj: pystac.Collection, add_if_missing: bool = False
+    ) -> "SummariesSatExtension":
         """Returns the extended summaries object for the given collection."""
+        if not add_if_missing:
+            cls.validate_has_extension(obj)
+        else:
+            cls.add_to(obj)
         return SummariesSatExtension(obj)
 
 

--- a/pystac/extensions/sat.py
+++ b/pystac/extensions/sat.py
@@ -38,7 +38,9 @@ class OrbitState(str, enum.Enum):
 
 
 class SatExtension(
-    Generic[T], PropertiesExtension, ExtensionManagementMixin[pystac.Item]
+    Generic[T],
+    PropertiesExtension,
+    ExtensionManagementMixin[pystac.Item, pystac.Collection],
 ):
     """An abstract class that can be used to extend the properties of an
     :class:`~pystac.Item` or :class:`~pystac.Asset` with properties from the

--- a/pystac/extensions/sat.py
+++ b/pystac/extensions/sat.py
@@ -229,6 +229,10 @@ class SummariesSatExtension(SummariesExtension):
     defined in the :stac-ext:`Satellite Extension <sat>`.
     """
 
+    def __init__(self, collection: pystac.Collection) -> None:
+        SatExtension.add_to(collection)
+        super().__init__(collection)
+
     @property
     def platform_international_designator(self) -> Optional[List[str]]:
         """Get or sets the summary of

--- a/pystac/extensions/sat.py
+++ b/pystac/extensions/sat.py
@@ -229,10 +229,6 @@ class SummariesSatExtension(SummariesExtension):
     defined in the :stac-ext:`Satellite Extension <sat>`.
     """
 
-    def __init__(self, collection: pystac.Collection) -> None:
-        SatExtension.add_to(collection)
-        super().__init__(collection)
-
     @property
     def platform_international_designator(self) -> Optional[List[str]]:
         """Get or sets the summary of

--- a/pystac/extensions/scientific.py
+++ b/pystac/extensions/scientific.py
@@ -322,10 +322,6 @@ class SummariesScientificExtension(SummariesExtension):
     defined in the :stac-ext:`Scientific Citation Extension <scientific>`.
     """
 
-    def __init__(self, collection: pystac.Collection) -> None:
-        ScientificExtension.add_to(collection)
-        super().__init__(collection)
-
     @property
     def citation(self) -> Optional[List[str]]:
         """Get or sets the summary of :attr:`ScientificExtension.citation` values

--- a/pystac/extensions/scientific.py
+++ b/pystac/extensions/scientific.py
@@ -248,9 +248,15 @@ class ScientificExtension(
                 f"Scientific extension does not apply to type '{type(obj).__name__}'"
             )
 
-    @staticmethod
-    def summaries(obj: pystac.Collection) -> "SummariesScientificExtension":
+    @classmethod
+    def summaries(
+        cls, obj: pystac.Collection, add_if_missing: bool = False
+    ) -> "SummariesScientificExtension":
         """Returns the extended summaries object for the given collection."""
+        if not add_if_missing:
+            cls.validate_has_extension(obj)
+        else:
+            cls.add_to(obj)
         return SummariesScientificExtension(obj)
 
 

--- a/pystac/extensions/scientific.py
+++ b/pystac/extensions/scientific.py
@@ -322,6 +322,10 @@ class SummariesScientificExtension(SummariesExtension):
     defined in the :stac-ext:`Scientific Citation Extension <scientific>`.
     """
 
+    def __init__(self, collection: pystac.Collection) -> None:
+        ScientificExtension.add_to(collection)
+        super().__init__(collection)
+
     @property
     def citation(self) -> Optional[List[str]]:
         """Get or sets the summary of :attr:`ScientificExtension.citation` values

--- a/pystac/extensions/timestamps.py
+++ b/pystac/extensions/timestamps.py
@@ -143,9 +143,15 @@ class TimestampsExtension(
                 f"Timestamps extension does not apply to type '{type(obj).__name__}'"
             )
 
-    @staticmethod
-    def summaries(obj: pystac.Collection) -> "SummariesTimestampsExtension":
+    @classmethod
+    def summaries(
+        cls, obj: pystac.Collection, add_if_missing: bool = False
+    ) -> "SummariesTimestampsExtension":
         """Returns the extended summaries object for the given collection."""
+        if not add_if_missing:
+            cls.validate_has_extension(obj)
+        else:
+            cls.add_to(obj)
         return SummariesTimestampsExtension(obj)
 
 

--- a/pystac/extensions/timestamps.py
+++ b/pystac/extensions/timestamps.py
@@ -207,10 +207,6 @@ class SummariesTimestampsExtension(SummariesExtension):
     defined in the :stac-ext:`Timestamps Extension <timestamps>`.
     """
 
-    def __init__(self, collection: pystac.Collection) -> None:
-        TimestampsExtension.add_to(collection)
-        super().__init__(collection)
-
     @property
     def published(self) -> Optional[RangeSummary[datetime]]:
         """Get or sets the summary of :attr:`TimestampsExtension.published` values

--- a/pystac/extensions/timestamps.py
+++ b/pystac/extensions/timestamps.py
@@ -26,7 +26,9 @@ UNPUBLISHED_PROP = "unpublished"
 
 
 class TimestampsExtension(
-    Generic[T], PropertiesExtension, ExtensionManagementMixin[pystac.Item]
+    Generic[T],
+    PropertiesExtension,
+    ExtensionManagementMixin[pystac.Item, pystac.Collection],
 ):
     """An abstract class that can be used to extend the properties of an
     :class:`~pystac.Item` or :class:`~pystac.Asset` with properties from the

--- a/pystac/extensions/timestamps.py
+++ b/pystac/extensions/timestamps.py
@@ -207,6 +207,10 @@ class SummariesTimestampsExtension(SummariesExtension):
     defined in the :stac-ext:`Timestamps Extension <timestamps>`.
     """
 
+    def __init__(self, collection: pystac.Collection) -> None:
+        TimestampsExtension.add_to(collection)
+        super().__init__(collection)
+
     @property
     def published(self) -> Optional[RangeSummary[datetime]]:
         """Get or sets the summary of :attr:`TimestampsExtension.published` values

--- a/pystac/extensions/timestamps.py
+++ b/pystac/extensions/timestamps.py
@@ -5,7 +5,7 @@ https://github.com/stac-extensions/timestamps
 
 from datetime import datetime as datetime
 from pystac.summaries import RangeSummary
-from typing import Dict, Any, Iterable, Generic, Optional, TypeVar, cast
+from typing import Dict, Any, Iterable, Generic, Optional, TypeVar, Union, cast
 
 import pystac
 from pystac.extensions.base import (
@@ -28,7 +28,7 @@ UNPUBLISHED_PROP = "unpublished"
 class TimestampsExtension(
     Generic[T],
     PropertiesExtension,
-    ExtensionManagementMixin[pystac.Item, pystac.Collection],
+    ExtensionManagementMixin[Union[pystac.Item, pystac.Collection]],
 ):
     """An abstract class that can be used to extend the properties of an
     :class:`~pystac.Item` or :class:`~pystac.Asset` with properties from the

--- a/pystac/extensions/view.py
+++ b/pystac/extensions/view.py
@@ -236,10 +236,6 @@ class SummariesViewExtension(SummariesExtension):
     defined in the :stac-ext:`View Object Extension <view>`.
     """
 
-    def __init__(self, collection: pystac.Collection) -> None:
-        ViewExtension.add_to(collection)
-        super().__init__(collection)
-
     @property
     def off_nadir(self) -> Optional[RangeSummary[float]]:
         """Get or sets the summary of :attr:`ViewExtension.off_nadir` values for

--- a/pystac/extensions/view.py
+++ b/pystac/extensions/view.py
@@ -3,7 +3,7 @@
 https://github.com/stac-extensions/view
 """
 
-from typing import Any, Dict, Generic, Iterable, Optional, TypeVar, cast
+from typing import Any, Dict, Generic, Iterable, Optional, TypeVar, Union, cast
 
 import pystac
 from pystac.summaries import RangeSummary
@@ -29,7 +29,7 @@ SUN_ELEVATION_PROP: str = PREFIX + "sun_elevation"
 class ViewExtension(
     Generic[T],
     PropertiesExtension,
-    ExtensionManagementMixin[pystac.Item, pystac.Collection],
+    ExtensionManagementMixin[Union[pystac.Item, pystac.Collection]],
 ):
     """An abstract class that can be used to extend the properties of an
     :class:`~pystac.Item` with properties from the :stac-ext:`View Geometry

--- a/pystac/extensions/view.py
+++ b/pystac/extensions/view.py
@@ -172,9 +172,15 @@ class ViewExtension(
                 f"View extension does not apply to type '{type(obj).__name__}'"
             )
 
-    @staticmethod
-    def summaries(obj: pystac.Collection) -> "SummariesViewExtension":
+    @classmethod
+    def summaries(
+        cls, obj: pystac.Collection, add_if_missing: bool = False
+    ) -> "SummariesViewExtension":
         """Returns the extended summaries object for the given collection."""
+        if not add_if_missing:
+            cls.validate_has_extension(obj)
+        else:
+            cls.add_to(obj)
         return SummariesViewExtension(obj)
 
 

--- a/pystac/extensions/view.py
+++ b/pystac/extensions/view.py
@@ -27,7 +27,9 @@ SUN_ELEVATION_PROP: str = PREFIX + "sun_elevation"
 
 
 class ViewExtension(
-    Generic[T], PropertiesExtension, ExtensionManagementMixin[pystac.Item]
+    Generic[T],
+    PropertiesExtension,
+    ExtensionManagementMixin[pystac.Item, pystac.Collection],
 ):
     """An abstract class that can be used to extend the properties of an
     :class:`~pystac.Item` with properties from the :stac-ext:`View Geometry

--- a/pystac/extensions/view.py
+++ b/pystac/extensions/view.py
@@ -236,6 +236,10 @@ class SummariesViewExtension(SummariesExtension):
     defined in the :stac-ext:`View Object Extension <view>`.
     """
 
+    def __init__(self, collection: pystac.Collection) -> None:
+        ViewExtension.add_to(collection)
+        super().__init__(collection)
+
     @property
     def off_nadir(self) -> Optional[RangeSummary[float]]:
         """Get or sets the summary of :attr:`ViewExtension.off_nadir` values for

--- a/tests/extensions/test_eo.py
+++ b/tests/extensions/test_eo.py
@@ -214,6 +214,13 @@ class EOTest(unittest.TestCase):
         self.assertEqual(len(col_dict["summaries"]["eo:bands"]), 1)
         self.assertEqual(col_dict["summaries"]["eo:cloud_cover"]["minimum"], 1.0)
 
+    def test_summaries_adds_uri(self) -> None:
+        col = pystac.Collection.from_file(self.EO_COLLECTION_URI)
+        col.stac_extensions = []
+        _ = EOExtension.summaries(col)
+
+        self.assertIn(EOExtension.get_schema_uri(), col.stac_extensions)
+
     def test_read_pre_09_fields_into_common_metadata(self) -> None:
         eo_item = pystac.Item.from_file(
             TestCases.get_path(

--- a/tests/extensions/test_eo.py
+++ b/tests/extensions/test_eo.py
@@ -217,7 +217,14 @@ class EOTest(unittest.TestCase):
     def test_summaries_adds_uri(self) -> None:
         col = pystac.Collection.from_file(self.EO_COLLECTION_URI)
         col.stac_extensions = []
-        _ = EOExtension.summaries(col)
+        self.assertRaisesRegex(
+            pystac.ExtensionNotImplemented,
+            r"Could not find extension schema URI.*",
+            EOExtension.summaries,
+            col,
+            False,
+        )
+        _ = EOExtension.summaries(col, add_if_missing=True)
 
         self.assertIn(EOExtension.get_schema_uri(), col.stac_extensions)
 

--- a/tests/extensions/test_eo.py
+++ b/tests/extensions/test_eo.py
@@ -221,6 +221,9 @@ class EOTest(unittest.TestCase):
 
         self.assertIn(EOExtension.get_schema_uri(), col.stac_extensions)
 
+        EOExtension.remove_from(col)
+        self.assertNotIn(EOExtension.get_schema_uri(), col.stac_extensions)
+
     def test_read_pre_09_fields_into_common_metadata(self) -> None:
         eo_item = pystac.Item.from_file(
             TestCases.get_path(

--- a/tests/extensions/test_label.py
+++ b/tests/extensions/test_label.py
@@ -448,6 +448,13 @@ class LabelSummariesTest(unittest.TestCase):
         "data-files/label/spacenet-roads/roads_collection.json"
     )
 
+    def test_summaries_adds_uri(self) -> None:
+        col = pystac.Collection.from_file(self.EXAMPLE_COLLECTION)
+        col.stac_extensions = []
+        _ = LabelExtension.summaries(col)
+
+        self.assertIn(LabelExtension.get_schema_uri(), col.stac_extensions)
+
     def test_label_properties_summary(self) -> None:
         label_properties = ["road_type", "lane_number", "paved"]
         collection = Collection.from_file(self.EXAMPLE_COLLECTION)

--- a/tests/extensions/test_label.py
+++ b/tests/extensions/test_label.py
@@ -455,6 +455,9 @@ class LabelSummariesTest(unittest.TestCase):
 
         self.assertIn(LabelExtension.get_schema_uri(), col.stac_extensions)
 
+        LabelExtension.remove_from(col)
+        self.assertNotIn(LabelExtension.get_schema_uri(), col.stac_extensions)
+
     def test_label_properties_summary(self) -> None:
         label_properties = ["road_type", "lane_number", "paved"]
         collection = Collection.from_file(self.EXAMPLE_COLLECTION)

--- a/tests/extensions/test_label.py
+++ b/tests/extensions/test_label.py
@@ -468,7 +468,7 @@ class LabelSummariesTest(unittest.TestCase):
     def test_label_properties_summary(self) -> None:
         label_properties = ["road_type", "lane_number", "paved"]
         collection = Collection.from_file(self.EXAMPLE_COLLECTION)
-        label_ext_summaries = LabelExtension.summaries(collection)
+        label_ext_summaries = LabelExtension.summaries(collection, True)
 
         label_ext_summaries.label_properties = label_properties
 
@@ -491,7 +491,7 @@ class LabelSummariesTest(unittest.TestCase):
             LabelClasses({"name": "paved", "classes": ["0", "1"]}),
         ]
         collection = Collection.from_file(self.EXAMPLE_COLLECTION)
-        label_ext_summaries = LabelExtension.summaries(collection)
+        label_ext_summaries = LabelExtension.summaries(collection, True)
 
         label_ext_summaries.label_classes = label_classes
 
@@ -510,7 +510,7 @@ class LabelSummariesTest(unittest.TestCase):
     def test_label_type_summary(self) -> None:
         label_types = [LabelType.VECTOR]
         collection = Collection.from_file(self.EXAMPLE_COLLECTION)
-        label_ext_summaries = LabelExtension.summaries(collection)
+        label_ext_summaries = LabelExtension.summaries(collection, True)
 
         label_ext_summaries.label_type = label_types
 
@@ -527,7 +527,7 @@ class LabelSummariesTest(unittest.TestCase):
     def test_label_task_summary(self) -> None:
         label_tasks: List[Union[LabelTask, str]] = [LabelTask.REGRESSION]
         collection = Collection.from_file(self.EXAMPLE_COLLECTION)
-        label_ext_summaries = LabelExtension.summaries(collection)
+        label_ext_summaries = LabelExtension.summaries(collection, True)
 
         label_ext_summaries.label_tasks = label_tasks
 
@@ -544,7 +544,7 @@ class LabelSummariesTest(unittest.TestCase):
     def test_label_methods_summary(self) -> None:
         label_methods: List[Union[LabelMethod, str]] = [LabelMethod.AUTOMATED]
         collection = Collection.from_file(self.EXAMPLE_COLLECTION)
-        label_ext_summaries = LabelExtension.summaries(collection)
+        label_ext_summaries = LabelExtension.summaries(collection, True)
 
         label_ext_summaries.label_methods = label_methods
 

--- a/tests/extensions/test_label.py
+++ b/tests/extensions/test_label.py
@@ -451,7 +451,14 @@ class LabelSummariesTest(unittest.TestCase):
     def test_summaries_adds_uri(self) -> None:
         col = pystac.Collection.from_file(self.EXAMPLE_COLLECTION)
         col.stac_extensions = []
-        _ = LabelExtension.summaries(col)
+        self.assertRaisesRegex(
+            pystac.ExtensionNotImplemented,
+            r"Could not find extension schema URI.*",
+            LabelExtension.summaries,
+            col,
+            False,
+        )
+        _ = LabelExtension.summaries(col, True)
 
         self.assertIn(LabelExtension.get_schema_uri(), col.stac_extensions)
 

--- a/tests/extensions/test_projection.py
+++ b/tests/extensions/test_projection.py
@@ -490,3 +490,6 @@ class ProjectionSummariesTest(unittest.TestCase):
         _ = ProjectionExtension.summaries(col)
 
         self.assertIn(ProjectionExtension.get_schema_uri(), col.stac_extensions)
+
+        ProjectionExtension.remove_from(col)
+        self.assertNotIn(ProjectionExtension.get_schema_uri(), col.stac_extensions)

--- a/tests/extensions/test_projection.py
+++ b/tests/extensions/test_projection.py
@@ -483,3 +483,10 @@ class ProjectionSummariesTest(unittest.TestCase):
         col_dict = col.to_dict()
         self.assertEqual(len(col_dict["summaries"]["proj:epsg"]), 1)
         self.assertEqual(col_dict["summaries"]["proj:epsg"][0], 4326)
+
+    def test_summaries_adds_uri(self) -> None:
+        col = pystac.Collection.from_file(self.example_uri)
+        col.stac_extensions = []
+        _ = ProjectionExtension.summaries(col)
+
+        self.assertIn(ProjectionExtension.get_schema_uri(), col.stac_extensions)

--- a/tests/extensions/test_projection.py
+++ b/tests/extensions/test_projection.py
@@ -509,7 +509,14 @@ class ProjectionSummariesTest(unittest.TestCase):
     def test_summaries_adds_uri(self) -> None:
         col = pystac.Collection.from_file(self.example_uri)
         col.stac_extensions = []
-        _ = ProjectionExtension.summaries(col)
+        self.assertRaisesRegex(
+            pystac.ExtensionNotImplemented,
+            r"Could not find extension schema URI.*",
+            ProjectionExtension.summaries,
+            col,
+            False,
+        )
+        _ = ProjectionExtension.summaries(col, True)
 
         self.assertIn(ProjectionExtension.get_schema_uri(), col.stac_extensions)
 

--- a/tests/extensions/test_raster.py
+++ b/tests/extensions/test_raster.py
@@ -11,7 +11,6 @@ from pystac.extensions.raster import (
     Sampling,
     DataType,
     Statistics,
-    SummariesRasterExtension,
 )
 from tests.utils import TestCases, assert_to_from_dict
 
@@ -250,7 +249,7 @@ class RasterTest(unittest.TestCase):
             col,
             False,
         )
-        _ = SummariesRasterExtension(col)
+        _ = RasterExtension.summaries(col, True)
 
         self.assertIn(RasterExtension.get_schema_uri(), col.stac_extensions)
 

--- a/tests/extensions/test_raster.py
+++ b/tests/extensions/test_raster.py
@@ -243,6 +243,13 @@ class RasterTest(unittest.TestCase):
             TestCases.get_path("data-files/label/spacenet-roads/roads_collection.json")
         )
         col.stac_extensions = []
+        self.assertRaisesRegex(
+            pystac.ExtensionNotImplemented,
+            r"Could not find extension schema URI.*",
+            RasterExtension.summaries,
+            col,
+            False,
+        )
         _ = SummariesRasterExtension(col)
 
         self.assertIn(RasterExtension.get_schema_uri(), col.stac_extensions)

--- a/tests/extensions/test_raster.py
+++ b/tests/extensions/test_raster.py
@@ -11,6 +11,7 @@ from pystac.extensions.raster import (
     Sampling,
     DataType,
     Statistics,
+    SummariesRasterExtension,
 )
 from tests.utils import TestCases, assert_to_from_dict
 
@@ -236,3 +237,12 @@ class RasterTest(unittest.TestCase):
             RasterExtension.ext,
             object(),
         )
+
+    def test_summaries_adds_uri(self) -> None:
+        col = pystac.Collection.from_file(
+            TestCases.get_path("data-files/label/spacenet-roads/roads_collection.json")
+        )
+        col.stac_extensions = []
+        _ = SummariesRasterExtension(col)
+
+        self.assertIn(RasterExtension.get_schema_uri(), col.stac_extensions)

--- a/tests/extensions/test_raster.py
+++ b/tests/extensions/test_raster.py
@@ -246,3 +246,6 @@ class RasterTest(unittest.TestCase):
         _ = SummariesRasterExtension(col)
 
         self.assertIn(RasterExtension.get_schema_uri(), col.stac_extensions)
+
+        RasterExtension.remove_from(col)
+        self.assertNotIn(RasterExtension.get_schema_uri(), col.stac_extensions)

--- a/tests/extensions/test_sat.py
+++ b/tests/extensions/test_sat.py
@@ -9,7 +9,7 @@ import pystac
 from pystac.utils import str_to_datetime, datetime_to_str
 from pystac import ExtensionTypeError
 from pystac.extensions import sat
-from pystac.extensions.sat import OrbitState, SatExtension
+from pystac.extensions.sat import OrbitState, SatExtension, SummariesSatExtension
 from tests.utils import TestCases
 
 
@@ -329,3 +329,10 @@ class SatSummariesTest(unittest.TestCase):
                 "maximum": datetime_to_str(anx_datetime_range.maximum),
             },
         )
+
+    def test_summaries_adds_uri(self) -> None:
+        col = self.collection()
+        col.stac_extensions = []
+        _ = SummariesSatExtension(col)
+
+        self.assertIn(SatExtension.get_schema_uri(), col.stac_extensions)

--- a/tests/extensions/test_sat.py
+++ b/tests/extensions/test_sat.py
@@ -336,3 +336,6 @@ class SatSummariesTest(unittest.TestCase):
         _ = SummariesSatExtension(col)
 
         self.assertIn(SatExtension.get_schema_uri(), col.stac_extensions)
+
+        SatExtension.remove_from(col)
+        self.assertNotIn(SatExtension.get_schema_uri(), col.stac_extensions)

--- a/tests/extensions/test_sat.py
+++ b/tests/extensions/test_sat.py
@@ -9,7 +9,7 @@ import pystac
 from pystac.utils import str_to_datetime, datetime_to_str
 from pystac import ExtensionTypeError
 from pystac.extensions import sat
-from pystac.extensions.sat import OrbitState, SatExtension, SummariesSatExtension
+from pystac.extensions.sat import OrbitState, SatExtension
 from tests.utils import TestCases
 
 
@@ -231,7 +231,7 @@ class SatSummariesTest(unittest.TestCase):
 
     def test_platform_international_designation(self) -> None:
         collection = self.collection()
-        summaries_ext = SatExtension.summaries(collection)
+        summaries_ext = SatExtension.summaries(collection, True)
         platform_international_designator_list = ["2018-080A"]
 
         summaries_ext.platform_international_designator = ["2018-080A"]
@@ -250,7 +250,7 @@ class SatSummariesTest(unittest.TestCase):
 
     def test_orbit_state(self) -> None:
         collection = self.collection()
-        summaries_ext = SatExtension.summaries(collection)
+        summaries_ext = SatExtension.summaries(collection, True)
         orbit_state_list = [OrbitState.ASCENDING]
 
         summaries_ext.orbit_state = orbit_state_list
@@ -269,7 +269,7 @@ class SatSummariesTest(unittest.TestCase):
 
     def test_absolute_orbit(self) -> None:
         collection = self.collection()
-        summaries_ext = SatExtension.summaries(collection)
+        summaries_ext = SatExtension.summaries(collection, True)
         absolute_orbit_range = RangeSummary(2000, 3000)
 
         summaries_ext.absolute_orbit = absolute_orbit_range
@@ -288,7 +288,7 @@ class SatSummariesTest(unittest.TestCase):
 
     def test_relative_orbit(self) -> None:
         collection = self.collection()
-        summaries_ext = SatExtension.summaries(collection)
+        summaries_ext = SatExtension.summaries(collection, True)
         relative_orbit_range = RangeSummary(50, 100)
 
         summaries_ext.relative_orbit = relative_orbit_range
@@ -307,7 +307,7 @@ class SatSummariesTest(unittest.TestCase):
 
     def test_anx_datetime(self) -> None:
         collection = self.collection()
-        summaries_ext = SatExtension.summaries(collection)
+        summaries_ext = SatExtension.summaries(collection, True)
         anx_datetime_range = RangeSummary(
             str_to_datetime("2020-01-01T00:00:00.000Z"),
             str_to_datetime("2020-01-02T00:00:00.000Z"),
@@ -333,7 +333,14 @@ class SatSummariesTest(unittest.TestCase):
     def test_summaries_adds_uri(self) -> None:
         col = self.collection()
         col.stac_extensions = []
-        _ = SummariesSatExtension(col)
+        self.assertRaisesRegex(
+            pystac.ExtensionNotImplemented,
+            r"Could not find extension schema URI.*",
+            SatExtension.summaries,
+            col,
+            False,
+        )
+        _ = SatExtension.summaries(col, True)
 
         self.assertIn(SatExtension.get_schema_uri(), col.stac_extensions)
 

--- a/tests/extensions/test_scientific.py
+++ b/tests/extensions/test_scientific.py
@@ -14,7 +14,6 @@ from pystac.extensions.scientific import (
     Publication,
     ScientificExtension,
     ScientificRelType,
-    SummariesScientificExtension,
     remove_link,
 )
 from tests.utils import TestCases
@@ -461,7 +460,14 @@ class SummariesScientificTest(unittest.TestCase):
     def test_summaries_adds_uri(self) -> None:
         collection = self.collection.clone()
         collection.stac_extensions = []
-        _ = SummariesScientificExtension(collection)
+        self.assertRaisesRegex(
+            pystac.ExtensionNotImplemented,
+            r"Could not find extension schema URI.*",
+            ScientificExtension.summaries,
+            collection,
+            False,
+        )
+        _ = ScientificExtension.summaries(collection, True)
 
         self.assertIn(ScientificExtension.get_schema_uri(), collection.stac_extensions)
 

--- a/tests/extensions/test_scientific.py
+++ b/tests/extensions/test_scientific.py
@@ -464,3 +464,8 @@ class SummariesScientificTest(unittest.TestCase):
         _ = SummariesScientificExtension(collection)
 
         self.assertIn(ScientificExtension.get_schema_uri(), collection.stac_extensions)
+
+        ScientificExtension.remove_from(collection)
+        self.assertNotIn(
+            ScientificExtension.get_schema_uri(), collection.stac_extensions
+        )

--- a/tests/extensions/test_scientific.py
+++ b/tests/extensions/test_scientific.py
@@ -14,6 +14,7 @@ from pystac.extensions.scientific import (
     Publication,
     ScientificExtension,
     ScientificRelType,
+    SummariesScientificExtension,
     remove_link,
 )
 from tests.utils import TestCases
@@ -456,3 +457,10 @@ class SummariesScientificTest(unittest.TestCase):
 
         assert new_dois is not None
         self.assertListEqual([PUB2_DOI], new_dois)
+
+    def test_summaries_adds_uri(self) -> None:
+        collection = self.collection.clone()
+        collection.stac_extensions = []
+        _ = SummariesScientificExtension(collection)
+
+        self.assertIn(ScientificExtension.get_schema_uri(), collection.stac_extensions)

--- a/tests/extensions/test_timestamps.py
+++ b/tests/extensions/test_timestamps.py
@@ -347,3 +347,8 @@ class TimestampsSummariesTest(unittest.TestCase):
         _ = SummariesTimestampsExtension(collection)
 
         self.assertIn(TimestampsExtension.get_schema_uri(), collection.stac_extensions)
+
+        TimestampsExtension.remove_from(collection)
+        self.assertNotIn(
+            TimestampsExtension.get_schema_uri(), collection.stac_extensions
+        )

--- a/tests/extensions/test_timestamps.py
+++ b/tests/extensions/test_timestamps.py
@@ -5,10 +5,7 @@ from datetime import datetime
 import pystac
 from pystac import ExtensionTypeError
 from pystac.summaries import RangeSummary
-from pystac.extensions.timestamps import (
-    SummariesTimestampsExtension,
-    TimestampsExtension,
-)
+from pystac.extensions.timestamps import TimestampsExtension
 from pystac.utils import get_opt, str_to_datetime, datetime_to_str
 from tests.utils import TestCases, assert_to_from_dict
 
@@ -268,7 +265,7 @@ class TimestampsSummariesTest(unittest.TestCase):
 
     def test_published(self) -> None:
         collection = self.collection()
-        summaries_ext = TimestampsExtension.summaries(collection)
+        summaries_ext = TimestampsExtension.summaries(collection, True)
         published_range = RangeSummary(
             str_to_datetime("2020-01-01T00:00:00.000Z"),
             str_to_datetime("2020-01-02T00:00:00.000Z"),
@@ -293,7 +290,7 @@ class TimestampsSummariesTest(unittest.TestCase):
 
     def test_expires(self) -> None:
         collection = self.collection()
-        summaries_ext = TimestampsExtension.summaries(collection)
+        summaries_ext = TimestampsExtension.summaries(collection, True)
         expires_range = RangeSummary(
             str_to_datetime("2020-01-01T00:00:00.000Z"),
             str_to_datetime("2020-01-02T00:00:00.000Z"),
@@ -318,7 +315,7 @@ class TimestampsSummariesTest(unittest.TestCase):
 
     def test_unpublished(self) -> None:
         collection = self.collection()
-        summaries_ext = TimestampsExtension.summaries(collection)
+        summaries_ext = TimestampsExtension.summaries(collection, True)
         unpublished_range = RangeSummary(
             str_to_datetime("2020-01-01T00:00:00.000Z"),
             str_to_datetime("2020-01-02T00:00:00.000Z"),
@@ -344,7 +341,14 @@ class TimestampsSummariesTest(unittest.TestCase):
     def test_summaries_adds_uri(self) -> None:
         collection = self.collection()
         collection.stac_extensions = []
-        _ = SummariesTimestampsExtension(collection)
+        self.assertRaisesRegex(
+            pystac.ExtensionNotImplemented,
+            r"Could not find extension schema URI.*",
+            TimestampsExtension.summaries,
+            collection,
+            False,
+        )
+        _ = TimestampsExtension.summaries(collection, True)
 
         self.assertIn(TimestampsExtension.get_schema_uri(), collection.stac_extensions)
 

--- a/tests/extensions/test_timestamps.py
+++ b/tests/extensions/test_timestamps.py
@@ -5,7 +5,10 @@ from datetime import datetime
 import pystac
 from pystac import ExtensionTypeError
 from pystac.summaries import RangeSummary
-from pystac.extensions.timestamps import TimestampsExtension
+from pystac.extensions.timestamps import (
+    SummariesTimestampsExtension,
+    TimestampsExtension,
+)
 from pystac.utils import get_opt, str_to_datetime, datetime_to_str
 from tests.utils import TestCases, assert_to_from_dict
 
@@ -337,3 +340,10 @@ class TimestampsSummariesTest(unittest.TestCase):
                 "maximum": datetime_to_str(unpublished_range.maximum),
             },
         )
+
+    def test_summaries_adds_uri(self) -> None:
+        collection = self.collection()
+        collection.stac_extensions = []
+        _ = SummariesTimestampsExtension(collection)
+
+        self.assertIn(TimestampsExtension.get_schema_uri(), collection.stac_extensions)

--- a/tests/extensions/test_view.py
+++ b/tests/extensions/test_view.py
@@ -362,3 +362,6 @@ class ViewSummariesTest(unittest.TestCase):
         _ = SummariesViewExtension(collection)
 
         self.assertIn(ViewExtension.get_schema_uri(), collection.stac_extensions)
+
+        ViewExtension.remove_from(collection)
+        self.assertNotIn(ViewExtension.get_schema_uri(), collection.stac_extensions)

--- a/tests/extensions/test_view.py
+++ b/tests/extensions/test_view.py
@@ -6,7 +6,7 @@ import unittest
 
 import pystac
 from pystac.summaries import RangeSummary
-from pystac.extensions.view import ViewExtension
+from pystac.extensions.view import SummariesViewExtension, ViewExtension
 from tests.utils import TestCases, assert_to_from_dict
 
 
@@ -355,3 +355,10 @@ class ViewSummariesTest(unittest.TestCase):
         self.assertDictEqual(
             {"minimum": -10, "maximum": 38}, view_summaries.sun_elevation.to_dict()
         )
+
+    def test_summaries_adds_uri(self) -> None:
+        collection = self.collection.clone()
+        collection.stac_extensions = []
+        _ = SummariesViewExtension(collection)
+
+        self.assertIn(ViewExtension.get_schema_uri(), collection.stac_extensions)

--- a/tests/extensions/test_view.py
+++ b/tests/extensions/test_view.py
@@ -6,7 +6,7 @@ import unittest
 
 import pystac
 from pystac.summaries import RangeSummary
-from pystac.extensions.view import SummariesViewExtension, ViewExtension
+from pystac.extensions.view import ViewExtension
 from tests.utils import TestCases, assert_to_from_dict
 
 
@@ -279,35 +279,37 @@ class ViewSummariesTest(unittest.TestCase):
         self.collection = Collection.from_file(example_uri)
 
     def test_get_off_nadir_summaries(self) -> None:
-        off_nadirs = ViewExtension.summaries(self.collection).off_nadir
+        off_nadirs = ViewExtension.summaries(self.collection, True).off_nadir
 
         assert off_nadirs is not None
 
         self.assertDictEqual({"minimum": 0.5, "maximum": 7.3}, off_nadirs.to_dict())
 
     def test_get_incidence_angle_summaries(self) -> None:
-        incidence_angles = ViewExtension.summaries(self.collection).incidence_angle
+        incidence_angles = ViewExtension.summaries(
+            self.collection, True
+        ).incidence_angle
 
         assert incidence_angles is not None
 
         self.assertDictEqual({"minimum": 23, "maximum": 35}, incidence_angles.to_dict())
 
     def test_get_azimuth_summaries(self) -> None:
-        azimuths = ViewExtension.summaries(self.collection).azimuth
+        azimuths = ViewExtension.summaries(self.collection, True).azimuth
 
         assert azimuths is not None
 
         self.assertDictEqual({"minimum": 20, "maximum": 186}, azimuths.to_dict())
 
     def test_get_sun_azimuth_summaries(self) -> None:
-        sun_azimuths = ViewExtension.summaries(self.collection).sun_azimuth
+        sun_azimuths = ViewExtension.summaries(self.collection, True).sun_azimuth
 
         assert sun_azimuths is not None
 
         self.assertDictEqual({"minimum": 48, "maximum": 78}, sun_azimuths.to_dict())
 
     def test_get_sun_elevation_summaries(self) -> None:
-        sun_elevations = ViewExtension.summaries(self.collection).sun_elevation
+        sun_elevations = ViewExtension.summaries(self.collection, True).sun_elevation
 
         assert sun_elevations is not None
 
@@ -315,7 +317,7 @@ class ViewSummariesTest(unittest.TestCase):
 
     def test_set_off_nadir_summaries(self) -> None:
         collection = self.collection.clone()
-        view_summaries = ViewExtension.summaries(collection)
+        view_summaries = ViewExtension.summaries(collection, True)
 
         view_summaries.off_nadir = RangeSummary(0, 10)
         self.assertDictEqual(
@@ -324,7 +326,7 @@ class ViewSummariesTest(unittest.TestCase):
 
     def test_set_incidence_angle_summaries(self) -> None:
         collection = self.collection.clone()
-        view_summaries = ViewExtension.summaries(collection)
+        view_summaries = ViewExtension.summaries(collection, True)
 
         view_summaries.incidence_angle = RangeSummary(5, 15)
         self.assertDictEqual(
@@ -333,14 +335,14 @@ class ViewSummariesTest(unittest.TestCase):
 
     def test_set_azimuth_summaries(self) -> None:
         collection = self.collection.clone()
-        view_summaries = ViewExtension.summaries(collection)
+        view_summaries = ViewExtension.summaries(collection, True)
 
         view_summaries.azimuth = None
         self.assertIsNone(view_summaries.azimuth)
 
     def test_set_sun_azimuth_summaries(self) -> None:
         collection = self.collection.clone()
-        view_summaries = ViewExtension.summaries(collection)
+        view_summaries = ViewExtension.summaries(collection, True)
 
         view_summaries.sun_azimuth = RangeSummary(210, 275)
         self.assertDictEqual(
@@ -349,7 +351,7 @@ class ViewSummariesTest(unittest.TestCase):
 
     def test_set_sun_elevation_summaries(self) -> None:
         collection = self.collection.clone()
-        view_summaries = ViewExtension.summaries(collection)
+        view_summaries = ViewExtension.summaries(collection, True)
 
         view_summaries.sun_elevation = RangeSummary(-10, 38)
         self.assertDictEqual(
@@ -359,7 +361,14 @@ class ViewSummariesTest(unittest.TestCase):
     def test_summaries_adds_uri(self) -> None:
         collection = self.collection.clone()
         collection.stac_extensions = []
-        _ = SummariesViewExtension(collection)
+        self.assertRaisesRegex(
+            pystac.ExtensionNotImplemented,
+            r"Could not find extension schema URI.*",
+            ViewExtension.summaries,
+            collection,
+            False,
+        )
+        _ = ViewExtension.summaries(collection, True)
 
         self.assertIn(ViewExtension.get_schema_uri(), collection.stac_extensions)
 


### PR DESCRIPTION
**Related Issue(s):** #525 


**Description:** This PR adds `pystac.Collection` to the `ExtensionManagementMixin` type params (via a `Union`) for all extensions that provide concrete implementations of `SummariesExtension`.


**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- ~Documentation has been updated to reflect changes, if applicable~
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.