### PR TITLE
Deepcopy Asset.extra_fields when cloning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Fixed
 
+- Mutating `Asset.extra_fields` on a cloned `Asset` also mutated the original asset ([#826](https://github.com/stac-utils/pystac/pull/826))
 - "How to create STAC catalogs" tutorial ([#775](https://github.com/stac-utils/pystac/pull/775))
 - Add a `variables` argument, to accompany `dimensions`, for the `apply` method of stac objects extended with datacube ([#782](https://github.com/stac-utils/pystac/pull/782))
 - Deepcopy collection properties on clone. Implement `clone` method for `Summaries` ([#794](https://github.com/stac-utils/pystac/pull/794))

--- a/pystac/asset.py
+++ b/pystac/asset.py
@@ -136,7 +136,7 @@ class Asset:
         return d
 
     def clone(self) -> "Asset":
-        """Clones this asset.
+        """Clones this asset. Makes a ``deepcopy`` of the :attr:`~pystac.Asset.extra_fields`.
 
         Returns:
             Asset: The clone of this asset.

--- a/pystac/asset.py
+++ b/pystac/asset.py
@@ -1,5 +1,5 @@
 from html import escape
-from copy import copy
+from copy import copy, deepcopy
 from typing import Any, Dict, List, Optional, TYPE_CHECKING, Union
 
 from pystac import common_metadata
@@ -148,7 +148,7 @@ class Asset:
             description=self.description,
             media_type=self.media_type,
             roles=self.roles,
-            extra_fields=self.extra_fields,
+            extra_fields=deepcopy(self.extra_fields),
         )
 
     @property

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -311,6 +311,9 @@ class AssetTest(unittest.TestCase):
         original_asset.roles = ["new role"]
         self.assertDictEqual(cloned_asset.to_dict(), self.asset_dict)
 
+        original_asset.roles.append("new role")
+        self.assertDictEqual(cloned_asset.to_dict(), self.asset_dict)
+
         original_asset.extra_fields["new_field"] = "new_value"
         self.assertDictEqual(cloned_asset.to_dict(), self.asset_dict)
 

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -280,6 +280,41 @@ class ItemSubClassTest(unittest.TestCase):
         self.assertIsInstance(cloned_item, self.BasicCustomItem)
 
 
+class AssetTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.maxDiff = None
+        with open(TestCases.get_path("data-files/item/sample-item.json")) as src:
+            item_dict = json.load(src)
+
+        self.asset_dict = item_dict["assets"]["analytic"]
+
+    def example_asset(self) -> Asset:
+        return Asset.from_dict(self.asset_dict)
+
+    def test_clone(self) -> None:
+        original_asset = self.example_asset()
+        cloned_asset = original_asset.clone()
+
+        self.assertDictEqual(original_asset.to_dict(), self.asset_dict)
+        self.assertDictEqual(cloned_asset.to_dict(), self.asset_dict)
+
+        # Changes to original asset should not affect cloned Asset
+        original_asset.description = "Some new description"
+        self.assertDictEqual(cloned_asset.to_dict(), self.asset_dict)
+
+        original_asset.href = "/path/to/new/href"
+        self.assertDictEqual(cloned_asset.to_dict(), self.asset_dict)
+
+        original_asset.title = "New Title"
+        self.assertDictEqual(cloned_asset.to_dict(), self.asset_dict)
+
+        original_asset.roles = ["new role"]
+        self.assertDictEqual(cloned_asset.to_dict(), self.asset_dict)
+
+        original_asset.extra_fields["new_field"] = "new_value"
+        self.assertDictEqual(cloned_asset.to_dict(), self.asset_dict)
+
+
 class AssetSubClassTest(unittest.TestCase):
     class CustomAsset(Asset):
         pass


### PR DESCRIPTION
**Related Issue(s):**

- Closes #820 

**Description:**

Uses `deepcopy` on `Asset.extra_fields` when cloning so that mutating the cloned Asset's extra fields does not mutate the original asset.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
