### PR TITLE
Fix paths to saved sub-catalogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Use `PropertiesExtension._get_property` to properly set return type in `TableExtension` ([#712](https://github.com/stac-utils/pystac/pull/712))
 - `DatacubeExtension.variables` now has a setter ([#699](https://github.com/stac-utils/pystac/pull/699)])
 - Landsat STAC tutorial is now up-to-date with all package changes ([#692](https://github.com/stac-utils/pystac/pull/674))
+- Paths to sub-catalog files when using `Catalog.save` ([#714](https://github.com/stac-utils/pystac/pull/714))
 
 ### Deprecated
 

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -766,7 +766,7 @@ class Catalog(STACObject):
                     child_dest_href = make_absolute_href(
                         rel_href, dest_href, start_is_dir=True
                     )
-                    child.save(dest_href=child_dest_href)
+                    child.save(dest_href=os.path.dirname(child_dest_href))
                 else:
                     child.save()
 


### PR DESCRIPTION
**Related Issue(s):**

- Closes #713


**Description:**

Fixes the paths to which sub-catalogs are saved by ensuring that the `dest_href` argument to `Catalog.save` is a directory when called on child catalogs.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
