### PR TITLE
Avoid implicit re-exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,13 @@
 
 ### Changed
 
+- Enable [strict
+  mode](https://mypy.readthedocs.io/en/latest/command_line.html?highlight=strict%20mode#cmdoption-mypy-strict)
+  for `mypy` ([#591](https://github.com/stac-utils/pystac/pull/591))
+
 ### Fixed
+
+- Avoid implicit re-exports ([#591](https://github.com/stac-utils/pystac/pull/591))
 
 ### Deprecated
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,18 +1,6 @@
 [mypy]
-check_untyped_defs = True
-disallow_any_generics = True
-disallow_incomplete_defs = True
-disallow_subclassing_any = True
-disallow_untyped_calls = True
-disallow_untyped_decorators = True
-disallow_untyped_defs = True
-no_implicit_optional = True
 show_error_codes = True
-strict_equality = True
-warn_redundant_casts = True
-warn_return_any = True
-warn_unused_configs = True
-warn_unused_ignores = True
+strict = True
 
 [mypy-jsonschema.*]
 ignore_missing_imports = True

--- a/pystac/__init__.py
+++ b/pystac/__init__.py
@@ -1,6 +1,43 @@
 """
 PySTAC is a library for working with SpatioTemporal Asset Catalogs (STACs)
 """
+__all__ = [
+    "__version__",
+    "STACError",
+    "STACTypeError",
+    "DuplicateObjectKeyError",
+    "ExtensionAlreadyExistsError",
+    "ExtensionNotImplemented",
+    "ExtensionTypeError",
+    "RequiredPropertyMissing",
+    "STACValidationError",
+    "MediaType",
+    "RelType",
+    "StacIO",
+    "STACObject",
+    "STACObjectType",
+    "Link",
+    "HIERARCHICAL_LINKS",
+    "Catalog",
+    "CatalogType",
+    "Collection",
+    "Extent",
+    "SpatialExtent",
+    "TemporalExtent",
+    "Summaries",
+    "CommonMetadata",
+    "RangeSummary",
+    "Item",
+    "Asset",
+    "ItemCollection",
+    "Provider",
+    "ProviderRole",
+    "read_file",
+    "read_dict",
+    "write_file",
+    "get_stac_version",
+    "set_stac_version",
+]
 
 from pystac.errors import (
     STACError,
@@ -30,11 +67,11 @@ from pystac.collection import (
     Extent,
     SpatialExtent,
     TemporalExtent,
-    Summaries,
 )
 from pystac.common_metadata import CommonMetadata
-from pystac.summaries import RangeSummary
-from pystac.item import Item, Asset
+from pystac.summaries import RangeSummary, Summaries
+from pystac.asset import Asset
+from pystac.item import Item
 from pystac.item_collection import ItemCollection
 from pystac.provider import ProviderRole, Provider
 import pystac.validation

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -32,7 +32,8 @@ from pystac.serialization import (
 from pystac.utils import is_absolute_href, make_absolute_href, make_relative_href
 
 if TYPE_CHECKING:
-    from pystac.item import Asset as Asset_Type, Item as Item_Type
+    from pystac.asset import Asset as Asset_Type
+    from pystac.item import Item as Item_Type
     from pystac.collection import Collection as Collection_Type
 
 

--- a/pystac/serialization/__init__.py
+++ b/pystac/serialization/__init__.py
@@ -1,3 +1,10 @@
+__all__ = [
+    "merge_common_properties",
+    "migrate_to_latest",
+    "STACVersionRange",
+    "identify_stac_object",
+    "identify_stac_object_type",
+]
 from pystac.serialization.identify import (
     STACVersionRange,
     identify_stac_object,

--- a/tests/extensions/test_scientific.py
+++ b/tests/extensions/test_scientific.py
@@ -4,7 +4,7 @@ import datetime
 
 from pystac import ExtensionTypeError
 from pystac.link import Link
-from pystac.collection import Summaries
+from pystac.summaries import Summaries
 import unittest
 from typing import List, Optional
 

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,3 +1,10 @@
+__all__ = [
+    "TestCases",
+    "ARBITRARY_GEOM",
+    "ARBITRARY_BBOX",
+    "ARBITRARY_EXTENT",
+    "MockStacIO",
+]
 from typing import Any, Dict, TYPE_CHECKING, Type
 import unittest
 from tests.utils.test_cases import (


### PR DESCRIPTION
**Related Issue(s):**

- #582

**Description:**

Avoids implicit re-exports by using `__all__` in `__init__.py` files where we intentionally re-export values and removing references to other implicitly re-exported values.

This also allows us to enable `strict = True` for `mypy`.


**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.