### PR TITLE
Use stable Python 3.10 in CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,7 +14,6 @@ jobs:
   test:
     name: test
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ startsWith(matrix.python-version, '3.10')}}
     strategy:
       # Allow other matrix jobs to complete if 1 fails
       fail-fast: false
@@ -23,7 +22,7 @@ jobs:
           - "3.7"
           - "3.8"
           - "3.9"
-          - "3.10.0-rc.1"
+          - "3.10"
         os:
           - ubuntu-latest
           - windows-latest
@@ -38,10 +37,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - uses: actions-rs/toolchain@v1
-        # No wheels exist for orjson on Python 3.10 on MacOS or Windows, and the Linux
-        #  wheels are sometimes not uploaded until after the package is initially
-        # published. This sets up the Rust nightly toolchain so we can build the orjson
-        # wheel.
+        # Wheels for orjson on Python 3.10 are still spotty on MacOS or Windows. This sets up the Rust nightly
+        # toolchain so we can build the orjson wheel.
         if: ${{ startsWith(matrix.python-version, '3.10')}}
         with:
           toolchain: stable
@@ -142,7 +139,7 @@ jobs:
           - "3.7"
           - "3.8"
           - "3.9"
-          - "3.10.0-rc.1"
+          - "3.10"
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ for Python versions. This means that users can expect support for Python 3.7 to 
 removed from the `main` branch after Dec 26, 2021 and therefore from the next release
 after that date.
 
-*Support for Python >= 3.10 should be considered experimental
-until further notice.*
+Note that while we support Python 3.10.\*, wheels for the `orjson` library are not always immediately available for all
+platforms. If you install PySTAC with the `orjson` extra, you may need to have the Rust toolchain installed in order to
+build the package from source.
 
 PySTAC has a single required dependency (`python-dateutil`).
 PySTAC can be installed from pip or the source repository.


### PR DESCRIPTION
**Description:**

Updates CI to use stable Python 3.10 version. Also updates the note in the README to remove language about 3.10 support being experimental. Since the `orjson` wheels are still not always available immediately for all platforms (see ijl/orjson#214), I've left a note on that in the README.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [ ] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
