### PR TITLE
Clarify error using add_if_missing on ownerless asset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 - Self links no longer included in Items for "relative published" catalogs ([#725](https://github.com/stac-utils/pystac/pull/725))
 - Adding New and Custom Extensions tutorial now up-to-date with new extensions API ([#724](https://github.com/stac-utils/pystac/pull/724))
+- Clarify error message when using `PropertyExtension.ext(..., add_if_missing=True)` on an `Asset`
+  with no owner([#746](https://github.com/stac-utils/pystac/pull/746))
 
 ### Deprecated
 

--- a/pystac/extensions/base.py
+++ b/pystac/extensions/base.py
@@ -151,7 +151,8 @@ class ExtensionManagementMixin(Generic[S], ABC):
         if asset.owner is None:
             if add_if_missing:
                 raise pystac.STACError(
-                    "Can only add schema URIs to Assets with an owner."
+                    "Attempted to use add_if_missing=True for an Asset with no owner. "
+                    "Use Asset.set_owner or set add_if_missing=False."
                 )
             else:
                 return


### PR DESCRIPTION
**Related Issue(s):**

- Closes #634 

**Description:**

Clarifies the error message when someone tries to use `add_if_missing=True` on an `Asset` with no owner.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
