### PR TITLE
Packaging: Add Trove Classifier for Python 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     project_urls={
         "Tracker": "https://github.com/stac-utils/pystac/issues",


### PR DESCRIPTION
Support for 3.10 was added in https://github.com/stac-utils/pystac/pull/656
This ensures that packages will be marked as supporting 3.10

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- ~[ ] Documentation has been updated to reflect changes, if applicable~
- [x] This PR maintains or improves overall codebase code coverage.
- ~[ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.~
