### PR TITLE
Downgrade doc8 dependency

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,7 +6,7 @@ codespell==2.1.0
 
 jsonschema==4.14.0
 coverage==6.4.2
-doc8==1.0.0
+doc8==0.11.2
 
 types-python-dateutil==2.8.19
 types-orjson==3.6.2


### PR DESCRIPTION
**Related Issue(s):** None

**Description:**

The v1 of doc8 was breaking dependency resolution:

```
ERROR: Cannot install -r ./requirements-docs.txt (line 2), -r ./requirements-docs.txt (line 4), -r ./requirements-docs.txt (line 5), -r ./requirements-docs.txt (line 6) and -r ./requirements-test.txt (line 9) because these package versions have conflicting dependencies.

The conflict is caused by:
    sphinx 4.5.0 depends on docutils<0.18 and >=0.14
    nbsphinx 0.8.9 depends on docutils
    pydata-sphinx-theme 0.8.1 depends on docutils!=0.17.0
    sphinx-panels 0.6.0 depends on docutils
    doc8 1.0.0 depends on docutils<0.21 and >=0.19
```

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
