### PR TITLE
Build zipped HTML instead of PDF

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 formats:
   # Temporarily disabling PDF downloads due to problem with nbsphinx in LateX builds
   # - pdf
-  - epub
+  - htmlzip
 
 python:
   version: "3.8"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@
 - Type annotations for instance attributes on all classes ([#705](https://github.com/stac-utils/pystac/pull/705))
 - `extensions.datacube.Variable.to_dict` method ([#699](https://github.com/stac-utils/pystac/pull/699)])
 - Clarification of possible errors when using `.ext` to extend an object ([#701](https://github.com/stac-utils/pystac/pull/701))
+- Downloadable documentation as zipped HTML ([#715](https://github.com/stac-utils/pystac/pull/715))
 
 ### Removed
+
+- Downloadable documentation in ePub format ([#715](https://github.com/stac-utils/pystac/pull/715))
 
 ### Changed
 


### PR DESCRIPTION
**Related Issue(s):**

N/A

**Description:**

Uses zipped HTML instead of PDF as our downloadable documentation format since PyData theme does not support LateX builds (we had already disabled PDF builds due to another issue with packaging the notebooks). This will provide a downloadable version of the docs that mimics our online docs as closely as possible.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
