### PR TITLE
Fix docs build, add config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,19 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+formats:
+  - pdf
+  - epub
+
+python:
+  version: "3.7"
+  install:
+    - requirements: requirements-docs.txt
+    - method: pip
+      path: .
+
+sphinx:
+  fail_on_warning: false

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,7 +5,8 @@
 version: 2
 
 formats:
-  - pdf
+  # Temporarily disabling PDF downloads due to problem with nbsphinx in LateX builds
+  # - pdf
   - epub
 
 python:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,2 @@
-ipython==7.25.0
-Sphinx==4.1.0
-sphinxcontrib-fulltoc==1.2.0
-nbsphinx==0.8.6
-
-jinja2<4.0
-
+-r ./requirements-docs.txt
 -r ./requirements-test.txt

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,6 @@
+ipython==7.25.0
+Sphinx==4.1.0
+sphinxcontrib-fulltoc==1.2.0
+nbsphinx==0.8.6
+
+jinja2<4.0


### PR DESCRIPTION
**Related Issue(s):**

* #552

**Description:**

This temporarily disables building the PDF docs until the underlying issue with `nbsphinx` is resolved. Also moves our docs dependencies into a separate file and uses a `.readthedocs.yaml` file for configuration.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.