### PR TITLE
Include typing information during packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- Include type information during packaging for use with e.g. `mypy` ([#579](https://github.com/stac-utils/pystac/pull/579))
 - Optional `dest_href` argument to `Catalog.save` to allow saving `Catalog` instances to
   locations other than their `self` href ([#565](https://github.com/stac-utils/pystac/pull/565))
 

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,9 @@ setup(
     author_email="stac@radiant.earth",
     url="https://github.com/stac-utils/pystac",
     packages=find_packages(),
+    package_data={p: ["py.typed"] for p in find_packages()},
     py_modules=[splitext(basename(path))[0] for path in glob("pystac/*.py")],
-    include_package_data=False,
+    include_package_data=True,
     python_requires=">=3.7",
     install_requires=[
         "python-dateutil>=2.7.0",

--- a/setup.py
+++ b/setup.py
@@ -20,9 +20,8 @@ setup(
     author_email="stac@radiant.earth",
     url="https://github.com/stac-utils/pystac",
     packages=find_packages(),
-    package_data={p: ["py.typed"] for p in find_packages()},
+    package_data={"": ["py.typed"]},
     py_modules=[splitext(basename(path))[0] for path in glob("pystac/*.py")],
-    include_package_data=True,
     python_requires=">=3.7",
     install_requires=[
         "python-dateutil>=2.7.0",


### PR DESCRIPTION
**Related Issue(s):**
stac-utils/stactools#155

**Description:**
This includes type information in the packages so that users of `pystac` can utilize it. This is particularly useful if the downstream project uses `mypy` or any of its competitors.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- ~[ ] Documentation has been updated to reflect changes, if applicable~
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.