### PR TITLE
Add instance attribute annotations to all classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Type annotations for instance attributes on all classes ([#705](https://github.com/stac-utils/pystac/pull/705))
+
 ### Removed
 
 ### Changed

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -104,6 +104,10 @@ Provider
 Summaries
 ~~~~~~~~~
 
+.. autoclass:: pystac.RangeSummary
+   :members:
+   :undoc-members:
+
 .. autoclass:: pystac.Summaries
    :members:
    :undoc-members:

--- a/pystac/cache.py
+++ b/pystac/cache.py
@@ -59,6 +59,18 @@ class ResolvedObjectCache:
             to collections.
     """
 
+    id_keys_to_objects: Dict[str, "STACObject_Type"]
+    """Existing cache of a key made up of the STACObject and it's parents IDs mapped
+    to the cached STACObject."""
+
+    hrefs_to_objects: Dict[str, "STACObject_Type"]
+    """STAC Object HREFs matched to their cached object."""
+
+    ids_to_collections: Dict[str, "Collection_Type"]
+    """Map of collection IDs to collections."""
+
+    _collection_cache: Optional["ResolvedObjectCollectionCache"]
+
     def __init__(
         self,
         id_keys_to_objects: Optional[Dict[str, "STACObject_Type"]] = None,
@@ -69,7 +81,7 @@ class ResolvedObjectCache:
         self.hrefs_to_objects = hrefs_to_objects or {}
         self.ids_to_collections = ids_to_collections or {}
 
-        self._collection_cache: Optional[ResolvedObjectCollectionCache] = None
+        self._collection_cache = None
 
     def get_or_cache(self, obj: "STACObject_Type") -> "STACObject_Type":
         """Gets the STACObject that is the cached version of the given STACObject; or, if
@@ -233,6 +245,9 @@ class CollectionCache:
     in common properties.
     """
 
+    cached_ids: Dict[str, Union["Collection_Type", Dict[str, Any]]]
+    cached_hrefs: Dict[str, Union["Collection_Type", Dict[str, Any]]]
+
     def __init__(
         self,
         cached_ids: Optional[
@@ -274,6 +289,9 @@ class CollectionCache:
 
 
 class ResolvedObjectCollectionCache(CollectionCache):
+
+    resolved_object_cache: ResolvedObjectCache
+
     def __init__(
         self,
         resolved_object_cache: ResolvedObjectCache,

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -123,19 +123,27 @@ class Catalog(STACObject):
             catalog's self link's HREF.
         catalog_type : Optional catalog type for this catalog. Must
             be one of the values in :class`~pystac.CatalogType`.
-
-    Attributes:
-        id : Identifier for the catalog.
-        description : Detailed multi-line description to fully explain the catalog.
-        title : Optional short descriptive one-line title for the catalog.
-        stac_extensions : Optional list of extensions the Catalog
-            implements.
-        extra_fields : Extra fields that are part of the top-level JSON
-            properties of the Catalog.
-        links : A list of :class:`~pystac.Link` objects representing
-            all links associated with this Catalog.
-        catalog_type : The catalog type. Defaults to ABSOLUTE_PUBLISHED
     """
+
+    catalog_type: CatalogType
+    """The catalog type. Defaults to :attr:`CatalogType.ABSOLUTE_PUBLISHED`."""
+
+    description: str
+    """Detailed multi-line description to fully explain the catalog."""
+
+    extra_fields: Dict[str, Any]
+    """Extra fields that are part of the top-level JSON properties of the Catalog."""
+
+    id: str
+    """Identifier for the catalog."""
+
+    title: Optional[str]
+    """Optional short descriptive one-line title for the catalog."""
+
+    stac_extensions: List[str]
+    """List of extensions the Catalog implements."""
+
+    _resolved_objects: ResolvedObjectCache
 
     STAC_OBJECT_TYPE = pystac.STACObjectType.CATALOG
 

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -23,6 +23,7 @@ from pystac.asset import Asset
 from pystac.catalog import Catalog
 from pystac.layout import HrefLayoutStrategy
 from pystac.link import Link
+from pystac.provider import Provider
 from pystac.utils import datetime_to_str
 from pystac.serialization import (
     identify_stac_object_type,
@@ -439,29 +440,43 @@ class Collection(Catalog):
             either a set of values or statistics such as a range.
         extra_fields : Extra fields that are part of the top-level
             JSON properties of the Collection.
-
-    Attributes:
-        id : Identifier for the collection.
-        description : Detailed multi-line description to fully explain the
-            collection.
-        extent : Spatial and temporal extents that describe the bounds of
-            all items contained within this Collection.
-        title : Optional short descriptive one-line title for the
-            collection.
-        stac_extensions : Optional list of extensions the Collection
-            implements.
-        keywords : Optional list of keywords describing the
-            collection.
-        providers : Optional list of providers of this
-            Collection.
-        assets : Optional map of Assets
-        summaries : An optional map of property summaries,
-            either a set of values or statistics such as a range.
-        links : A list of :class:`~pystac.Link` objects representing
-            all links associated with this Collection.
-        extra_fields : Extra fields that are part of the top-level
-            JSON properties of the Catalog.
     """
+
+    assets: Dict[str, Asset]
+    """Optional map of Assets"""
+
+    description: str
+    """Detailed multi-line description to fully explain the collection."""
+
+    extent: Extent
+    """Spatial and temporal extents that describe the bounds of all items contained within
+    this Collection."""
+
+    id: str
+    """Identifier for the collection."""
+
+    keywords: Optional[List[str]]
+    """Optional list of keywords describing the collection."""
+
+    providers: Optional[List[Provider]]
+    """Optional list of providers of this Collection."""
+
+    stac_extensions: List[str]
+    """List of extensions the Collection implements."""
+
+    title: Optional[str]
+    """Optional short descriptive one-line title for the collection."""
+
+    summaries: Summaries
+    """Optional map of property summaries, either a set of values or statistics such as
+    a range."""
+
+    links: List[Link]
+    """A list of :class:`~pystac.Link` objects representing all links associated with
+    this Collection."""
+
+    extra_fields: Dict[str, Any]
+    """Extra fields that are part of the top-level JSON properties of the Collection."""
 
     STAC_OBJECT_TYPE = STACObjectType.COLLECTION
 
@@ -501,7 +516,7 @@ class Collection(Catalog):
         self.providers = providers
         self.summaries = summaries or Summaries.empty()
 
-        self.assets: Dict[str, Asset] = {}
+        self.assets = {}
 
     def __repr__(self) -> str:
         return "<Collection id={}>".format(self.id)

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -44,6 +44,8 @@ class Band:
     Use :meth:`Band.create` to create a new Band.
     """
 
+    properties: Dict[str, Any]
+
     def __init__(self, properties: Dict[str, Any]) -> None:
         self.properties = properties
 

--- a/pystac/extensions/file.py
+++ b/pystac/extensions/file.py
@@ -3,7 +3,7 @@
 https://github.com/stac-extensions/file
 """
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, Iterable, List, Optional, Union
 
 import pystac
 from pystac.extensions.base import ExtensionManagementMixin, PropertiesExtension
@@ -98,6 +98,16 @@ class FileExtension(
        >>> asset: pystac.Asset = ...
        >>> file_ext = FileExtension.ext(asset)
     """
+
+    asset_href: str
+    """The ``href`` value of the :class:`~pystac.Asset` being extended."""
+
+    properties: Dict[str, Any]
+    """The :class:`~pystac.Asset` fields, including extension properties."""
+
+    additional_read_properties: Optional[Iterable[Dict[str, Any]]] = None
+    """If present, this will be a list containing 1 dictionary representing the
+    properties of the owning :class:`~pystac.Item`."""
 
     def __init__(self, asset: pystac.Asset):
         self.asset_href = asset.href

--- a/pystac/extensions/hooks.py
+++ b/pystac/extensions/hooks.py
@@ -64,6 +64,8 @@ class ExtensionHooks(ABC):
 
 
 class RegisteredExtensionHooks:
+    hooks: Dict[str, ExtensionHooks]
+
     def __init__(self, hooks: Iterable[ExtensionHooks]):
         self.hooks = dict([(e.schema_uri, e) for e in hooks])
 

--- a/pystac/extensions/item_assets.py
+++ b/pystac/extensions/item_assets.py
@@ -29,6 +29,8 @@ class AssetDefinition:
     See the :stac-ext:`Asset Object <item-assets#asset-object>` for details.
     """
 
+    properties: Dict[str, Any]
+
     def __init__(self, properties: Dict[str, Any]) -> None:
         self.properties = properties
 
@@ -119,6 +121,8 @@ class AssetDefinition:
 
 
 class ItemAssetsExtension(ExtensionManagementMixin[pystac.Collection]):
+    collection: pystac.Collection
+
     def __init__(self, collection: pystac.Collection) -> None:
         self.collection = collection
 

--- a/pystac/extensions/label.py
+++ b/pystac/extensions/label.py
@@ -67,6 +67,8 @@ class LabelClasses:
     Use :meth:`LabelClasses.create` to create a new instance from property values.
     """
 
+    properties: Dict[str, Any]
+
     def __init__(self, properties: Dict[str, Any]):
         self.properties = properties
 
@@ -150,6 +152,8 @@ class LabelCount:
     Use :meth:`LabelCount.create` to create a new instance.
     """
 
+    properties: Dict[str, Any]
+
     def __init__(self, properties: Dict[str, Any]):
         self.properties = properties
 
@@ -214,6 +218,8 @@ class LabelStatistics:
     Use :meth:`LabelStatistics.create` to create a new instance.
     """
 
+    properties: Dict[str, Any]
+
     def __init__(self, properties: Dict[str, Any]) -> None:
         self.properties = properties
 
@@ -277,6 +283,8 @@ class LabelOverview:
 
     Use :meth:`LabelOverview.create` to create a new instance.
     """
+
+    properties: Dict[str, Any]
 
     def __init__(self, properties: Dict[str, Any]):
         self.properties = properties
@@ -436,6 +444,9 @@ class LabelExtension(ExtensionManagementMixin[Union[pystac.Item, pystac.Collecti
        >>> item: pystac.Item = ...
        >>> label_ext = LabelExtension.ext(item)
     """
+
+    obj: pystac.Item
+    schema_uri: str
 
     def __init__(self, item: pystac.Item) -> None:
         self.obj = item

--- a/pystac/extensions/pointcloud.py
+++ b/pystac/extensions/pointcloud.py
@@ -2,7 +2,7 @@
 
 https://github.com/stac-extensions/pointcloud
 """
-from typing import Any, Dict, Generic, List, Optional, TypeVar, cast, Union
+from typing import Any, Dict, Iterable, Generic, List, Optional, TypeVar, cast, Union
 
 import pystac
 from pystac.extensions.base import (
@@ -53,6 +53,8 @@ class Schema:
     Use :meth:`Schema.create` to create a new instance of ``Schema`` from
     properties.
     """
+
+    properties: Dict[str, Any]
 
     def __init__(self, properties: Dict[str, Any]) -> None:
         self.properties = properties
@@ -132,6 +134,8 @@ class Statistic:
 
     Use :meth:`Statistic.create` to create a new instance of
     ``Statistic`` from property values."""
+
+    properties: Dict[str, Any]
 
     def __init__(self, properties: Dict[str, Any]) -> None:
         self.properties = properties
@@ -475,6 +479,9 @@ class ItemPointcloudExtension(PointcloudExtension[pystac.Item]):
     :meth:`PointcloudExtension.ext` on an :class:`~pystac.Item` to extend it.
     """
 
+    item: pystac.Item
+    properties: Dict[str, Any]
+
     def __init__(self, item: pystac.Item):
         self.item = item
         self.properties = item.properties
@@ -491,6 +498,16 @@ class AssetPointcloudExtension(PointcloudExtension[pystac.Asset]):
     This class should generally not be instantiated directly. Instead, call
     :meth:`PointcloudExtension.ext` on an :class:`~pystac.Asset` to extend it.
     """
+
+    asset_href: str
+    """The ``href`` value of the :class:`~pystac.Asset` being extended."""
+
+    properties: Dict[str, Any]
+    """The :class:`~pystac.Asset` fields, including extension properties."""
+
+    additional_read_properties: Optional[Iterable[Dict[str, Any]]] = None
+    """If present, this will be a list containing 1 dictionary representing the
+    properties of the owning :class:`~pystac.Item`."""
 
     def __init__(self, asset: pystac.Asset):
         self.asset_href = asset.href

--- a/pystac/extensions/raster.py
+++ b/pystac/extensions/raster.py
@@ -48,6 +48,8 @@ class Statistics:
     Use Statistics.create to create a new Statistics instance.
     """
 
+    properties: Dict[str, Any]
+
     def __init__(self, properties: Dict[str, Optional[float]]) -> None:
         self.properties = properties
 
@@ -208,6 +210,8 @@ class Histogram:
     Use Band.create to create a new Band.
     """
 
+    properties: Dict[str, Any]
+
     def __init__(self, properties: Dict[str, Any]) -> None:
         self.properties = properties
 
@@ -341,6 +345,8 @@ class RasterBand:
 
     Use Band.create to create a new Band.
     """
+
+    properties: Dict[str, Any]
 
     def __init__(self, properties: Dict[str, Any]) -> None:
         self.properties = properties

--- a/pystac/extensions/scientific.py
+++ b/pystac/extensions/scientific.py
@@ -54,6 +54,9 @@ def doi_to_url(doi: str) -> str:
 class Publication:
     """Helper for Publication entries."""
 
+    citation: Optional[str]
+    doi: Optional[str]
+
     def __init__(self, doi: Optional[str], citation: Optional[str]) -> None:
         self.doi = doi
         self.citation = citation
@@ -113,6 +116,8 @@ class ScientificExtension(
        >>> item: pystac.Item = ...
        >>> sci_ext = ScientificExtension.ext(item)
     """
+
+    obj: pystac.STACObject
 
     def __init__(self, obj: pystac.STACObject) -> None:
         self.obj = obj

--- a/pystac/extensions/version.py
+++ b/pystac/extensions/version.py
@@ -3,7 +3,7 @@
 https://github.com/stac-extensions/version
 """
 from pystac.utils import get_required, map_opt
-from typing import Generic, List, Optional, TypeVar, Union, cast
+from typing import Any, Dict, Generic, List, Optional, TypeVar, Union, cast
 
 import pystac
 from pystac.utils import StringEnum
@@ -226,6 +226,10 @@ class CollectionVersionExtension(VersionExtension[pystac.Collection]):
     :meth:`VersionExtension.ext` on an :class:`~pystac.Collection` to extend it.
     """
 
+    collection: pystac.Collection
+    links: List[pystac.Link]
+    properties: Dict[str, Any]
+
     def __init__(self, collection: pystac.Collection):
         self.collection = collection
         self.properties = collection.extra_fields
@@ -244,6 +248,10 @@ class ItemVersionExtension(VersionExtension[pystac.Item]):
     This class should generally not be instantiated directly. Instead, call
     :meth:`VersionExtension.ext` on an :class:`~pystac.Item` to extend it.
     """
+
+    item: pystac.Item
+    links: List[pystac.Link]
+    properties: Dict[str, Any]
 
     def __init__(self, item: pystac.Item):
         self.item = item

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -49,32 +49,48 @@ class Item(STACObject):
             belongs to.
         extra_fields : Extra fields that are part of the top-level JSON
             properties of the Item.
-
-    Attributes:
-        id : Provider identifier. Unique within the STAC.
-        geometry : Defines the full footprint of the asset represented by this
-            item, formatted according to
-            `RFC 7946, section 3.1 (GeoJSON) <https://tools.ietf.org/html/rfc7946>`_.
-        bbox :  Bounding Box of the asset represented by this item
-            using either 2D or 3D geometries. The length of the array is 2*n where n
-            is the number of dimensions. Could also be None in the case of a null
-            geometry.
-        datetime : Datetime associated with this item. If None,
-            the start_datetime and end_datetime in the common_metadata
-            will supply the datetime range of the Item.
-        properties : A dictionary of additional metadata for the item.
-        stac_extensions : Optional list of extensions the Item
-            implements.
-        collection : Collection that this item is a part of.
-        links : A list of :class:`~pystac.Link` objects representing
-            all links associated with this STACObject.
-        assets : Dictionary of asset objects that can be downloaded,
-            each with a unique key.
-        collection_id : The Collection ID that this item belongs to, if
-            any.
-        extra_fields : Extra fields that are part of the top-level JSON
-            properties of the Item.
     """
+
+    assets: Dict[str, Asset]
+    """Dictionary of :class:`~pystac.Asset` objects, each with a unique key."""
+
+    bbox: Optional[List[float]]
+    """Bounding Box of the asset represented by this item using either 2D or 3D
+    geometries. The length of the array is 2*n where n is the number of dimensions.
+    Could also be None in the case of a null geometry."""
+
+    collection: Optional[Collection]
+    """Collection that this item is a part of, if any."""
+
+    collection_id: Optional[str]
+    """The Collection ID that this item belongs to, if any."""
+
+    datetime: Optional[Datetime]
+    """Datetime associated with this item. If ``None``, then
+    :attr:`~pystac.CommonMetadata.start_datetime` and
+    :attr:`~pystac.CommonMetadata.end_datetime` in :attr:`~pystac.Item.common_metadata`
+    will supply the datetime range of the Item."""
+
+    extra_fields: Dict[str, Any]
+    """Extra fields that are part of the top-level JSON fields the Item."""
+
+    geometry: Optional[Dict[str, Any]]
+    """Defines the full footprint of the asset represented by this item, formatted
+    according to `RFC 7946, section 3.1 (GeoJSON)
+    <https://tools.ietf.org/html/rfc7946>`_."""
+
+    id: str
+    """Provider identifier. Unique within the STAC."""
+
+    links: List[Link]
+    """A list of :class:`~pystac.Link` objects representing all links associated with
+    this Item."""
+
+    properties: Dict[str, Any]
+    """A dictionary of additional metadata for the Item."""
+
+    stac_extensions: List[str]
+    """List of extensions the Item implements."""
 
     STAC_OBJECT_TYPE = STACObjectType.ITEM
 

--- a/pystac/layout.py
+++ b/pystac/layout.py
@@ -75,6 +75,16 @@ class LayoutTemplate:
             will be used in case a value cannot be derived from a stac object.
     """
 
+    template: str
+    """The template string to use."""
+
+    defaults: Dict[str, str]
+    """A dictionary of template vars to values. These values will be used in case a
+    value cannot be derived from a stac object."""
+
+    template_vars: List[str]
+    """List of template vars to use when templating."""
+
     # Special template vars specific to Items
     ITEM_TEMPLATE_VARS = ["date", "year", "month", "day", "collection"]
 
@@ -85,7 +95,7 @@ class LayoutTemplate:
         self.defaults = defaults or {}
 
         # Generate list of template vars
-        template_vars: List[str] = []
+        template_vars = []
         for formatter_parse_result in Formatter().parse(template):
             v = formatter_parse_result[1]
             if v is not None:
@@ -287,6 +297,24 @@ class CustomLayoutStrategy(HrefLayoutStrategy):
             :class:`~pystac.layout.BestPracticesLayoutStrategy`
     """
 
+    catalog_func: Optional[Callable[["Catalog_Type", str, bool], str]]
+    """A function that takes a :class:`~pystac.Catalog`, a parent directory, and a
+    boolean specifying whether or not this Catalog is the root. If it is the root, it
+    is usually best to not create a subdirectory and put the Catalog file directly
+    in the parent directory. Must return the string path."""
+
+    collection_func: Optional[Callable[["Collection_Type", str, bool], str]]
+    """A function that is used for collections in the same manner as
+    :attr:`~catalog_func`. This takes the same parameters."""
+
+    fallback_strategy: HrefLayoutStrategy
+    """The fallback strategy to use if a function is not provided for a stac object
+    type. Defaults to :class:`~pystac.layout.BestPracticesLayoutStrategy`."""
+
+    item_func: Optional[Callable[["Item_Type", str], str]]
+    """An optional function that takes an :class:`~pystac.Item` and a parent directory
+    and returns the path to be used for the Item."""
+
     def __init__(
         self,
         catalog_func: Optional[Callable[["Catalog_Type", str, bool], str]] = None,
@@ -299,7 +327,7 @@ class CustomLayoutStrategy(HrefLayoutStrategy):
         self.catalog_func = catalog_func
         if fallback_strategy is None:
             fallback_strategy = BestPracticesLayoutStrategy()
-        self.fallback_strategy: HrefLayoutStrategy = fallback_strategy
+        self.fallback_strategy = fallback_strategy
 
     def get_catalog_href(
         self, cat: "Catalog_Type", parent_dir: str, is_root: bool
@@ -352,6 +380,22 @@ class TemplateLayoutStrategy(HrefLayoutStrategy):
             :class:`~pystac.layout.BestPracticesLayoutStrategy`
     """
 
+    catalog_template: Optional[LayoutTemplate]
+    """The template string to use for catalog paths. Must be a valid template string
+    that can be used by :class:`~pystac.layout.LayoutTemplate`."""
+
+    collection_template: Optional[LayoutTemplate]
+    """The template string to use for collection paths. Must be a valid template string
+    that can be used by :class:`~pystac.layout.LayoutTemplate`."""
+
+    fallback_strategy: HrefLayoutStrategy
+    """The fallback strategy to use if a template is not provided. Defaults to
+    :class:`~pystac.layout.BestPracticesLayoutStrategy`."""
+
+    item_template: Optional[LayoutTemplate]
+    """The template string to use for item paths. Must be a valid template string that
+    can be used by :class:`~pystac.layout.LayoutTemplate`."""
+
     def __init__(
         self,
         catalog_template: Optional[str] = None,
@@ -373,7 +417,7 @@ class TemplateLayoutStrategy(HrefLayoutStrategy):
 
         if fallback_strategy is None:
             fallback_strategy = BestPracticesLayoutStrategy()
-        self.fallback_strategy: HrefLayoutStrategy = fallback_strategy
+        self.fallback_strategy = fallback_strategy
 
     def get_catalog_href(
         self, cat: "Catalog_Type", parent_dir: str, is_root: bool

--- a/pystac/serialization/identify.py
+++ b/pystac/serialization/identify.py
@@ -37,6 +37,10 @@ class STACVersionID:
     For instance, ``1.0.0-beta.2 < 1.0.0``
     """
 
+    version_string: str
+    version_core: str
+    version_prerelease: Optional[str]
+
     def __init__(self, version_string: str) -> None:
         self.version_string = version_string
 
@@ -75,6 +79,9 @@ class STACVersionID:
 
 class STACVersionRange:
     """Defines a range of STAC versions."""
+
+    min_version: STACVersionID
+    max_version: STACVersionID
 
     def __init__(
         self,
@@ -148,6 +155,10 @@ class STACJSONDescription:
         extensions : List of extension schema URIs for extensions this
             object implements
     """
+
+    object_type: "STACObjectType_Type"
+    version_range: STACVersionRange
+    extensions: Set[str]
 
     def __init__(
         self,

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -36,7 +36,7 @@ class STACObject(ABC):
     STAC_OBJECT_TYPE: STACObjectType
 
     def __init__(self, stac_extensions: List[str]) -> None:
-        self.links: List[Link] = []
+        self.links = []
         self.stac_extensions = stac_extensions
 
     def validate(self) -> List[Any]:

--- a/pystac/summaries.py
+++ b/pystac/summaries.py
@@ -58,6 +58,12 @@ T = TypeVar("T", bound=Union[_Comparable_x, _Comparable_other])
 
 
 class RangeSummary(Generic[T]):
+    minimum: T
+    """The minimum range value."""
+
+    maximum: T
+    """The maximum range value."""
+
     def __init__(self, minimum: T, maximum: T):
         self.minimum = minimum
         self.maximum = maximum
@@ -116,6 +122,8 @@ class Summarizer:
         If no file is passed, a default one will be used.
     """
 
+    summaryfields: Dict[str, SummaryStrategy]
+
     def __init__(self, fields: Optional[str] = None):
         fieldspath = fields or FIELDS_JSON_URL
         try:
@@ -132,7 +140,7 @@ class Summarizer:
         self._set_field_definitions(jsonfields)
 
     def _set_field_definitions(self, fields: Dict[str, Any]) -> None:
-        self.summaryfields: Dict[str, SummaryStrategy] = {}
+        self.summaryfields = {}
         for name, desc in fields["metadata"].items():
             if isinstance(desc, dict):
                 strategy_value = desc.get("summary", True)
@@ -194,16 +202,21 @@ DEFAULT_MAXCOUNT = 25
 
 
 class Summaries:
+    lists: Dict[str, List[Any]]
+    other: Dict[str, Any]
+    ranges: Dict[str, RangeSummary[Any]]
+    schemas: Dict[str, Dict[str, Any]]
+
     def __init__(
         self, summaries: Dict[str, Any], maxcount: int = DEFAULT_MAXCOUNT
     ) -> None:
         self._summaries = summaries
         self.maxcount = maxcount
 
-        self.lists: Dict[str, List[Any]] = {}
-        self.ranges: Dict[str, RangeSummary[Any]] = {}
-        self.schemas: Dict[str, Dict[str, Any]] = {}
-        self.other: Dict[str, Any] = {}
+        self.lists = {}
+        self.ranges = {}
+        self.schemas = {}
+        self.other = {}
 
         for prop_key, summary in summaries.items():
             self.add(prop_key, summary)

--- a/pystac/summaries.py
+++ b/pystac/summaries.py
@@ -59,10 +59,7 @@ T = TypeVar("T", bound=Union[_Comparable_x, _Comparable_other])
 
 class RangeSummary(Generic[T]):
     minimum: T
-    """The minimum range value."""
-
     maximum: T
-    """The maximum range value."""
 
     def __init__(self, minimum: T, maximum: T):
         self.minimum = minimum
@@ -202,10 +199,13 @@ DEFAULT_MAXCOUNT = 25
 
 
 class Summaries:
+    _summaries: Dict[str, Any]
+
     lists: Dict[str, List[Any]]
     other: Dict[str, Any]
     ranges: Dict[str, RangeSummary[Any]]
     schemas: Dict[str, Dict[str, Any]]
+    maxcount: int
 
     def __init__(
         self, summaries: Dict[str, Any], maxcount: int = DEFAULT_MAXCOUNT

--- a/pystac/validation/stac_validator.py
+++ b/pystac/validation/stac_validator.py
@@ -131,6 +131,9 @@ class JsonSchemaSTACValidator(STACValidator):
     This class requires the ``jsonschema`` library to be installed.
     """
 
+    schema_uri_map: SchemaUriMap
+    schema_cache: Dict[str, Dict[str, Any]]
+
     def __init__(self, schema_uri_map: Optional[SchemaUriMap] = None) -> None:
         if jsonschema is None:
             raise Exception("Cannot instantiate, requires jsonschema package")
@@ -140,7 +143,7 @@ class JsonSchemaSTACValidator(STACValidator):
         else:
             self.schema_uri_map = DefaultSchemaUriMap()
 
-        self.schema_cache: Dict[str, Dict[str, Any]] = {}
+        self.schema_cache = {}
 
     def get_schema_from_uri(self, schema_uri: str) -> Tuple[Dict[str, Any], Any]:
         if schema_uri not in self.schema_cache:


### PR DESCRIPTION
**Related Issue(s):**

- Closes #321 


**Description:**

Adds type annotations for instance attributes for all classes. Where the class docstring had an `Attributes` section, I removed those and added a docstring on each type annotation.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
