### PR TITLE
Fix PySTAC Introduction tutorial link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - `DatacubeExtension.variables` now has a setter ([#699](https://github.com/stac-utils/pystac/pull/699)])
 - Landsat STAC tutorial is now up-to-date with all package changes ([#692](https://github.com/stac-utils/pystac/pull/674))
 - Paths to sub-catalog files when using `Catalog.save` ([#714](https://github.com/stac-utils/pystac/pull/714))
+- Link to PySTAC Introduction tutorial in tutorials index page ([#719](https://github.com/stac-utils/pystac/pull/719))
 
 ### Deprecated
 

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -7,7 +7,7 @@ PySTAC Introduction
 -------------------
 
 - :tutorial:`GitHub version <pystac-introduction.ipynb>`
-- :ref:`Docs version </tutorials/pystac-spacenet-tutorial.ipynb>`
+- :ref:`Docs version </tutorials/pystac-introduction.ipynb>`
 
 This tutorial gives an introduction to PySTAC concepts through code examples.
 


### PR DESCRIPTION
**Related Issue(s):**
- #711


**Description:**

Fixes link to PySTAC Introduction tutorial in tutorials index page.

cc: @KennSmithDS

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
