### PR TITLE
Return None from Asset.get_absolute_href when owning Item self HREF is NOne

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -10,6 +10,3 @@ ignore_missing_imports = True
 
 [mypy-setuptools.*]
 ignore_missing_imports = True
-
-[mypy-sphinx.util]
-ignore_missing_imports = True

--- a/pystac/asset.py
+++ b/pystac/asset.py
@@ -92,7 +92,8 @@ class Asset:
         """Gets the absolute href for this asset, if possible.
 
         If this Asset has no associated Item, and the asset HREF is a relative path,
-            this method will return None.
+            this method will return ``None``. If the Item that owns the Asset has no
+            self HREF, this will also return ``None``.
 
         Returns:
             str: The absolute HREF of this asset, or None if an absolute HREF could not

--- a/pystac/asset.py
+++ b/pystac/asset.py
@@ -102,9 +102,10 @@ class Asset:
             return self.href
         else:
             if self.owner is not None:
-                return utils.make_absolute_href(self.href, self.owner.get_self_href())
-            else:
-                return None
+                item_self = self.owner.get_self_href()
+                if item_self is not None:
+                    return utils.make_absolute_href(self.href, item_self)
+            return None
 
     def to_dict(self) -> Dict[str, Any]:
         """Generate a dictionary representing the JSON of this Asset.

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -72,13 +72,27 @@ class ItemTest(unittest.TestCase):
                 self.assertFalse(is_absolute_href(asset.href))
 
     def test_asset_absolute_href(self) -> None:
+        item_path = TestCases.get_path("data-files/item/sample-item.json")
         item_dict = self.get_example_item_dict()
         item = Item.from_dict(item_dict)
+        item.set_self_href(item_path)
         rel_asset = Asset("./data.geojson")
         rel_asset.set_owner(item)
-        expected_href = os.path.abspath("./data.geojson")
+        expected_href = os.path.abspath(
+            os.path.join(os.path.dirname(item_path), "./data.geojson")
+        )
         actual_href = rel_asset.get_absolute_href()
         self.assertEqual(expected_href, actual_href)
+
+    def test_asset_absolute_href_no_item_self(self) -> None:
+        item_dict = self.get_example_item_dict()
+        item = Item.from_dict(item_dict)
+        assert item.get_self_href() is None
+
+        rel_asset = Asset("./data.geojson")
+        rel_asset.set_owner(item)
+        actual_href = rel_asset.get_absolute_href()
+        self.assertEqual(None, actual_href)
 
     def test_extra_fields(self) -> None:
         item = pystac.Item.from_file(


### PR DESCRIPTION
**Related Issue(s):

* Closes #754 

**Description:**

`Asset.get_absolute_href` now returns `None` when the owning `Item` has no self HREF.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [ ] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
