### PR TITLE
Deepcopy Collection properties on clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 - "How to create STAC catalogs" tutorial ([#775](https://github.com/stac-utils/pystac/pull/775))
 - Add a `variables` argument, to accompany `dimensions`, for the `apply` method of stac objects extended with datacube ([#782](https://github.com/stac-utils/pystac/pull/782))
-- Deepcopy collection properties on clone. Implement `clone` method for `Summaries`. ([#794](https://github.com/stac-utils/pystac/pull/794))
+- Deepcopy collection properties on clone. Implement `clone` method for `Summaries` ([#794](https://github.com/stac-utils/pystac/pull/794))
 
 ## [v1.4.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - "How to create STAC catalogs" tutorial ([#775](https://github.com/stac-utils/pystac/pull/775))
 - Add a `variables` argument, to accompany `dimensions`, for the `apply` method of stac objects extended with datacube ([#782](https://github.com/stac-utils/pystac/pull/782))
+- Deepcopy collection properties on clone. Implement `clone` method for `Summaries`. ([#794](https://github.com/stac-utils/pystac/pull/794))
 
 ## [v1.4.0]
 

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -517,7 +517,7 @@ class Catalog(STACObject):
             id=self.id,
             description=self.description,
             title=self.title,
-            stac_extensions=deepcopy(self.stac_extensions),
+            stac_extensions=self.stac_extensions.copy(),
             extra_fields=deepcopy(self.extra_fields),
             catalog_type=self.catalog_type,
         )

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -517,7 +517,7 @@ class Catalog(STACObject):
             id=self.id,
             description=self.description,
             title=self.title,
-            stac_extensions=self.stac_extensions,
+            stac_extensions=deepcopy(self.stac_extensions),
             extra_fields=deepcopy(self.extra_fields),
             catalog_type=self.catalog_type,
         )

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -562,11 +562,11 @@ class Collection(Catalog):
             description=self.description,
             extent=self.extent.clone(),
             title=self.title,
-            stac_extensions=deepcopy(self.stac_extensions),
+            stac_extensions=self.stac_extensions.copy(),
             extra_fields=deepcopy(self.extra_fields),
             catalog_type=self.catalog_type,
             license=self.license,
-            keywords=deepcopy(self.keywords),
+            keywords=self.keywords.copy() if self.keywords is not None else None,
             providers=deepcopy(self.providers),
             summaries=self.summaries.clone(),
         )

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -562,13 +562,13 @@ class Collection(Catalog):
             description=self.description,
             extent=self.extent.clone(),
             title=self.title,
-            stac_extensions=self.stac_extensions,
-            extra_fields=self.extra_fields,
+            stac_extensions=deepcopy(self.stac_extensions),
+            extra_fields=deepcopy(self.extra_fields),
             catalog_type=self.catalog_type,
             license=self.license,
-            keywords=self.keywords,
-            providers=self.providers,
-            summaries=self.summaries,
+            keywords=deepcopy(self.keywords),
+            providers=deepcopy(self.providers),
+            summaries=self.summaries.clone(),
         )
 
         clone._resolved_objects.cache(clone)

--- a/pystac/summaries.py
+++ b/pystac/summaries.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import sys
 import numbers
 from enum import Enum
@@ -286,6 +287,21 @@ class Summaries:
         return not (
             any(self.lists) or any(self.ranges) or any(self.schemas) or any(self.other)
         )
+
+    def clone(self) -> "Summaries":
+        """Clones this object.
+
+        Returns:
+            Summaries: The clone of this object
+        """
+        summaries = Summaries(
+            summaries=deepcopy(self._summaries), maxcount=self.maxcount
+        )
+        summaries.lists = deepcopy(self.lists)
+        summaries.other = deepcopy(self.other)
+        summaries.ranges = deepcopy(self.ranges)
+        summaries.schemas = deepcopy(self.schemas)
+        return summaries
 
     def to_dict(self) -> Dict[str, Any]:
         return {

--- a/tests/extensions/test_scientific.py
+++ b/tests/extensions/test_scientific.py
@@ -452,7 +452,7 @@ class SummariesScientificTest(unittest.TestCase):
         sci_summaries = ScientificExtension.summaries(collection)
 
         sci_summaries.doi = [PUB2_DOI]
-        new_dois = ScientificExtension.summaries(self.collection).doi
+        new_dois = ScientificExtension.summaries(collection).doi
 
         assert new_dois is not None
         self.assertListEqual([PUB2_DOI], new_dois)

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -80,6 +80,17 @@ class CollectionTest(unittest.TestCase):
         clone = catalog.clone()
         self.assertEqual(clone.catalog_type, CatalogType.SELF_CONTAINED)
 
+    def test_clone_cant_mutate_original(self) -> None:
+        collection = TestCases.test_case_8()
+        self.assertListEqual(collection.keywords, ["disaster", "open"])
+        clone = collection.clone()
+        clone.extra_fields["test"] = "extra"
+        self.assertNotIn("test", collection.extra_fields)
+        clone.keywords.append("clone")
+        self.assertListEqual(clone.keywords, ["disaster", "open", "clone"])
+        self.assertListEqual(collection.keywords, ["disaster", "open"])
+        self.assertNotEqual(id(collection.summaries), id(clone.summaries))
+
     def test_multiple_extents(self) -> None:
         cat1 = TestCases.test_case_1()
         country = cat1.get_child("country-1")

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -82,10 +82,12 @@ class CollectionTest(unittest.TestCase):
 
     def test_clone_cant_mutate_original(self) -> None:
         collection = TestCases.test_case_8()
+        assert collection.keywords is not None
         self.assertListEqual(collection.keywords, ["disaster", "open"])
         clone = collection.clone()
         clone.extra_fields["test"] = "extra"
         self.assertNotIn("test", collection.extra_fields)
+        assert clone.keywords is not None
         clone.keywords.append("clone")
         self.assertListEqual(clone.keywords, ["disaster", "open", "clone"])
         self.assertListEqual(collection.keywords, ["disaster", "open"])

--- a/tests/test_summaries.py
+++ b/tests/test_summaries.py
@@ -59,6 +59,17 @@ class SummariesTest(unittest.TestCase):
         summaries = Summarizer().summarize(coll.get_all_items())
         self.assertFalse(summaries.is_empty())
 
+    def test_clone_summary(self) -> None:
+        coll = TestCases.test_case_5()
+        summaries = Summarizer().summarize(coll.get_all_items())
+        summaries_dict = summaries.to_dict()
+        self.assertEqual(len(summaries_dict["eo:bands"]), 4)
+        self.assertEqual(len(summaries_dict["proj:epsg"]), 1)
+        clone = summaries.clone()
+        self.assertTrue(isinstance(clone, Summaries))
+        clone_dict = clone.to_dict()
+        self.assertDictEqual(clone_dict, summaries_dict)
+
 
 class RangeSummaryTest(unittest.TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
**Related Issue(s):** Fixes #787 


**Description:** Makes sure that all the mutable properties of a `Collection` get deepcopied when the collection is cloned. Implements `clone` on `Summaries` to make sure cloned collection will point to a new instance of `Summaries` after being cloned.

I have some weird mypy errors from the tests that I added. Still trying to figure out how to fix. I would love some help on that.



**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [NA] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
