### PR TITLE
Use Sequence for annotations for label classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   as `root.stac_io`, if that value is not `None`
   ([#590](https://github.com/stac-utils/pystac/pull/590))
 - Links will get their `title` from their target if no `title` is provided ([#607](https://github.com/stac-utils/pystac/pull/607))
+- Relax typing on `LabelClasses` from `List` to `Sequence` ([#627](https://github.com/stac-utils/pystac/pull/627))
 
 ### Fixed
 

--- a/pystac/extensions/label.py
+++ b/pystac/extensions/label.py
@@ -5,7 +5,7 @@ https://github.com/stac-extensions/label
 
 from enum import Enum
 from pystac.extensions.base import ExtensionManagementMixin, SummariesExtension
-from typing import Any, Dict, Iterable, List, Optional, Union, cast
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Union, cast
 
 import pystac
 from pystac.serialization.identify import STACJSONDescription, STACVersionID
@@ -73,7 +73,7 @@ class LabelClasses:
 
     def apply(
         self,
-        classes: List[Union[str, int, float]],
+        classes: Sequence[Union[str, int, float]],
         name: Optional[str] = None,
     ) -> None:
         """Sets the properties for this instance.
@@ -90,7 +90,7 @@ class LabelClasses:
     @classmethod
     def create(
         cls,
-        classes: List[Union[str, int, float]],
+        classes: Sequence[Union[str, int, float]],
         name: Optional[str] = None,
     ) -> "LabelClasses":
         """Creates a new :class:`~LabelClasses` instance.
@@ -106,12 +106,12 @@ class LabelClasses:
         return c
 
     @property
-    def classes(self) -> List[Union[str, int, float]]:
+    def classes(self) -> Sequence[Union[str, int, float]]:
         """Gets or sets the class values."""
         return get_required(self.properties.get("classes"), self, "classes")
 
     @classes.setter
-    def classes(self, v: List[Union[str, int, float]]) -> None:
+    def classes(self, v: Sequence[Union[str, int, float]]) -> None:
         self.properties["classes"] = v
 
     @property

--- a/tests/extensions/test_label.py
+++ b/tests/extensions/test_label.py
@@ -248,6 +248,10 @@ class LabelTest(unittest.TestCase):
 
         label_item.validate()
 
+    def test_label_classes_typing(self) -> None:
+        classes: List[str] = ["foo", "bar"]
+        LabelClasses.create(classes=classes)
+
     def test_label_tasks(self) -> None:
         label_item = pystac.Item.from_file(self.label_example_1_uri)
 


### PR DESCRIPTION
**Related Issue(s):** n/a


**Description:** Per https://mypy.readthedocs.io/en/stable/common_issues.html#variance,
`List` is invariant, so the LabelClasses.classes type annotation is
unncessarily strict. This commit relaxes the type annotation to use
`Sequence`, including a simple unit test.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- ~[ ] Documentation has been updated to reflect changes, if applicable~
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
