### PR TITLE
Preserve Collection assets on clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Updated AssetDefinition to have create, apply methods ([#768](https://github.com/stac-utils/pystac/pull/768))
 - Add Grid Extension support ([#799](https://github.com/stac-utils/pystac/pull/799))
 - Rich HTML representations for Jupyter Notebook display ([#743](https://github.com/stac-utils/pystac/pull/743))
+- Add `assets` argument to `Item` and `Collection` init methods to allow adding Assets during object initialization ([#834](https://github.com/stac-utils/pystac/pull/834))
 
 ### Removed
 
@@ -24,6 +25,7 @@
 - "How to create STAC catalogs" tutorial ([#775](https://github.com/stac-utils/pystac/pull/775))
 - Add a `variables` argument, to accompany `dimensions`, for the `apply` method of stac objects extended with datacube ([#782](https://github.com/stac-utils/pystac/pull/782))
 - Deepcopy collection properties on clone. Implement `clone` method for `Summaries` ([#794](https://github.com/stac-utils/pystac/pull/794))
+- Collection assets are now preserved when using `Collection.clone` ([#834](https://github.com/stac-utils/pystac/pull/834))
 
 ## [v1.4.0]
 

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -587,6 +587,7 @@ class Collection(Catalog):
             keywords=self.keywords.copy() if self.keywords is not None else None,
             providers=deepcopy(self.providers),
             summaries=self.summaries.clone(),
+            assets={k: asset.clone() for k, asset in self.assets.items()},
         )
 
         clone._resolved_objects.cache(clone)

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -271,6 +271,22 @@ class CollectionTest(unittest.TestCase):
         with self.assertRaises(pystac.STACTypeError):
             _ = pystac.Collection.from_dict(catalog_dict)
 
+    def test_clone_preserves_assets(self) -> None:
+        path = TestCases.get_path("data-files/collections/with-assets.json")
+        original_collection = Collection.from_file(path)
+        assert len(original_collection.assets) > 0
+
+        cloned_collection = original_collection.clone()
+
+        original_assets_dict = {
+            k: asset.to_dict() for k, asset in original_collection.assets.items()
+        }
+        cloned_assets_dict = {
+            k: asset.to_dict() for k, asset in cloned_collection.assets.items()
+        }
+
+        self.assertDictEqual(original_assets_dict, cloned_assets_dict)
+
 
 class ExtentTest(unittest.TestCase):
     def setUp(self) -> None:

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -275,17 +275,20 @@ class CollectionTest(unittest.TestCase):
         path = TestCases.get_path("data-files/collections/with-assets.json")
         original_collection = Collection.from_file(path)
         assert len(original_collection.assets) > 0
+        assert all(
+            asset.owner is original_collection
+            for asset in original_collection.assets.values()
+        )
 
         cloned_collection = original_collection.clone()
 
-        original_assets_dict = {
-            k: asset.to_dict() for k, asset in original_collection.assets.items()
-        }
-        cloned_assets_dict = {
-            k: asset.to_dict() for k, asset in cloned_collection.assets.items()
-        }
-
-        self.assertDictEqual(original_assets_dict, cloned_assets_dict)
+        for key in original_collection.assets:
+            with self.subTest(f"Preserves {key} asset"):
+                self.assertIn(key, cloned_collection.assets)
+            cloned_asset = cloned_collection.assets.get(key)
+            if cloned_asset is not None:
+                with self.subTest(f"Sets owner for {key}"):
+                    self.assertIs(cloned_asset.owner, cloned_collection)
 
 
 class ExtentTest(unittest.TestCase):

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -221,15 +221,23 @@ class ItemTest(unittest.TestCase):
         )
         self.assertFalse(did_merge)
 
-    def test_clone_sets_asset_owner(self) -> None:
+    def test_clone_preserves_assets(self) -> None:
         cat = TestCases.test_case_2()
-        item = next(iter(cat.get_all_items()))
-        original_asset = list(item.assets.values())[0]
-        assert original_asset.owner is item
+        original_item = next(iter(cat.get_all_items()))
+        assert len(original_item.assets) > 0
+        assert all(
+            asset.owner is original_item for asset in original_item.assets.values()
+        )
 
-        clone = item.clone()
-        clone_asset = list(clone.assets.values())[0]
-        self.assertIs(clone_asset.owner, clone)
+        cloned_item = original_item.clone()
+
+        for key in original_item.assets:
+            with self.subTest(f"Preserves {key} asset"):
+                self.assertIn(key, cloned_item.assets)
+            cloned_asset = cloned_item.assets.get(key)
+            if cloned_asset is not None:
+                with self.subTest(f"Sets owner for {key}"):
+                    self.assertIs(cloned_asset.owner, cloned_item)
 
     def test_make_asset_href_relative_is_noop_on_relative_hrefs(self) -> None:
         cat = TestCases.test_case_2()


### PR DESCRIPTION
**Related Issue(s):**

- Closes #747 


**Description:**

Adds an `assets` argument to `Item.__init__` and `Collection.__init__` that accepts a dictionary mapping strings to `Asset` objects, which allows us to attach Assets to these objects as part of instantiation. 

Also preserves Collection assets when using `Collection.clone` and adds regression test.

cc: @cholden-ag

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
