### PR TITLE
RFC: Use mutable dictionaries for object properties

### DIFF
--- a/pystac/asset.py
+++ b/pystac/asset.py
@@ -60,7 +60,7 @@ class Asset(base.JSONObject):
     @property
     def href(self) -> str:
         """Link to the asset object. Relative and absolute links are both allowed."""
-        return self._get_field("href", str, required=True)
+        return utils.get_required(self.fields.get("href"), self, "href")
 
     @href.setter
     def href(self, v: str) -> None:
@@ -69,7 +69,7 @@ class Asset(base.JSONObject):
     @property
     def title(self) -> Optional[str]:
         """Optional displayed title for clients and users."""
-        return self._get_field("title", str)
+        return self.fields.get("title")
 
     @title.setter
     def title(self, v: Optional[str]) -> None:
@@ -80,7 +80,7 @@ class Asset(base.JSONObject):
         """A description of the Asset providing additional details, such as how it was
         processed or created. CommonMark 0.29 syntax MAY be used for rich text
         representation."""
-        return self._get_field("description", str)
+        return self.fields.get("description")
 
     @description.setter
     def description(self, v: Optional[str]) -> None:
@@ -90,7 +90,7 @@ class Asset(base.JSONObject):
     def media_type(self) -> Optional[Union[MediaType, str]]:
         """Optional description of the media type. Registered Media Types are preferred.
         See :class:`~pystac.MediaType` for common media types."""
-        return self._get_field("type", str)
+        return self.fields.get("type")
 
     @media_type.setter
     def media_type(self, v: Optional[Union[MediaType, str]]) -> None:
@@ -100,7 +100,7 @@ class Asset(base.JSONObject):
     def roles(self) -> Optional[List[str]]:
         """Optional, Semantic roles (i.e. thumbnail, overview, data, metadata) of the
         asset."""
-        return self._get_field("roles", List[str])
+        return self.fields.get("roles")
 
     @roles.setter
     def roles(self, v: Optional[List[str]]) -> None:

--- a/pystac/base.py
+++ b/pystac/base.py
@@ -1,7 +1,5 @@
 from copy import deepcopy
-from typing import Any, Dict, Type, TypeVar
-
-from pystac.utils import get_required
+from typing import Any, Dict, TypeVar
 
 
 V = TypeVar("V")
@@ -9,25 +7,20 @@ V = TypeVar("V")
 
 class JSONObject:
     """A base class for objects that can be represented as JSON objects.
-    
+
     Instances of ``JSONObject`` have a :attr:`JSONObject.fields` attribute that is a
     dictionary representation of the JSON object. Any property getters/setters on
     inheriting classes MUST be sure to keep this dictionary up-to-date.
     """
-    fields = {}
+
+    fields: Dict[str, Any] = {}
 
     def to_dict(self, preserve_dict: bool = True) -> Dict[str, Any]:
         if preserve_dict:
             return deepcopy(self.fields)
         else:
             return self.fields
-    
-    def _get_field(self, name: str, _type: Type, *, required: bool = False) -> V:
-        if required:
-            return get_required(self.fields.get(name), self, name)
-        else:
-            return self.fields.get(name)
-    
+
     def _set_field(self, name: str, v: Any, *, pop_if_none: bool = False) -> None:
         if v is None and pop_if_none:
             self.fields.pop(name, None)

--- a/pystac/base.py
+++ b/pystac/base.py
@@ -1,0 +1,35 @@
+from copy import deepcopy
+from typing import Any, Dict, Type, TypeVar
+
+from pystac.utils import get_required
+
+
+V = TypeVar("V")
+
+
+class JSONObject:
+    """A base class for objects that can be represented as JSON objects.
+    
+    Instances of ``JSONObject`` have a :attr:`JSONObject.fields` attribute that is a
+    dictionary representation of the JSON object. Any property getters/setters on
+    inheriting classes MUST be sure to keep this dictionary up-to-date.
+    """
+    fields = {}
+
+    def to_dict(self, preserve_dict: bool = True) -> Dict[str, Any]:
+        if preserve_dict:
+            return deepcopy(self.fields)
+        else:
+            return self.fields
+    
+    def _get_field(self, name: str, _type: Type, *, required: bool = False) -> V:
+        if required:
+            return get_required(self.fields.get(name), self, name)
+        else:
+            return self.fields.get(name)
+    
+    def _set_field(self, name: str, v: Any, *, pop_if_none: bool = False) -> None:
+        if v is None and pop_if_none:
+            self.fields.pop(name, None)
+        else:
+            self.fields[name] = v

--- a/pystac/common_metadata.py
+++ b/pystac/common_metadata.py
@@ -1,9 +1,10 @@
 from datetime import datetime as Datetime
-from pystac.errors import STACError
 from typing import Any, cast, Dict, List, Optional, Type, TYPE_CHECKING, TypeVar, Union
 
 import pystac
 from pystac import utils
+from pystac.base import JSONObject
+from pystac.errors import STACError
 
 if TYPE_CHECKING:
     from pystac.provider import Provider as Provider_Type
@@ -32,19 +33,16 @@ class CommonMetadata:
     def _set_field(self, prop_name: str, v: Optional[Any]) -> None:
         if hasattr(self.object, prop_name):
             setattr(self.object, prop_name, v)
-        elif hasattr(self.object, "properties"):
-            item = cast("Item_Type", self.object)
+        elif isinstance(self.object, pystac.Item):
             if v is None:
-                item.properties.pop(prop_name, None)
+                self.object.properties.pop(prop_name, None)
             else:
-                item.properties[prop_name] = v
-        elif hasattr(self.object, "extra_fields") and isinstance(
-            self.object.extra_fields, Dict
-        ):
+                self.object.properties[prop_name] = v
+        elif isinstance(self.object, JSONObject):
             if v is None:
-                self.object.extra_fields.pop(prop_name, None)
+                self.object.fields.pop(prop_name, None)
             else:
-                self.object.extra_fields[prop_name] = v
+                self.object.fields[prop_name] = v
         else:
             raise pystac.STACError(f"Cannot set field {prop_name} on {self}.")
 

--- a/pystac/extensions/datacube.py
+++ b/pystac/extensions/datacube.py
@@ -528,7 +528,7 @@ class AssetDatacubeExtension(DatacubeExtension[pystac.Asset]):
 
     def __init__(self, asset: pystac.Asset):
         self.asset_href = asset.href
-        self.properties = asset.extra_fields
+        self.properties = asset.fields
         if asset.owner and isinstance(asset.owner, pystac.Item):
             self.additional_read_properties = [asset.owner.properties]
         else:

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -455,7 +455,7 @@ class AssetEOExtension(EOExtension[pystac.Asset]):
 
     def __init__(self, asset: pystac.Asset):
         self.asset_href = asset.href
-        self.properties = asset.extra_fields
+        self.properties = asset.fields
         if asset.owner and isinstance(asset.owner, pystac.Item):
             self.additional_read_properties = [asset.owner.properties]
 

--- a/pystac/extensions/file.py
+++ b/pystac/extensions/file.py
@@ -102,7 +102,7 @@ class FileExtension(
 
     def __init__(self, asset: pystac.Asset):
         self.asset_href = asset.href
-        self.properties = asset.extra_fields
+        self.properties = asset.fields
         if asset.owner and isinstance(asset.owner, pystac.Item):
             self.additional_read_properties = [asset.owner.properties]
 

--- a/pystac/extensions/pointcloud.py
+++ b/pystac/extensions/pointcloud.py
@@ -495,7 +495,7 @@ class AssetPointcloudExtension(PointcloudExtension[pystac.Asset]):
 
     def __init__(self, asset: pystac.Asset):
         self.asset_href = asset.href
-        self.properties = asset.extra_fields
+        self.properties = asset.fields
         if asset.owner and isinstance(asset.owner, pystac.Item):
             self.additional_read_properties = [asset.owner.properties]
             self.repr_id = f"href={asset.href} item.id={asset.owner.id}"

--- a/pystac/extensions/projection.py
+++ b/pystac/extensions/projection.py
@@ -335,7 +335,7 @@ class AssetProjectionExtension(ProjectionExtension[pystac.Asset]):
 
     def __init__(self, asset: pystac.Asset):
         self.asset_href = asset.href
-        self.properties = asset.extra_fields
+        self.properties = asset.fields
         if asset.owner and isinstance(asset.owner, pystac.Item):
             self.additional_read_properties = [asset.owner.properties]
 

--- a/pystac/extensions/raster.py
+++ b/pystac/extensions/raster.py
@@ -651,7 +651,7 @@ class RasterExtension(
 
     def __init__(self, asset: pystac.Asset):
         self.asset_href = asset.href
-        self.properties = asset.extra_fields
+        self.properties = asset.fields
         if asset.owner and isinstance(asset.owner, pystac.Item):
             self.additional_read_properties = [asset.owner.properties]
 

--- a/pystac/extensions/sar.py
+++ b/pystac/extensions/sar.py
@@ -381,7 +381,7 @@ class AssetSarExtension(SarExtension[pystac.Asset]):
 
     def __init__(self, asset: pystac.Asset):
         self.asset_href = asset.href
-        self.properties = asset.extra_fields
+        self.properties = asset.fields
         if asset.owner and isinstance(asset.owner, pystac.Item):
             self.additional_read_properties = [asset.owner.properties]
 

--- a/pystac/extensions/sat.py
+++ b/pystac/extensions/sat.py
@@ -214,7 +214,7 @@ class AssetSatExtension(SatExtension[pystac.Asset]):
 
     def __init__(self, asset: pystac.Asset):
         self.asset_href = asset.href
-        self.properties = asset.extra_fields
+        self.properties = asset.fields
         if asset.owner and isinstance(asset.owner, pystac.Item):
             self.additional_read_properties = [asset.owner.properties]
 

--- a/pystac/extensions/timestamps.py
+++ b/pystac/extensions/timestamps.py
@@ -192,7 +192,7 @@ class AssetTimestampsExtension(TimestampsExtension[pystac.Asset]):
 
     def __init__(self, asset: pystac.Asset):
         self.asset_href = asset.href
-        self.properties = asset.extra_fields
+        self.properties = asset.fields
         if asset.owner and isinstance(asset.owner, pystac.Item):
             self.additional_read_properties = [asset.owner.properties]
 

--- a/pystac/extensions/view.py
+++ b/pystac/extensions/view.py
@@ -221,7 +221,7 @@ class AssetViewExtension(ViewExtension[pystac.Asset]):
 
     def __init__(self, asset: pystac.Asset):
         self.asset_href = asset.href
-        self.properties = asset.extra_fields
+        self.properties = asset.fields
         if asset.owner and isinstance(asset.owner, pystac.Item):
             self.additional_read_properties = [asset.owner.properties]
 

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -168,10 +168,10 @@ class Item(STACObject):
         Returns:
             datetime or None
         """
-        if asset is None or "datetime" not in asset.extra_fields:
+        if asset is None or "datetime" not in asset.fields:
             return self.datetime
         else:
-            asset_dt = asset.extra_fields.get("datetime")
+            asset_dt = asset.fields.get("datetime")
             if asset_dt is None:
                 return None
             else:
@@ -186,7 +186,7 @@ class Item(STACObject):
         if asset is None:
             self.datetime = datetime
         else:
-            asset.extra_fields["datetime"] = datetime_to_str(datetime)
+            asset.fields["datetime"] = datetime_to_str(datetime)
 
     def get_assets(self) -> Dict[str, Asset]:
         """Get this item's assets.

--- a/tests/extensions/test_custom.py
+++ b/tests/extensions/test_custom.py
@@ -94,7 +94,7 @@ class ItemCustomExtension(CustomExtension[pystac.Item]):
 class AssetCustomExtension(CustomExtension[pystac.Asset]):
     def __init__(self, asset: pystac.Asset) -> None:
         self.catalog = asset
-        self.properties = asset.extra_fields
+        self.properties = asset.fields
         if asset.owner:
             if isinstance(asset.owner, pystac.Item):
                 self.additional_read_properties = [asset.owner.properties]

--- a/tests/extensions/test_pointcloud.py
+++ b/tests/extensions/test_pointcloud.py
@@ -271,7 +271,7 @@ class PointcloudTest(unittest.TestCase):
         pc_item.add_asset("data", asset)
         ext = AssetPointcloudExtension(asset)
         self.assertEqual(ext.asset_href, asset.href)
-        self.assertEqual(ext.properties, asset.extra_fields)
+        self.assertEqual(ext.properties, asset.fields)
         self.assertEqual(ext.additional_read_properties, [pc_item.properties])
 
     def test_ext(self) -> None:


### PR DESCRIPTION
**Related Issue(s):**

- #546 


**Description:**

This PR is intended to be a proof-of-concept for changing the JSON-serializable classes to maintain a mutable dictionary in a `fields` property instead of setting instance attributes. The current draft only implements this for the `Asset` class, but if there is interest I will attempt to implement this for the `Link` class next since we have seen performance issues in the `to_dict` method there.

Some possible advantages to this approach are:

- Improvement in serialization/deserialization performance, especially when using `preserve_dict=False`
- Possibly easier/clearer typing
   If we are able to implement this for all JSON serializable classes, then we may not need some of the `Union` types in our `PropertiesExtension` classes since those could utilize the `fields` dictionary instead. This _may_ also ease some of our circular imports since we might be able to avoid some blocks like:
   ```python
   if isinstance(obj, pystac.Item):
       ...
   elif isinstance(obj, pystac.Asset):
       ...
   ```
   that are necessitating those imports
- Methods like `Item.set_collection` might no longer be necessary if we can handle them within the setters
 
Some possible hiccups:

- Handling attributes of the `Item` class might be tricky since some of them are at the top level and some are in the `properties`.
- Possibly worse performance when accessing instance attributes (e.g. `Asset.href`) since we are now accessing those as properties.
- May not be able to completely preserve backwards compatibility
   The current behavior of the `extra_fields` attribute on some of the classes may be hard to replicate. Currently, this attribute is a mutable dictionary that only includes the fields not covered by specific attributes (e.g. `Asset.href`), but also allows mutatation of the object (e.g. `asset.extra_fields["some_field"] = "some_value"` will add the `"some_field"` property to the Asset when serialized).

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [ ] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.

cc: @TomAugspurger @gjoseph92