### PR TITLE
Changes to main for v1.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ### Added
 
+### Removed
+
+### Changed
+
+### Fixed
+
+### Deprecated
+
+## [v1.2.0]
+
+### Added
+
 - Added Table-extension ([#646](https://github.com/stac-utils/pystac/pull/646))
 - Stable support for Python 3.10 ([#656](https://github.com/stac-utils/pystac/pull/656))
 - `.python-version` files are now ignored by Git ([#647](https://github.com/stac-utils/pystac/pull/647))
@@ -30,8 +42,6 @@
 - Avoid implicit re-exports ([#591](https://github.com/stac-utils/pystac/pull/591))
 - Fix issue that caused incorrect root links when constructing multi-leveled catalogs ([#658](https://github.com/stac-utils/pystac/pull/658))
 - Regression where string `Enum` values were not serialized properly in methods like `Link.to_dict` ([#654](https://github.com/stac-utils/pystac/pull/654))
-
-### Deprecated
 
 ## [v1.1.0]
 
@@ -515,7 +525,8 @@ use `Band.create`
 
 Initial release.
 
-[Unreleased]: <https://github.com/stac-utils/pystac/compare/v1.1.0..main>
+[Unreleased]: <https://github.com/stac-utils/pystac/compare/v1.2.0..main>
+[v1.2.0]: <https://github.com/stac-utils/pystac/compare/v1.1.0..v1.2.0>
 [v1.1.0]: <https://github.com/stac-utils/pystac/compare/v1.0.1..v1.1.0>
 [v1.0.1]: <https://github.com/stac-utils/pystac/compare/v1.0.0..v1.0.1>
 [v1.0.0]: <https://github.com/stac-utils/pystac/compare/v1.0.0-rc.3..v1.0.0>

--- a/pystac/version.py
+++ b/pystac/version.py
@@ -1,7 +1,7 @@
 import os
 from typing import Optional
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 """Library version"""
 
 


### PR DESCRIPTION
**Description:**

Updates to package version and CHANGELOG for v1.2.0 release.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.

TODO:

- [x] Rebase on master after merging #647, #658, #659, and #654 