### PR TITLE
Fix docs for StacIO.read/write_text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - "How to create STAC catalogs" tutorial ([#775](https://github.com/stac-utils/pystac/pull/775))
 - Add a `variables` argument, to accompany `dimensions`, for the `apply` method of stac objects extended with datacube ([#782](https://github.com/stac-utils/pystac/pull/782))
 - Deepcopy collection properties on clone. Implement `clone` method for `Summaries` ([#794](https://github.com/stac-utils/pystac/pull/794))
+- Docstrings for `StacIO.read_text` and `StacIO.write_text` now match the type annotations for the `source` argument. ([#835](https://github.com/stac-utils/pystac/pull/835))
 
 ## [v1.4.0]
 

--- a/pystac/stac_io.py
+++ b/pystac/stac_io.py
@@ -42,11 +42,11 @@ class StacIO(ABC):
     def read_text(self, source: HREF, *args: Any, **kwargs: Any) -> str:
         """Read text from the given URI.
 
-        The source to read from can be specified as a string or a
-        :class:`~pystac.Link`. If it is a string, it must be a URI or local path from
-        which to read. Using a :class:`~pystac.Link` enables implementations to use
-        additional link information, such as paging information contained in the
-        extended links described in the `STAC API spec
+        The source to read from can be specified as a string or :class:`os.PathLike`
+        object (:class:`~pystac.Link` is a path-like object). If it is a string, it
+        must be a URI or local path from which to read. Using a :class:`~pystac.Link`
+        enables implementations to use additional link information, such as paging
+        information contained in the extended links described in the `STAC API spec
         <https://github.com/radiantearth/stac-api-spec/tree/master/item-search#paging>`__.
 
         Args:
@@ -71,10 +71,11 @@ class StacIO(ABC):
     ) -> None:
         """Write the given text to a file at the given URI.
 
-        The destination to write to from can be specified as a string or a
-        :class:`~pystac.Link`. If it is a string, it must be a URI or local path from
-        which to read. Using a :class:`~pystac.Link` enables implementations to use
-        additional link information.
+        The destination to write to can be specified as a string or
+        :class:`os.PathLike` object (:class:`~pystac.Link` is a path-like object). If
+        it is a string, it must be a URI or local path from which to read. Using a
+        :class:`~pystac.Link` enables implementations to use additional link
+        information.
 
         Args:
             dest : The destination to write to.


### PR DESCRIPTION
**Related Issue(s):**

- Closes #764 


**Description:**

Fixes docstrings for `StacIO.read_text` and `StacIO.write_text` to match the type annotations for the `source` argument.

cc: @l0b0 

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [ ] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
