### PR TITLE
Better control on subfolders in `generate_subcatalogs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 
 ### Fixed
 
+- `generate_subcatalogs` can include multiple template values in a single subfolder layer 
+  ([#595](https://github.com/stac-utils/pystac/pull/595))
+
 ### Deprecated
 
 ## [v1.1.0]

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -69,7 +69,7 @@ To use them you can pass in a strategy to the normalize_hrefs call.
 Using templates
 '''''''''''''''
 
-You can utilze template strings to determine the file paths of HREFs set on Catalogs,
+You can utilize template strings to determine the file paths of HREFs set on Catalogs,
 Collection or Items. These templates use python format strings, which can name
 the property or attribute of the item you want to use for replacing the template
 variable. For example:
@@ -84,7 +84,9 @@ variable. For example:
 
 The above code will save items in subfolders based on the collection ID, year and month
 of it's datetime (or start_datetime if a date range is defined and no datetime is
-defined).
+defined). Note that the forward slash (``/``) should be used as path separator in the
+template string regardless of the system path separator (thus both in POSIX-compliant
+and Windows environments).
 
 You can use dot notation to specify attributes of objects or keys in dictionaries for
 template variables. PySTAC will look at the object, it's ``properties`` and its

--- a/pystac/layout.py
+++ b/pystac/layout.py
@@ -54,6 +54,10 @@ class LayoutTemplate:
     | ``collection``     | The collection ID of an Item's collection.             |
     +--------------------+--------------------------------------------------------+
 
+    The forward slash (``/``) should be used as path separator in the template
+    string regardless of the system path separator (thus both in POSIX-compliant
+    and Windows environments).
+
     Examples::
 
         # Uses the year, month and day of the item

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -413,6 +413,30 @@ class CatalogTest(unittest.TestCase):
                     actual, expected, msg=" for child '{}'".format(child.id)
                 )
 
+    def test_generate_subcatalogs_merge_template_elements(self) -> None:
+        catalog = Catalog(id="test", description="Test")
+        item_properties = [
+            dict(property1=p1, property2=p2) for p1 in ("A", "B") for p2 in (1, 2)
+        ]
+        for ni, properties in enumerate(item_properties):
+            catalog.add_item(
+                Item(
+                    id="item{}".format(ni),
+                    geometry=ARBITRARY_GEOM,
+                    bbox=ARBITRARY_BBOX,
+                    datetime=datetime.utcnow(),
+                    properties=properties,
+                )
+            )
+        result = catalog.generate_subcatalogs("${property1}_${property2}")
+
+        actual_subcats = set([cat.id for cat in result])
+        expected_subcats = set(
+            ["{}_{}".format(d["property1"], d["property2"]) for d in item_properties]
+        )
+        self.assertEqual(len(result), len(expected_subcats))
+        self.assertSetEqual(actual_subcats, expected_subcats)
+
     def test_generate_subcatalogs_can_be_applied_multiple_times(self) -> None:
         catalog = TestCases.test_case_8()
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -535,9 +535,7 @@ class CatalogTest(unittest.TestCase):
                 )
             )
 
-        result = catalog.generate_subcatalogs(
-            join_path_or_url(JoinType.PATH, "${property1}", "${property2}")
-        )
+        result = catalog.generate_subcatalogs("${property1}/${property2}")
         self.assertEqual(len(result), 6)
 
         catalog.normalize_hrefs("/")


### PR DESCRIPTION
**Related Issue(s):** #480 


**Description:**

Fix `Catalog.generate_subcatalogs()` to allow for better control on the subcatalogs:
* subfolders can include multiple template values (e.g. using "${property1}_${property2}" will add a single subfolder layer);
* subfolders that are common to all items can be setup directly via the template (e.g. "2021-08-04/${property1}" will add the `2021-08-04` subcatalog for all items, without having to use the `defaults` argument)

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/develop/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.