### PR TITLE
Fix string enum serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - `generate_subcatalogs` can include multiple template values in a single subfolder layer 
   ([#595](https://github.com/stac-utils/pystac/pull/595))
 - Avoid implicit re-exports ([#591](https://github.com/stac-utils/pystac/pull/591))
+- Regression where string `Enum` values were not serialized properly in methods like `Link.to_dict` ([#654](https://github.com/stac-utils/pystac/pull/654))
 
 ### Deprecated
 

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -1,6 +1,5 @@
 import os
 from copy import deepcopy
-from enum import Enum
 from pystac.errors import STACTypeError
 from typing import (
     Any,
@@ -29,7 +28,12 @@ from pystac.serialization import (
     identify_stac_object,
     migrate_to_latest,
 )
-from pystac.utils import is_absolute_href, make_absolute_href, make_relative_href
+from pystac.utils import (
+    StringEnum,
+    is_absolute_href,
+    make_absolute_href,
+    make_relative_href,
+)
 
 if TYPE_CHECKING:
     from pystac.asset import Asset as Asset_Type
@@ -37,7 +41,7 @@ if TYPE_CHECKING:
     from pystac.collection import Collection as Collection_Type
 
 
-class CatalogType(str, Enum):
+class CatalogType(StringEnum):
     SELF_CONTAINED = "SELF_CONTAINED"
     """A 'self-contained catalog' is one that is designed for portability.
     Users may want to download an online catalog from and be able to use it on their

--- a/pystac/extensions/datacube.py
+++ b/pystac/extensions/datacube.py
@@ -4,7 +4,6 @@ https://github.com/stac-extensions/datacube
 """
 
 from abc import ABC
-from enum import Enum
 from typing import Any, Dict, Generic, List, Optional, TypeVar, Union, cast
 
 import pystac
@@ -13,7 +12,7 @@ from pystac.extensions.base import (
     PropertiesExtension,
 )
 from pystac.extensions.hooks import ExtensionHooks
-from pystac.utils import get_required
+from pystac.utils import StringEnum, get_required
 
 T = TypeVar("T", pystac.Collection, pystac.Item, pystac.Asset)
 
@@ -42,14 +41,14 @@ VAR_DIMENSIONS_PROP = "dimensions"
 VAR_UNIT_PROP = "unit"
 
 
-class DimensionType(str, Enum):
+class DimensionType(StringEnum):
     """Dimension object types for spatial and temporal Dimension Objects."""
 
     SPATIAL = "spatial"
     TEMPORAL = "temporal"
 
 
-class HorizontalSpatialDimensionAxis(str, Enum):
+class HorizontalSpatialDimensionAxis(StringEnum):
     """Allowed values for ``axis`` field of :class:`HorizontalSpatialDimension`
     object."""
 
@@ -57,7 +56,7 @@ class HorizontalSpatialDimensionAxis(str, Enum):
     Y = "y"
 
 
-class VerticalSpatialDimensionAxis(str, Enum):
+class VerticalSpatialDimensionAxis(StringEnum):
     """Allowed values for ``axis`` field of :class:`VerticalSpatialDimension`
     object."""
 
@@ -407,7 +406,7 @@ class AdditionalDimension(Dimension):
             self.properties[DIM_REF_SYS_PROP] = v
 
 
-class VariableType(str, Enum):
+class VariableType(StringEnum):
     """Variable object types"""
 
     DATA = "data"

--- a/pystac/extensions/file.py
+++ b/pystac/extensions/file.py
@@ -3,7 +3,6 @@
 https://github.com/stac-extensions/file
 """
 
-from enum import Enum
 from typing import Any, Dict, List, Optional, Union
 
 import pystac
@@ -14,7 +13,7 @@ from pystac.serialization.identify import (
     STACJSONDescription,
     STACVersionID,
 )
-from pystac.utils import get_required
+from pystac.utils import StringEnum, get_required
 
 SCHEMA_URI = "https://stac-extensions.github.io/file/v2.0.0/schema.json"
 
@@ -26,7 +25,7 @@ SIZE_PROP = PREFIX + "size"
 VALUES_PROP = PREFIX + "values"
 
 
-class ByteOrder(str, Enum):
+class ByteOrder(StringEnum):
     """List of allows values for the ``"file:byte_order"`` field defined by the
     :stac-ext:`File Info Extension <file>`."""
 

--- a/pystac/extensions/label.py
+++ b/pystac/extensions/label.py
@@ -3,14 +3,13 @@
 https://github.com/stac-extensions/label
 """
 
-from enum import Enum
 from pystac.extensions.base import ExtensionManagementMixin, SummariesExtension
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Union, cast
 
 import pystac
 from pystac.serialization.identify import STACJSONDescription, STACVersionID
 from pystac.extensions.hooks import ExtensionHooks
-from pystac.utils import get_required, map_opt
+from pystac.utils import StringEnum, get_required, map_opt
 
 SCHEMA_URI = "https://stac-extensions.github.io/label/v1.0.0/schema.json"
 
@@ -25,7 +24,7 @@ METHODS_PROP = PREFIX + "methods"
 OVERVIEWS_PROP = PREFIX + "overviews"
 
 
-class LabelRelType(str, Enum):
+class LabelRelType(StringEnum):
     """A list of rel types defined in the Label Extension.
 
     See the :stac-ext:`Label Extension Links <label#links-source-imagery>`
@@ -36,7 +35,7 @@ class LabelRelType(str, Enum):
     """Used to indicate a link to the source item to which a label item applies."""
 
 
-class LabelType(str, Enum):
+class LabelType(StringEnum):
     """Enumerates valid label types ("raster" or "vector")."""
 
     VECTOR = "vector"
@@ -46,7 +45,7 @@ class LabelType(str, Enum):
     """Convenience attribute for checking if values are valid label types"""
 
 
-class LabelTask(str, Enum):
+class LabelTask(StringEnum):
     """Enumerates recommended values for "label:tasks" field."""
 
     REGRESSION = "regression"
@@ -55,7 +54,7 @@ class LabelTask(str, Enum):
     SEGMENTATION = "segmentation"
 
 
-class LabelMethod(str, Enum):
+class LabelMethod(StringEnum):
     """Enumerates recommended values for "label:methods" field."""
 
     AUTOMATED = "automated"

--- a/pystac/extensions/pointcloud.py
+++ b/pystac/extensions/pointcloud.py
@@ -2,7 +2,6 @@
 
 https://github.com/stac-extensions/pointcloud
 """
-from enum import Enum
 from typing import Any, Dict, Generic, List, Optional, TypeVar, cast, Union
 
 import pystac
@@ -13,7 +12,7 @@ from pystac.extensions.base import (
 )
 from pystac.extensions.hooks import ExtensionHooks
 from pystac.summaries import RangeSummary
-from pystac.utils import map_opt, get_required
+from pystac.utils import StringEnum, map_opt, get_required
 
 T = TypeVar("T", pystac.Item, pystac.Asset)
 
@@ -28,7 +27,7 @@ DENSITY_PROP = PREFIX + "density"
 STATISTICS_PROP = PREFIX + "statistics"
 
 
-class PhenomenologyType(str, Enum):
+class PhenomenologyType(StringEnum):
     """Valid values for the ``pc:type`` field in the :stac-ext:`Pointcloud Item
     Properties <pointcloud#item-properties>`."""
 
@@ -39,7 +38,7 @@ class PhenomenologyType(str, Enum):
     OTHER = "other"
 
 
-class SchemaType(str, Enum):
+class SchemaType(StringEnum):
     """Valid values for the ``type`` field in a :stac-ext:`Schema Object
     <pointcloud#schema-object>`."""
 

--- a/pystac/extensions/raster.py
+++ b/pystac/extensions/raster.py
@@ -3,7 +3,6 @@
 https://github.com/stac-extensions/raster
 """
 
-import enum
 from typing import Any, Dict, Iterable, List, Optional, Union
 
 import pystac
@@ -12,19 +11,19 @@ from pystac.extensions.base import (
     PropertiesExtension,
     SummariesExtension,
 )
-from pystac.utils import get_opt, get_required, map_opt
+from pystac.utils import StringEnum, get_opt, get_required, map_opt
 
 SCHEMA_URI = "https://stac-extensions.github.io/raster/v1.0.0/schema.json"
 
 BANDS_PROP = "raster:bands"
 
 
-class Sampling(str, enum.Enum):
+class Sampling(StringEnum):
     AREA = "area"
     POINT = "point"
 
 
-class DataType(str, enum.Enum):
+class DataType(StringEnum):
     INT8 = "int8"
     INT16 = "int16"
     INT32 = "int32"

--- a/pystac/extensions/sar.py
+++ b/pystac/extensions/sar.py
@@ -3,7 +3,6 @@
 https://github.com/stac-extensions/sar
 """
 
-import enum
 from typing import Any, Dict, Generic, Iterable, List, Optional, TypeVar, cast, Union
 
 import pystac
@@ -15,7 +14,7 @@ from pystac.extensions.base import (
     SummariesExtension,
 )
 from pystac.extensions.hooks import ExtensionHooks
-from pystac.utils import get_required, map_opt
+from pystac.utils import StringEnum, get_required, map_opt
 
 T = TypeVar("T", pystac.Item, pystac.Asset)
 
@@ -40,7 +39,7 @@ LOOKS_EQUIVALENT_NUMBER_PROP: str = PREFIX + "looks_equivalent_number"
 OBSERVATION_DIRECTION_PROP: str = PREFIX + "observation_direction"
 
 
-class FrequencyBand(str, enum.Enum):
+class FrequencyBand(StringEnum):
     P = "P"
     L = "L"
     S = "S"
@@ -51,14 +50,14 @@ class FrequencyBand(str, enum.Enum):
     KA = "Ka"
 
 
-class Polarization(str, enum.Enum):
+class Polarization(StringEnum):
     HH = "HH"
     VV = "VV"
     HV = "HV"
     VH = "VH"
 
 
-class ObservationDirection(str, enum.Enum):
+class ObservationDirection(StringEnum):
     LEFT = "left"
     RIGHT = "right"
 

--- a/pystac/extensions/sat.py
+++ b/pystac/extensions/sat.py
@@ -3,7 +3,6 @@
 https://github.com/stac-extensions/sat
 """
 
-import enum
 from datetime import datetime as Datetime
 from pystac.summaries import RangeSummary
 from typing import Dict, Any, List, Iterable, Generic, Optional, TypeVar, Union, cast
@@ -15,7 +14,7 @@ from pystac.extensions.base import (
     SummariesExtension,
 )
 from pystac.extensions.hooks import ExtensionHooks
-from pystac.utils import str_to_datetime, datetime_to_str, map_opt
+from pystac.utils import StringEnum, str_to_datetime, datetime_to_str, map_opt
 
 T = TypeVar("T", pystac.Item, pystac.Asset)
 
@@ -31,7 +30,7 @@ RELATIVE_ORBIT_PROP: str = PREFIX + "relative_orbit"
 ANX_DATETIME_PROP: str = PREFIX + "anx_datetime"
 
 
-class OrbitState(str, enum.Enum):
+class OrbitState(StringEnum):
     ASCENDING = "ascending"
     DESCENDING = "descending"
     GEOSTATIONARY = "geostationary"

--- a/pystac/extensions/scientific.py
+++ b/pystac/extensions/scientific.py
@@ -8,7 +8,6 @@ https://doi.org/10.1000/182
 """
 
 import copy
-from enum import Enum
 from typing import Any, Dict, Generic, List, Optional, TypeVar, Union, cast
 from urllib import parse
 
@@ -19,7 +18,7 @@ from pystac.extensions.base import (
     SummariesExtension,
 )
 from pystac.extensions.hooks import ExtensionHooks
-from pystac.utils import map_opt
+from pystac.utils import StringEnum, map_opt
 
 T = TypeVar("T", pystac.Collection, pystac.Item)
 
@@ -35,7 +34,7 @@ DOI_URL_BASE = "https://doi.org/"
 
 
 # Link rel type.
-class ScientificRelType(str, Enum):
+class ScientificRelType(StringEnum):
     """A list of rel types defined in the Scientific Citation Extension.
 
     See the :stac-ext:`Scientific Citation Extension Relation types

--- a/pystac/extensions/version.py
+++ b/pystac/extensions/version.py
@@ -2,11 +2,11 @@
 
 https://github.com/stac-extensions/version
 """
-from enum import Enum
 from pystac.utils import get_required, map_opt
 from typing import Generic, List, Optional, TypeVar, Union, cast
 
 import pystac
+from pystac.utils import StringEnum
 from pystac.extensions.base import (
     ExtensionManagementMixin,
     PropertiesExtension,
@@ -23,7 +23,7 @@ VERSION: str = "version"
 DEPRECATED: str = "deprecated"
 
 
-class VersionRelType(str, Enum):
+class VersionRelType(StringEnum):
     """A list of rel types defined in the Version Extension.
 
     See the `Version Extension Relation types

--- a/pystac/media_type.py
+++ b/pystac/media_type.py
@@ -1,7 +1,7 @@
-from enum import Enum
+from pystac.utils import StringEnum
 
 
-class MediaType(str, Enum):
+class MediaType(StringEnum):
     """A list of common media types that can be used in STAC Asset and Link metadata."""
 
     COG = "image/tiff; application=geotiff; profile=cloud-optimized"

--- a/pystac/provider.py
+++ b/pystac/provider.py
@@ -1,8 +1,9 @@
-from enum import Enum
 from typing import Any, Dict, List, Optional
 
+from pystac.utils import StringEnum
 
-class ProviderRole(str, Enum):
+
+class ProviderRole(StringEnum):
     """Enumerates the allows values of the Provider "role" field."""
 
     LICENSOR = "licensor"

--- a/pystac/rel_type.py
+++ b/pystac/rel_type.py
@@ -1,7 +1,7 @@
-from enum import Enum
+from pystac.utils import StringEnum
 
 
-class RelType(str, Enum):
+class RelType(StringEnum):
     """A list of common rel types that can be used in STAC Link metadata.
     See :stac-spec:`"Using Relation Types <best-practices.md#using-relation-types>`
     in the STAC Best Practices for guidelines on using relation types. You may also want

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -1,17 +1,16 @@
 from abc import ABC, abstractmethod
-from enum import Enum
 from typing import Any, Dict, Iterable, List, Optional, Type, cast, TYPE_CHECKING, Union
 
 import pystac
 from pystac import STACError
 from pystac.link import Link
-from pystac.utils import is_absolute_href, make_absolute_href
+from pystac.utils import StringEnum, is_absolute_href, make_absolute_href
 
 if TYPE_CHECKING:
     from pystac.catalog import Catalog as Catalog_Type
 
 
-class STACObjectType(str, Enum):
+class STACObjectType(StringEnum):
     CATALOG = "Catalog"
     COLLECTION = "Collection"
     ITEM = "Feature"

--- a/pystac/utils.py
+++ b/pystac/utils.py
@@ -2,7 +2,7 @@ import os
 import posixpath
 from enum import Enum
 from pystac.errors import RequiredPropertyMissing
-from typing import Any, Callable, Dict, List, Optional, TypeVar, Union
+from typing import Any, Callable, Dict, List, Optional, TypeVar, Union, cast
 from urllib.parse import urljoin, urlparse, urlunparse, ParseResult as URLParseResult
 from datetime import datetime, timezone
 import dateutil.parser
@@ -37,7 +37,14 @@ def safe_urlparse(href: str) -> URLParseResult:
         return parsed
 
 
-class JoinType(str, Enum):
+class StringEnum(str, Enum):
+    """Base Enum class for string enums that will serialize as the string value."""
+
+    def __str__(self) -> str:
+        return cast(str, self.value)
+
+
+class JoinType(StringEnum):
     """Allowed join types for the :func:`_join` function."""
 
     @staticmethod

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -186,6 +186,18 @@ class LinkTest(unittest.TestCase):
         assert link.title == link_title
         assert link.to_dict().get("title") == link_title
 
+    @unittest.expectedFailure
+    def test_serialize_link(self) -> None:
+        href = "https://some-domain/path/to/item.json"
+        title = "A Test Link"
+        link = pystac.Link(pystac.RelType.SELF, href, pystac.MediaType.JSON, title)
+        link_dict = link.to_dict()
+
+        assert str(link_dict["rel"]) == "self"
+        assert str(link_dict["type"]) == "application/json"
+        assert link_dict["title"] == title
+        assert link_dict["href"] == href
+
 
 class StaticLinkTest(unittest.TestCase):
     def setUp(self) -> None:

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -192,10 +192,10 @@ class LinkTest(unittest.TestCase):
         link = pystac.Link(pystac.RelType.SELF, href, pystac.MediaType.JSON, title)
         link_dict = link.to_dict()
 
-        assert str(link_dict["rel"]) == "self"
-        assert str(link_dict["type"]) == "application/json"
-        assert link_dict["title"] == title
-        assert link_dict["href"] == href
+        self.assertEqual(str(link_dict["rel"]), "self")
+        self.assertEqual(str(link_dict["type"]), "application/json")
+        self.assertEqual(link_dict["title"], title)
+        self.assertEqual(link_dict["href"], href)
 
 
 class StaticLinkTest(unittest.TestCase):

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -186,7 +186,6 @@ class LinkTest(unittest.TestCase):
         assert link.title == link_title
         assert link.to_dict().get("title") == link_title
 
-    @unittest.expectedFailure
     def test_serialize_link(self) -> None:
         href = "https://some-domain/path/to/item.json"
         title = "A Test Link"


### PR DESCRIPTION
**Related Issue(s):**

- Closes #652 
- Closes #626


**Description:**

Creates a `StringEnum` class that overwrites the default `__str__` method to return the value of the enum. All instances of classes inheriting from `str` and `Enum` have been updated to inherit from this base class, including `RelType`.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.