### PR TITLE
Release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,10 @@
 # Changelog
 
-## [Unreleased]
-
-### Added
-
-### Removed
+## [v1.0.1]
 
 ### Changed
 
 - HREFs in `Link` objects with `rel == "self"` are converted to absolute HREFs ([#574](https://github.com/stac-utils/pystac/pull/574))
-
-### Deprecated
-
-### Fixed
 
 ## [v1.0.0]
 
@@ -479,7 +471,8 @@ use `Band.create`
 
 Initial release.
 
-[Unreleased]: <https://github.com/stac-utils/pystac/compare/v1.0.0..main>
+[Unreleased]: <https://github.com/stac-utils/pystac/compare/v1.0.1..main>
+[v1.0.1]: <https://github.com/stac-utils/pystac/compare/v1.0.0..v1.0.1>
 [v1.0.0]: <https://github.com/stac-utils/pystac/compare/v1.0.0-rc.3..v1.0.0>
 [v1.0.0-rc.3]: <https://github.com/stac-utils/pystac/compare/v1.0.0-rc.2..v1.0.0-rc.3>
 [v1.0.0-rc.2]: <https://github.com/stac-utils/pystac/compare/v1.0.0-rc.1..v1.0.0-rc.2>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changed
 
+- HREFs in `Link` objects with `rel == "self"` are converted to absolute HREFs ([#574](https://github.com/stac-utils/pystac/pull/574))
+
 ### Deprecated
 
 ### Fixed

--- a/pystac/link.py
+++ b/pystac/link.py
@@ -68,6 +68,9 @@ class Link:
     :class:`~pystac.resolved_object_cache.ResolvedObjectCache` to resolve objects, and
     will create absolute HREFs from relative HREFs against the owner's self HREF."""
 
+    _target_href: Optional[str]
+    _target_object: Optional["STACObject_Type"]
+
     def __init__(
         self,
         rel: Union[str, pystac.RelType],
@@ -78,7 +81,10 @@ class Link:
     ) -> None:
         self.rel = rel
         if isinstance(target, str):
-            self._target_href: Optional[str] = target
+            if rel == pystac.RelType.SELF:
+                self._target_href = make_absolute_href(target)
+            else:
+                self._target_href = target
             self._target_object = None
         else:
             self._target_href = None

--- a/pystac/version.py
+++ b/pystac/version.py
@@ -1,7 +1,7 @@
 import os
 from typing import Optional
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 """Library version"""
 
 

--- a/tests/data-files/file/item.json
+++ b/tests/data-files/file/item.json
@@ -83,10 +83,6 @@
   },
   "links": [
     {
-      "rel": "self",
-      "href": "./item.json"
-    },
-    {
       "rel": "parent",
       "href": "./collection.json",
       "file:checksum": "11146d97123fd2c02dec9a1b6d3b13136dbe600cf966"


### PR DESCRIPTION
Patch release v1.0.1 to include change from #574.

@lossyrob I'm not sure if this is the best way to handle updating the CHANGELOG and library version. Making the change on this branch means our `main` branch is out of sync with the latest CHANGELOG and version. Applying the changes to `main` would mean that installing from that branch would include changes from #565 but be marked as `v1.0.1`, which didn't seem right. Let me know if there's a better strategy for this.

**PR Checklist:**

- [ ] Code is formatted (run `pre-commit run --all-files`)
- [ ] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [ ] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.