### PR TITLE
Fix typo + wrong code

### DIFF
--- a/docs/tutorials/how-to-create-stac-catalogs.ipynb
+++ b/docs/tutorials/how-to-create-stac-catalogs.ipynb
@@ -692,7 +692,7 @@
     }
    ],
    "source": [
-    "with open(item.self_href) as f:\n",
+    "with open(catalog.self_href) as f:\n",
     "    print(f.read())"
    ]
   },
@@ -1374,7 +1374,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Beyond what a Catalog reqiures, a Collection requires a license, and an `Extent` that describes the range of space and time that the items it hold occupy."
+    "Beyond what a Catalog requires, a Collection requires a license, and an `Extent` that describes the range of space and time that the items it hold occupy."
    ]
   },
   {


### PR DESCRIPTION
**Related Issue(s):** #


**Description:**

I have fixed a small typo and a wrong code snippet.
Indeed the 26th cell is
```
with open(item.self_href) as f:
    print(f.read())
```
But it should be the `catalog` object that is read.

**PR Checklist:**

- [ ] Code is formatted (run `pre-commit run --all-files`)
- [ ] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [ ] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
