### PR TITLE
Raise exception when using add_if_missing on ownerless Asset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 ### Changed
 
 - The `from_dict` method on STACObjects will set the object's root link when a `root` parameter is present. An ItemCollection `from_dict` with a root parameter will set the root on each of it's Items. ([#549](https://github.com/stac-utils/pystac/pull/549))
+- Calling `ExtensionManagementMixin.validate_has_extension` with `add_if_missing = True`
+  on an ownerless `Asset` will raise a `STACError` ([#554](https://github.com/stac-utils/pystac/pull/554))
 
 ### Fixed
 

--- a/pystac/extensions/base.py
+++ b/pystac/extensions/base.py
@@ -126,15 +126,26 @@ class ExtensionManagementMixin(Generic[S], ABC):
         )
 
     @classmethod
-    def validate_has_extension(cls, obj: Union[S, pystac.Asset]) -> None:
-        """Given a :class:`~pystac.STACObject` or :class:`pystac.Asset` instance, checks
-        if the object (or its owner in the case of an Asset) has this extension's schema
-        URI in it's :attr:`~pystac.STACObject.stac_extensions` list."""
-        extensible = obj.owner if isinstance(obj, pystac.Asset) else obj
-        if (
-            extensible is not None
-            and cls.get_schema_uri() not in extensible.stac_extensions
-        ):
+    def validate_has_extension(
+        cls, extensible: Optional[S], add_if_missing: bool
+    ) -> None:
+        """Given a :class:`~pystac.STACObject`, checks if the object has this
+        extension's schema URI in it's :attr:`~pystac.STACObject.stac_extensions` list.
+        If ``add_if_missing`` is ``True``, the schema URI will be added to the object.
+
+        Args:
+            extensible : The object to validate.
+            add_if_missing : Whether to add the schema URI to the object if the URI is
+                not already present.
+
+        """
+        if add_if_missing:
+            cls.add_to(extensible)
+
+        if extensible is None:
+            return
+
+        if cls.get_schema_uri() not in extensible.stac_extensions:
             raise pystac.ExtensionNotImplemented(
                 f"Could not find extension schema URI {cls.get_schema_uri()} in object."
             )

--- a/pystac/extensions/base.py
+++ b/pystac/extensions/base.py
@@ -138,8 +138,14 @@ class ExtensionManagementMixin(Generic[S], ABC):
             add_if_missing : Whether to add the schema URI to the object if the URI is
                 not already present.
 
+        Raises:
+            STACError : If ``add_if_missing`` is ``True`` and ``extensible`` is None.
         """
         if add_if_missing:
+            if extensible is None:
+                raise pystac.STACError(
+                    "Can only add schema URIs to Assets with an owner."
+                )
             cls.add_to(extensible)
 
         if extensible is None:

--- a/pystac/extensions/base.py
+++ b/pystac/extensions/base.py
@@ -126,15 +126,13 @@ class ExtensionManagementMixin(Generic[S], ABC):
         )
 
     @classmethod
-    def validate_has_extension(
-        cls, extensible: Optional[S], add_if_missing: bool
-    ) -> None:
+    def validate_has_extension(cls, obj: Optional[S], add_if_missing: bool) -> None:
         """Given a :class:`~pystac.STACObject`, checks if the object has this
         extension's schema URI in it's :attr:`~pystac.STACObject.stac_extensions` list.
         If ``add_if_missing`` is ``True``, the schema URI will be added to the object.
 
         Args:
-            extensible : The object to validate.
+            obj : The object to validate.
             add_if_missing : Whether to add the schema URI to the object if the URI is
                 not already present.
 
@@ -142,16 +140,16 @@ class ExtensionManagementMixin(Generic[S], ABC):
             STACError : If ``add_if_missing`` is ``True`` and ``extensible`` is None.
         """
         if add_if_missing:
-            if extensible is None:
+            if obj is None:
                 raise pystac.STACError(
                     "Can only add schema URIs to Assets with an owner."
                 )
-            cls.add_to(extensible)
+            cls.add_to(obj)
 
-        if extensible is None:
+        if obj is None:
             return
 
-        if cls.get_schema_uri() not in extensible.stac_extensions:
+        if cls.get_schema_uri() not in obj.stac_extensions:
             raise pystac.ExtensionNotImplemented(
                 f"Could not find extension schema URI {cls.get_schema_uri()} in object."
             )

--- a/pystac/extensions/datacube.py
+++ b/pystac/extensions/datacube.py
@@ -340,19 +340,13 @@ class DatacubeExtension(
     @classmethod
     def ext(cls, obj: T, add_if_missing: bool = False) -> "DatacubeExtension[T]":
         if isinstance(obj, pystac.Collection):
-            if add_if_missing:
-                cls.add_to(obj)
-            cls.validate_has_extension(obj)
+            cls.validate_has_extension(obj, add_if_missing)
             return cast(DatacubeExtension[T], CollectionDatacubeExtension(obj))
         if isinstance(obj, pystac.Item):
-            if add_if_missing:
-                cls.add_to(obj)
-            cls.validate_has_extension(obj)
+            cls.validate_has_extension(obj, add_if_missing)
             return cast(DatacubeExtension[T], ItemDatacubeExtension(obj))
         elif isinstance(obj, pystac.Asset):
-            if add_if_missing and obj.owner is not None:
-                cls.add_to(obj.owner)
-            cls.validate_has_extension(obj)
+            cls.validate_has_extension(obj.owner, add_if_missing)
             return cast(DatacubeExtension[T], AssetDatacubeExtension(obj))
         else:
             raise pystac.ExtensionTypeError(

--- a/pystac/extensions/datacube.py
+++ b/pystac/extensions/datacube.py
@@ -346,7 +346,7 @@ class DatacubeExtension(
             cls.validate_has_extension(obj, add_if_missing)
             return cast(DatacubeExtension[T], ItemDatacubeExtension(obj))
         elif isinstance(obj, pystac.Asset):
-            cls.validate_has_extension(obj.owner, add_if_missing)
+            cls.validate_owner_has_extension(obj, add_if_missing)
             return cast(DatacubeExtension[T], AssetDatacubeExtension(obj))
         else:
             raise pystac.ExtensionTypeError(

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -364,7 +364,7 @@ class EOExtension(
             cls.validate_has_extension(obj, add_if_missing)
             return cast(EOExtension[T], ItemEOExtension(obj))
         elif isinstance(obj, pystac.Asset):
-            cls.validate_has_extension(obj.owner, add_if_missing)
+            cls.validate_owner_has_extension(obj, add_if_missing)
             return cast(EOExtension[T], AssetEOExtension(obj))
         else:
             raise pystac.ExtensionTypeError(

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -361,14 +361,10 @@ class EOExtension(
             pystac.ExtensionTypeError : If an invalid object type is passed.
         """
         if isinstance(obj, pystac.Item):
-            if add_if_missing:
-                cls.add_to(obj)
-            cls.validate_has_extension(obj)
+            cls.validate_has_extension(obj, add_if_missing)
             return cast(EOExtension[T], ItemEOExtension(obj))
         elif isinstance(obj, pystac.Asset):
-            if add_if_missing and isinstance(obj.owner, pystac.Item):
-                cls.add_to(obj.owner)
-            cls.validate_has_extension(obj)
+            cls.validate_has_extension(obj.owner, add_if_missing)
             return cast(EOExtension[T], AssetEOExtension(obj))
         else:
             raise pystac.ExtensionTypeError(
@@ -380,10 +376,7 @@ class EOExtension(
         cls, obj: pystac.Collection, add_if_missing: bool = False
     ) -> "SummariesEOExtension":
         """Returns the extended summaries object for the given collection."""
-        if not add_if_missing:
-            cls.validate_has_extension(obj)
-        else:
-            cls.add_to(obj)
+        cls.validate_has_extension(obj, add_if_missing)
         return SummariesEOExtension(obj)
 
 

--- a/pystac/extensions/file.py
+++ b/pystac/extensions/file.py
@@ -199,7 +199,7 @@ class FileExtension(
         This extension can be applied to instances of :class:`~pystac.Asset`.
         """
         if isinstance(obj, pystac.Asset):
-            cls.validate_has_extension(obj.owner, add_if_missing)
+            cls.validate_owner_has_extension(obj, add_if_missing)
             return cls(obj)
         else:
             raise pystac.ExtensionTypeError(

--- a/pystac/extensions/file.py
+++ b/pystac/extensions/file.py
@@ -4,7 +4,7 @@ https://github.com/stac-extensions/file
 """
 
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import pystac
 from pystac.extensions.base import ExtensionManagementMixin, PropertiesExtension
@@ -85,7 +85,9 @@ class MappingObject:
         self.properties["summary"] = v
 
 
-class FileExtension(PropertiesExtension, ExtensionManagementMixin[pystac.Item]):
+class FileExtension(
+    PropertiesExtension, ExtensionManagementMixin[Union[pystac.Item, pystac.Collection]]
+):
     """A class that can be used to extend the properties of an :class:`~pystac.Asset`
     with properties from the :stac-ext:`File Info Extension <file>`.
 
@@ -197,9 +199,7 @@ class FileExtension(PropertiesExtension, ExtensionManagementMixin[pystac.Item]):
         This extension can be applied to instances of :class:`~pystac.Asset`.
         """
         if isinstance(obj, pystac.Asset):
-            if add_if_missing and isinstance(obj.owner, pystac.Item):
-                cls.add_to(obj.owner)
-            cls.validate_has_extension(obj)
+            cls.validate_has_extension(obj.owner, add_if_missing)
             return cls(obj)
         else:
             raise pystac.ExtensionTypeError(

--- a/pystac/extensions/item_assets.py
+++ b/pystac/extensions/item_assets.py
@@ -119,8 +119,7 @@ class ItemAssetsExtension(ExtensionManagementMixin[pystac.Collection]):
         cls, obj: pystac.Collection, add_if_missing: bool = False
     ) -> "ItemAssetsExtension":
         if isinstance(obj, pystac.Collection):
-            if add_if_missing:
-                cls.add_to(obj)
+            cls.validate_has_extension(obj, add_if_missing)
             return cls(obj)
         else:
             raise pystac.ExtensionTypeError(

--- a/pystac/extensions/label.py
+++ b/pystac/extensions/label.py
@@ -691,9 +691,7 @@ class LabelExtension(ExtensionManagementMixin[Union[pystac.Item, pystac.Collecti
         This extension can be applied to instances of :class:`~pystac.Item`.
         """
         if isinstance(obj, pystac.Item):
-            if add_if_missing:
-                cls.add_to(obj)
-            cls.validate_has_extension(obj)
+            cls.validate_has_extension(obj, add_if_missing)
             return cls(obj)
         else:
             raise pystac.ExtensionTypeError(
@@ -705,10 +703,7 @@ class LabelExtension(ExtensionManagementMixin[Union[pystac.Item, pystac.Collecti
         cls, obj: pystac.Collection, add_if_missing: bool = False
     ) -> "SummariesLabelExtension":
         """Returns the extended summaries object for the given collection."""
-        if not add_if_missing:
-            cls.validate_has_extension(obj)
-        else:
-            cls.add_to(obj)
+        cls.validate_has_extension(obj, add_if_missing)
         return SummariesLabelExtension(obj)
 
 

--- a/pystac/extensions/pointcloud.py
+++ b/pystac/extensions/pointcloud.py
@@ -486,10 +486,7 @@ class PointcloudExtension(
     def summaries(
         cls, obj: pystac.Collection, add_if_missing: bool = False
     ) -> "SummariesPointcloudExtension":
-        if not add_if_missing:
-            cls.validate_has_extension(obj)
-        else:
-            cls.add_to(obj)
+        cls.validate_has_extension(obj, add_if_missing)
         return SummariesPointcloudExtension(obj)
 
 

--- a/pystac/extensions/pointcloud.py
+++ b/pystac/extensions/pointcloud.py
@@ -525,14 +525,15 @@ class PointcloudExtension(
     @classmethod
     def ext(cls, obj: T, add_if_missing: bool = False) -> "PointcloudExtension[T]":
         if isinstance(obj, pystac.Item):
-            if add_if_missing:
-                cls.add_to(obj)
-            cls.validate_has_extension(obj)
+            cls.validate_has_extension(obj, add_if_missing)
             return cast(PointcloudExtension[T], ItemPointcloudExtension(obj))
         elif isinstance(obj, pystac.Asset):
-            if add_if_missing and isinstance(obj.owner, pystac.Item):
-                cls.add_to(obj.owner)
-            cls.validate_has_extension(obj)
+            if obj.owner is not None and not isinstance(obj.owner, pystac.Item):
+                raise pystac.ExtensionTypeError(
+                    "Pointcloud extension does not apply to Assets owned by anything "
+                    "other than an Item."
+                )
+            cls.validate_has_extension(obj.owner, add_if_missing)
             return cast(PointcloudExtension[T], AssetPointcloudExtension(obj))
         else:
             raise pystac.ExtensionTypeError(

--- a/pystac/extensions/pointcloud.py
+++ b/pystac/extensions/pointcloud.py
@@ -530,10 +530,9 @@ class PointcloudExtension(
         elif isinstance(obj, pystac.Asset):
             if obj.owner is not None and not isinstance(obj.owner, pystac.Item):
                 raise pystac.ExtensionTypeError(
-                    "Pointcloud extension does not apply to Assets owned by anything "
-                    "other than an Item."
+                    "Pointcloud extension does not apply to Collection Assets."
                 )
-            cls.validate_has_extension(obj.owner, add_if_missing)
+            cls.validate_owner_has_extension(obj, add_if_missing)
             return cast(PointcloudExtension[T], AssetPointcloudExtension(obj))
         else:
             raise pystac.ExtensionTypeError(

--- a/pystac/extensions/projection.py
+++ b/pystac/extensions/projection.py
@@ -275,7 +275,7 @@ class ProjectionExtension(
             cls.validate_has_extension(obj, add_if_missing)
             return cast(ProjectionExtension[T], ItemProjectionExtension(obj))
         elif isinstance(obj, pystac.Asset):
-            cls.validate_has_extension(obj.owner, add_if_missing)
+            cls.validate_owner_has_extension(obj, add_if_missing)
             return cast(ProjectionExtension[T], AssetProjectionExtension(obj))
         else:
             raise pystac.ExtensionTypeError(

--- a/pystac/extensions/projection.py
+++ b/pystac/extensions/projection.py
@@ -272,14 +272,10 @@ class ProjectionExtension(
             pystac.ExtensionTypeError : If an invalid object type is passed.
         """
         if isinstance(obj, pystac.Item):
-            if add_if_missing:
-                cls.add_to(obj)
-            cls.validate_has_extension(obj)
+            cls.validate_has_extension(obj, add_if_missing)
             return cast(ProjectionExtension[T], ItemProjectionExtension(obj))
         elif isinstance(obj, pystac.Asset):
-            if add_if_missing and isinstance(obj.owner, pystac.Item):
-                cls.add_to(obj.owner)
-            cls.validate_has_extension(obj)
+            cls.validate_has_extension(obj.owner, add_if_missing)
             return cast(ProjectionExtension[T], AssetProjectionExtension(obj))
         else:
             raise pystac.ExtensionTypeError(
@@ -291,10 +287,7 @@ class ProjectionExtension(
         cls, obj: pystac.Collection, add_if_missing: bool = False
     ) -> "SummariesProjectionExtension":
         """Returns the extended summaries object for the given collection."""
-        if not add_if_missing:
-            cls.validate_has_extension(obj)
-        else:
-            cls.add_to(obj)
+        cls.validate_has_extension(obj, add_if_missing)
         return SummariesProjectionExtension(obj)
 
 

--- a/pystac/extensions/raster.py
+++ b/pystac/extensions/raster.py
@@ -704,9 +704,7 @@ class RasterExtension(
             pystac.ExtensionTypeError : If an invalid object type is passed.
         """
         if isinstance(obj, pystac.Asset):
-            if add_if_missing and isinstance(obj.owner, pystac.Item):
-                cls.add_to(obj.owner)
-            cls.validate_has_extension(obj)
+            cls.validate_has_extension(obj.owner, add_if_missing)
             return cls(obj)
         else:
             raise pystac.ExtensionTypeError(
@@ -717,10 +715,7 @@ class RasterExtension(
     def summaries(
         cls, obj: pystac.Collection, add_if_missing: bool = False
     ) -> "SummariesRasterExtension":
-        if not add_if_missing:
-            cls.validate_has_extension(obj)
-        else:
-            cls.add_to(obj)
+        cls.validate_has_extension(obj, add_if_missing)
         return SummariesRasterExtension(obj)
 
 

--- a/pystac/extensions/raster.py
+++ b/pystac/extensions/raster.py
@@ -704,7 +704,7 @@ class RasterExtension(
             pystac.ExtensionTypeError : If an invalid object type is passed.
         """
         if isinstance(obj, pystac.Asset):
-            cls.validate_has_extension(obj.owner, add_if_missing)
+            cls.validate_owner_has_extension(obj, add_if_missing)
             return cls(obj)
         else:
             raise pystac.ExtensionTypeError(

--- a/pystac/extensions/sar.py
+++ b/pystac/extensions/sar.py
@@ -315,14 +315,15 @@ class SarExtension(
             pystac.ExtensionTypeError : If an invalid object type is passed.
         """
         if isinstance(obj, pystac.Item):
-            if add_if_missing:
-                cls.add_to(obj)
-            cls.validate_has_extension(obj)
+            cls.validate_has_extension(obj, add_if_missing)
             return cast(SarExtension[T], ItemSarExtension(obj))
         elif isinstance(obj, pystac.Asset):
-            if add_if_missing and isinstance(obj.owner, pystac.Item):
-                cls.add_to(obj.owner)
-            cls.validate_has_extension(obj)
+            if obj.owner is not None and not isinstance(obj.owner, pystac.Item):
+                raise pystac.ExtensionTypeError(
+                    "SAR extension does not apply to Assets owned by anything "
+                    "other than an Item."
+                )
+            cls.validate_has_extension(obj.owner, add_if_missing)
             return cast(SarExtension[T], AssetSarExtension(obj))
         else:
             raise pystac.ExtensionTypeError(

--- a/pystac/extensions/sar.py
+++ b/pystac/extensions/sar.py
@@ -335,10 +335,7 @@ class SarExtension(
         cls, obj: pystac.Collection, add_if_missing: bool = False
     ) -> "SummariesSarExtension":
         """Returns the extended summaries object for the given collection."""
-        if not add_if_missing:
-            cls.validate_has_extension(obj)
-        else:
-            cls.add_to(obj)
+        cls.validate_has_extension(obj, add_if_missing)
         return SummariesSarExtension(obj)
 
 

--- a/pystac/extensions/sar.py
+++ b/pystac/extensions/sar.py
@@ -320,10 +320,9 @@ class SarExtension(
         elif isinstance(obj, pystac.Asset):
             if obj.owner is not None and not isinstance(obj.owner, pystac.Item):
                 raise pystac.ExtensionTypeError(
-                    "SAR extension does not apply to Assets owned by anything "
-                    "other than an Item."
+                    "SAR extension does not apply to Collection Assets."
                 )
-            cls.validate_has_extension(obj.owner, add_if_missing)
+            cls.validate_owner_has_extension(obj, add_if_missing)
             return cast(SarExtension[T], AssetSarExtension(obj))
         else:
             raise pystac.ExtensionTypeError(

--- a/pystac/extensions/sat.py
+++ b/pystac/extensions/sat.py
@@ -149,14 +149,10 @@ class SatExtension(
             pystac.ExtensionTypeError : If an invalid object type is passed.
         """
         if isinstance(obj, pystac.Item):
-            if add_if_missing:
-                cls.add_to(obj)
-            cls.validate_has_extension(obj)
+            cls.validate_has_extension(obj, add_if_missing)
             return cast(SatExtension[T], ItemSatExtension(obj))
         elif isinstance(obj, pystac.Asset):
-            if add_if_missing and isinstance(obj.owner, pystac.Item):
-                cls.add_to(obj.owner)
-            cls.validate_has_extension(obj)
+            cls.validate_has_extension(obj.owner, add_if_missing)
             return cast(SatExtension[T], AssetSatExtension(obj))
         else:
             raise pystac.ExtensionTypeError(
@@ -168,10 +164,7 @@ class SatExtension(
         cls, obj: pystac.Collection, add_if_missing: bool = False
     ) -> "SummariesSatExtension":
         """Returns the extended summaries object for the given collection."""
-        if not add_if_missing:
-            cls.validate_has_extension(obj)
-        else:
-            cls.add_to(obj)
+        cls.validate_has_extension(obj, add_if_missing)
         return SummariesSatExtension(obj)
 
 

--- a/pystac/extensions/sat.py
+++ b/pystac/extensions/sat.py
@@ -152,7 +152,7 @@ class SatExtension(
             cls.validate_has_extension(obj, add_if_missing)
             return cast(SatExtension[T], ItemSatExtension(obj))
         elif isinstance(obj, pystac.Asset):
-            cls.validate_has_extension(obj.owner, add_if_missing)
+            cls.validate_owner_has_extension(obj, add_if_missing)
             return cast(SatExtension[T], AssetSatExtension(obj))
         else:
             raise pystac.ExtensionTypeError(

--- a/pystac/extensions/scientific.py
+++ b/pystac/extensions/scientific.py
@@ -234,14 +234,10 @@ class ScientificExtension(
             pystac.ExtensionTypeError : If an invalid object type is passed.
         """
         if isinstance(obj, pystac.Collection):
-            if add_if_missing:
-                cls.add_to(obj)
-            cls.validate_has_extension(obj)
+            cls.validate_has_extension(obj, add_if_missing)
             return cast(ScientificExtension[T], CollectionScientificExtension(obj))
         if isinstance(obj, pystac.Item):
-            if add_if_missing:
-                cls.add_to(obj)
-            cls.validate_has_extension(obj)
+            cls.validate_has_extension(obj, add_if_missing)
             return cast(ScientificExtension[T], ItemScientificExtension(obj))
         else:
             raise pystac.ExtensionTypeError(
@@ -253,10 +249,7 @@ class ScientificExtension(
         cls, obj: pystac.Collection, add_if_missing: bool = False
     ) -> "SummariesScientificExtension":
         """Returns the extended summaries object for the given collection."""
-        if not add_if_missing:
-            cls.validate_has_extension(obj)
-        else:
-            cls.add_to(obj)
+        cls.validate_has_extension(obj, add_if_missing)
         return SummariesScientificExtension(obj)
 
 

--- a/pystac/extensions/timestamps.py
+++ b/pystac/extensions/timestamps.py
@@ -129,14 +129,10 @@ class TimestampsExtension(
             pystac.ExtensionTypeError : If an invalid object type is passed.
         """
         if isinstance(obj, pystac.Item):
-            if add_if_missing:
-                cls.add_to(obj)
-            cls.validate_has_extension(obj)
+            cls.validate_has_extension(obj, add_if_missing)
             return cast(TimestampsExtension[T], ItemTimestampsExtension(obj))
         elif isinstance(obj, pystac.Asset):
-            if add_if_missing and isinstance(obj.owner, pystac.Item):
-                cls.add_to(obj.owner)
-            cls.validate_has_extension(obj)
+            cls.validate_has_extension(obj.owner, add_if_missing)
             return cast(TimestampsExtension[T], AssetTimestampsExtension(obj))
         else:
             raise pystac.ExtensionTypeError(
@@ -148,10 +144,7 @@ class TimestampsExtension(
         cls, obj: pystac.Collection, add_if_missing: bool = False
     ) -> "SummariesTimestampsExtension":
         """Returns the extended summaries object for the given collection."""
-        if not add_if_missing:
-            cls.validate_has_extension(obj)
-        else:
-            cls.add_to(obj)
+        cls.validate_has_extension(obj, add_if_missing)
         return SummariesTimestampsExtension(obj)
 
 

--- a/pystac/extensions/timestamps.py
+++ b/pystac/extensions/timestamps.py
@@ -132,7 +132,7 @@ class TimestampsExtension(
             cls.validate_has_extension(obj, add_if_missing)
             return cast(TimestampsExtension[T], ItemTimestampsExtension(obj))
         elif isinstance(obj, pystac.Asset):
-            cls.validate_has_extension(obj.owner, add_if_missing)
+            cls.validate_owner_has_extension(obj, add_if_missing)
             return cast(TimestampsExtension[T], AssetTimestampsExtension(obj))
         else:
             raise pystac.ExtensionTypeError(

--- a/pystac/extensions/version.py
+++ b/pystac/extensions/version.py
@@ -205,14 +205,10 @@ class VersionExtension(
             pystac.ExtensionTypeError : If an invalid object type is passed.
         """
         if isinstance(obj, pystac.Collection):
-            if add_if_missing:
-                cls.add_to(obj)
-            cls.validate_has_extension(obj)
+            cls.validate_has_extension(obj, add_if_missing)
             return cast(VersionExtension[T], CollectionVersionExtension(obj))
         if isinstance(obj, pystac.Item):
-            if add_if_missing:
-                cls.add_to(obj)
-            cls.validate_has_extension(obj)
+            cls.validate_has_extension(obj, add_if_missing)
             return cast(VersionExtension[T], ItemVersionExtension(obj))
         else:
             raise pystac.ExtensionTypeError(

--- a/pystac/extensions/view.py
+++ b/pystac/extensions/view.py
@@ -161,7 +161,7 @@ class ViewExtension(
             cls.validate_has_extension(obj, add_if_missing)
             return cast(ViewExtension[T], ItemViewExtension(obj))
         elif isinstance(obj, pystac.Asset):
-            cls.validate_has_extension(obj.owner, add_if_missing)
+            cls.validate_owner_has_extension(obj, add_if_missing)
             return cast(ViewExtension[T], AssetViewExtension(obj))
         else:
             raise pystac.ExtensionTypeError(

--- a/pystac/extensions/view.py
+++ b/pystac/extensions/view.py
@@ -158,14 +158,10 @@ class ViewExtension(
             pystac.ExtensionTypeError : If an invalid object type is passed.
         """
         if isinstance(obj, pystac.Item):
-            if add_if_missing:
-                cls.add_to(obj)
-            cls.validate_has_extension(obj)
+            cls.validate_has_extension(obj, add_if_missing)
             return cast(ViewExtension[T], ItemViewExtension(obj))
         elif isinstance(obj, pystac.Asset):
-            if add_if_missing and isinstance(obj.owner, pystac.Item):
-                cls.add_to(obj.owner)
-            cls.validate_has_extension(obj)
+            cls.validate_has_extension(obj.owner, add_if_missing)
             return cast(ViewExtension[T], AssetViewExtension(obj))
         else:
             raise pystac.ExtensionTypeError(
@@ -177,10 +173,7 @@ class ViewExtension(
         cls, obj: pystac.Collection, add_if_missing: bool = False
     ) -> "SummariesViewExtension":
         """Returns the extended summaries object for the given collection."""
-        if not add_if_missing:
-            cls.validate_has_extension(obj)
-        else:
-            cls.add_to(obj)
+        cls.validate_has_extension(obj, add_if_missing)
         return SummariesViewExtension(obj)
 
 

--- a/tests/extensions/test_eo.py
+++ b/tests/extensions/test_eo.py
@@ -316,6 +316,14 @@ class EOTest(unittest.TestCase):
 
         self.assertIn(EOExtension.get_schema_uri(), item.stac_extensions)
 
+    def test_asset_ext_add_to_ownerless_asset(self) -> None:
+        item = pystac.Item.from_file(self.PLAIN_ITEM)
+        asset_dict = item.assets["thumbnail"].to_dict()
+        asset = pystac.Asset.from_dict(asset_dict)
+
+        with self.assertRaises(pystac.STACError):
+            _ = EOExtension.ext(asset, add_if_missing=True)
+
     def test_should_raise_exception_when_passing_invalid_extension_object(
         self,
     ) -> None:


### PR DESCRIPTION
**Related Issue(s):**

* #521

**Description:**

Raises an `STACError` if `add_if_missing` is `True` for an `Asset` with no `owner`. 

This PR also moves the `add_if_missing` logic into `ExtensionManagementMixin.validate_has_extension` for DRYer code in the extension implementations.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [ ] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.