### PR TITLE
Add `ProjectionExtension.crs_string`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+- `ProjectionExtension.crs_string` to provide a single string to describe the coordinate reference system (CRS).
+  Useful because projections can be defined by EPSG code, WKT, or projjson.
+  ([#548](https://github.com/stac-utils/pystac/pull/548))
+
 ### Removed
 
 ### Changed

--- a/pystac/extensions/projection.py
+++ b/pystac/extensions/projection.py
@@ -3,6 +3,7 @@
 https://github.com/stac-extensions/projection
 """
 
+import json
 from typing import Any, Dict, Generic, Iterable, List, Optional, TypeVar, cast
 
 import pystac
@@ -143,6 +144,27 @@ class ProjectionExtension(
     @projjson.setter
     def projjson(self, v: Optional[Dict[str, Any]]) -> None:
         self._set_property(PROJJSON_PROP, v)
+
+    @property
+    def crs_string(self) -> Optional[str]:
+        """Returns the coordinate reference system (CRS) string for the extension.
+
+        This string can be used to feed, e.g., ``rasterio.crs.CRS.from_string``.
+        The string is determined by the following heuristic:
+
+        1. If an EPSG code is set, return "EPSG:{code}", else
+        2. If wkt2 is set, return the WKT string, else,
+        3. If projjson is set, return the projjson as a string, else,
+        4. Return None
+        """
+        if self.epsg:
+            return f"EPSG:{self.epsg}"
+        elif self.wkt2:
+            return self.wkt2
+        elif self.projjson:
+            return json.dumps(self.projjson)
+        else:
+            return None
 
     @property
     def geometry(self) -> Optional[Dict[str, Any]]:

--- a/tests/extensions/test_projection.py
+++ b/tests/extensions/test_projection.py
@@ -222,6 +222,28 @@ class ProjectionTest(unittest.TestCase):
             ProjectionExtension.ext(proj_item).projjson = {"bad": "data"}
             proj_item.validate()
 
+    def test_crs_string(self) -> None:
+        item = pystac.Item.from_file(self.example_uri)
+        ProjectionExtension.remove_from(item)
+        for key in list(item.properties.keys()):
+            if key.startswith("proj:"):
+                item.properties.pop(key)
+        self.assertIsNone(item.properties.get("proj:epsg"))
+        self.assertIsNone(item.properties.get("proj:wkt2"))
+        self.assertIsNone(item.properties.get("proj:projjson"))
+
+        projection = ProjectionExtension.ext(item, add_if_missing=True)
+        self.assertIsNone(projection.crs_string)
+
+        projection.projjson = PROJJSON
+        self.assertEqual(projection.crs_string, json.dumps(PROJJSON))
+
+        projection.wkt2 = WKT2
+        self.assertEqual(projection.crs_string, WKT2)
+
+        projection.epsg = 4326
+        self.assertEqual(projection.crs_string, "EPSG:4326")
+
     def test_geometry(self) -> None:
         proj_item = pystac.Item.from_file(self.example_uri)
 


### PR DESCRIPTION
**Related Issue(s):** None


**Description:** This can be used to feed, e.g. rasterio's CRS.from_string without having to worry about which projection field is set.


**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.