### PR TITLE
Update Python 3.11 alpha-release in CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -32,13 +32,13 @@ jobs:
         experimental:
           - false
         include:
-          - python-version: "3.11.0-alpha.3"
+          - python-version: "3.11.0-alpha.6"
             os: ubuntu-latest
             experimental: true
-          - python-version: "3.11.0-alpha.3"
+          - python-version: "3.11.0-alpha.6"
             os: windows-latest
             experimental: true
-          - python-version: "3.11.0-alpha.3"
+          - python-version: "3.11.0-alpha.6"
             os: macos-latest
             experimental: true
 
@@ -127,7 +127,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11.0-alpha.3"
+          - "3.11.0-alpha.6"
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
**Related Issue(s):**

None

**Description:**

Updates the Python 3.11 alpha release version in the CI to the latest available in GitHub Actions (3.11.0-alpha.6).

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
