### PR TITLE
Allow relative stac_extension paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Dependency resolution when installing `requirements-dev.txt` ([#897](https://github.com/stac-utils/pystac/pull/897))
 - Serializing optional Collection attributes ([#916](https://github.com/stac-utils/pystac/pull/916))
 - A couple non-running tests ([#912](https://github.com/stac-utils/pystac/pull/912))
+- Support relative stac extension paths via `make_absolute_href` ([#884](https://github.com/stac-utils/pystac/pull/884))
 
 ## [v1.6.1]
 

--- a/pystac/validation/stac_validator.py
+++ b/pystac/validation/stac_validator.py
@@ -4,6 +4,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Tuple
 
 import pystac
+import pystac.utils
 from pystac.stac_object import STACObjectType
 from pystac.validation.schema_uri_map import DefaultSchemaUriMap, SchemaUriMap
 
@@ -250,6 +251,7 @@ class JsonSchemaSTACValidator(STACValidator):
 
         if schema_uri is None:
             return None
+        schema_uri = pystac.utils.make_absolute_href(schema_uri, href)
 
         try:
             self._validate_from_uri(stac_dict, schema_uri)

--- a/tests/data-files/item/sample-item-with-relative-extension-path.json
+++ b/tests/data-files/item/sample-item-with-relative-extension-path.json
@@ -1,0 +1,75 @@
+{
+  "type": "Feature",
+  "stac_version": "1.0.0",
+  "id": "CS3-20160503_132131_05",
+  "properties": {
+    "datetime": "2016-05-03T13:22:30.040000Z",
+    "title": "A CS3 item",
+    "license": "PDDL-1.0",
+    "providers": [
+      {
+        "name": "CoolSat",
+        "roles": [
+          "producer",
+          "licensor"
+        ],
+        "url": "https://cool-sat.com/"
+      }
+    ],
+    "proj:epsg": 4326
+  },
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          -122.308150179,
+          37.488035566
+        ],
+        [
+          -122.597502109,
+          37.538869539
+        ],
+        [
+          -122.576687533,
+          37.613537207
+        ],
+        [
+          -122.2880486,
+          37.562818007
+        ],
+        [
+          -122.308150179,
+          37.488035566
+        ]
+      ]
+    ]
+  },
+  "links": [
+    {
+      "rel": "collection",
+      "href": "https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/collection-spec/examples/sentinel2.json"
+    }
+  ],
+  "assets": {
+    "analytic": {
+      "href": "http://cool-sat.com/catalog/CS3-20160503_132130_04/analytic.tif",
+      "title": "4-Band Analytic",
+      "product": "http://cool-sat.com/catalog/products/analytic.json"
+    },
+    "thumbnail": {
+      "href": "http://cool-sat.com/catalog/CS3-20160503_132130_04/thumbnail.png",
+      "title": "Thumbnail"
+    }
+  },
+  "bbox": [
+    -122.59750209,
+    37.48803556,
+    -122.2880486,
+    37.613537207
+  ],
+  "stac_extensions": [
+    "../schemas/v1.0.0-projection.json"
+  ],
+  "collection": "CS3"
+}

--- a/tests/data-files/schemas/v1.0.0-projection.json
+++ b/tests/data-files/schemas/v1.0.0-projection.json
@@ -1,0 +1,193 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+  "title": "Projection Extension",
+  "description": "STAC Projection Extension for STAC Items.",
+  "oneOf": [
+    {
+      "$comment": "This is the schema for STAC Items.",
+      "allOf": [
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "properties",
+            "assets"
+          ],
+          "properties": {
+            "type": {
+              "const": "Feature"
+            },
+            "properties": {
+              "allOf": [
+                {
+                  "$comment": "Require fields here for item properties.",
+                  "required": [
+                    "proj:epsg"
+                  ]
+                },
+                {
+                  "$ref": "#/definitions/fields"
+                }
+              ]
+            },
+            "assets": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/fields"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/stac_extensions"
+        }
+      ]
+    },
+    {
+      "$comment": "This is the schema for STAC Collections.",
+      "allOf": [
+        {
+          "type": "object",
+          "required": [
+            "type"
+          ],
+          "properties": {
+            "type": {
+              "const": "Collection"
+            },
+            "assets": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/fields"
+              }
+            },
+            "item_assets": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/fields"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/stac_extensions"
+        }
+      ]
+    }
+  ],
+  "definitions": {
+    "stac_extensions": {
+      "type": "object",
+      "required": [
+        "stac_extensions"
+      ],
+      "properties": {
+        "stac_extensions": {
+          "type": "array"
+        }
+      }
+    },
+    "fields": {
+      "$comment": "Add your new fields here. Don't require them here, do that above in the item schema.",
+      "type": "object",
+      "properties": {
+        "proj:epsg": {
+          "title": "EPSG code",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "proj:wkt2": {
+          "title": "Coordinate Reference System in WKT2 format",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "proj:projjson": {
+          "title": "Coordinate Reference System in PROJJSON format",
+          "oneOf": [
+            {
+              "$ref": "https://proj.org/schemas/v0.2/projjson.schema.json"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "proj:geometry": {
+          "$ref": "https://geojson.org/schema/Geometry.json"
+        },
+        "proj:bbox": {
+          "title": "Extent",
+          "type": "array",
+          "oneOf": [
+            {
+              "minItems": 4,
+              "maxItems": 4
+            },
+            {
+              "minItems": 6,
+              "maxItems": 6
+            }
+          ],
+          "items": {
+            "type": "number"
+          }
+        },
+        "proj:centroid": {
+          "title": "Centroid",
+          "type": "object",
+          "required": [
+            "lat",
+            "lon"
+          ],
+          "properties": {
+            "lat": {
+              "type": "number",
+              "minimum": -90,
+              "maximum": 90
+            },
+            "lon": {
+              "type": "number",
+              "minimum": -180,
+              "maximum": 180
+            }
+          }
+        },
+        "proj:shape": {
+          "title": "Shape",
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": {
+            "type": "integer"
+          }
+        },
+        "proj:transform": {
+          "title": "Transform",
+          "type": "array",
+          "oneOf": [
+            {
+              "minItems": 6,
+              "maxItems": 6
+            },
+            {
+              "minItems": 9,
+              "maxItems": 9
+            }
+          ],
+          "items": {
+            "type": "number"
+          }
+        }
+      },
+      "patternProperties": {
+        "^(?!proj:)": {}
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -282,6 +282,14 @@ class ItemTest(unittest.TestCase):
         )
         self.assertEqual(item.geometry, item.__geo_interface__)
 
+    def test_relative_extension_path(self) -> None:
+        item = pystac.Item.from_file(
+            TestCases.get_path(
+                "data-files/item/sample-item-with-relative-extension-path.json"
+            )
+        )
+        item.validate()
+
 
 class ItemSubClassTest(unittest.TestCase):
     """This tests cases related to creating classes inheriting from pystac.Catalog to


### PR DESCRIPTION
**Related Issue(s):** None


**Description:**

There's nothing in the specification that disallows relative stac_extension paths, so we should allow it. This commit uses make_absolute_href on all schema uris.

I use the projection extension for the unit test, but I modified the jsonschema to not require the absolute URI of the schema in `stac_extensions`.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
