### PR TITLE
Pin rustc version to nightly-2021-04-27 in CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -44,7 +44,7 @@ jobs:
         # wheel.
         if: ${{ startsWith(matrix.python-version, '3.10')}}
         with:
-          toolchain: nightly
+          toolchain: nightly-2021-04-27
           override: true
           default: true
           profile: minimal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Changed
 
+- Pin the rustc version in Continuous Integration to work around https://github.com/rust-lang/cargo/pull/9727 ([#581](https://github.com/stac-utils/pystac/pull/581))
+
 ### Fixed
 
 ### Deprecated


### PR DESCRIPTION
**Related Issue(s):** https://github.com/stac-utils/pystac/pull/577#issuecomment-886879246


**Description:** When orjson doesn't have a wheel available for a given OS+Python, we have to build it from source during CI. This requires the rust compiler (and associated tooling). There was a minor regression in the output of the `--version` command in one rust tool (`cargo`) which caused the `orjson` build chain to break. When https://github.com/rust-lang/cargo/pull/9727 is incorporated back into nightly Rust releases we can unpin this toolchain and revert it back to `nightly`.


The check that was failing because of the regression:
https://github.com/PyO3/maturin/blob/5f134e3a4adbbf21f04c10f1dc9722742156f959/maturin/__init__.py#L114-L122

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- ~[ ] Documentation has been updated to reflect changes, if applicable~
- ~[ ] This PR maintains or improves overall codebase code coverage.~
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.