### PR TITLE
Fix some type issues exposed via the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@
 
 - Added `Collections` as a type that can be extended for extensions whose fields can appear in collection summaries ([#547](https://github.com/stac-utils/pystac/pull/547))
 - Allow resolved self links when getting an object's self href ([#555](https://github.com/stac-utils/pystac/pull/555))
+- Fixed type annotation on SummariesLabelExtension.label_properties setter ([#562](https://github.com/stac-utils/pystac/pull/562))
+- Allow comparable types with alternate parameter naming of __lt__ method to pass structural type linting for RangeSummary ([#562](https://github.com/stac-utils/pystac/pull/562))
 
 ### Deprecated
 

--- a/pystac/extensions/label.py
+++ b/pystac/extensions/label.py
@@ -722,7 +722,7 @@ class SummariesLabelExtension(SummariesExtension):
         return self.summaries.get_list(PROPERTIES_PROP)
 
     @label_properties.setter
-    def label_properties(self, v: Optional[List[LabelClasses]]) -> None:
+    def label_properties(self, v: Optional[List[str]]) -> None:
         self._set_summary(PROPERTIES_PROP, v)
 
     @property

--- a/pystac/summaries.py
+++ b/pystac/summaries.py
@@ -30,15 +30,31 @@ if TYPE_CHECKING:
 from abc import abstractmethod
 
 
-class Comparable(Protocol):
-    """Protocol for annotating comparable types."""
+class _Comparable_x(Protocol):
+    """Protocol for annotating comparable types.
+
+    For matching __lt__ that takes an 'x' parameter
+    (e.g. float)
+    """
 
     @abstractmethod
     def __lt__(self: "T", x: "T") -> bool:
         return NotImplemented
 
 
-T = TypeVar("T", bound=Comparable)
+class _Comparable_other(Protocol):
+    """Protocol for annotating comparable types.
+
+    For matching __lt___ that takes an 'other' parameter
+    (e.g. datetime)
+    """
+
+    @abstractmethod
+    def __lt__(self: "T", other: "T") -> bool:
+        return NotImplemented
+
+
+T = TypeVar("T", bound=Union[_Comparable_x, _Comparable_other])
 
 
 class RangeSummary(Generic[T]):


### PR DESCRIPTION
These couple of issues were found while reviewing #561. VS Code running pylance/pyright showed some errors. This PR fixes errors that would be exposed to users using that tooling with PySTAC.

The first is straightforward, the setter of SummariesLabelExtension.label_properties was mis-typed.

The second is more subtle - for [structural typing](https://www.python.org/dev/peps/pep-0544/), it is required that the parameter names of the method in the Protocol be the same as the implementing type in order for type checking to pass. We defined a `Comparable` Protocol that required a method `__lt__(self, x: T) -> bool`, which was used as the bounds for the `RangeSummary` generic type. This works with things like floats and ints, which define their `__lt__` methods with the parameter name being `x`. However, `datetime.datetime` defines it's method as `__lt__(self, other)`. This caused Pyright to say that datetime didn't fit the structural type, and so `RangeSummary[datetime]` was not valid.

This PR moves splits `Comparable` protocol into two, `_Comparable_x` and `_Comparable_other`. I think the underscore naming here is appropriate I think as it's not for usage by PySTAC users but instead an internal mechanism. I then changed the bounds of the `T` TypeVar that's used in RangeSummary to be `Union[_Comparable_x, _Comparable_other]`, which allows structural types that fit either the `x` or `other` parameter naming for the `__lt__` method to pass the type linter.

This covers numeric types and datetime, but to note is that if a user wants to create a RangeSummary of a type that does support __lt__ but names the parameter differently, Pyright will call that an error. I couldn't find a way to try and get the structural type to ignore the parameter name.

There were a few other errors that Pyright was reporting, but those were only for internal code, were particular to how pyright things about types, and so changes for those were not included.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.