### PR TITLE
Attribute `code` has type `str` but is used as type `None`

### DIFF
--- a/tests/extensions/test_grid.py
+++ b/tests/extensions/test_grid.py
@@ -92,6 +92,18 @@ class GridTest(unittest.TestCase):
             # that does not conform to the type signature.
             # https://github.com/stac-utils/pystac/pull/878#discussion_r957352232
             GridExtension.ext(self.item).code = None  # type: ignore
+        with self.assertRaises(ValueError):
+            # First segment has to be all caps
+            # https://github.com/stac-utils/pystac/pull/878#discussion_r957354927
+            GridExtension.ext(self.item).code = "this-is-not-a-grid-code"
+        with self.assertRaises(ValueError):
+            # Folks might try to put an epsg code in
+            # https://github.com/stac-utils/pystac/pull/878#discussion_r957355415
+            GridExtension.ext(self.item).code = "4326"
+        with self.assertRaises(ValueError):
+            # Folks might try to put an epsg code in
+            # https://github.com/stac-utils/pystac/pull/878#discussion_r957355415
+            GridExtension.ext(self.item).code = "EPSG:4326"
 
     def test_extension_not_implemented(self) -> None:
         # Should raise exception if Item does not include extension URI

--- a/tests/extensions/test_grid.py
+++ b/tests/extensions/test_grid.py
@@ -1,4 +1,6 @@
 """Tests for pystac.extensions.grid."""
+# This is for the type checking on GridTest.test_clear_code
+# mypy: warn_unused_ignores=False
 
 import datetime
 from typing import Any, Dict
@@ -86,7 +88,10 @@ class GridTest(unittest.TestCase):
         GridExtension.ext(self.item).apply(code)
 
         with self.assertRaises(ValueError):
-            GridExtension.ext(self.item).code = ""
+            # Ignore type errors because this test intentionally checks behavior
+            # that does not conform to the type signature.
+            # https://github.com/stac-utils/pystac/pull/878#discussion_r957352232
+            GridExtension.ext(self.item).code = None  # type: ignore
 
     def test_extension_not_implemented(self) -> None:
         # Should raise exception if Item does not include extension URI

--- a/tests/extensions/test_grid.py
+++ b/tests/extensions/test_grid.py
@@ -86,7 +86,7 @@ class GridTest(unittest.TestCase):
         GridExtension.ext(self.item).apply(code)
 
         with self.assertRaises(ValueError):
-            GridExtension.ext(self.item).code = None
+            GridExtension.ext(self.item).code = ""
 
     def test_extension_not_implemented(self) -> None:
         # Should raise exception if Item does not include extension URI


### PR DESCRIPTION
**Related Issue(s):** #
Type error found with Pyre

**Description:**
"filename": "tests/extensions/test_grid.py"
"warning_type": "Incompatible attribute type [8]"
"warning_message": " Attribute `code` declared in class `GridExtension` has type `str` but is used as type `None`."
"warning_line": 89
"fix": None to ""
