### PR TITLE
Fix/576 AssetDefinition missing create, apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Enum MediaType entry for PDF documents ([#758](https://github.com/stac-utils/pystac/pull/758)) 
 - Updated Link to obtain stac_io from owner root ([#762](https://github.com/stac-utils/pystac/pull/762))
-- Updated AssetDefinition to have create, apply methods
+- Updated AssetDefinition to have create, apply methods ([#768](https://github.com/stac-utils/pystac/pull/768))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Enum MediaType entry for PDF documents ([#758](https://github.com/stac-utils/pystac/pull/758)) 
 - Updated Link to obtain stac_io from owner root ([#762](https://github.com/stac-utils/pystac/pull/762))
+- Updated AssetDefinition to have create, apply methods
 
 ### Removed
 

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -115,7 +115,7 @@ class Catalog(STACObject):
     Args:
         id : Identifier for the catalog. Must be unique within the STAC.
         description : Detailed multi-line description to fully explain the catalog.
-            `CommonMark 0.28 syntax <https://commonmark.org/>`_ MAY be used for rich
+            `CommonMark 0.29 syntax <https://commonmark.org/>`_ MAY be used for rich
             text representation.
         title : Optional short descriptive one-line title for the catalog.
         stac_extensions : Optional list of extensions the Catalog implements.

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -421,7 +421,7 @@ class Collection(Catalog):
     Args:
         id : Identifier for the collection. Must be unique within the STAC.
         description : Detailed multi-line description to fully explain the
-            collection. `CommonMark 0.28 syntax <https://commonmark.org/>`_ MAY
+            collection. `CommonMark 0.29 syntax <https://commonmark.org/>`_ MAY
             be used for rich text representation.
         extent : Spatial and temporal extents that describe the bounds of
             all items contained within this Collection.

--- a/pystac/extensions/item_assets.py
+++ b/pystac/extensions/item_assets.py
@@ -36,6 +36,64 @@ class AssetDefinition:
             return NotImplemented
         return self.to_dict() == o.to_dict()
 
+    @classmethod
+    def create(
+        cls,
+        title: Optional[str],
+        description: Optional[str],
+        media_type: Optional[str],
+        roles: Optional[List[str]],
+    ) -> "AssetDefinition":
+        """
+        Creates a new asset definition.
+
+        Args:
+            title : Displayed title for clients and users.
+            description : Description of the Asset providing additional details,
+                such as how it was processed or created.
+                `CommonMark 0.29 <http://commonmark.org/>`__ syntax MAY be used
+                for rich text representation.
+            media_type : `media type
+                <https://github.com/radiantearth/stac-spec/tree/v1.0.0/catalog-spec/catalog-spec.md#media-types>`__
+                 of the asset.
+            roles : `semantic roles
+                <https://github.com/radiantearth/stac-spec/tree/v1.0.0/item-spec/item-spec.md#asset-role-types>`__
+                of the asset, similar to the use of rel in links.
+        """
+        asset_defn = cls({})
+        asset_defn.apply(
+            title=title, description=description, media_type=media_type, roles=roles
+        )
+        return asset_defn
+
+    def apply(
+        self,
+        title: Optional[str],
+        description: Optional[str],
+        media_type: Optional[str],
+        roles: Optional[List[str]],
+    ) -> None:
+        """
+        Sets the properties for this asset definition.
+
+        Args:
+            title : Displayed title for clients and users.
+            description : Description of the Asset providing additional details,
+                such as how it was processed or created.
+                `CommonMark 0.29 <http://commonmark.org/>`__ syntax MAY be used
+                for rich text representation.
+            media_type : `media type
+                <https://github.com/radiantearth/stac-spec/tree/v1.0.0/catalog-spec/catalog-spec.md#media-types>`__
+                 of the asset.
+            roles : `semantic roles
+                <https://github.com/radiantearth/stac-spec/tree/v1.0.0/item-spec/item-spec.md#asset-role-types>`__
+                of the asset, similar to the use of rel in links.
+        """
+        self.title = title
+        self.description = description
+        self.media_type = media_type
+        self.roles = roles
+
     @property
     def title(self) -> Optional[str]:
         """Gets or sets the displayed title for clients and users."""
@@ -65,7 +123,7 @@ class AssetDefinition:
     @property
     def media_type(self) -> Optional[str]:
         """Gets or sets the `media type
-        <https://github.com/radiantearth/stac-spec/tree/v1.0.0-rc.1/catalog-spec/catalog-spec.md#media-types>`__
+        <https://github.com/radiantearth/stac-spec/tree/v1.0.0/catalog-spec/catalog-spec.md#media-types>`__
         of the asset."""
         return self.properties.get(ASSET_TYPE_PROP)
 
@@ -79,7 +137,7 @@ class AssetDefinition:
     @property
     def roles(self) -> Optional[List[str]]:
         """Gets or sets the `semantic roles
-        <https://github.com/radiantearth/stac-spec/tree/v1.0.0-rc.1/item-spec/item-spec.md#asset-role-types>`__
+        <https://github.com/radiantearth/stac-spec/tree/v1.0.0/item-spec/item-spec.md#asset-role-types>`__
         of the asset, similar to the use of rel in links."""
         return self.properties.get(ASSET_ROLES_PROP)
 

--- a/tests/extensions/test_eo.py
+++ b/tests/extensions/test_eo.py
@@ -21,6 +21,7 @@ class BandsTest(unittest.TestCase):
             description=Band.band_description("red"),
             center_wavelength=0.65,
             full_width_half_max=0.1,
+            solar_illumination=42.0,
         )
 
         self.assertEqual(band.name, "B01")
@@ -28,7 +29,7 @@ class BandsTest(unittest.TestCase):
         self.assertEqual(band.description, "Common name: red, Range: 0.6 to 0.7")
         self.assertEqual(band.center_wavelength, 0.65)
         self.assertEqual(band.full_width_half_max, 0.1)
-
+        self.assertEqual(band.solar_illumination, 42.0)
         self.assertEqual(band.__repr__(), "<Band name=B01>")
 
     def test_band_description_unknown_band(self) -> None:

--- a/tests/extensions/test_item_assets.py
+++ b/tests/extensions/test_item_assets.py
@@ -46,6 +46,19 @@ class TestAssetDefinition(unittest.TestCase):
             TestCases.get_path("data-files/item-assets/example-landsat8.json")
         )
 
+    def test_create(self) -> None:
+        title = "Coastal Band (B1)"
+        description = "Coastal Band Top Of the Atmosphere"
+        media_type = "image/tiff; application=geotiff"
+        roles = ["data"]
+        asset_defn = AssetDefinition.create(
+            title=title, description=description, media_type=media_type, roles=roles
+        )
+        self.assertEqual(asset_defn.title, title)
+        self.assertEqual(asset_defn.description, description)
+        self.assertEqual(asset_defn.media_type, media_type)
+        self.assertEqual(asset_defn.roles, roles)
+
     def test_title(self) -> None:
         asset_defn = AssetDefinition({})
         title = "Very Important Asset"


### PR DESCRIPTION
**Related Issue(s):** #

Fixes https://github.com/stac-utils/pystac/issues/576

**Description:**

* Adds missing create and apply to Asset Definition
* Enhances an unrelated unit test, which I noticed while comparing other code (test_eo.py)
* Fixes old commonmark version in some docstrings.
* Fixes docstrings referencing RC of stac spec.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [X] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
