### PR TITLE
Use get_required to raise RequiredPropertyMissing when appropriate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,11 @@
 - Calling `ExtensionManagementMixin.validate_has_extension` with `add_if_missing = True`
   on an ownerless `Asset` will raise a `STACError` ([#554](https://github.com/stac-utils/pystac/pull/554))
 - `PointcloudSchema` -> `Schema`, `PointcloudStatistic` -> `Statistic` for consistency
-  with naming convention in other extensions ([#548](https://github.com/stac-utils/pystac/pull/548))
+  with naming convention in other extensions
+  ([#548](https://github.com/stac-utils/pystac/pull/548))
+- `RequiredPropertyMissing` always raised when trying to get a required property that is
+  `None` (`STACError` or `KeyError` was previously being raised in some cases)
+  ([#561](https://github.com/stac-utils/pystac/pull/561))
 
 ### Fixed
 

--- a/pystac/extensions/datacube.py
+++ b/pystac/extensions/datacube.py
@@ -12,7 +12,7 @@ from pystac.extensions.base import (
     PropertiesExtension,
 )
 from pystac.extensions.hooks import ExtensionHooks
-from pystac.utils import get_required, map_opt
+from pystac.utils import get_required
 
 T = TypeVar("T", pystac.Collection, pystac.Item, pystac.Asset)
 
@@ -63,13 +63,13 @@ class Dimension(ABC):
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> "Dimension":
-        dim_type = d.get(DIM_TYPE_PROP)
-        if dim_type is None:
-            raise pystac.RequiredPropertyMissing("cube_dimension", DIM_TYPE_PROP)
+        dim_type: str = get_required(
+            d.get(DIM_TYPE_PROP), "cube_dimension", DIM_TYPE_PROP
+        )
         if dim_type == "spatial":
-            axis = d.get(DIM_AXIS_PROP)
-            if axis is None:
-                raise pystac.RequiredPropertyMissing("cube_dimension", DIM_AXIS_PROP)
+            axis: str = get_required(
+                d.get(DIM_AXIS_PROP), "cube_dimension", DIM_AXIS_PROP
+            )
             if axis == "z":
                 return VerticalSpatialDimension(d)
             else:
@@ -320,14 +320,10 @@ class DatacubeExtension(
 
     @property
     def dimensions(self) -> Dict[str, Dimension]:
-        return get_required(
-            map_opt(
-                lambda d: {k: Dimension.from_dict(v) for k, v in d.items()},
-                self._get_property(DIMENSIONS_PROP, Dict[str, Any]),
-            ),
-            self,
-            DIMENSIONS_PROP,
+        result = get_required(
+            self._get_property(DIMENSIONS_PROP, Dict[str, Any]), self, DIMENSIONS_PROP
         )
+        return {k: Dimension.from_dict(v) for k, v in result.items()}
 
     @dimensions.setter
     def dimensions(self, v: Dict[str, Dimension]) -> None:

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -121,7 +121,7 @@ class Band:
         Returns:
             str
         """
-        return get_required(self.properties["name"], self, "name")
+        return get_required(self.properties.get("name"), self, "name")
 
     @name.setter
     def name(self, v: str) -> None:

--- a/pystac/extensions/file.py
+++ b/pystac/extensions/file.py
@@ -69,7 +69,7 @@ class MappingObject:
     def values(self) -> List[Any]:
         """Gets or sets the list of value(s) in the file. At least one array element is
         required."""
-        return get_required(self.properties["values"], self, "values")
+        return get_required(self.properties.get("values"), self, "values")
 
     @values.setter
     def values(self, v: List[Any]) -> None:
@@ -78,7 +78,7 @@ class MappingObject:
     @property
     def summary(self) -> str:
         """Gets or sets the short description of the value(s)."""
-        return get_required(self.properties["summary"], self, "summary")
+        return get_required(self.properties.get("summary"), self, "summary")
 
     @summary.setter
     def summary(self, v: str) -> None:

--- a/pystac/extensions/pointcloud.py
+++ b/pystac/extensions/pointcloud.py
@@ -88,12 +88,7 @@ class Schema:
     @property
     def size(self) -> int:
         """Gets or sets the size value."""
-        result: Optional[int] = self.properties.get("size")
-        if result is None:
-            raise pystac.STACError(
-                f"Pointcloud schema does not have size property: {self.properties}"
-            )
-        return result
+        return get_required(self.properties.get("size"), self, "size")
 
     @size.setter
     def size(self, v: int) -> None:
@@ -105,12 +100,7 @@ class Schema:
     @property
     def name(self) -> str:
         """Gets or sets the name property for this Schema."""
-        result: Optional[str] = self.properties.get("name")
-        if result is None:
-            raise pystac.STACError(
-                f"Pointcloud schema does not have name property: {self.properties}"
-            )
-        return result
+        return get_required(self.properties.get("name"), self, "name")
 
     @name.setter
     def name(self, v: str) -> None:
@@ -128,7 +118,9 @@ class Schema:
 
     def __repr__(self) -> str:
         return "<Schema name={} size={} type={}>".format(
-            self.name, self.size, self.type
+            self.properties.get("name"),
+            self.properties.get("size"),
+            self.properties.get("type"),
         )
 
     def to_dict(self) -> Dict[str, Any]:
@@ -217,12 +209,7 @@ class Statistic:
     @property
     def name(self) -> str:
         """Gets or sets the name property."""
-        result: Optional[str] = self.properties.get("name")
-        if result is None:
-            raise pystac.STACError(
-                f"Pointcloud statistics does not have name property: {self.properties}"
-            )
-        return result
+        return get_required(self.properties.get("name"), self, "name")
 
     @name.setter
     def name(self, v: str) -> None:
@@ -381,10 +368,7 @@ class PointcloudExtension(
     @property
     def count(self) -> int:
         """Gets or sets the number of points in the Item."""
-        result = self._get_property(COUNT_PROP, int)
-        if result is None:
-            raise pystac.RequiredPropertyMissing(self, COUNT_PROP)
-        return result
+        return get_required(self._get_property(COUNT_PROP, int), self, COUNT_PROP)
 
     @count.setter
     def count(self, v: int) -> None:
@@ -393,11 +377,7 @@ class PointcloudExtension(
     @property
     def type(self) -> Union[PhenomenologyType, str]:
         """Gets or sets the phenomenology type for the point cloud."""
-        return get_required(
-            self._get_property(TYPE_PROP, str),
-            self,
-            TYPE_PROP,
-        )
+        return get_required(self._get_property(TYPE_PROP, str), self, TYPE_PROP)
 
     @type.setter
     def type(self, v: Union[PhenomenologyType, str]) -> None:
@@ -406,10 +386,7 @@ class PointcloudExtension(
     @property
     def encoding(self) -> str:
         """Gets or sets the content encoding or format of the data."""
-        result = self._get_property(ENCODING_PROP, str)
-        if result is None:
-            raise pystac.RequiredPropertyMissing(self, ENCODING_PROP)
-        return result
+        return get_required(self._get_property(ENCODING_PROP, str), self, ENCODING_PROP)
 
     @encoding.setter
     def encoding(self, v: str) -> None:
@@ -420,9 +397,9 @@ class PointcloudExtension(
         """Gets or sets the list of :class:`Schema` instances defining
         dimensions and types for the data.
         """
-        result = self._get_property(SCHEMAS_PROP, List[Dict[str, Any]])
-        if result is None:
-            raise pystac.RequiredPropertyMissing(self, SCHEMAS_PROP)
+        result = get_required(
+            self._get_property(SCHEMAS_PROP, List[Dict[str, Any]]), self, SCHEMAS_PROP
+        )
         return [Schema(s) for s in result]
 
     @schemas.setter

--- a/pystac/extensions/raster.py
+++ b/pystac/extensions/raster.py
@@ -272,7 +272,7 @@ class Histogram:
         Returns:
             int
         """
-        return get_required(self.properties["count"], self, "count")
+        return get_required(self.properties.get("count"), self, "count")
 
     @count.setter
     def count(self, v: int) -> None:
@@ -285,7 +285,7 @@ class Histogram:
         Returns:
             float
         """
-        return get_required(self.properties["min"], self, "min")
+        return get_required(self.properties.get("min"), self, "min")
 
     @min.setter
     def min(self, v: float) -> None:
@@ -298,7 +298,7 @@ class Histogram:
         Returns:
             float
         """
-        return get_required(self.properties["max"], self, "max")
+        return get_required(self.properties.get("max"), self, "max")
 
     @max.setter
     def max(self, v: float) -> None:
@@ -312,7 +312,7 @@ class Histogram:
         Returns:
             List[int]
         """
-        return get_required(self.properties["buckets"], self, "buckets")
+        return get_required(self.properties.get("buckets"), self, "buckets")
 
     @buckets.setter
     def buckets(self, v: List[int]) -> None:

--- a/pystac/extensions/sar.py
+++ b/pystac/extensions/sar.py
@@ -289,10 +289,9 @@ class SarExtension(
     @property
     def observation_direction(self) -> Optional[ObservationDirection]:
         """Gets or sets an observation direction for the item."""
-        result = self._get_property(OBSERVATION_DIRECTION_PROP, str)
-        if result is None:
-            return None
-        return ObservationDirection(result)
+        return map_opt(
+            ObservationDirection, self._get_property(OBSERVATION_DIRECTION_PROP, str)
+        )
 
     @observation_direction.setter
     def observation_direction(self, v: Optional[ObservationDirection]) -> None:

--- a/tests/extensions/test_pointcloud.py
+++ b/tests/extensions/test_pointcloud.py
@@ -6,7 +6,7 @@ import unittest
 
 import pystac
 from pystac.asset import Asset
-from pystac.errors import ExtensionTypeError, STACError
+from pystac.errors import ExtensionTypeError, STACError, RequiredPropertyMissing
 from pystac.extensions.pointcloud import (
     AssetPointcloudExtension,
     PhenomenologyType,
@@ -193,12 +193,10 @@ class PointcloudTest(unittest.TestCase):
             schema.size = 0.5  # type: ignore
 
         empty_schema = Schema({})
-        with self.assertRaises(STACError):
-            empty_schema.size
-        with self.assertRaises(STACError):
-            empty_schema.name
-        with self.assertRaises(STACError):
-            empty_schema.type
+        for required_prop in {"size", "name", "type"}:
+            with self.subTest(attr=required_prop):
+                with self.assertRaises(RequiredPropertyMissing):
+                    getattr(empty_schema, required_prop)
 
     def test_pointcloud_statistics(self) -> None:
         props: Dict[str, Any] = {
@@ -251,7 +249,7 @@ class PointcloudTest(unittest.TestCase):
         self.assertNotIn("variance", stat.properties)
 
         empty_stat = Statistic({})
-        with self.assertRaises(STACError):
+        with self.assertRaises(RequiredPropertyMissing):
             empty_stat.name
 
     def test_statistics_accessor_when_no_stats(self) -> None:


### PR DESCRIPTION
**Related Issue(s):**

- Closes #315

**Description:**

Updates codebase to use `utils.get_required` instead of raising `RequiredPropertyMissing` directly. Also updates usages to always use `.get(some_prop)` instead of `[some_prop]` to ensure we get `RequiredPropertyMissing` instead of `KeyError`.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.