### PR TITLE
Adde enum MediaType for PDF files

### DIFF
--- a/pystac/media_type.py
+++ b/pystac/media_type.py
@@ -17,3 +17,4 @@ class MediaType(StringEnum):
     TEXT = "text/plain"
     TIFF = "image/tiff"
     XML = "application/xml"
+    PDF = "application/pdf"


### PR DESCRIPTION
**Related Issue(s):** #
N/A

**Description:**
Radiant MLHub team consistently uses PDF files as documentation reference to accompany published datasets. Instead of requiring us to serialize an Item to dictionary to add the custom MediaType and deserialize back to STAC Item Object, adding this Enum type simplifies a process we frequently execute. It's also a common media file type.

**PR Checklist:**

- [ x ] Code is formatted (run `pre-commit run --all-files`)
- [ x ] Tests pass (run `scripts/test`)
- [ N/A ] Documentation has been updated to reflect changes, if applicable
- [ x ] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
