### PR TITLE
Fix dependencies

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: requirements-test.txt
 
       - uses: actions-rs/toolchain@v1
@@ -66,7 +66,7 @@ jobs:
           pip install --upgrade pip
           pip install -r requirements-test.txt
           pip install -e ".[validation]"
-      
+
       - name: Execute test suite
         run: ./scripts/test
         shell: bash
@@ -83,15 +83,15 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.8"
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: requirements-test.txt
-      
+
       - name: Install dependencies
         run: |
           pip install --upgrade pip
           pip install -r requirements-test.txt
           pip install -e ".[validation]"
-      
+
       - name: Execute test suite
         run: ./scripts/test
         env:
@@ -101,14 +101,14 @@ jobs:
         # Ignore the configured fail-under to ensure we upload the coverage report. We
         # will trigger a failure for coverage drops in a later job
         run: coverage xml --fail-under 0
-      
+
       - name: Upload All coverage to Codecov
         uses: codecov/codecov-action@v3
         if: ${{ env.GITHUB_REPOSITORY }} == 'stac-utils/pystac'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
-          fail_ci_if_error: false 
+          fail_ci_if_error: false
 
       - name: Check for coverage drop
         # This will use the configured fail-under, causing this job to fail if the
@@ -134,9 +134,9 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: requirements-test.txt
-      
+
       - name: Install dependencies
         run: |
           pip install --upgrade pip
@@ -147,16 +147,16 @@ jobs:
 
   vanilla:
     runs-on: ubuntu-latest
-    steps:  
+    steps:
       - uses: actions/checkout@v3
-      
+
       - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
 
       - name: Install without orjson
         run: pip install '.[validation]'
-      
+
       - name: Run unittests
         run: python -m unittest discover tests
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -31,13 +31,13 @@ jobs:
         experimental:
           - false
         include:
-          - python-version: "3.11.0-alpha.7"
+          - python-version: "3.11.0-rc.2"
             os: ubuntu-latest
             experimental: true
-          - python-version: "3.11.0-alpha.7"
+          - python-version: "3.11.0-rc.2"
             os: windows-latest
             experimental: true
-          - python-version: "3.11.0-alpha.7"
+          - python-version: "3.11.0-rc.2"
             os: macos-latest
             experimental: true
 
@@ -125,7 +125,7 @@ jobs:
           - "3.8"
           - "3.9"
           - "3.10"
-          - "3.11.0-alpha.7"
+          - "3.11.0-rc.2"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -159,3 +159,17 @@ jobs:
       
       - name: Run unittests
         run: python -m unittest discover tests
+
+  check-dev-dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.8"
+          cache: "pip"
+          cache-dependency-path: requirements-dev.txt
+
+      - name: Install dev dependencies
+        run: pip install -r requirements-dev.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Dependency resolution when installing `requirements-dev.txt` ([#897](https://github.com/stac-utils/pystac/pull/897))
+
 ## [v1.6.1]
 
 ### Fixed
@@ -135,13 +137,14 @@
 ## [v1.1.0]
 
 ### Added
+
 - Include type information during packaging for use with e.g. `mypy` ([#579](https://github.com/stac-utils/pystac/pull/579))
 - Optional `dest_href` argument to `Catalog.save` to allow saving `Catalog` instances to
   locations other than their `self` href ([#565](https://github.com/stac-utils/pystac/pull/565))
 
 ### Changed
 
-- Pin the rustc version in Continuous Integration to work around https://github.com/rust-lang/cargo/pull/9727 ([#581](https://github.com/stac-utils/pystac/pull/581))
+- Pin the rustc version in Continuous Integration to work around <https://github.com/rust-lang/cargo/pull/9727> ([#581](https://github.com/stac-utils/pystac/pull/581))
 
 ## [v1.0.1]
 
@@ -193,9 +196,9 @@
 ### Added
 
 - (Experimental) support for Python 3.10 ([#473](https://github.com/stac-utils/pystac/pull/473))
--  `LabelTask` enum in `pystac.extensions.label` with recommended values for
+- `LabelTask` enum in `pystac.extensions.label` with recommended values for
   `"label:tasks"` field ([#484](https://github.com/stac-utils/pystac/pull/484))
--  `LabelMethod` enum in `pystac.extensions.label` with recommended values for
+- `LabelMethod` enum in `pystac.extensions.label` with recommended values for
   `"label:methods"` field ([#484](https://github.com/stac-utils/pystac/pull/484))
 - Label Extension summaries ([#484](https://github.com/stac-utils/pystac/pull/484))
 - Timestamps Extension summaries ([#513](https://github.com/stac-utils/pystac/pull/513))
@@ -408,7 +411,6 @@
 
 - Be more strict with CatalogType in `Catalog.save` ([#244](https://github.com/stac-utils/pystac/pull/244))
 
-
 ## [v0.5.3]
 
 ### Added
@@ -508,6 +510,7 @@ asset extension renamed to item-assets and renamed assets field in Collections t
 ## [v0.4.0]
 
 The two major changes for this release are:
+
 - Upgrade to STAC 0.9.0
 - Refactor the extensions API to accommodate items that implement multiple extensions (e.g. `eo` and `view`)
 
@@ -517,7 +520,7 @@ See the [stac-spec 0.9.0 changelog](https://github.com/radiantearth/stac-spec/bl
 
 These are the major API changes that will have to be accounted for when upgrading PySTAC:
 
-#### Extensions are wrappers around Catalogs, Collection and Items, and no longer inherit.
+#### Extensions are wrappers around Catalogs, Collection and Items, and no longer inherit
 
 This change affects the two extensions that were implemented for Item - `EOItem` and `LabelItem`
 have become `EOItemExt` and `LabelItemExt`, and no longer inherit from Item.
@@ -529,7 +532,8 @@ be able to account well for these new items that implemented both the `eo` and `
 See the [Extensions section](https://pystac.readthedocs.io/en/0.4/concepts.html#extensions) in the
 documentation for more information on the new way to use extensions.
 
-#### Extensions have moved to their own package:
+#### Extensions have moved to their own package
+
 - `pystac.label` -> `pystac.extensions.label`
 - `pystac.eo` -> `pystac.extensions.eo`
 - `pystac.single_file_stac` -> `pystac.extensions.single_file_stac`
@@ -542,6 +546,7 @@ documentation for more information on the new way to use extensions.
 - Added support for the [commons](https://github.com/radiantearth/stac-spec/tree/v0.9.0/extensions/commons) extension.
 
 ### Changed
+
 - Migrated CI workflows from Travis CI to GitHub Actions [#108](https://github.com/azavea/pystac/pull/108)
 - Dropped support for Python 3.5 [#108](https://github.com/azavea/pystac/pull/108)
 
@@ -551,7 +556,6 @@ documentation for more information on the new way to use extensions.
 - Asset properties always return a dict instead of being None for Assets that have non-core properties.
 - The `Band` constructor in the EO extension changed to taking a dict. To create a band from property values,
 use `Band.create`
-
 
 ## [v0.3.4] - 2020-06-20
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,7 +6,7 @@ codespell==2.1.0
 
 jsonschema==4.16.0
 coverage==6.5.0
-doc8==1.0.0
+doc8==0.11.2
 
 types-python-dateutil==2.8.19
 types-orjson==3.6.2


### PR DESCRIPTION
**Related Issue(s):**

Should unblock #895, #882, and others.

**Description:**

Dependency resolution was broken for `pip install -r requirements-dev.txt`:

```sh
$ pip install -r requirements-dev.txt
... snip ...
ERROR: Cannot install -r ./requirements-docs.txt (line 2), -r ./requirements-docs.txt (line 4), -r ./requirements-docs.txt (line 5), -r ./requirements-docs.txt (line 6) and -r ./requirements-test.txt (line 9) because these package versions have conflicting dependencies.

The conflict is caused by:
    sphinx 4.5.0 depends on docutils<0.18 and >=0.14
    nbsphinx 0.8.9 depends on docutils
    pydata-sphinx-theme 0.8.1 depends on docutils!=0.17.0
    sphinx-panels 0.6.0 depends on docutils
    doc8 1.0.0 depends on docutils<0.21 and >=0.19
```

This wasn't caught by CI because we never install `requirements-dev.txt` on CI. This PR:

1. Adds a check for `requirements-dev.txt` install
2. Downgrades doc8 version to fix the break
3. Updates the python-version for 3.11 to rc.2
4. Does some minor linting on the CI file.


**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
