### PR TITLE
update stac_io from owner root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Enum MediaType entry for PDF documents ([#758](https://github.com/stac-utils/pystac/pull/758)) 
+- Updated Link to obtain stac_io from owner root ([#762](https://github.com/stac-utils/pystac/pull/762))
 
 ### Removed
 

--- a/pystac/link.py
+++ b/pystac/link.py
@@ -298,7 +298,7 @@ class Link(PathLike):
                     if self.owner is not None:
                         if isinstance(self.owner, pystac.Catalog):
                             stac_io = self.owner._stac_io
-                        else:
+                        elif self.rel != pystac.RelType.ROOT:
                             owner_root = self.owner.get_root()
                             if owner_root is not None:
                                 stac_io = owner_root._stac_io

--- a/pystac/link.py
+++ b/pystac/link.py
@@ -298,6 +298,10 @@ class Link(PathLike):
                     if self.owner is not None:
                         if isinstance(self.owner, pystac.Catalog):
                             stac_io = self.owner._stac_io
+                        else:
+                            owner_root = self.owner.get_root()
+                            if owner_root is not None:
+                                stac_io = owner_root._stac_io
                     if stac_io is None:
                         stac_io = pystac.StacIO.default()
 


### PR DESCRIPTION
**Related Issue(s):** #742 


**Description:**

Updated edge case for when `stac_io is None`, `owner is not None` and instance is not `pystac.Catalog`. Desired behavior now fetches the root of the owner to update the `stac_io` of a `Link` object.

**PR Checklist:**

- [X] Code is formatted (run `pre-commit run --all-files`)
- [X] Tests pass (run `scripts/test`)
- [N/A] Documentation has been updated to reflect changes, if applicable
- [X] This PR maintains or improves overall codebase code coverage.
- [X] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
