### PR TITLE
Allow resolved self links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Fixed
 
 - Added `Collections` as a type that can be extended for extensions whose fields can appear in collection summaries ([#547](https://github.com/stac-utils/pystac/pull/547))
+- Allow resolved self links when getting an object's self href ([#555](https://github.com/stac-utils/pystac/pull/555))
 
 ### Deprecated
 

--- a/pystac/link.py
+++ b/pystac/link.py
@@ -203,6 +203,10 @@ class Link:
         else:
             return None
 
+    def has_target_href(self) -> bool:
+        """Returns true if this link has a string href in its target information."""
+        return self._target_href is not None
+
     def __repr__(self) -> str:
         return "<Link rel={} target={}>".format(self.rel, self.target)
 

--- a/pystac/link.py
+++ b/pystac/link.py
@@ -191,8 +191,17 @@ class Link:
             self._target_object = target
 
     def get_target_str(self) -> Optional[str]:
-        """Returns this link's target as a string."""
-        return self._target_href
+        """Returns this link's target as a string.
+
+        If a string href was provided, returns that. If not, tries to resolve
+        the self link of the target object.
+        """
+        if self._target_href:
+            return self._target_href
+        elif self._target_object:
+            return self._target_object.get_self_href()
+        else:
+            return None
 
     def __repr__(self) -> str:
         return "<Link rel={} target={}>".format(self.rel, self.target)

--- a/pystac/link.py
+++ b/pystac/link.py
@@ -1,5 +1,5 @@
 from copy import copy
-from typing import Any, Dict, Optional, TYPE_CHECKING, Union, cast
+from typing import Any, Dict, Optional, TYPE_CHECKING, Union
 
 import pystac
 from pystac.utils import make_absolute_href, make_relative_href, is_absolute_href
@@ -52,11 +52,6 @@ class Link:
     """The relation of the link (e.g. 'child', 'item'). Registered rel Types are
     preferred. See :class:`~pystac.RelType` for common media types."""
 
-    target: Union[str, "STACObject_Type"]
-    """The target of the link. If the link is unresolved, or the link is to something
-    that is not a STACObject, the target is an HREF. If resolved, the target is a
-    STACObject."""
-
     media_type: Optional[str]
     """Optional description of the media type. Registered Media Types are preferred.
     See :class:`~pystac.MediaType` for common media types."""
@@ -82,7 +77,12 @@ class Link:
         extra_fields: Optional[Dict[str, Any]] = None,
     ) -> None:
         self.rel = rel
-        self.target = target
+        if isinstance(target, str):
+            self._target_href: Optional[str] = target
+            self._target_object = None
+        else:
+            self._target_href = None
+            self._target_object = target
         self.media_type = media_type
         self.title = title
         self.extra_fields = extra_fields or {}
@@ -119,10 +119,10 @@ class Link:
             In all other cases, this method will return an absolute HREF.
         """
         # get the self href
-        if self.is_resolved():
-            href = cast(pystac.STACObject, self.target).get_self_href()
+        if self._target_object:
+            href = self._target_object.get_self_href()
         else:
-            href = cast(Optional[str], self.target)
+            href = self._target_href
 
         if href and is_absolute_href(href) and self.owner and self.owner.get_root():
             root = self.owner.get_root()
@@ -158,15 +158,41 @@ class Link:
             from this link; however, if the link is relative, has no owner,
             and has an unresolved target, this will return a relative HREF.
         """
-        if self.is_resolved():
-            href = cast(pystac.STACObject, self.target).get_self_href()
+        if self._target_object:
+            href = self._target_object.get_self_href()
         else:
-            href = cast(Optional[str], self.target)
+            href = self._target_href
 
         if href is not None and self.owner is not None:
             href = make_absolute_href(href, self.owner.get_self_href())
 
         return href
+
+    @property
+    def target(self) -> Union[str, "STACObject_Type"]:
+        """The target of the link. If the link is unresolved, or the link is to something
+        that is not a STACObject, the target is an HREF. If resolved, the target is a
+        STACObject."""
+        if self._target_object:
+            return self._target_object
+        elif self._target_href:
+            return self._target_href
+        else:
+            raise ValueError("No target defined for link.")
+
+    @target.setter
+    def target(self, target: Union[str, "STACObject_Type"]) -> None:
+        """Sets this link's target to a string or a STAC object."""
+        if isinstance(target, str):
+            self._target_href = target
+            self._target_object = None
+        else:
+            self._target_href = None
+            self._target_object = target
+
+    def get_target_str(self) -> Optional[str]:
+        """Returns this link's target as a string."""
+        return self._target_href
 
     def __repr__(self) -> str:
         return "<Link rel={} target={}>".format(self.rel, self.target)
@@ -180,8 +206,10 @@ class Link:
                 If provided, the root's resolved object cache is used to search for
                 previously resolved instances of the STAC object.
         """
-        if isinstance(self.target, str):
-            target_href = self.target
+        if self._target_object:
+            pass
+        elif self._target_href:
+            target_href = self._target_href
 
             # If it's a relative link, base it off the parent.
             if not is_absolute_href(target_href):
@@ -221,17 +249,17 @@ class Link:
                 if root is not None:
                     obj = root._resolved_objects.get_or_cache(obj)
                     obj.set_root(root)
+            self._target_object = obj
         else:
-            obj = self.target
-
-        self.target = obj
+            raise ValueError("Cannot resolve STAC object without a target")
 
         if (
             self.owner
             and self.rel in [pystac.RelType.CHILD, pystac.RelType.ITEM]
             and isinstance(self.owner, pystac.Catalog)
         ):
-            self.target.set_parent(self.owner)
+            assert self._target_object
+            self._target_object.set_parent(self.owner)
 
         return self
 
@@ -241,7 +269,7 @@ class Link:
         Returns:
             bool: True if this link is resolved.
         """
-        return not isinstance(self.target, str)
+        return self._target_object is not None
 
     def to_dict(self) -> Dict[str, Any]:
         """Generate a dictionary representing the JSON of this serialized Link.

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -159,7 +159,7 @@ class STACObject(ABC):
         """
         self_link = self.get_single_link(pystac.RelType.SELF)
         if self_link:
-            return cast(str, self_link.target)
+            return self_link.get_target_str()
         else:
             return None
 

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -158,7 +158,7 @@ class STACObject(ABC):
             links have absolute (as opposed to relative) HREFs.
         """
         self_link = self.get_single_link(pystac.RelType.SELF)
-        if self_link:
+        if self_link and self_link.has_target_href():
             return self_link.get_target_str()
         else:
             return None

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -1,5 +1,7 @@
 import datetime
+import os.path
 import unittest
+from tempfile import TemporaryDirectory
 from typing import Any, Dict, List
 
 import pystac
@@ -81,6 +83,17 @@ class LinkTest(unittest.TestCase):
     def test_resolve_stac_object_no_root_and_target_is_item(self) -> None:
         link = pystac.Link("my rel", target=self.item)
         link.resolve_stac_object()
+
+    def test_resolved_self_href(self) -> None:
+        catalog = pystac.Catalog(id="test", description="test desc")
+        with TemporaryDirectory() as temporary_directory:
+            catalog.normalize_and_save(temporary_directory)
+            path = os.path.join(temporary_directory, "catalog.json")
+            catalog = pystac.Catalog.from_file(path)
+            link = catalog.get_single_link(pystac.RelType.SELF)
+            assert link
+            link.resolve_stac_object()
+            self.assertEqual(link.get_absolute_href(), path)
 
 
 class StaticLinkTest(unittest.TestCase):

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -95,6 +95,24 @@ class LinkTest(unittest.TestCase):
             link.resolve_stac_object()
             self.assertEqual(link.get_absolute_href(), path)
 
+    def test_target_getter_setter(self) -> None:
+        link = pystac.Link("my rel", target="./foo/bar.json")
+        self.assertEqual(link.target, "./foo/bar.json")
+        self.assertEqual(link.get_target_str(), "./foo/bar.json")
+
+        link.target = self.item
+        self.assertEqual(link.target, self.item)
+        self.assertEqual(link.get_target_str(), self.item.get_self_href())
+
+        link.target = "./bar/foo.json"
+        self.assertEqual(link.target, "./bar/foo.json")
+
+    def test_get_target_str_no_href(self) -> None:
+        self.item.remove_links("self")
+        link = pystac.Link("self", target=self.item)
+        self.item.add_link(link)
+        self.assertIsNone(link.get_target_str())
+
 
 class StaticLinkTest(unittest.TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
**Related Issue(s):** #499.

**Description:** When getting a STAC object's self href, there was a cast that assumed that the object's self link's target was a string, which was not always the case (the self link's target could be a string or another STAC object). This commit removes that cast by splitting a link's target into two separate "private" attributes, `_target_href` and `_target_object`.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.