### PR TITLE
Update SAR Extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - `ProjectionExtension.crs_string` to provide a single string to describe the coordinate reference system (CRS).
   Useful because projections can be defined by EPSG code, WKT, or projjson.
   ([#548](https://github.com/stac-utils/pystac/pull/548))
+- SAR Extension summaries([#556](https://github.com/stac-utils/pystac/pull/556))
+- Migration for `sar:type` -> `sar:product_type` and `sar:polarization` ->
+  `sar:polarizations` for pre-0.9 catalogs
+  ([#556](https://github.com/stac-utils/pystac/pull/556))
 
 ### Removed
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -499,8 +499,63 @@ RasterExtension
    :show-inheritance:
    :inherited-members:
 
+SAR Extension
+-------------
+These classes are representations of the :stac-ext:`SAR Extension Spec
+<sar>`.
+
+FrequencyBand
+~~~~~~~~~~~~~
+
+.. autoclass:: pystac.extensions.sar.FrequencyBand
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Polarization
+~~~~~~~~~~~~
+
+.. autoclass:: pystac.extensions.sar.Polarization
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+ObservationDirection
+~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: pystac.extensions.sar.ObservationDirection
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+SarExtension
+~~~~~~~~~~~~
+
+.. autoclass:: pystac.extensions.sar.SarExtension
+   :members:
+   :show-inheritance:
+   :inherited-members:
+
+ItemSarExtension
+~~~~~~~~~~~~~~~~
+
+.. autoclass:: pystac.extensions.sar.ItemSarExtension
+   :members:
+   :show-inheritance:
+   :inherited-members:
+
+AssetSarExtension
+~~~~~~~~~~~~~~~~~
+
+.. autoclass:: pystac.extensions.sar.AssetSarExtension
+   :members:
+   :show-inheritance:
+   :inherited-members:
+
 Satellite Extension
 -------------------
+These classes are representations of the :stac-ext:`Satellite Extension Spec
+<sat>`.
 
 OrbitState
 ~~~~~~~~~~

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -283,8 +283,7 @@ class EOExtension(
     :class:`~pystac.Item` or :class:`~pystac.Asset` with properties from the
     :stac-ext:`Electro-Optical Extension <eo>`. This class is generic over the type of
     STAC Object to be extended (e.g. :class:`~pystac.Item`,
-    :class:`~pystac.
-    Asset`).
+    :class:`~pystac.Asset`).
 
     To create a concrete instance of :class:`EOExtension`, use the
     :meth:`EOExtension.ext` method. For example:

--- a/pystac/extensions/sar.py
+++ b/pystac/extensions/sar.py
@@ -570,26 +570,42 @@ class SarExtensionHooks(ExtensionHooks):
                 PREFIX + "platform" in obj["properties"]
                 and "platform" not in obj["properties"]
             ):
-                obj["properties"]["platform"] = obj["properties"][PREFIX + "platform"]
-                del obj["properties"][PREFIX + "platform"]
+                obj["properties"]["platform"] = obj["properties"].pop(
+                    PREFIX + "platform"
+                )
 
             if (
                 PREFIX + "instrument" in obj["properties"]
                 and "instruments" not in obj["properties"]
             ):
                 obj["properties"]["instruments"] = [
-                    obj["properties"][PREFIX + "instrument"]
+                    obj["properties"].pop(PREFIX + "instrument")
                 ]
-                del obj["properties"][PREFIX + "instrument"]
 
             if (
                 PREFIX + "constellation" in obj["properties"]
                 and "constellation" not in obj["properties"]
             ):
-                obj["properties"]["constellation"] = obj["properties"][
+                obj["properties"]["constellation"] = obj["properties"].pop(
                     PREFIX + "constellation"
+                )
+
+            # Some SAR fields changed property names
+            if (
+                PREFIX + "type" in obj["properties"]
+                and PRODUCT_TYPE_PROP not in obj["properties"]
+            ):
+                obj["properties"][PRODUCT_TYPE_PROP] = obj["properties"].pop(
+                    PREFIX + "type"
+                )
+
+            if (
+                PREFIX + "polarization" in obj["properties"]
+                and POLARIZATIONS_PROP not in obj["properties"]
+            ):
+                obj["properties"][POLARIZATIONS_PROP] = [
+                    obj["properties"].pop(PREFIX + "polarization")
                 ]
-                del obj["properties"][PREFIX + "constellation"]
 
         super().migrate(obj, version, info)
 

--- a/pystac/extensions/sar.py
+++ b/pystac/extensions/sar.py
@@ -4,7 +4,7 @@ https://github.com/stac-extensions/sar
 """
 
 import enum
-from typing import Any, Dict, Generic, List, Optional, TypeVar, cast
+from typing import Any, Dict, Generic, Iterable, List, Optional, TypeVar, cast
 
 import pystac
 from pystac.serialization.identify import STACJSONDescription, STACVersionID
@@ -14,24 +14,25 @@ from pystac.utils import get_required, map_opt
 
 T = TypeVar("T", pystac.Item, pystac.Asset)
 
-SCHEMA_URI = "https://stac-extensions.github.io/sar/v1.0.0/schema.json"
+SCHEMA_URI: str = "https://stac-extensions.github.io/sar/v1.0.0/schema.json"
+PREFIX: str = "sar:"
 
 # Required
-INSTRUMENT_MODE: str = "sar:instrument_mode"
-FREQUENCY_BAND: str = "sar:frequency_band"
-POLARIZATIONS: str = "sar:polarizations"
-PRODUCT_TYPE: str = "sar:product_type"
+INSTRUMENT_MODE: str = PREFIX + "instrument_mode"
+FREQUENCY_BAND: str = PREFIX + "frequency_band"
+POLARIZATIONS: str = PREFIX + "polarizations"
+PRODUCT_TYPE: str = PREFIX + "product_type"
 
 # Not required
-CENTER_FREQUENCY: str = "sar:center_frequency"
-RESOLUTION_RANGE: str = "sar:resolution_range"
-RESOLUTION_AZIMUTH: str = "sar:resolution_azimuth"
-PIXEL_SPACING_RANGE: str = "sar:pixel_spacing_range"
-PIXEL_SPACING_AZIMUTH: str = "sar:pixel_spacing_azimuth"
-LOOKS_RANGE: str = "sar:looks_range"
-LOOKS_AZIMUTH: str = "sar:looks_azimuth"
-LOOKS_EQUIVALENT_NUMBER: str = "sar:looks_equivalent_number"
-OBSERVATION_DIRECTION: str = "sar:observation_direction"
+CENTER_FREQUENCY: str = PREFIX + "center_frequency"
+RESOLUTION_RANGE: str = PREFIX + "resolution_range"
+RESOLUTION_AZIMUTH: str = PREFIX + "resolution_azimuth"
+PIXEL_SPACING_RANGE: str = PREFIX + "pixel_spacing_range"
+PIXEL_SPACING_AZIMUTH: str = PREFIX + "pixel_spacing_azimuth"
+LOOKS_RANGE: str = PREFIX + "looks_range"
+LOOKS_AZIMUTH: str = PREFIX + "looks_azimuth"
+LOOKS_EQUIVALENT_NUMBER: str = PREFIX + "looks_equivalent_number"
+OBSERVATION_DIRECTION: str = PREFIX + "observation_direction"
 
 
 class FrequencyBand(str, enum.Enum):
@@ -60,17 +61,19 @@ class ObservationDirection(enum.Enum):
 class SarExtension(
     Generic[T], PropertiesExtension, ExtensionManagementMixin[pystac.Item]
 ):
-    """SarItemExt extends Item to add sar properties to a STAC Item.
+    """An abstract class that can be used to extend the properties of an
+    :class:`~pystac.Item` or :class:`~pystac.Asset` with properties from the
+    :stac-ext:`SAR Extension <sar>`. This class is generic over the type of
+    STAC Object to be extended (e.g. :class:`~pystac.Item`,
+    :class:`~pystac.Asset`).
 
-    Args:
-        item : The item to be extended.
+    To create a concrete instance of :class:`SARExtension`, use the
+    :meth:`SARExtension.ext` method. For example:
 
-    Attributes:
-        item : The item that is being extended.
+    .. code-block:: python
 
-    Note:
-        Using SarItemExt to directly wrap an item will add the 'sar'
-        extension ID to the item's stac_extensions.
+       >>> item: pystac.Item = ...
+       >>> sar_ext = SARExtension.ext(item)
     """
 
     def apply(
@@ -149,11 +152,7 @@ class SarExtension(
 
     @property
     def instrument_mode(self) -> str:
-        """Get or sets an instrument mode string for the item.
-
-        Returns:
-            str
-        """
+        """Gets or sets an instrument mode string for the item."""
         return get_required(
             self._get_property(INSTRUMENT_MODE, str), self, INSTRUMENT_MODE
         )
@@ -164,11 +163,7 @@ class SarExtension(
 
     @property
     def frequency_band(self) -> FrequencyBand:
-        """Get or sets a FrequencyBand for the item.
-
-        Returns:
-            FrequencyBand
-        """
+        """Gets or sets a FrequencyBand for the item."""
         return get_required(
             map_opt(
                 lambda x: FrequencyBand(x), self._get_property(FREQUENCY_BAND, str)
@@ -183,11 +178,7 @@ class SarExtension(
 
     @property
     def polarizations(self) -> List[Polarization]:
-        """Get or sets a list of polarizations for the item.
-
-        Returns:
-            List[Polarization]
-        """
+        """Gets or sets a list of polarizations for the item."""
         return get_required(
             map_opt(
                 lambda values: [Polarization(v) for v in values],
@@ -205,11 +196,7 @@ class SarExtension(
 
     @property
     def product_type(self) -> str:
-        """Get or sets a product type string for the item.
-
-        Returns:
-            str
-        """
+        """Gets or sets a product type string for the item."""
         return get_required(self._get_property(PRODUCT_TYPE, str), self, PRODUCT_TYPE)
 
     @product_type.setter
@@ -218,7 +205,7 @@ class SarExtension(
 
     @property
     def center_frequency(self) -> Optional[float]:
-        """Get or sets a center frequency for the item."""
+        """Gets or sets a center frequency for the item."""
         return self._get_property(CENTER_FREQUENCY, float)
 
     @center_frequency.setter
@@ -227,7 +214,7 @@ class SarExtension(
 
     @property
     def resolution_range(self) -> Optional[float]:
-        """Get or sets a resolution range for the item."""
+        """Gets or sets a resolution range for the item."""
         return self._get_property(RESOLUTION_RANGE, float)
 
     @resolution_range.setter
@@ -236,7 +223,7 @@ class SarExtension(
 
     @property
     def resolution_azimuth(self) -> Optional[float]:
-        """Get or sets a resolution azimuth for the item."""
+        """Gets or sets a resolution azimuth for the item."""
         return self._get_property(RESOLUTION_AZIMUTH, float)
 
     @resolution_azimuth.setter
@@ -245,7 +232,7 @@ class SarExtension(
 
     @property
     def pixel_spacing_range(self) -> Optional[float]:
-        """Get or sets a pixel spacing range for the item."""
+        """Gets or sets a pixel spacing range for the item."""
         return self._get_property(PIXEL_SPACING_RANGE, float)
 
     @pixel_spacing_range.setter
@@ -254,7 +241,7 @@ class SarExtension(
 
     @property
     def pixel_spacing_azimuth(self) -> Optional[float]:
-        """Get or sets a pixel spacing azimuth for the item."""
+        """Gets or sets a pixel spacing azimuth for the item."""
         return self._get_property(PIXEL_SPACING_AZIMUTH, float)
 
     @pixel_spacing_azimuth.setter
@@ -263,7 +250,7 @@ class SarExtension(
 
     @property
     def looks_range(self) -> Optional[int]:
-        """Get or sets a looks range for the item."""
+        """Gets or sets a looks range for the item."""
         return self._get_property(LOOKS_RANGE, int)
 
     @looks_range.setter
@@ -272,7 +259,7 @@ class SarExtension(
 
     @property
     def looks_azimuth(self) -> Optional[int]:
-        """Get or sets a looks azimuth for the item."""
+        """Gets or sets a looks azimuth for the item."""
         return self._get_property(LOOKS_AZIMUTH, int)
 
     @looks_azimuth.setter
@@ -281,7 +268,7 @@ class SarExtension(
 
     @property
     def looks_equivalent_number(self) -> Optional[float]:
-        """Get or sets a looks equivalent number for the item."""
+        """Gets or sets a looks equivalent number for the item."""
         return self._get_property(LOOKS_EQUIVALENT_NUMBER, float)
 
     @looks_equivalent_number.setter
@@ -290,7 +277,7 @@ class SarExtension(
 
     @property
     def observation_direction(self) -> Optional[ObservationDirection]:
-        """Get or sets an observation direction for the item."""
+        """Gets or sets an observation direction for the item."""
         result = self._get_property(OBSERVATION_DIRECTION, str)
         if result is None:
             return None
@@ -306,6 +293,16 @@ class SarExtension(
 
     @classmethod
     def ext(cls, obj: T, add_if_missing: bool = False) -> "SarExtension[T]":
+        """Extends the given STAC Object with properties from the :stac-ext:`SAR
+        Extension <sar>`.
+
+        This extension can be applied to instances of :class:`~pystac.Item` or
+        :class:`~pystac.Asset`.
+
+        Raises:
+
+            pystac.ExtensionTypeError : If an invalid object type is passed.
+        """
         if isinstance(obj, pystac.Item):
             if add_if_missing:
                 cls.add_to(obj)
@@ -323,6 +320,20 @@ class SarExtension(
 
 
 class ItemSarExtension(SarExtension[pystac.Item]):
+    """A concrete implementation of :class:`SARExtension` on an :class:`~pystac.Item`
+    that extends the properties of the Item to include properties defined in the
+    :stac-ext:`SAR Extension <sar>`.
+
+    This class should generally not be instantiated directly. Instead, call
+    :meth:`SARExtension.ext` on an :class:`~pystac.Item` to extend it.
+    """
+
+    item: pystac.Item
+    """The :class:`~pystac.Item` being extended."""
+
+    properties: Dict[str, Any]
+    """The :class:`~pystac.Item` properties, including extension properties."""
+
     def __init__(self, item: pystac.Item):
         self.item = item
         self.properties = item.properties
@@ -332,6 +343,24 @@ class ItemSarExtension(SarExtension[pystac.Item]):
 
 
 class AssetSarExtension(SarExtension[pystac.Asset]):
+    """A concrete implementation of :class:`SARExtension` on an :class:`~pystac.Asset`
+    that extends the Asset fields to include properties defined in the
+    :stac-ext:`SAR Extension <sar>`.
+
+    This class should generally not be instantiated directly. Instead, call
+    :meth:`SARExtension.ext` on an :class:`~pystac.Asset` to extend it.
+    """
+
+    asset_href: str
+    """The ``href`` value of the :class:`~pystac.Asset` being extended."""
+
+    properties: Dict[str, Any]
+    """The :class:`~pystac.Asset` fields, including extension properties."""
+
+    additional_read_properties: Optional[Iterable[Dict[str, Any]]] = None
+    """If present, this will be a list containing 1 dictionary representing the
+    properties of the owning :class:`~pystac.Item`."""
+
     def __init__(self, asset: pystac.Asset):
         self.asset_href = asset.href
         self.properties = asset.extra_fields
@@ -353,27 +382,29 @@ class SarExtensionHooks(ExtensionHooks):
         if version < "0.9":
             # Some sar fields became common_metadata
             if (
-                "sar:platform" in obj["properties"]
+                PREFIX + "platform" in obj["properties"]
                 and "platform" not in obj["properties"]
             ):
-                obj["properties"]["platform"] = obj["properties"]["sar:platform"]
-                del obj["properties"]["sar:platform"]
+                obj["properties"]["platform"] = obj["properties"][PREFIX + "platform"]
+                del obj["properties"][PREFIX + "platform"]
 
             if (
-                "sar:instrument" in obj["properties"]
+                PREFIX + "instrument" in obj["properties"]
                 and "instruments" not in obj["properties"]
             ):
-                obj["properties"]["instruments"] = [obj["properties"]["sar:instrument"]]
-                del obj["properties"]["sar:instrument"]
+                obj["properties"]["instruments"] = [
+                    obj["properties"][PREFIX + "instrument"]
+                ]
+                del obj["properties"][PREFIX + "instrument"]
 
             if (
-                "sar:constellation" in obj["properties"]
+                PREFIX + "constellation" in obj["properties"]
                 and "constellation" not in obj["properties"]
             ):
                 obj["properties"]["constellation"] = obj["properties"][
-                    "sar:constellation"
+                    PREFIX + "constellation"
                 ]
-                del obj["properties"]["sar:constellation"]
+                del obj["properties"][PREFIX + "constellation"]
 
         super().migrate(obj, version, info)
 

--- a/tests/extensions/test_sar.py
+++ b/tests/extensions/test_sar.py
@@ -10,7 +10,13 @@ from string import ascii_letters
 import pystac
 from pystac import ExtensionTypeError
 from pystac.extensions import sar
-from pystac.extensions.sar import SarExtension
+from pystac.extensions.sar import (
+    FrequencyBand,
+    ObservationDirection,
+    Polarization,
+    SarExtension,
+)
+from pystac.summaries import RangeSummary
 from tests.utils import TestCases
 
 
@@ -47,16 +53,16 @@ class SarItemExtTest(unittest.TestCase):
             mode, frequency_band, polarizations, product_type
         )
         self.assertEqual(mode, SarExtension.ext(self.item).instrument_mode)
-        self.assertIn(sar.INSTRUMENT_MODE, self.item.properties)
+        self.assertIn(sar.INSTRUMENT_MODE_PROP, self.item.properties)
 
         self.assertEqual(frequency_band, SarExtension.ext(self.item).frequency_band)
-        self.assertIn(sar.FREQUENCY_BAND, self.item.properties)
+        self.assertIn(sar.FREQUENCY_BAND_PROP, self.item.properties)
 
         self.assertEqual(polarizations, SarExtension.ext(self.item).polarizations)
-        self.assertIn(sar.POLARIZATIONS, self.item.properties)
+        self.assertIn(sar.POLARIZATIONS_PROP, self.item.properties)
 
         self.assertEqual(product_type, SarExtension.ext(self.item).product_type)
-        self.assertIn(sar.PRODUCT_TYPE, self.item.properties)
+        self.assertIn(sar.PRODUCT_TYPE_PROP, self.item.properties)
 
         self.item.validate()
 
@@ -95,41 +101,41 @@ class SarItemExtTest(unittest.TestCase):
         )
 
         self.assertEqual(center_frequency, SarExtension.ext(self.item).center_frequency)
-        self.assertIn(sar.CENTER_FREQUENCY, self.item.properties)
+        self.assertIn(sar.CENTER_FREQUENCY_PROP, self.item.properties)
 
         self.assertEqual(resolution_range, SarExtension.ext(self.item).resolution_range)
-        self.assertIn(sar.RESOLUTION_RANGE, self.item.properties)
+        self.assertIn(sar.RESOLUTION_RANGE_PROP, self.item.properties)
 
         self.assertEqual(
             resolution_azimuth, SarExtension.ext(self.item).resolution_azimuth
         )
-        self.assertIn(sar.RESOLUTION_AZIMUTH, self.item.properties)
+        self.assertIn(sar.RESOLUTION_AZIMUTH_PROP, self.item.properties)
 
         self.assertEqual(
             pixel_spacing_range, SarExtension.ext(self.item).pixel_spacing_range
         )
-        self.assertIn(sar.PIXEL_SPACING_RANGE, self.item.properties)
+        self.assertIn(sar.PIXEL_SPACING_RANGE_PROP, self.item.properties)
 
         self.assertEqual(
             pixel_spacing_azimuth, SarExtension.ext(self.item).pixel_spacing_azimuth
         )
-        self.assertIn(sar.PIXEL_SPACING_AZIMUTH, self.item.properties)
+        self.assertIn(sar.PIXEL_SPACING_AZIMUTH_PROP, self.item.properties)
 
         self.assertEqual(looks_range, SarExtension.ext(self.item).looks_range)
-        self.assertIn(sar.LOOKS_RANGE, self.item.properties)
+        self.assertIn(sar.LOOKS_RANGE_PROP, self.item.properties)
 
         self.assertEqual(looks_azimuth, SarExtension.ext(self.item).looks_azimuth)
-        self.assertIn(sar.LOOKS_AZIMUTH, self.item.properties)
+        self.assertIn(sar.LOOKS_AZIMUTH_PROP, self.item.properties)
 
         self.assertEqual(
             looks_equivalent_number, SarExtension.ext(self.item).looks_equivalent_number
         )
-        self.assertIn(sar.LOOKS_EQUIVALENT_NUMBER, self.item.properties)
+        self.assertIn(sar.LOOKS_EQUIVALENT_NUMBER_PROP, self.item.properties)
 
         self.assertEqual(
             observation_direction, SarExtension.ext(self.item).observation_direction
         )
-        self.assertIn(sar.OBSERVATION_DIRECTION, self.item.properties)
+        self.assertIn(sar.OBSERVATION_DIRECTION_PROP, self.item.properties)
 
         self.item.validate()
 
@@ -202,4 +208,259 @@ class SarItemExtTest(unittest.TestCase):
             r"^SAR extension does not apply to type 'object'$",
             SarExtension.ext,
             object(),
+        )
+
+
+class SarSummariesTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.maxDiff = None
+        self.collection = pystac.Collection.from_file(
+            TestCases.get_path("data-files/collections/multi-extent.json")
+        )
+
+    def test_instrument_mode(self) -> None:
+        collection = self.collection.clone()
+        summaries_ext = SarExtension.summaries(collection, True)
+        instrument_mode_list = ["WV"]
+
+        summaries_ext.instrument_mode = instrument_mode_list
+
+        self.assertEqual(
+            summaries_ext.instrument_mode,
+            instrument_mode_list,
+        )
+
+        summaries_dict = collection.to_dict()["summaries"]
+
+        self.assertEqual(
+            summaries_dict["sar:instrument_mode"],
+            instrument_mode_list,
+        )
+
+    def test_frequency_band(self) -> None:
+        collection = self.collection.clone()
+        summaries_ext = SarExtension.summaries(collection, True)
+        frequency_band_list = [FrequencyBand.P, FrequencyBand.L]
+
+        summaries_ext.frequency_band = frequency_band_list
+
+        self.assertEqual(
+            summaries_ext.frequency_band,
+            frequency_band_list,
+        )
+
+        summaries_dict = collection.to_dict()["summaries"]
+
+        self.assertEqual(
+            summaries_dict["sar:frequency_band"],
+            frequency_band_list,
+        )
+
+    def test_polarizations(self) -> None:
+        collection = self.collection.clone()
+        summaries_ext = SarExtension.summaries(collection, True)
+        polarizations_list = [Polarization.HH]
+
+        summaries_ext.polarizations = polarizations_list
+
+        self.assertEqual(
+            summaries_ext.polarizations,
+            polarizations_list,
+        )
+
+        summaries_dict = collection.to_dict()["summaries"]
+
+        self.assertEqual(
+            summaries_dict["sar:polarizations"],
+            polarizations_list,
+        )
+
+    def test_product_type(self) -> None:
+        collection = self.collection.clone()
+        summaries_ext = SarExtension.summaries(collection, True)
+        product_type_list = ["SSC"]
+
+        summaries_ext.product_type = product_type_list
+
+        self.assertEqual(
+            summaries_ext.product_type,
+            product_type_list,
+        )
+
+        summaries_dict = collection.to_dict()["summaries"]
+
+        self.assertEqual(
+            summaries_dict["sar:product_type"],
+            product_type_list,
+        )
+
+    def test_center_frequency(self) -> None:
+        collection = self.collection.clone()
+        summaries_ext = SarExtension.summaries(collection, True)
+        center_frequency_range = RangeSummary(4.405, 6.405)
+
+        summaries_ext.center_frequency = center_frequency_range
+
+        self.assertEqual(
+            summaries_ext.center_frequency,
+            center_frequency_range,
+        )
+
+        summaries_dict = collection.to_dict()["summaries"]
+
+        self.assertEqual(
+            summaries_dict["sar:center_frequency"],
+            center_frequency_range.to_dict(),
+        )
+
+    def test_resolution_range(self) -> None:
+        collection = self.collection.clone()
+        summaries_ext = SarExtension.summaries(collection, True)
+        resolution_range_range = RangeSummary(800.0, 1200.0)
+
+        summaries_ext.resolution_range = resolution_range_range
+
+        self.assertEqual(
+            summaries_ext.resolution_range,
+            resolution_range_range,
+        )
+
+        summaries_dict = collection.to_dict()["summaries"]
+
+        self.assertEqual(
+            summaries_dict["sar:resolution_range"],
+            resolution_range_range.to_dict(),
+        )
+
+    def test_resolution_azimuth(self) -> None:
+        collection = self.collection.clone()
+        summaries_ext = SarExtension.summaries(collection, True)
+        resolution_azimuth_range = RangeSummary(800.0, 1200.0)
+
+        summaries_ext.resolution_azimuth = resolution_azimuth_range
+
+        self.assertEqual(
+            summaries_ext.resolution_azimuth,
+            resolution_azimuth_range,
+        )
+
+        summaries_dict = collection.to_dict()["summaries"]
+
+        self.assertEqual(
+            summaries_dict["sar:resolution_azimuth"],
+            resolution_azimuth_range.to_dict(),
+        )
+
+    def test_pixel_spacing_range(self) -> None:
+        collection = self.collection.clone()
+        summaries_ext = SarExtension.summaries(collection, True)
+        pixel_spacing_range_range = RangeSummary(400.0, 600.0)
+
+        summaries_ext.pixel_spacing_range = pixel_spacing_range_range
+
+        self.assertEqual(
+            summaries_ext.pixel_spacing_range,
+            pixel_spacing_range_range,
+        )
+
+        summaries_dict = collection.to_dict()["summaries"]
+
+        self.assertEqual(
+            summaries_dict["sar:pixel_spacing_range"],
+            pixel_spacing_range_range.to_dict(),
+        )
+
+    def test_pixel_spacing_azimuth(self) -> None:
+        collection = self.collection.clone()
+        summaries_ext = SarExtension.summaries(collection, True)
+        pixel_spacing_azimuth_range = RangeSummary(400.0, 600.0)
+
+        summaries_ext.pixel_spacing_azimuth = pixel_spacing_azimuth_range
+
+        self.assertEqual(
+            summaries_ext.pixel_spacing_azimuth,
+            pixel_spacing_azimuth_range,
+        )
+
+        summaries_dict = collection.to_dict()["summaries"]
+
+        self.assertEqual(
+            summaries_dict["sar:pixel_spacing_azimuth"],
+            pixel_spacing_azimuth_range.to_dict(),
+        )
+
+    def test_looks_range(self) -> None:
+        collection = self.collection.clone()
+        summaries_ext = SarExtension.summaries(collection, True)
+        looks_range_range = RangeSummary(400, 600)
+
+        summaries_ext.looks_range = looks_range_range
+
+        self.assertEqual(
+            summaries_ext.looks_range,
+            looks_range_range,
+        )
+
+        summaries_dict = collection.to_dict()["summaries"]
+
+        self.assertEqual(
+            summaries_dict["sar:looks_range"],
+            looks_range_range.to_dict(),
+        )
+
+    def test_looks_azimuth(self) -> None:
+        collection = self.collection.clone()
+        summaries_ext = SarExtension.summaries(collection, True)
+        looks_azimuth_range = RangeSummary(400, 600)
+
+        summaries_ext.looks_azimuth = looks_azimuth_range
+
+        self.assertEqual(
+            summaries_ext.looks_azimuth,
+            looks_azimuth_range,
+        )
+
+        summaries_dict = collection.to_dict()["summaries"]
+
+        self.assertEqual(
+            summaries_dict["sar:looks_azimuth"],
+            looks_azimuth_range.to_dict(),
+        )
+
+    def test_looks_equivalent_number(self) -> None:
+        collection = self.collection.clone()
+        summaries_ext = SarExtension.summaries(collection, True)
+        looks_equivalent_number_range = RangeSummary(400.0, 600.0)
+
+        summaries_ext.looks_equivalent_number = looks_equivalent_number_range
+
+        self.assertEqual(
+            summaries_ext.looks_equivalent_number,
+            looks_equivalent_number_range,
+        )
+
+        summaries_dict = collection.to_dict()["summaries"]
+
+        self.assertEqual(
+            summaries_dict["sar:looks_equivalent_number"],
+            looks_equivalent_number_range.to_dict(),
+        )
+
+    def test_observation_direction(self) -> None:
+        collection = self.collection.clone()
+        summaries_ext = SarExtension.summaries(collection, True)
+        observation_direction_list = [ObservationDirection.LEFT]
+
+        summaries_ext.observation_direction = observation_direction_list
+
+        self.assertEqual(
+            summaries_ext.observation_direction,
+            observation_direction_list,
+        )
+
+        summaries_dict = collection.to_dict()["summaries"]
+
+        self.assertEqual(
+            summaries_dict["sar:observation_direction"],
+            observation_direction_list,
         )


### PR DESCRIPTION
**Related Issue(s):**

- #326
- #327
- #262


**Description:**

- Updates docstrings for SAR Extension implementation
- Adds Collection summaries for SAR Extension
- Adds migration for pre-0.9 SAR fields:
    - `sar:type` -> `sar:product_type`
    - `sar:polarization` -> `sar:polarizations`

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.