### PR TITLE
Allow root to be set during to_dict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changed
 
+- The `from_dict` method on STACObjects will set the object's root link when a `root` parameter is present. An ItemCollection `from_dict` with a root parameter will set the root on each of it's Items. ([#549](https://github.com/stac-utils/pystac/pull/549))
+
 ### Deprecated
 
 ## [v1.0.0-rc.3]

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -963,6 +963,9 @@ class Catalog(STACObject):
             if link["rel"] != pystac.RelType.SELF or href is None:
                 cat.add_link(Link.from_dict(link))
 
+        if root:
+            cat.set_root(root)
+
         return cat
 
     def full_copy(

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -732,6 +732,9 @@ class Collection(Catalog):
             for asset_key, asset_dict in assets.items():
                 collection.add_asset(asset_key, Asset.from_dict(asset_dict))
 
+        if root:
+            collection.set_root(root)
+
         return collection
 
     def get_assets(self) -> Dict[str, Asset]:

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -970,6 +970,9 @@ class Item(STACObject):
             asset.set_owner(item)
             item.assets[k] = asset
 
+        if root:
+            item.set_root(root)
+
         return item
 
     @property

--- a/pystac/item_collection.py
+++ b/pystac/item_collection.py
@@ -135,7 +135,10 @@ class ItemCollection(Collection[pystac.Item]):
 
     @classmethod
     def from_dict(
-        cls, d: Dict[str, Any], preserve_dict: bool = True
+        cls,
+        d: Dict[str, Any],
+        preserve_dict: bool = True,
+        root: Optional[pystac.Catalog] = None,
     ) -> "ItemCollection":
         """Creates a :class:`ItemCollection` instance from a dictionary.
 
@@ -151,7 +154,7 @@ class ItemCollection(Collection[pystac.Item]):
             raise STACTypeError("Dict is not a valid ItemCollection")
 
         items = [
-            pystac.Item.from_dict(item, preserve_dict=preserve_dict)
+            pystac.Item.from_dict(item, preserve_dict=preserve_dict, root=root)
             for item in d.get("features", [])
         ]
         extra_fields = {k: v for k, v in d.items() if k not in ("features", "type")}

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -505,9 +505,9 @@ class STACObject(ABC):
             d : The dict to parse.
             href : Optional href that is the file location of the object being
                 parsed.
-            root : Optional root of the catalog for this object.
-                If provided, the root's resolved object cache can be used to search for
-                previously resolved instances of the STAC object.
+            root : Optional root catalog for this object.
+                If provided, the root of the returned STACObject will be set
+                to this parameter.
             migrate: Use True if this dict represents JSON from an older STAC object,
                 so that migrations are run against it.
             preserve_dict: If False, the dict parameter ``d`` may be modified

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -99,6 +99,14 @@ class CatalogTest(unittest.TestCase):
         _ = Catalog.from_dict(param_dict, preserve_dict=False)
         self.assertNotEqual(param_dict, catalog_dict)
 
+    def test_from_dict_set_root(self) -> None:
+        path = TestCases.get_path("data-files/catalogs/test-case-1/catalog.json")
+        with open(path) as f:
+            cat_dict = json.load(f)
+        root_cat = pystac.Catalog(id="test", description="test desc")
+        collection = Catalog.from_dict(cat_dict, root=root_cat)
+        self.assertIs(collection.get_root(), root_cat)
+
     def test_read_remote(self) -> None:
         # TODO: Move this URL to the main stac-spec repo once the example JSON is fixed.
         catalog_url = (

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -228,6 +228,14 @@ class CollectionTest(unittest.TestCase):
         _ = Collection.from_dict(param_dict, preserve_dict=False)
         self.assertNotEqual(param_dict, collection_dict)
 
+    def test_from_dict_set_root(self) -> None:
+        path = TestCases.get_path("data-files/examples/hand-0.8.1/collection.json")
+        with open(path) as f:
+            collection_dict = json.load(f)
+        catalog = pystac.Catalog(id="test", description="test desc")
+        collection = Collection.from_dict(collection_dict, root=catalog)
+        self.assertIs(collection.get_root(), catalog)
+
     def test_schema_summary(self) -> None:
         collection = pystac.Collection.from_file(
             TestCases.get_path(

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -47,6 +47,12 @@ class ItemTest(unittest.TestCase):
         _ = Item.from_dict(param_dict, preserve_dict=False)
         self.assertNotEqual(param_dict, item_dict)
 
+    def test_from_dict_set_root(self) -> None:
+        item_dict = self.get_example_item_dict()
+        catalog = pystac.Catalog(id="test", description="test desc")
+        item = Item.from_dict(item_dict, root=catalog)
+        self.assertIs(item.get_root(), catalog)
+
     def test_set_self_href_does_not_break_asset_hrefs(self) -> None:
         cat = TestCases.test_case_2()
         for item in cat.get_all_items():

--- a/tests/test_item_collection.py
+++ b/tests/test_item_collection.py
@@ -169,3 +169,10 @@ class TestItemCollection(unittest.TestCase):
         # non-default parameter
         _ = ItemCollection.from_dict(param_dict, preserve_dict=False)
         self.assertNotEqual(param_dict, self.item_collection_dict)
+
+    def test_from_dict_sets_root(self) -> None:
+        param_dict = deepcopy(self.item_collection_dict)
+        catalog = pystac.Catalog(id="test", description="test desc")
+        item_collection = ItemCollection.from_dict(param_dict, root=catalog)
+        for item in item_collection.items:
+            self.assertEqual(item.get_root(), catalog)


### PR DESCRIPTION
**Related Issue(s):** #546


**Description:**
There was existing unused arguments for setting the root on from_dict for Catalogs, Collections and Items. This commit implements and tests that the root is set to the parameter if present, and adds the parameter to ItemCollection, which itself does not have a root but instead passes the root onto each of the Items parsed during the from_dict call.

This will allow pystac_client to pass in the client Catalog as the root of the Items returned during a search. This will drastically speed up the `item.to_dict()` calls as the logic in to_dict checks the root to see if the HREFs should be absolute or relative, which ends up reading the root object for each Item in the search results; instead if the root is set at the time of `item.from_dict`, the reading of the root link of the item can be skipped.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.