### PR TITLE
`stac_io` as argument to `Catalog.save`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Experimental support for Python 3.11 ([#731](https://github.com/stac-utils/pystac/pull/731))
 - Accept PathLike objects in `StacIO` I/O methods, `pystac.read_file` and `pystac.write_file` ([#728](https://github.com/stac-utils/pystac/pull/728))
+- Optional `StacIO` instance as argument to `Catalog.save`/`Catalog.normalize_and_save` ([#751](https://github.com/stac-utils/pystac/pull/751))
 
 ### Removed
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -378,7 +378,7 @@ class CatalogTest(unittest.TestCase):
             catalog.save(
                 catalog_type=CatalogType.ABSOLUTE_PUBLISHED,
                 dest_href=tmp_dir,
-                stac_io=stac_io
+                stac_io=stac_io,
             )
 
         hrefs = []


### PR DESCRIPTION
**Related Issue(s):** 

Closes #666

**Description:**
Add the possibility of providing a `StacIO` instance to write out a catalog, as useful e.g. to read from and write to different file systems. 

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
