### PR TITLE
Use PropertiesExtension._get_property in table extension

### DIFF
--- a/pystac/extensions/table.py
+++ b/pystac/extensions/table.py
@@ -183,7 +183,7 @@ class TableExtension(
     @property
     def primary_geometry(self) -> Optional[str]:
         """The primary geometry column name"""
-        return self.properties.get(PRIMARY_GEOMETRY_PROP)
+        return self._get_property(PRIMARY_GEOMETRY_PROP, str)
 
     @primary_geometry.setter
     def primary_geometry(self, v: Optional[str]) -> None:
@@ -195,7 +195,7 @@ class TableExtension(
     @property
     def row_count(self) -> Optional[int]:
         """The number of rows in the dataset"""
-        return self.properties.get(ROW_COUNT_PROP)
+        return self._get_property(ROW_COUNT_PROP, int)
 
     @row_count.setter
     def row_count(self, v: Optional[int]) -> None:


### PR DESCRIPTION
**Related Issue(s):**

- Closes #677 

**Description:**

Uses `PropertiesExtension._get_property` in `TableExtension` to properly set return type.

There are no other extensions classes inheriting from `PropertiesExtension` that have a similar issue, but there are a number of similar `bad-return-type` errors from `pytype` resulting from vague typing in the `summaries` module and in some of the other dict-like classes in the extension modules. I will open a separate PR to address the typing issues in the `summaries` module, and I think the typing issues with the other dict-like classes would be best addressed in a PR that implements some of the JSON serde logic suggested in [#700 (comment)](https://github.com/stac-utils/pystac/pull/700#pullrequestreview-850861003) and begun in #617.



**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [ ] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
