### PR TITLE
Use type alias for temporal intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Self links no longer included in Items for "relative published" catalogs ([#725](https://github.com/stac-utils/pystac/pull/725))
 - Adding New and Custom Extensions tutorial now up-to-date with new extensions API ([#724](https://github.com/stac-utils/pystac/pull/724))
+- Type errors when initializing `TemporalExtent` using a list of `datetime` objects ([#744](https://github.com/stac-utils/pystac/pull/744))
 
 ### Deprecated
 

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -38,7 +38,9 @@ if TYPE_CHECKING:
 
 T = TypeVar("T")
 TemporalIntervals = Union[List[List[datetime]], List[List[Optional[datetime]]]]
-TemporalIntervalsLike = Union[TemporalIntervals, List[datetime], List[List[datetime]]]
+TemporalIntervalsLike = Union[
+    TemporalIntervals, List[datetime], List[Optional[datetime]]
+]
 
 
 class SpatialExtent:

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -37,6 +37,8 @@ if TYPE_CHECKING:
     from pystac.provider import Provider as Provider_Type
 
 T = TypeVar("T")
+TemporalIntervals = Union[List[List[datetime]], List[List[Optional[datetime]]]]
+TemporalIntervalsLike = Union[TemporalIntervals, List[datetime], List[List[datetime]]]
 
 
 class SpatialExtent:
@@ -176,7 +178,7 @@ class TemporalExtent:
         Datetimes are required to be in UTC.
     """
 
-    intervals: List[List[Optional[datetime]]]
+    intervals: TemporalIntervals
     """A list of two datetimes wrapped in a list,
     representing the temporal extent of a Collection. Open date ranges are
     represented by either the start (the first element of the interval) or the
@@ -188,16 +190,16 @@ class TemporalExtent:
 
     def __init__(
         self,
-        intervals: Union[List[List[Optional[datetime]]], List[Optional[datetime]]],
+        intervals: TemporalIntervals,
         extra_fields: Optional[Dict[str, Any]] = None,
     ):
         # A common mistake is to pass in a single interval instead of a
         # list of intervals. Account for this by transforming the input
         # in that case.
         if isinstance(intervals, list) and isinstance(intervals[0], datetime):
-            self.intervals = [cast(List[Optional[datetime]], intervals)]
+            self.intervals = intervals
         else:
-            self.intervals = cast(List[List[Optional[datetime]]], intervals)
+            self.intervals = intervals
 
         self.extra_fields = extra_fields or {}
 

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -18,7 +18,7 @@ from pystac import (
     CatalogType,
     Provider,
 )
-from pystac.utils import datetime_to_str, get_required
+from pystac.utils import datetime_to_str, get_required, str_to_datetime
 from tests.utils import TestCases, ARBITRARY_GEOM, ARBITRARY_BBOX
 
 TEST_DATETIME = datetime(2020, 3, 14, 16, 32)
@@ -262,6 +262,14 @@ class CollectionTest(unittest.TestCase):
 class ExtentTest(unittest.TestCase):
     def setUp(self) -> None:
         self.maxDiff = None
+
+    def test_temporal_extent_init_typing(self) -> None:
+        # This test exists purely to test the typing of the intervals argument to
+        # TemporalExtent
+        start_datetime = str_to_datetime("2022-01-01T00:00:00Z")
+        end_datetime = str_to_datetime("2022-01-31T23:59:59Z")
+
+        _ = TemporalExtent([[start_datetime, end_datetime]])
 
     def test_spatial_allows_single_bbox(self) -> None:
         temporal_extent = TemporalExtent(intervals=[[TEST_DATETIME, None]])


### PR DESCRIPTION
**Related Issue(s):**

- Closes #586 

**Description:**

Adds 2 type variables that are used in the `TemporalExtent` class:

- `TemporalIntervals` - This is used for properly formatted [STAC temporal intervals](https://github.com/radiantearth/stac-spec/blob/master/collection-spec/collection-spec.md#temporal-extent-object) (i.e. a list of lists)
- `TemporalIntervalsLike` - This is used for the `intervals` argument to `TemporalExtent` where we allow either a list of lists or a list of optional datetimes and convert it into a list of lists.

I tried using a covariant `TypeVar` as I had initially suggested in [#586 (comment)](https://github.com/stac-utils/pystac/issues/586#issuecomment-889199716), but that did not fix the type errors. Using a `Union` type of all the possible combinations seemed to be the only way to make `mypy` happy.

Also note that this adds a test whose only purpose is type checking when we run `mypy`. If there are suggestions on a better place to put this kind of check I'm happy to change that.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
