### PR TITLE
Add helper methods for RFC 3339 datetime handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Additional util methods `now_in_utc` and `now_to_rfc3339_str` ([#760](https://github.com/stac-utils/pystac/pull/760))
 - Add `media_type` and `role` filtering to Item and Collection `get_assets()` method ([#936](https://github.com/stac-utils/pystac/pull/936))
 - `Asset.has_role` ([#936](https://github.com/stac-utils/pystac/pull/936))
 - Enum MediaType entry for flatgeobuf ([discussion](https://github.com/flatgeobuf/flatgeobuf/discussions/112#discussioncomment-4606721)) ([#938](https://github.com/stac-utils/pystac/pull/938))

--- a/pystac/utils.py
+++ b/pystac/utils.py
@@ -329,12 +329,26 @@ def datetime_to_str(dt: datetime, timespec: str = "auto") -> str:
 def str_to_datetime(s: str) -> datetime:
     """Converts a string timestamp to a :class:`datetime.datetime` instance using
     :meth:`dateutil.parser.parse` under the hood. The input string may be in any
-    format :std:doc:`supported by the parser <parser>`.
+    format :std:doc:`supported by the parser <parser>`. This includes many formats
+    including ISO 8601 and RFC 3339.
 
     Args:
         s (str) : The string to convert to :class:`datetime.datetime`.
+
+    Returns:
+        str: The :class:`datetime.datetime` represented the by the string.
     """
     return dateutil.parser.isoparse(s)
+
+
+def now_in_utc() -> datetime:
+    """Returns a datetime value of now with the UTC timezone applied"""
+    return datetime.now(timezone.utc)
+
+
+def now_to_rfc3339_str() -> str:
+    """Returns an RFC 3339 string representing now"""
+    return datetime_to_str(now_in_utc())
 
 
 def geometry_to_bbox(geometry: Dict[str, Any]) -> List[float]:


### PR DESCRIPTION
**Related Issue(s):** n/a


**Description:**

There are a number of places in the STAC ecosystem where datetimes are converted two and from RFC 3339 strings. Many of these places are doing this incorrectly. These changes aim to add a correct implementations to:

- rfc3339_str_to_datetime: parse ONLY a valid RFC 3339 string to a datetime
- str_to_interval: parse an interval string into a datetime tuple
- now_in_utc: create a datetime with UTC set as the datetime (since utcnow() inexplicably does not do this)
- now_to_rfc3339_str: create an RFC3339 string representing now

My primary motivation is to replace the numerous uses of the stac_pydantic constant `DATETIME_RFC339`(sic) with uses of these methods. Other libraries that depend on pystac will also use them, and there are likely several places even within pystac that these could be used instead of the current code.

One downside to this is that the tests need the pytest parameterized decorator to run, and this doesn't work in the class-based test modules that unittest requires. I ran the existing tests with pytest and it seems to run them all fine, so we could change to using pytest to run the test without needing to convert all the tests from unittest to pytest.

**PR Checklist:**

- [X] Code is formatted (run `pre-commit run --all-files`)
- [X] Tests pass (run `scripts/test`)
- [X] Documentation has been updated to reflect changes, if applicable
- [X] This PR maintains or improves overall codebase code coverage.
- [X] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
