### PR TITLE
update raster extension to v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 ### Changed
 
+- Updated Raster Extension from v1.0.0 to v1.1.0 ([#809](https://github.com/stac-utils/pystac/pull/809))
+
 ### Fixed
 
 - "How to create STAC catalogs" tutorial ([#775](https://github.com/stac-utils/pystac/pull/775))

--- a/pystac/extensions/raster.py
+++ b/pystac/extensions/raster.py
@@ -10,7 +10,7 @@ from pystac.extensions.base import (
 )
 from pystac.utils import StringEnum, get_opt, get_required, map_opt
 
-SCHEMA_URI = "https://stac-extensions.github.io/raster/v1.0.0/schema.json"
+SCHEMA_URI = "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
 
 BANDS_PROP = "raster:bands"
 
@@ -37,6 +37,12 @@ class DataType(StringEnum):
     CFLOAT32 = "cfloat32"
     CFLOAT64 = "cfloat64"
     OTHER = "other"
+
+
+class NoDataStrings(StringEnum):
+    INF = "inf"
+    NINF = "-inf"
+    NAN = "nan"
 
 
 class Statistics:
@@ -350,7 +356,7 @@ class RasterBand:
 
     def apply(
         self,
-        nodata: Optional[float] = None,
+        nodata: Optional[Union[float, NoDataStrings]] = None,
         sampling: Optional[Sampling] = None,
         data_type: Optional[DataType] = None,
         bits_per_sample: Optional[float] = None,
@@ -400,7 +406,7 @@ class RasterBand:
     @classmethod
     def create(
         cls,
-        nodata: Optional[float] = None,
+        nodata: Optional[Union[float, NoDataStrings]] = None,
         sampling: Optional[Sampling] = None,
         data_type: Optional[DataType] = None,
         bits_per_sample: Optional[float] = None,
@@ -452,7 +458,7 @@ class RasterBand:
         return b
 
     @property
-    def nodata(self) -> Optional[float]:
+    def nodata(self) -> Optional[Union[float, NoDataStrings]]:
         """Get or sets the nodata pixel value
 
         Returns:
@@ -461,7 +467,7 @@ class RasterBand:
         return self.properties.get("nodata")
 
     @nodata.setter
-    def nodata(self, v: Optional[float]) -> None:
+    def nodata(self, v: Optional[Union[float, NoDataStrings]]) -> None:
         if v is not None:
             self.properties["nodata"] = v
         else:

--- a/tests/data-files/raster/raster-planet-example.json
+++ b/tests/data-files/raster/raster-planet-example.json
@@ -1245,6 +1245,6 @@
     "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
     "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/processing/v1.0.0/schema.json",
-    "https://stac-extensions.github.io/raster/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
   ]
 }

--- a/tests/data-files/raster/raster-sentinel2-example.json
+++ b/tests/data-files/raster/raster-sentinel2-example.json
@@ -548,6 +548,13 @@
           "full_width_half_max": 0.026
         }
       ],
+      "raster:bands": [
+        {
+          "data_type": "uint16",
+          "spatial_resolution": 60,
+          "nodata": "nan"
+        }
+      ],
       "proj:shape": [
         1830,
         1830
@@ -711,7 +718,7 @@
     "https://stac-extensions.github.io/eo/v1.0.0/schema.json",
     "https://stac-extensions.github.io/view/v1.0.0/schema.json",
     "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
-    "https://stac-extensions.github.io/raster/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
   ],
   "virtual:assets": {
     "SIR": {


### PR DESCRIPTION
**Related Issue(s):** #789 


**Description:**

Makes "nan", "inf", and "-inf" valid values for the `nodata` property in `raster:bands`.

- update schema uri
- align the `nodata` type with the updated schema, which allows for numeric and "nan", "inf", and "-inf" strings.
- update tests and test data. For the test data, the `raster:bands` object added to the `B09` asset is from the sentinel example in the Raster Extension repo.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
