### PR TITLE
Bump library version to 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,15 @@
 
 ### Changed
 
-- HREFs in `Link` objects with `rel == "self"` are converted to absolute HREFs ([#574](https://github.com/stac-utils/pystac/pull/574))
+### Fixed
 
 ### Deprecated
 
-### Fixed
+## [v1.0.1]
+
+### Changed
+
+- HREFs in `Link` objects with `rel == "self"` are converted to absolute HREFs ([#574](https://github.com/stac-utils/pystac/pull/574))
 
 ## [v1.0.0]
 
@@ -481,7 +485,8 @@ use `Band.create`
 
 Initial release.
 
-[Unreleased]: <https://github.com/stac-utils/pystac/compare/v1.0.0..main>
+[Unreleased]: <https://github.com/stac-utils/pystac/compare/v1.0.1..main>
+[v1.0.1]: <https://github.com/stac-utils/pystac/compare/v1.0.0..v1.0.1>
 [v1.0.0]: <https://github.com/stac-utils/pystac/compare/v1.0.0-rc.3..v1.0.0>
 [v1.0.0-rc.3]: <https://github.com/stac-utils/pystac/compare/v1.0.0-rc.2..v1.0.0-rc.3>
 [v1.0.0-rc.2]: <https://github.com/stac-utils/pystac/compare/v1.0.0-rc.1..v1.0.0-rc.2>

--- a/pystac/version.py
+++ b/pystac/version.py
@@ -1,7 +1,7 @@
 import os
 from typing import Optional
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 """Library version"""
 
 


### PR DESCRIPTION
Bumps PySTAC version to 1.0.1. 

This patch release includes changes from #574.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.