### PR TITLE
gitignore .python-version file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,14 +106,14 @@ ipython_config.py
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:
-# .python-version
+.python-version
 
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
 #   However, in case of collaboration, if having platform-specific dependencies or dependencies
 #   having no cross-platform support, pipenv may install dependencies that don't work, or not
 #   install all needed dependencies.
-#Pipfile.lock
+# Pipfile.lock
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow
 __pypackages__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added Table-extension ([#646](https://github.com/stac-utils/pystac/pull/646))
 - Stable support for Python 3.10 ([#656](https://github.com/stac-utils/pystac/pull/656))
+- `.python-version` files are now ignored by Git ([#647](https://github.com/stac-utils/pystac/pull/647))
 
 ### Removed
 


### PR DESCRIPTION
**Related Issue(s):** #

None

**Description:**

Adds `.python-version` files (used by `pyenv` and `pyenv-virtualenv` to set a local Python environment) to the `.gitignore` file.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [ ] ~Documentation has been updated to reflect changes, if applicable~ **N/A**
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
