### PR TITLE
Replace test.com with special-use domain name.

### DIFF
--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -327,7 +327,7 @@ class CatalogTest(unittest.TestCase):
     def test_save_to_provided_href(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             catalog = TestCases.test_case_1()
-            href = "http://test.com"
+            href = "https://stac.test"
             folder = os.path.join(tmp_dir, "cat")
             catalog.normalize_hrefs(href)
             catalog.save(catalog_type=CatalogType.ABSOLUTE_PUBLISHED, dest_href=folder)
@@ -341,7 +341,7 @@ class CatalogTest(unittest.TestCase):
     def test_save_relative_published_no_self_links(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             catalog = TestCases.test_case_1()
-            href = "http://test.com"
+            href = "https://stac.test"
             folder = os.path.join(tmp_dir, "cat")
             catalog.normalize_hrefs(href)
             catalog.save(catalog_type=CatalogType.RELATIVE_PUBLISHED, dest_href=folder)
@@ -394,7 +394,7 @@ class CatalogTest(unittest.TestCase):
     def test_subcatalogs_saved_to_correct_path(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             catalog = TestCases.test_case_1()
-            href = "http://test.com"
+            href = "https://stac.test"
 
             catalog.normalize_hrefs(href)
             catalog.save(catalog_type=CatalogType.ABSOLUTE_PUBLISHED, dest_href=tmp_dir)


### PR DESCRIPTION
**Related Issue(s):** #

Fixes https://github.com/stac-utils/pystac/issues/732

**Description:**

Use stac.test instead of test.com, following https://www.rfc-editor.org/rfc/rfc6761.html

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
