### PR TITLE
Add an extra SELF_CONTAINED catalog test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,10 @@
 
 ### Fixed
 
-- `generate_subcatalogs` can include multiple template values in a single subfolder layer 
+- `generate_subcatalogs` can include multiple template values in a single subfolder layer
   ([#595](https://github.com/stac-utils/pystac/pull/595))
 - Avoid implicit re-exports ([#591](https://github.com/stac-utils/pystac/pull/591))
+- Fix issue that caused incorrect root links when constructing multi-leveled catalogs ([#658](https://github.com/stac-utils/pystac/pull/658))
 
 ### Deprecated
 

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -187,12 +187,12 @@ class Catalog(STACObject):
                 root._resolved_objects, self._resolved_objects
             )
 
-        # Walk through resolved object links and update the root
-        for link in self.links:
-            if link.rel == pystac.RelType.CHILD or link.rel == pystac.RelType.ITEM:
-                target = link.target
-                if isinstance(target, STACObject):
-                    target.set_root(root)
+            # Walk through resolved object links and update the root
+            for link in self.links:
+                if link.rel == pystac.RelType.CHILD or link.rel == pystac.RelType.ITEM:
+                    target = link.target
+                    if isinstance(target, STACObject):
+                        target.set_root(root)
 
     def is_relative(self) -> bool:
         return self.catalog_type in [

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -187,6 +187,13 @@ class Catalog(STACObject):
                 root._resolved_objects, self._resolved_objects
             )
 
+        # Walk through resolved object links and update the root
+        for link in self.links:
+            if link.rel == pystac.RelType.CHILD or link.rel == pystac.RelType.ITEM:
+                target = link.target
+                if isinstance(target, STACObject):
+                    target.set_root(root)
+
     def is_relative(self) -> bool:
         return self.catalog_type in [
             CatalogType.RELATIVE_PUBLISHED,

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -363,7 +363,11 @@ class STACObject(ABC):
         if root is None and isinstance(clone, pystac.Catalog):
             root = clone
 
-        clone.set_root(cast(pystac.Catalog, root))
+        # Set the root of the STAC Object using the base class,
+        # avoiding child class overrides
+        # extra logic which can be incompatible with the full copy.
+        STACObject.set_root(clone, cast(pystac.Catalog, root))
+
         if parent:
             clone.set_parent(parent)
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -842,11 +842,13 @@ class CatalogTest(unittest.TestCase):
             cat = TestCases.test_case_9()
             cat.normalize_hrefs(tmp_dir)
             cat.validate_all()
-            print(f'Saving catalog to: {tmp_dir}')
+            print(f"Saving catalog to: {tmp_dir}")
             cat.save(catalog_type=CatalogType.SELF_CONTAINED)
 
             # read the item back, to make experiment clean
-            item = Item.from_file(f'{tmp_dir}/collection-issue-657/item-issue-657/item-issue-657.json')
+            item = Item.from_file(
+                f"{tmp_dir}/collection-issue-657/item-issue-657/item-issue-657.json"
+            )
             # ensure that all links in the output json are relative
             # everything of a nested level > 2 is not relative?
             for link in item.links:

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1119,7 +1119,7 @@ class FullCopyTest(unittest.TestCase):
             self.check_link(link, tag)
 
     def check_catalog(self, c: Catalog, tag: str) -> None:
-        self.assertEqual(len(c.get_links("root")), 1)
+        self.assertEqual(len(c.get_links("root")), 1, msg=f"{c}")
 
         for link in c.links:
             self.check_link(link, tag)

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -837,6 +837,23 @@ class CatalogTest(unittest.TestCase):
                 c2.catalog_type = CatalogType.ABSOLUTE_PUBLISHED
                 check_all_absolute(c2)
 
+    def test_self_contained_catalog_collection_item_links(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            cat = TestCases.test_case_9()
+            cat.normalize_hrefs(tmp_dir)
+            cat.validate_all()
+            print(f'Saving catalog to: {tmp_dir}')
+            cat.save(catalog_type=CatalogType.SELF_CONTAINED)
+
+            # read the item back, to make experiment clean
+            item = Item.from_file(f'{tmp_dir}/collection-issue-657/item-issue-657/item-issue-657.json')
+            # ensure that all links in the output json are relative
+            # everything of a nested level > 2 is not relative?
+            for link in item.links:
+                self.assertFalse(is_absolute_href(link.target))
+            # use time sleep to pause there and inspect catalogs manually
+            # time.sleep(10000)
+
     def test_full_copy_and_normalize_works_with_created_stac(self) -> None:
         cat = TestCases.test_case_3()
         cat_copy = cat.full_copy()

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -869,11 +869,10 @@ class CatalogTest(unittest.TestCase):
             catalog.validate_all()
 
             catalog.save(catalog_type=CatalogType.SELF_CONTAINED)
-            item_json = json.loads(
-                open(
-                    f"{tmp_dir}/collection-issue-657/item-issue-657/item-issue-657.json"
-                ).read()
-            )
+            with open(
+                f"{tmp_dir}/collection-issue-657/item-issue-657/item-issue-657.json"
+            ) as f:
+                item_json = json.load(f)
 
             for link in item_json["links"]:
                 # self links are always absolute

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -850,7 +850,9 @@ class CatalogTest(unittest.TestCase):
             # ensure that all links in the output json are relative
             # everything of a nested level > 2 is not relative?
             for link in item.links:
-                self.assertFalse(is_absolute_href(link.target))
+                href = link.get_href()
+                self.assertIsNotNone(href)
+                self.assertFalse(is_absolute_href(href))
             # use time sleep to pause there and inspect catalogs manually
             # time.sleep(10000)
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -842,7 +842,7 @@ class CatalogTest(unittest.TestCase):
             cat = TestCases.test_case_9()
             cat.normalize_hrefs(tmp_dir)
             cat.validate_all()
-            print(f"Saving catalog to: {tmp_dir}")
+
             cat.save(catalog_type=CatalogType.SELF_CONTAINED)
 
             # read the item back, to make experiment clean
@@ -852,11 +852,15 @@ class CatalogTest(unittest.TestCase):
             # ensure that all links in the output json are relative
             # everything of a nested level > 2 is not relative?
             for link in item.links:
+                # self links are always absolute
+                if link.rel == "self":
+                    continue
+
                 href = link.get_href()
                 assert href is not None
-                self.assertFalse(is_absolute_href(href))
-            # use time sleep to pause there and inspect catalogs manually
-            # time.sleep(10000)
+                self.assertFalse(
+                    is_absolute_href(href), msg=f"Link with rel={link.rel} is absolute!"
+                )
 
     def test_full_copy_and_normalize_works_with_created_stac(self) -> None:
         cat = TestCases.test_case_3()

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -853,7 +853,7 @@ class CatalogTest(unittest.TestCase):
             # everything of a nested level > 2 is not relative?
             for link in item.links:
                 href = link.get_href()
-                self.assertIsNotNone(href)
+                assert href is not None
                 self.assertFalse(is_absolute_href(href))
             # use time sleep to pause there and inspect catalogs manually
             # time.sleep(10000)

--- a/tests/utils/test_cases.py
+++ b/tests/utils/test_cases.py
@@ -242,32 +242,3 @@ class TestCases:
                 "data-files/catalogs/" "planet-example-v1.0.0-beta.2/collection.json"
             )
         )
-
-    @staticmethod
-    def test_case_9() -> Catalog:
-        """Manually created STAC Catalog, see issue https://github.com/stac-utils/pystac/issues/657"""
-        catalog = pystac.Catalog(
-            id="catalog-issue-657", description="catalog-issue-657"
-        )
-        collection = pystac.Collection(
-            "collection-issue-657",
-            "collection-issue-657",
-            pystac.Extent(
-                spatial=pystac.SpatialExtent([[-180.0, -90.0, 180.0, 90.0]]),
-                temporal=pystac.TemporalExtent([[datetime(2021, 11, 1), None]]),
-            ),
-            license="proprietary",
-        )
-
-        item = pystac.Item(
-            id="item-issue-657",
-            stac_extensions=[],
-            geometry=ARBITRARY_GEOM,
-            bbox=ARBITRARY_BBOX,
-            datetime=datetime(2021, 11, 1),
-            properties={},
-        )
-
-        collection.add_item(item)
-        catalog.add_child(collection)
-        return catalog

--- a/tests/utils/test_cases.py
+++ b/tests/utils/test_cases.py
@@ -242,3 +242,32 @@ class TestCases:
                 "data-files/catalogs/" "planet-example-v1.0.0-beta.2/collection.json"
             )
         )
+
+    @staticmethod
+    def test_case_9() -> Collection:
+        """Manually created STAC Catalog, see issue https://github.com/stac-utils/pystac/issues/657"""
+        catalog = pystac.Catalog(id="catalog-issue-657", description="catalog-issue-657")
+        collection = pystac.Collection(
+            "collection-issue-657",
+            "collection-issue-657",
+            pystac.Extent(
+                spatial=pystac.SpatialExtent([[-180, -90, 180, 90]]),
+                temporal=pystac.TemporalExtent(
+                    [[datetime(2021,11,1), None]]
+                ),
+            ),
+            license='proprietary'
+        )
+
+        item = pystac.Item(
+            id="item-issue-657",
+            stac_extensions=[],
+            geometry=ARBITRARY_GEOM,
+            bbox=ARBITRARY_BBOX,
+            datetime=datetime(2021,11,1),
+            properties={}
+        )
+
+        collection.add_item(item)
+        catalog.add_child(collection)
+        return catalog

--- a/tests/utils/test_cases.py
+++ b/tests/utils/test_cases.py
@@ -244,19 +244,19 @@ class TestCases:
         )
 
     @staticmethod
-    def test_case_9() -> Collection:
+    def test_case_9() -> Catalog:
         """Manually created STAC Catalog, see issue https://github.com/stac-utils/pystac/issues/657"""
-        catalog = pystac.Catalog(id="catalog-issue-657", description="catalog-issue-657")
+        catalog = pystac.Catalog(
+            id="catalog-issue-657", description="catalog-issue-657"
+        )
         collection = pystac.Collection(
             "collection-issue-657",
             "collection-issue-657",
             pystac.Extent(
-                spatial=pystac.SpatialExtent([[-180, -90, 180, 90]]),
-                temporal=pystac.TemporalExtent(
-                    [[datetime(2021,11,1), None]]
-                ),
+                spatial=pystac.SpatialExtent([[-180.0, -90.0, 180.0, 90.0]]),
+                temporal=pystac.TemporalExtent([[datetime(2021, 11, 1), None]]),
             ),
-            license='proprietary'
+            license="proprietary",
         )
 
         item = pystac.Item(
@@ -264,8 +264,8 @@ class TestCases:
             stac_extensions=[],
             geometry=ARBITRARY_GEOM,
             bbox=ARBITRARY_BBOX,
-            datetime=datetime(2021,11,1),
-            properties={}
+            datetime=datetime(2021, 11, 1),
+            properties={},
         )
 
         collection.add_item(item)


### PR DESCRIPTION
**Related Issue(s):** #657


**Description:**
Adds a unit test that tests #657 

I notcied that there is an issue only with catalogs of the full hierarchy:

* catalog
  * collection
     * item

The following one works as expected:
* catalog
  * item

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [ ] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
