### PR TITLE
Update CI to use Python 3.11.0-alpha.7

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -32,13 +32,13 @@ jobs:
         experimental:
           - false
         include:
-          - python-version: "3.11.0-alpha.6"
+          - python-version: "3.11.0-alpha.7"
             os: ubuntu-latest
             experimental: true
-          - python-version: "3.11.0-alpha.6"
+          - python-version: "3.11.0-alpha.7"
             os: windows-latest
             experimental: true
-          - python-version: "3.11.0-alpha.6"
+          - python-version: "3.11.0-alpha.7"
             os: macos-latest
             experimental: true
 
@@ -127,7 +127,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11.0-alpha.6"
+          - "3.11.0-alpha.7"
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
**Related Issue(s):**




**Description:**

Updates CI config to use Python 3.11.0-alpha.7. This should fix the failing builds for these jobs.


**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [ ] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
