### PR TITLE
Fix CI config

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -28,6 +28,8 @@ jobs:
           - ubuntu-latest
           - windows-latest
           - macos-latest
+        experimental:
+          - false
         include:
           - python-version: "3.11.0-alpha.3"
             os: ubuntu-latest


### PR DESCRIPTION
**Related Issue(s):**

None


**Description:**

#731 introduced a bug to the CI config by leaving out the `experimental` property in the test matrix. This was causing none of the test matrix jobs to run. This PR fixes that regression.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
