### PR TITLE
Update to Label Extension v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 
 ### Changed
 
+- Label Extension version updated to `v1.0.1` ([#726](https://github.com/stac-utils/pystac/pull/726))
+
 ### Fixed
 
 - Self links no longer included in Items for "relative published" catalogs ([#725](https://github.com/stac-utils/pystac/pull/725))

--- a/pystac/extensions/label.py
+++ b/pystac/extensions/label.py
@@ -11,7 +11,7 @@ from pystac.serialization.identify import STACJSONDescription, STACVersionID
 from pystac.extensions.hooks import ExtensionHooks
 from pystac.utils import StringEnum, get_required, map_opt
 
-SCHEMA_URI = "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+SCHEMA_URI = "https://stac-extensions.github.io/label/v1.0.1/schema.json"
 
 PREFIX = "label:"
 
@@ -791,7 +791,10 @@ class SummariesLabelExtension(SummariesExtension):
 
 class LabelExtensionHooks(ExtensionHooks):
     schema_uri: str = SCHEMA_URI
-    prev_extension_ids = {"label"}
+    prev_extension_ids = {
+        "label",
+        "https://stac-extensions.github.io/label/v1.0.0/schema.json",
+    }
     stac_object_types = {pystac.STACObjectType.ITEM}
 
     def get_object_links(

--- a/tests/data-files/catalogs/label_catalog-v0.8.1/acc/665946-labels/665946-labels.json
+++ b/tests/data-files/catalogs/label_catalog-v0.8.1/acc/665946-labels/665946-labels.json
@@ -288,7 +288,7 @@
         5.647261088925513
     ],
     "stac_extensions": [
-        "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+        "https://stac-extensions.github.io/label/v1.0.1/schema.json"
     ],
     "collection": "acc"
 }

--- a/tests/data-files/catalogs/label_catalog-v0.8.1/acc/a42435-labels/a42435-labels.json
+++ b/tests/data-files/catalogs/label_catalog-v0.8.1/acc/a42435-labels/a42435-labels.json
@@ -204,7 +204,7 @@
         5.619166711344742
     ],
     "stac_extensions": [
-        "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+        "https://stac-extensions.github.io/label/v1.0.1/schema.json"
     ],
     "collection": "acc"
 }

--- a/tests/data-files/catalogs/label_catalog-v0.8.1/acc/ca041a-labels/ca041a-labels.json
+++ b/tests/data-files/catalogs/label_catalog-v0.8.1/acc/ca041a-labels/ca041a-labels.json
@@ -200,7 +200,7 @@
         5.610742610987594
     ],
     "stac_extensions": [
-        "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+        "https://stac-extensions.github.io/label/v1.0.1/schema.json"
     ],
     "collection": "acc"
 }

--- a/tests/data-files/catalogs/label_catalog-v0.8.1/acc/d41d81-labels/d41d81-labels.json
+++ b/tests/data-files/catalogs/label_catalog-v0.8.1/acc/d41d81-labels/d41d81-labels.json
@@ -232,7 +232,7 @@
         5.593203677296213
     ],
     "stac_extensions": [
-        "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+        "https://stac-extensions.github.io/label/v1.0.1/schema.json"
     ],
     "collection": "acc"
 }

--- a/tests/data-files/catalogs/label_catalog-v0.8.1/dar/0a4c40-labels/0a4c40-labels.json
+++ b/tests/data-files/catalogs/label_catalog-v0.8.1/dar/0a4c40-labels/0a4c40-labels.json
@@ -608,7 +608,7 @@
         -6.801144663537702
     ],
     "stac_extensions": [
-        "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+        "https://stac-extensions.github.io/label/v1.0.1/schema.json"
     ],
     "collection": "dar"
 }

--- a/tests/data-files/catalogs/label_catalog-v0.8.1/dar/353093-labels/353093-labels.json
+++ b/tests/data-files/catalogs/label_catalog-v0.8.1/dar/353093-labels/353093-labels.json
@@ -224,7 +224,7 @@
         -6.783684392169557
     ],
     "stac_extensions": [
-        "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+        "https://stac-extensions.github.io/label/v1.0.1/schema.json"
     ],
     "collection": "dar"
 }

--- a/tests/data-files/catalogs/label_catalog-v0.8.1/dar/42f235-labels/42f235-labels.json
+++ b/tests/data-files/catalogs/label_catalog-v0.8.1/dar/42f235-labels/42f235-labels.json
@@ -850,7 +850,7 @@
         -6.800774407651622
     ],
     "stac_extensions": [
-        "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+        "https://stac-extensions.github.io/label/v1.0.1/schema.json"
     ],
     "collection": "dar"
 }

--- a/tests/data-files/catalogs/label_catalog-v0.8.1/dar/a017f9-labels/a017f9-labels.json
+++ b/tests/data-files/catalogs/label_catalog-v0.8.1/dar/a017f9-labels/a017f9-labels.json
@@ -820,7 +820,7 @@
         -6.759102343973786
     ],
     "stac_extensions": [
-        "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+        "https://stac-extensions.github.io/label/v1.0.1/schema.json"
     ],
     "collection": "dar"
 }

--- a/tests/data-files/catalogs/label_catalog-v0.8.1/dar/b15fce-labels/b15fce-labels.json
+++ b/tests/data-files/catalogs/label_catalog-v0.8.1/dar/b15fce-labels/b15fce-labels.json
@@ -176,7 +176,7 @@
         -6.786630132161881
     ],
     "stac_extensions": [
-        "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+        "https://stac-extensions.github.io/label/v1.0.1/schema.json"
     ],
     "collection": "dar"
 }

--- a/tests/data-files/catalogs/label_catalog-v0.8.1/dar/f883a0-labels/f883a0-labels.json
+++ b/tests/data-files/catalogs/label_catalog-v0.8.1/dar/f883a0-labels/f883a0-labels.json
@@ -1286,7 +1286,7 @@
         -6.773980646345491
     ],
     "stac_extensions": [
-        "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+        "https://stac-extensions.github.io/label/v1.0.1/schema.json"
     ],
     "collection": "dar"
 }

--- a/tests/data-files/catalogs/label_catalog-v0.8.1/kam/4e7c7f-labels/4e7c7f-labels.json
+++ b/tests/data-files/catalogs/label_catalog-v0.8.1/kam/4e7c7f-labels/4e7c7f-labels.json
@@ -420,7 +420,7 @@
         0.26207074609958386
     ],
     "stac_extensions": [
-        "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+        "https://stac-extensions.github.io/label/v1.0.1/schema.json"
     ],
     "collection": "kam"
 }

--- a/tests/data-files/catalogs/label_catalog-v0.8.1/mon/207cc7-labels/207cc7-labels.json
+++ b/tests/data-files/catalogs/label_catalog-v0.8.1/mon/207cc7-labels/207cc7-labels.json
@@ -236,7 +236,7 @@
         6.333146686841442
     ],
     "stac_extensions": [
-        "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+        "https://stac-extensions.github.io/label/v1.0.1/schema.json"
     ],
     "collection": "mon"
 }

--- a/tests/data-files/catalogs/label_catalog-v0.8.1/mon/401175-labels/401175-labels.json
+++ b/tests/data-files/catalogs/label_catalog-v0.8.1/mon/401175-labels/401175-labels.json
@@ -228,7 +228,7 @@
         6.339080445680323
     ],
     "stac_extensions": [
-        "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+        "https://stac-extensions.github.io/label/v1.0.1/schema.json"
     ],
     "collection": "mon"
 }

--- a/tests/data-files/catalogs/label_catalog-v0.8.1/mon/493701-labels/493701-labels.json
+++ b/tests/data-files/catalogs/label_catalog-v0.8.1/mon/493701-labels/493701-labels.json
@@ -196,7 +196,7 @@
         6.334626743333399
     ],
     "stac_extensions": [
-        "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+        "https://stac-extensions.github.io/label/v1.0.1/schema.json"
     ],
     "collection": "mon"
 }

--- a/tests/data-files/catalogs/label_catalog-v0.8.1/mon/f15272-labels/f15272-labels.json
+++ b/tests/data-files/catalogs/label_catalog-v0.8.1/mon/f15272-labels/f15272-labels.json
@@ -184,7 +184,7 @@
         6.331302091125989
     ],
     "stac_extensions": [
-        "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+        "https://stac-extensions.github.io/label/v1.0.1/schema.json"
     ],
     "collection": "mon"
 }

--- a/tests/data-files/catalogs/label_catalog-v0.8.1/nia/825a50-labels/825a50-labels.json
+++ b/tests/data-files/catalogs/label_catalog-v0.8.1/nia/825a50-labels/825a50-labels.json
@@ -124,7 +124,7 @@
         13.583969811536608
     ],
     "stac_extensions": [
-        "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+        "https://stac-extensions.github.io/label/v1.0.1/schema.json"
     ],
     "collection": "nia"
 }

--- a/tests/data-files/catalogs/label_catalog-v0.8.1/ptn/abe1a3-labels/abe1a3-labels.json
+++ b/tests/data-files/catalogs/label_catalog-v0.8.1/ptn/abe1a3-labels/abe1a3-labels.json
@@ -160,7 +160,7 @@
         -4.7665107950056145
     ],
     "stac_extensions": [
-        "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+        "https://stac-extensions.github.io/label/v1.0.1/schema.json"
     ],
     "collection": "ptn"
 }

--- a/tests/data-files/catalogs/label_catalog-v0.8.1/ptn/f49f31-labels/f49f31-labels.json
+++ b/tests/data-files/catalogs/label_catalog-v0.8.1/ptn/f49f31-labels/f49f31-labels.json
@@ -116,7 +116,7 @@
         -4.797722543259397
     ],
     "stac_extensions": [
-        "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+        "https://stac-extensions.github.io/label/v1.0.1/schema.json"
     ],
     "collection": "ptn"
 }

--- a/tests/data-files/catalogs/label_catalog-v0.8.1/znz/06f252-labels/06f252-labels.json
+++ b/tests/data-files/catalogs/label_catalog-v0.8.1/znz/06f252-labels/06f252-labels.json
@@ -91,7 +91,7 @@
         -5.878724233277496
     ],
     "stac_extensions": [
-        "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+        "https://stac-extensions.github.io/label/v1.0.1/schema.json"
     ],
     "collection": "znz"
 }

--- a/tests/data-files/catalogs/label_catalog-v0.8.1/znz/076995-labels/076995-labels.json
+++ b/tests/data-files/catalogs/label_catalog-v0.8.1/znz/076995-labels/076995-labels.json
@@ -103,7 +103,7 @@
         -5.824424385662977
     ],
     "stac_extensions": [
-        "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+        "https://stac-extensions.github.io/label/v1.0.1/schema.json"
     ],
     "collection": "znz"
 }

--- a/tests/data-files/catalogs/label_catalog-v0.8.1/znz/33cae6-labels/33cae6-labels.json
+++ b/tests/data-files/catalogs/label_catalog-v0.8.1/znz/33cae6-labels/33cae6-labels.json
@@ -1159,7 +1159,7 @@
         -5.719012276837555
     ],
     "stac_extensions": [
-        "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+        "https://stac-extensions.github.io/label/v1.0.1/schema.json"
     ],
     "collection": "znz"
 }

--- a/tests/data-files/catalogs/label_catalog-v0.8.1/znz/3b20d4-labels/3b20d4-labels.json
+++ b/tests/data-files/catalogs/label_catalog-v0.8.1/znz/3b20d4-labels/3b20d4-labels.json
@@ -87,7 +87,7 @@
         -5.824334109106769
     ],
     "stac_extensions": [
-        "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+        "https://stac-extensions.github.io/label/v1.0.1/schema.json"
     ],
     "collection": "znz"
 }

--- a/tests/data-files/catalogs/label_catalog-v0.8.1/znz/3f8360-labels/3f8360-labels.json
+++ b/tests/data-files/catalogs/label_catalog-v0.8.1/znz/3f8360-labels/3f8360-labels.json
@@ -91,7 +91,7 @@
         -5.905820682536527
     ],
     "stac_extensions": [
-        "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+        "https://stac-extensions.github.io/label/v1.0.1/schema.json"
     ],
     "collection": "znz"
 }

--- a/tests/data-files/catalogs/label_catalog-v0.8.1/znz/425403-labels/425403-labels.json
+++ b/tests/data-files/catalogs/label_catalog-v0.8.1/znz/425403-labels/425403-labels.json
@@ -87,7 +87,7 @@
         -5.933001378219889
     ],
     "stac_extensions": [
-        "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+        "https://stac-extensions.github.io/label/v1.0.1/schema.json"
     ],
     "collection": "znz"
 }

--- a/tests/data-files/catalogs/label_catalog-v0.8.1/znz/75cdfa-labels/75cdfa-labels.json
+++ b/tests/data-files/catalogs/label_catalog-v0.8.1/znz/75cdfa-labels/75cdfa-labels.json
@@ -91,7 +91,7 @@
         -5.851567529006198
     ],
     "stac_extensions": [
-        "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+        "https://stac-extensions.github.io/label/v1.0.1/schema.json"
     ],
     "collection": "znz"
 }

--- a/tests/data-files/catalogs/label_catalog-v0.8.1/znz/9b8638-labels/9b8638-labels.json
+++ b/tests/data-files/catalogs/label_catalog-v0.8.1/znz/9b8638-labels/9b8638-labels.json
@@ -143,7 +143,7 @@
         -5.8515539621204695
     ],
     "stac_extensions": [
-        "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+        "https://stac-extensions.github.io/label/v1.0.1/schema.json"
     ],
     "collection": "znz"
 }

--- a/tests/data-files/catalogs/label_catalog-v0.8.1/znz/aee7fd-labels/aee7fd-labels.json
+++ b/tests/data-files/catalogs/label_catalog-v0.8.1/znz/aee7fd-labels/aee7fd-labels.json
@@ -91,7 +91,7 @@
         -5.905835679883141
     ],
     "stac_extensions": [
-        "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+        "https://stac-extensions.github.io/label/v1.0.1/schema.json"
     ],
     "collection": "znz"
 }

--- a/tests/data-files/catalogs/label_catalog-v0.8.1/znz/bc32f1-labels/bc32f1-labels.json
+++ b/tests/data-files/catalogs/label_catalog-v0.8.1/znz/bc32f1-labels/bc32f1-labels.json
@@ -91,7 +91,7 @@
         -5.960140574104503
     ],
     "stac_extensions": [
-        "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+        "https://stac-extensions.github.io/label/v1.0.1/schema.json"
     ],
     "collection": "znz"
 }

--- a/tests/data-files/catalogs/label_catalog-v0.8.1/znz/bd5c14-labels/bd5c14-labels.json
+++ b/tests/data-files/catalogs/label_catalog-v0.8.1/znz/bd5c14-labels/bd5c14-labels.json
@@ -91,7 +91,7 @@
         -5.932984029391401
     ],
     "stac_extensions": [
-        "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+        "https://stac-extensions.github.io/label/v1.0.1/schema.json"
     ],
     "collection": "znz"
 }

--- a/tests/data-files/catalogs/label_catalog-v0.8.1/znz/c7415c-labels/c7415c-labels.json
+++ b/tests/data-files/catalogs/label_catalog-v0.8.1/znz/c7415c-labels/c7415c-labels.json
@@ -91,7 +91,7 @@
         -5.878712001912929
     ],
     "stac_extensions": [
-        "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+        "https://stac-extensions.github.io/label/v1.0.1/schema.json"
     ],
     "collection": "znz"
 }

--- a/tests/data-files/catalogs/label_catalog-v0.8.1/znz/e52478-labels/e52478-labels.json
+++ b/tests/data-files/catalogs/label_catalog-v0.8.1/znz/e52478-labels/e52478-labels.json
@@ -91,7 +91,7 @@
         -5.9329766232129995
     ],
     "stac_extensions": [
-        "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+        "https://stac-extensions.github.io/label/v1.0.1/schema.json"
     ],
     "collection": "znz"
 }

--- a/tests/data-files/catalogs/test-case-1/country-1/area-1-1/area-1-1-labels/area-1-1-labels.json
+++ b/tests/data-files/catalogs/test-case-1/country-1/area-1-1/area-1-1-labels/area-1-1-labels.json
@@ -87,7 +87,7 @@
     3.8916575492899987
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ],
   "collection": "area-1-1"
 }

--- a/tests/data-files/catalogs/test-case-1/country-1/area-1-2/area-1-2-labels/area-1-2-labels.json
+++ b/tests/data-files/catalogs/test-case-1/country-1/area-1-2/area-1-2-labels/area-1-2-labels.json
@@ -87,7 +87,7 @@
     3.8916575492899987
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ],
   "collection": "area-1-2"
 }

--- a/tests/data-files/catalogs/test-case-1/country-2/area-2-1/area-2-1-labels/area-2-1-labels.json
+++ b/tests/data-files/catalogs/test-case-1/country-2/area-2-1/area-2-1-labels/area-2-1-labels.json
@@ -87,7 +87,7 @@
     3.8916575492899987
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ],
   "collection": "area-2-1"
 }

--- a/tests/data-files/catalogs/test-case-1/country-2/area-2-2/area-2-2-labels/area-2-2-labels.json
+++ b/tests/data-files/catalogs/test-case-1/country-2/area-2-2/area-2-2-labels/area-2-2-labels.json
@@ -87,7 +87,7 @@
     3.8916575492899987
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ],
   "collection": "area-2-2"
 }

--- a/tests/data-files/catalogs/test-case-2/1a8c1632-fa91-4a62-b33e-3a87c2ebdf16/5b922d42-9a77-4f79-a672-86096f7f849e/cf73ec1a-d790-4b59-b077-e101738571ed/cf73ec1a-d790-4b59-b077-e101738571ed.json
+++ b/tests/data-files/catalogs/test-case-2/1a8c1632-fa91-4a62-b33e-3a87c2ebdf16/5b922d42-9a77-4f79-a672-86096f7f849e/cf73ec1a-d790-4b59-b077-e101738571ed/cf73ec1a-d790-4b59-b077-e101738571ed.json
@@ -909,6 +909,6 @@
     35.90922697349481
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ]
 }

--- a/tests/data-files/catalogs/test-case-4/acc/665946-labels/665946-labels.json
+++ b/tests/data-files/catalogs/test-case-4/acc/665946-labels/665946-labels.json
@@ -288,7 +288,7 @@
     5.647261088925513
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ],
   "collection": "acc"
 }

--- a/tests/data-files/catalogs/test-case-4/acc/a42435-labels/a42435-labels.json
+++ b/tests/data-files/catalogs/test-case-4/acc/a42435-labels/a42435-labels.json
@@ -204,7 +204,7 @@
     5.619166711344742
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ],
   "collection": "acc"
 }

--- a/tests/data-files/catalogs/test-case-4/acc/ca041a-labels/ca041a-labels.json
+++ b/tests/data-files/catalogs/test-case-4/acc/ca041a-labels/ca041a-labels.json
@@ -200,7 +200,7 @@
     5.610742610987594
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ],
   "collection": "acc"
 }

--- a/tests/data-files/catalogs/test-case-4/acc/d41d81-labels/d41d81-labels.json
+++ b/tests/data-files/catalogs/test-case-4/acc/d41d81-labels/d41d81-labels.json
@@ -232,7 +232,7 @@
     5.593203677296213
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ],
   "collection": "acc"
 }

--- a/tests/data-files/catalogs/test-case-4/dar/0a4c40-labels/0a4c40-labels.json
+++ b/tests/data-files/catalogs/test-case-4/dar/0a4c40-labels/0a4c40-labels.json
@@ -608,7 +608,7 @@
     -6.801144663537702
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ],
   "collection": "dar"
 }

--- a/tests/data-files/catalogs/test-case-4/dar/353093-labels/353093-labels.json
+++ b/tests/data-files/catalogs/test-case-4/dar/353093-labels/353093-labels.json
@@ -224,7 +224,7 @@
     -6.783684392169557
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ],
   "collection": "dar"
 }

--- a/tests/data-files/catalogs/test-case-4/dar/42f235-labels/42f235-labels.json
+++ b/tests/data-files/catalogs/test-case-4/dar/42f235-labels/42f235-labels.json
@@ -850,7 +850,7 @@
     -6.800774407651622
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ],
   "collection": "dar"
 }

--- a/tests/data-files/catalogs/test-case-4/dar/a017f9-labels/a017f9-labels.json
+++ b/tests/data-files/catalogs/test-case-4/dar/a017f9-labels/a017f9-labels.json
@@ -820,7 +820,7 @@
     -6.759102343973786
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ],
   "collection": "dar"
 }

--- a/tests/data-files/catalogs/test-case-4/dar/b15fce-labels/b15fce-labels.json
+++ b/tests/data-files/catalogs/test-case-4/dar/b15fce-labels/b15fce-labels.json
@@ -176,7 +176,7 @@
     -6.786630132161881
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ],
   "collection": "dar"
 }

--- a/tests/data-files/catalogs/test-case-4/dar/f883a0-labels/f883a0-labels.json
+++ b/tests/data-files/catalogs/test-case-4/dar/f883a0-labels/f883a0-labels.json
@@ -1286,7 +1286,7 @@
     -6.773980646345491
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ],
   "collection": "dar"
 }

--- a/tests/data-files/catalogs/test-case-4/kam/4e7c7f-labels/4e7c7f-labels.json
+++ b/tests/data-files/catalogs/test-case-4/kam/4e7c7f-labels/4e7c7f-labels.json
@@ -420,7 +420,7 @@
     0.26207074609958386
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ],
   "collection": "kam"
 }

--- a/tests/data-files/catalogs/test-case-4/mon/207cc7-labels/207cc7-labels.json
+++ b/tests/data-files/catalogs/test-case-4/mon/207cc7-labels/207cc7-labels.json
@@ -236,7 +236,7 @@
     6.333146686841442
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ],
   "collection": "mon"
 }

--- a/tests/data-files/catalogs/test-case-4/mon/401175-labels/401175-labels.json
+++ b/tests/data-files/catalogs/test-case-4/mon/401175-labels/401175-labels.json
@@ -228,7 +228,7 @@
     6.339080445680323
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ],
   "collection": "mon"
 }

--- a/tests/data-files/catalogs/test-case-4/mon/493701-labels/493701-labels.json
+++ b/tests/data-files/catalogs/test-case-4/mon/493701-labels/493701-labels.json
@@ -196,7 +196,7 @@
     6.334626743333399
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ],
   "collection": "mon"
 }

--- a/tests/data-files/catalogs/test-case-4/mon/f15272-labels/f15272-labels.json
+++ b/tests/data-files/catalogs/test-case-4/mon/f15272-labels/f15272-labels.json
@@ -184,7 +184,7 @@
     6.331302091125989
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ],
   "collection": "mon"
 }

--- a/tests/data-files/catalogs/test-case-4/nia/825a50-labels/825a50-labels.json
+++ b/tests/data-files/catalogs/test-case-4/nia/825a50-labels/825a50-labels.json
@@ -124,7 +124,7 @@
     13.583969811536608
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ],
   "collection": "nia"
 }

--- a/tests/data-files/catalogs/test-case-4/ptn/abe1a3-labels/abe1a3-labels.json
+++ b/tests/data-files/catalogs/test-case-4/ptn/abe1a3-labels/abe1a3-labels.json
@@ -160,7 +160,7 @@
     -4.7665107950056145
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ],
   "collection": "ptn"
 }

--- a/tests/data-files/catalogs/test-case-4/ptn/f49f31-labels/f49f31-labels.json
+++ b/tests/data-files/catalogs/test-case-4/ptn/f49f31-labels/f49f31-labels.json
@@ -116,7 +116,7 @@
     -4.797722543259397
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ],
   "collection": "ptn"
 }

--- a/tests/data-files/catalogs/test-case-4/znz/06f252-labels/06f252-labels.json
+++ b/tests/data-files/catalogs/test-case-4/znz/06f252-labels/06f252-labels.json
@@ -91,7 +91,7 @@
     -5.878724233277496
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ],
   "collection": "znz"
 }

--- a/tests/data-files/catalogs/test-case-4/znz/076995-labels/076995-labels.json
+++ b/tests/data-files/catalogs/test-case-4/znz/076995-labels/076995-labels.json
@@ -103,7 +103,7 @@
     -5.824424385662977
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ],
   "collection": "znz"
 }

--- a/tests/data-files/catalogs/test-case-4/znz/33cae6-labels/33cae6-labels.json
+++ b/tests/data-files/catalogs/test-case-4/znz/33cae6-labels/33cae6-labels.json
@@ -1159,7 +1159,7 @@
     -5.719012276837555
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ],
   "collection": "znz"
 }

--- a/tests/data-files/catalogs/test-case-4/znz/3b20d4-labels/3b20d4-labels.json
+++ b/tests/data-files/catalogs/test-case-4/znz/3b20d4-labels/3b20d4-labels.json
@@ -87,7 +87,7 @@
     -5.824334109106769
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ],
   "collection": "znz"
 }

--- a/tests/data-files/catalogs/test-case-4/znz/3f8360-labels/3f8360-labels.json
+++ b/tests/data-files/catalogs/test-case-4/znz/3f8360-labels/3f8360-labels.json
@@ -91,7 +91,7 @@
     -5.905820682536527
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ],
   "collection": "znz"
 }

--- a/tests/data-files/catalogs/test-case-4/znz/425403-labels/425403-labels.json
+++ b/tests/data-files/catalogs/test-case-4/znz/425403-labels/425403-labels.json
@@ -87,7 +87,7 @@
     -5.933001378219889
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ],
   "collection": "znz"
 }

--- a/tests/data-files/catalogs/test-case-4/znz/75cdfa-labels/75cdfa-labels.json
+++ b/tests/data-files/catalogs/test-case-4/znz/75cdfa-labels/75cdfa-labels.json
@@ -91,7 +91,7 @@
     -5.851567529006198
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ],
   "collection": "znz"
 }

--- a/tests/data-files/catalogs/test-case-4/znz/9b8638-labels/9b8638-labels.json
+++ b/tests/data-files/catalogs/test-case-4/znz/9b8638-labels/9b8638-labels.json
@@ -143,7 +143,7 @@
     -5.8515539621204695
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ],
   "collection": "znz"
 }

--- a/tests/data-files/catalogs/test-case-4/znz/aee7fd-labels/aee7fd-labels.json
+++ b/tests/data-files/catalogs/test-case-4/znz/aee7fd-labels/aee7fd-labels.json
@@ -91,7 +91,7 @@
     -5.905835679883141
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ],
   "collection": "znz"
 }

--- a/tests/data-files/catalogs/test-case-4/znz/bc32f1-labels/bc32f1-labels.json
+++ b/tests/data-files/catalogs/test-case-4/znz/bc32f1-labels/bc32f1-labels.json
@@ -91,7 +91,7 @@
     -5.960140574104503
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ],
   "collection": "znz"
 }

--- a/tests/data-files/catalogs/test-case-4/znz/bd5c14-labels/bd5c14-labels.json
+++ b/tests/data-files/catalogs/test-case-4/znz/bd5c14-labels/bd5c14-labels.json
@@ -91,7 +91,7 @@
     -5.932984029391401
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ],
   "collection": "znz"
 }

--- a/tests/data-files/catalogs/test-case-4/znz/c7415c-labels/c7415c-labels.json
+++ b/tests/data-files/catalogs/test-case-4/znz/c7415c-labels/c7415c-labels.json
@@ -91,7 +91,7 @@
     -5.878712001912929
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ],
   "collection": "znz"
 }

--- a/tests/data-files/catalogs/test-case-4/znz/e52478-labels/e52478-labels.json
+++ b/tests/data-files/catalogs/test-case-4/znz/e52478-labels/e52478-labels.json
@@ -91,7 +91,7 @@
     -5.9329766232129995
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ],
   "collection": "znz"
 }

--- a/tests/data-files/catalogs/test-case-6/12cb17a8-ae08-469c-a2be-4d0619240014/400c22e3-5b54-438b-b600-5e9bd6d0a498/3c67b59c-2e6f-47fb-ba3c-0dd106941096.json
+++ b/tests/data-files/catalogs/test-case-6/12cb17a8-ae08-469c-a2be-4d0619240014/400c22e3-5b54-438b-b600-5e9bd6d0a498/3c67b59c-2e6f-47fb-ba3c-0dd106941096.json
@@ -4160,7 +4160,7 @@
     -6.729678190172387
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ],
   "collection": "400c22e3-5b54-438b-b600-5e9bd6d0a498"
 }

--- a/tests/data-files/label/label-example-1.json
+++ b/tests/data-files/label/label-example-1.json
@@ -106,6 +106,6 @@
     3.8916575492899987
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ]
 }

--- a/tests/data-files/label/label-example-2.json
+++ b/tests/data-files/label/label-example-2.json
@@ -15,17 +15,10 @@
     ],
     "label:classes": [
       {
-        "name": "label",
+        "name": null,
         "classes": [
           "one",
           "two"
-        ]
-      },
-      {
-        "name": "label2",
-        "classes": [
-          "three",
-          "four"
         ]
       }
     ],
@@ -99,6 +92,6 @@
     3.8916575492899987
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/label/v1.0.1/schema.json"
   ]
 }

--- a/tests/extensions/test_label.py
+++ b/tests/extensions/test_label.py
@@ -196,6 +196,11 @@ class LabelTest(unittest.TestCase):
         # Set
         LabelExtension.ext(label_item).label_type = LabelType.RASTER
         self.assertEqual(LabelType.RASTER, label_item.properties["label:type"])
+        # name for each label:classes object must be null to pass validation
+        label_classes = LabelExtension.ext(label_item).label_classes
+        assert label_classes is not None
+        for classes_obj in label_classes:
+            classes_obj.name = None
         label_item.validate()
 
     def test_label_properties(self) -> None:


### PR DESCRIPTION
**Related Issue(s):**

- Closes #611 

**Description:**

Updates the Label Extension implementation to use v1.0.1.


**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
