### PR TITLE
Make absolute hrefs from urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 
 - Quickstart tutorial is now up-to-date with all package changes ([#674](https://github.com/stac-utils/pystac/pull/674))
+- Creating absolute URLs from absolute URLs ([#697](https://github.com/stac-utils/pystac/pull/697)])
 
 ### Deprecated
 

--- a/pystac/utils.py
+++ b/pystac/utils.py
@@ -241,10 +241,13 @@ def make_absolute_href(
     parsed_start = safe_urlparse(start_href)
     parsed_source = safe_urlparse(source_href)
 
-    if JoinType.from_parsed_uri(parsed_start) == JoinType.PATH:
-        return _make_absolute_href_path(parsed_source, parsed_start, start_is_dir)
-    else:
+    if (
+        JoinType.from_parsed_uri(parsed_source) == JoinType.URL
+        or JoinType.from_parsed_uri(parsed_start) == JoinType.URL
+    ):
         return _make_absolute_href_url(parsed_source, parsed_start, start_is_dir)
+    else:
+        return _make_absolute_href_path(parsed_source, parsed_start, start_is_dir)
 
 
 def is_absolute_href(href: str) -> bool:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -158,6 +158,7 @@ class UtilsTest(unittest.TestCase):
                 "https://stacspec.org/a/b/c/catalog.json",
                 "https://stacspec.org/a/b/item.json",
             ),
+            ("http://localhost:8000", None, "http://localhost:8000"),
         ]
 
         for source_href, start_href, expected in test_cases:


### PR DESCRIPTION
**Related Issue(s):** https://github.com/stac-utils/pystac-client/issues/113.


**Description:** The very basic case of `make_absolute_href(href, None, None)` was broken if `href` was a url. This fixes that breakage with a test case to demonstrate.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
