### PR TITLE
Add variables argument to the DatacubeExtension `apply` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixed
 
 - "How to create STAC catalogs" tutorial ([#775](https://github.com/stac-utils/pystac/pull/775))
+- Add a `variables` argument, to accompany `dimensions`, for the `apply` method of stac objects extended with datacube ([#782](https://github.com/stac-utils/pystac/pull/782))
 
 ## [v1.4.0]
 

--- a/pystac/extensions/datacube.py
+++ b/pystac/extensions/datacube.py
@@ -411,6 +411,12 @@ class VariableType(StringEnum):
 
 
 class Variable:
+    """Object representing a variable in the datacube. The dimensions field lists
+    zero or more :stac-ext:`Datacube Dimension Object <datacube#dimension-object>`
+    instances. See the :stac-ext:`Datacube Variable Object
+    <datacube#variable-object>` docs for details.
+    """
+
     properties: Dict[str, Any]
 
     def __init__(self, properties: Dict[str, Any]) -> None:
@@ -522,15 +528,22 @@ class DatacubeExtension(
        >>> dc_ext = DatacubeExtension.ext(item)
     """
 
-    def apply(self, dimensions: Dict[str, Dimension]) -> None:
+    def apply(
+        self,
+        dimensions: Dict[str, Dimension],
+        variables: Optional[Dict[str, Variable]] = None,
+    ) -> None:
         """Applies label extension properties to the extended
         :class:`~pystac.Collection`, :class:`~pystac.Item` or :class:`~pystac.Asset`.
 
         Args:
             dimensions : Dictionary mapping dimension name to a :class:`Dimension`
                 object.
+            variables : Dictionary mapping variable name to a :class:`Variable`
+                object.
         """
         self.dimensions = dimensions
+        self.variables = variables
 
     @property
     def dimensions(self) -> Dict[str, Dimension]:

--- a/tests/extensions/test_datacube.py
+++ b/tests/extensions/test_datacube.py
@@ -91,8 +91,12 @@ class DatacubeTest(unittest.TestCase):
     def test_apply_variables(self) -> None:
         item = pystac.Item.from_file(self.example_uri)
         cube = DatacubeExtension.ext(item)
-        key, value = cube.variables.popitem()
+        variables = cube.variables
+        assert variables is not None
+        key, value = variables.popitem()
         target = value.to_dict()
         cube.variables = None
         cube.apply(dimensions={}, variables={key: value})
+        variables = cube.variables
+        assert variables is not None
         self.assertEqual(target, cube.variables[key].to_dict())

--- a/tests/extensions/test_datacube.py
+++ b/tests/extensions/test_datacube.py
@@ -87,3 +87,12 @@ class DatacubeTest(unittest.TestCase):
         self.assertEqual(
             item.properties["cube:variables"], {"temp": new_variable.to_dict()}
         )
+
+    def test_apply_variables(self) -> None:
+        item = pystac.Item.from_file(self.example_uri)
+        cube = DatacubeExtension.ext(item)
+        key, value = cube.variables.popitem()
+        target = value.to_dict()
+        cube.variables = None
+        cube.apply(dimensions={}, variables={key: value})
+        self.assertEqual(target, cube.variables[key].to_dict())


### PR DESCRIPTION
**Related Issue(s):**

- Fixes #781
- Helps with #324

**Description:**

An optional argument is added to the `DatacubeExtension.apply` method called `variables` and handed off to the variable setter. The argument is optional because Variable Objects are optional in the datacube extension spec.

A new `test_apply_variables` method for the `DatacubeTest` class does a round-trip check on a variable present in the example item using `apply`.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
