### PR TITLE
Add experimental Python 3.11 support

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,6 +23,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11.0-alpha.4"
         os:
           - ubuntu-latest
           - windows-latest
@@ -37,9 +38,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - uses: actions-rs/toolchain@v1
-        # Wheels for orjson on Python 3.10 are still spotty on MacOS or Windows. This sets up the Rust
-        # toolchain so we can build the orjson wheel.
-        if: ${{ startsWith(matrix.python-version, '3.10')}}
+        # Wheels for orjson are not available for Python 3.11. This sets up the Rust
+        # toolchain so we can build orjson wheel from source.
+        if: ${{ startsWith(matrix.python-version, '3.11')}}
         with:
           toolchain: stable
           override: true
@@ -140,6 +141,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
+          - "3.11.0-alpha.4"
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Note that while we support Python 3.10.\*, wheels for the `orjson` library are n
 platforms. If you install PySTAC with the `orjson` extra, you may need to have the Rust toolchain installed (e.g. via [rustup](https://rustup.rs/)) in order to
 build the package from source.
 
+Support for Python 3.11 should be considered experimental until further notice.
+
 PySTAC has a single required dependency (`python-dateutil`).
 PySTAC can be installed from pip or the source repository.
 

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11"
     ],
     project_urls={
         "Tracker": "https://github.com/stac-utils/pystac/issues",


### PR DESCRIPTION
**Related Issue(s):**

None

**Description:**

Adds Python 3.11.0-alpha.4 to our CI test matrix and adds a note on experimental support to the README.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [ ] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
