### PR TITLE
No self links in relative published items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Self links no longer included in Items for "relative published" catalogs ([#725](https://github.com/stac-utils/pystac/pull/725))
+
 ### Deprecated
 
 ## [v1.3.0]

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -782,7 +782,10 @@ class Catalog(STACObject):
                     item_dest_href = make_absolute_href(
                         rel_href, dest_href, start_is_dir=True
                     )
-                    item.save_object(include_self_link=True, dest_href=item_dest_href)
+                    item.save_object(
+                        include_self_link=items_include_self_link,
+                        dest_href=item_dest_href,
+                    )
                 else:
                     item.save_object(include_self_link=items_include_self_link)
 


### PR DESCRIPTION
**Related Issue(s):**

- Closes #597 


**Description:**

Fixes issue where self links were included in Items for "relative published" catalogs.


**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
