### PR TITLE
Relative self hrefs break link resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changed
 
+- HREFs in `Link` objects with `rel == "self"` are converted to absolute HREFs ([#574](https://github.com/stac-utils/pystac/pull/574))
+
 ### Deprecated
 
 ### Fixed

--- a/pystac/link.py
+++ b/pystac/link.py
@@ -78,7 +78,10 @@ class Link:
     ) -> None:
         self.rel = rel
         if isinstance(target, str):
-            self._target_href: Optional[str] = target
+            if rel == pystac.RelType.SELF:
+                self._target_href: Optional[str] = make_absolute_href(target)
+            else:
+                self._target_href = target
             self._target_object = None
         else:
             self._target_href = None

--- a/pystac/link.py
+++ b/pystac/link.py
@@ -68,6 +68,9 @@ class Link:
     :class:`~pystac.resolved_object_cache.ResolvedObjectCache` to resolve objects, and
     will create absolute HREFs from relative HREFs against the owner's self HREF."""
 
+    _target_href: Optional[str]
+    _target_object: Optional["STACObject_Type"]
+
     def __init__(
         self,
         rel: Union[str, pystac.RelType],
@@ -79,7 +82,7 @@ class Link:
         self.rel = rel
         if isinstance(target, str):
             if rel == pystac.RelType.SELF:
-                self._target_href: Optional[str] = make_absolute_href(target)
+                self._target_href = make_absolute_href(target)
             else:
                 self._target_href = target
             self._target_object = None

--- a/tests/data-files/file/item.json
+++ b/tests/data-files/file/item.json
@@ -83,10 +83,6 @@
   },
   "links": [
     {
-      "rel": "self",
-      "href": "./item.json"
-    },
-    {
       "rel": "parent",
       "href": "./collection.json",
       "file:checksum": "11146d97123fd2c02dec9a1b6d3b13136dbe600cf966"

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -1,5 +1,5 @@
 import datetime
-import os.path
+import os
 import unittest
 from tempfile import TemporaryDirectory
 from typing import Any, Dict, List
@@ -112,6 +112,23 @@ class LinkTest(unittest.TestCase):
         link = pystac.Link("self", target=self.item)
         self.item.add_link(link)
         self.assertIsNone(link.get_target_str())
+
+    def test_relative_self_href(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            pystac.write_file(
+                self.item,
+                include_self_link=False,
+                dest_href=os.path.join(temporary_directory, "item.json"),
+            )
+            previous = os.getcwd()
+            try:
+                os.chdir(temporary_directory)
+                item = pystac.read_file("item.json")
+                href = item.get_self_href()
+                assert href
+                self.assertTrue(os.path.isabs(href), f"Not an absolute path: {href}")
+            finally:
+                os.chdir(previous)
 
 
 class StaticLinkTest(unittest.TestCase):

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -151,12 +151,13 @@ class StaticLinkTest(unittest.TestCase):
             {"rel": "r", "href": "t"},
             {"rel": "r", "href": "/t"},
             {"rel": "r", "href": "t", "type": "a/b", "title": "t", "c": "d", "1": 2},
-            # Special case.
-            {"rel": "self", "href": "t"},
         ]
         for d in test_cases:
             d2 = pystac.Link.from_dict(d).to_dict()
             self.assertEqual(d, d2)
+        d = {"rel": "self", "href": "t"}
+        d2 = {"rel": "self", "href": os.path.join(os.getcwd(), "t")}
+        self.assertEqual(pystac.Link.from_dict(d).to_dict(), d2)
 
     def test_from_dict_failures(self) -> None:
         dicts: List[Dict[str, Any]] = [{}, {"href": "t"}, {"rel": "r"}]


### PR DESCRIPTION
**Related Issue(s):** #571 


**Description:** Items created from relative paths can have relative self links, which breaks assumptions about self hrefs. Here's one place where the self href is assumed to be absolute: https://github.com/stac-utils/pystac/blob/76ef6a3b9bc3412cfcbc7f502d8fc1f56310b779/pystac/link.py#L234-L242

I did confirm that the issue was present in https://github.com/stac-utils/pystac/releases/tag/v1.0.0-rc.3, which means that #555 is likely _not_ the cause (we thought it might be since it did muck around with how links worked).

~Opening as a draft b/c it's just a failing test right now, will convert to a real pull request when there's a resolution.~

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.