### PR TITLE
Add __geo_interface__ for items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Ability to only update resolved links when using `Catalog.normalize_hrefs` and `Catalog.normalize_and_save`, via a new `skip_unresolved` argument ([#900](https://github.com/stac-utils/pystac/pull/900))
 - Add the optional argument `timespec` to `utils.datetime_to_str` ([#929](https://github.com/stac-utils/pystac/pull/929))
 - `isort` ([#961](https://github.com/stac-utils/pystac/pull/961))
+- `__geo_interface__` for items ([#885](https://github.com/stac-utils/pystac/pull/885))
 
 ### Removed
 

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -800,3 +800,22 @@ collection ID, which can help avoid multiple reads of
 collection links.
 
 Note that this feature was dropped in STAC 1.0.0-beta.1
+
+Geo interface
+=============
+
+:class:`~pystac.Item` implements ``__geo_interface__``, a de-facto standard for
+describing geospatial objects in Python:
+https://gist.github.com/sgillies/2217756. Many packages can automatically use
+objects that implement this protocol, e.g. `shapely
+<https://shapely.readthedocs.io/en/stable/manual.html>`_:
+
+.. code-block:: python
+
+   >>> from pystac import Item
+   >>> from shapely.geometry import mapping, shape
+   >>> item = Item.from_file("data-files/item/sample-item.json")
+   >>> print(shape(item))
+   POLYGON ((-122.308150179 37.488035566, -122.597502109 37.538869539,
+   -122.576687533 37.613537207, -122.2880486 37.562818007, -122.308150179
+   37.488035566))

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -481,3 +481,14 @@ class Item(STACObject):
     @classmethod
     def matches_object_type(cls, d: Dict[str, Any]) -> bool:
         return identify_stac_object_type(d) == STACObjectType.ITEM
+
+    @property
+    def __geo_interface__(self) -> Optional[Dict[str, Any]]:
+        """Returns this item's geometry.
+
+        https://gist.github.com/sgillies/2217756
+
+        Returns:
+            Dict[str, Any]: The Item's geometry
+        """
+        return deepcopy(self.geometry)

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -276,6 +276,12 @@ class ItemTest(unittest.TestCase):
         with self.assertRaises(pystac.STACTypeError):
             _ = pystac.Item.from_dict(catalog_dict)
 
+    def test_geo_interface(self) -> None:
+        item = pystac.Item.from_file(
+            TestCases.get_path("data-files/item/sample-item.json")
+        )
+        self.assertEqual(item.geometry, item.__geo_interface__)
+
 
 class ItemSubClassTest(unittest.TestCase):
     """This tests cases related to creating classes inheriting from pystac.Catalog to


### PR DESCRIPTION
**Related Issue(s):**
- Closes #786 

**Description:**
Adds `__geo_interface__` for items, collections, and spatial extent. Includes a `pystac.utils.box` function that cribs from shapely, with a couple of tweaks. Collection and spatial extent geo interfaces are impelemented per @duckontheweb's suggestion (if `len(bboxes) == 1`, use that as a Polygon; if `len(bboxes) > 1`, use `bboxes[1:]` as a MultiPolygon).

I can see @philvarner's point that we're making an opinionated decision w.r.t. the Collection geointerface that may not be correct. It'd be good to get other's opinions on the correct Collection approach, and if there's disagreement it may make sense to remove it from this PR and put that decision off until later. I've pulled in a couple of reviewers for that reason.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
