### PR TITLE
Add variables setter to datacube extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Type annotations for instance attributes on all classes ([#705](https://github.com/stac-utils/pystac/pull/705))
+- `extensions.datacube.Variable.to_dict` method ([#699](https://github.com/stac-utils/pystac/pull/699)])
 
 ### Removed
 
@@ -16,6 +17,7 @@
 - Creating absolute URLs from absolute URLs ([#697](https://github.com/stac-utils/pystac/pull/697)])
 - Serialization error when using `pystac.extensions.file.MappingObject` ([#700](https://github.com/stac-utils/pystac/pull/700))
 - Use `PropertiesExtension._get_property` to properly set return type in `TableExtension` ([#712](https://github.com/stac-utils/pystac/pull/712))
+- `DatacubeExtension.variables` now has a setter ([#699](https://github.com/stac-utils/pystac/pull/699)])
 
 ### Deprecated
 

--- a/pystac/extensions/datacube.py
+++ b/pystac/extensions/datacube.py
@@ -12,7 +12,7 @@ from pystac.extensions.base import (
     PropertiesExtension,
 )
 from pystac.extensions.hooks import ExtensionHooks
-from pystac.utils import StringEnum, get_required
+from pystac.utils import StringEnum, get_required, map_opt
 
 T = TypeVar("T", pystac.Collection, pystac.Item, pystac.Asset)
 
@@ -501,6 +501,9 @@ class Variable:
     def from_dict(d: Dict[str, Any]) -> "Variable":
         return Variable(d)
 
+    def to_dict(self) -> Dict[str, Any]:
+        return self.properties
+
 
 class DatacubeExtension(
     Generic[T],
@@ -552,6 +555,15 @@ class DatacubeExtension(
         if result is None:
             return None
         return {k: Variable.from_dict(v) for k, v in result.items()}
+
+    @variables.setter
+    def variables(self, v: Optional[Dict[str, Variable]]) -> None:
+        self._set_property(
+            VARIABLES_PROP,
+            map_opt(
+                lambda variables: {k: var.to_dict() for k, var in variables.items()}, v
+            ),
+        )
 
     @classmethod
     def get_schema_uri(cls) -> str:

--- a/tests/data-files/datacube/item.json
+++ b/tests/data-files/datacube/item.json
@@ -97,7 +97,18 @@
                     "blue"
                 ]
             }
-        }
+        },
+        "cube:variables": {
+            "temp": {
+              "dimensions": [
+                "time",
+                "y",
+                "x",
+                "pressure_levels"
+              ],
+              "type": "data"
+            }
+          }
     },
     "assets": {
         "data": {

--- a/tests/extensions/test_datacube.py
+++ b/tests/extensions/test_datacube.py
@@ -1,7 +1,7 @@
 import unittest
 import pystac
 from pystac import ExtensionTypeError
-from pystac.extensions.datacube import DatacubeExtension
+from pystac.extensions.datacube import DatacubeExtension, Variable
 
 from tests.utils import TestCases
 
@@ -60,4 +60,30 @@ class DatacubeTest(unittest.TestCase):
             r"^Datacube extension does not apply to type 'object'$",
             DatacubeExtension.ext,
             object(),
+        )
+
+    def test_get_variables(self) -> None:
+        item = pystac.Item.from_file(self.example_uri)
+        dc_ext = DatacubeExtension.ext(item)
+
+        assert dc_ext.variables is not None
+        self.assertIsInstance(dc_ext.variables, dict)
+        self.assertNotEqual(dc_ext.variables, {})
+
+        for var in dc_ext.variables.values():
+            self.assertIsInstance(var, Variable)
+
+    def test_set_variables(self) -> None:
+        item = pystac.Item.from_file(self.example_uri)
+        dc_ext = DatacubeExtension.ext(item)
+
+        new_variable = Variable.from_dict(
+            {"dimensions": ["time", "y", "x", "pressure_levels"], "type": "data"}
+        )
+        new_variables = {"temp": new_variable}
+
+        dc_ext.variables = new_variables
+
+        self.assertEqual(
+            item.properties["cube:variables"], {"temp": new_variable.to_dict()}
         )


### PR DESCRIPTION
**Related Issue(s):**

- Closes #681
- Begins to address #324 

**Description:**

Adds a setter for the `DatacubeExtension.variables` property and adds a `Variable.to_dict` method. Also adds tests for getting and setting `DatacubeExtension.variables`.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
