### PR TITLE
Add migration for eo:epsg to proj:epsg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Migration for `sar:type` -> `sar:product_type` and `sar:polarization` ->
   `sar:polarizations` for pre-0.9 catalogs
   ([#556](https://github.com/stac-utils/pystac/pull/556))
+- Migration from `eo:epsg` -> `proj:epsg` for pre-0.9 catalogs ([#557](https://github.com/stac-utils/pystac/pull/557))
 
 ### Removed
 

--- a/tests/extensions/test_eo.py
+++ b/tests/extensions/test_eo.py
@@ -6,6 +6,7 @@ from pystac import ExtensionTypeError, Item
 from pystac.summaries import RangeSummary
 from pystac.utils import get_opt
 from pystac.extensions.eo import EOExtension, Band
+from pystac.extensions.projection import ProjectionExtension
 from tests.utils import TestCases, assert_to_from_dict
 
 
@@ -325,3 +326,23 @@ class EOTest(unittest.TestCase):
             EOExtension.ext,
             object(),
         )
+
+
+class EOMigrationTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.maxDiff = None
+        self.item_0_8_path = TestCases.get_path(
+            "data-files/examples/0.8.1/item-spec/examples/sentinel2-sample.json"
+        )
+
+    def test_migration(self) -> None:
+        with open(self.item_0_8_path) as src:
+            item_dict = json.load(src)
+
+        self.assertIn("eo:epsg", item_dict["properties"])
+
+        item = Item.from_file(self.item_0_8_path)
+
+        self.assertNotIn("eo:epsg", item.properties)
+        self.assertIn("proj:epsg", item.properties)
+        self.assertIn(ProjectionExtension.get_schema_uri(), item.stac_extensions)


### PR DESCRIPTION
**Related Issue(s):**

- #262

**Description:**

Adds migration for `eo:epsg` to `proj:epsg` for pre-0.9 catalogs.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [ ] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.