### PR TITLE
Normalize hrefs while skipping unresolved links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 - Update Grid Extension support to v1.1.0 and fix issue with grid:code prefix validation ([#925](https://github.com/stac-utils/pystac/pull/925))
 - Adds custom `header` support to `DefaultStacIO` ([#889](https://github.com/stac-utils/pystac/pull/889))
 - Python 3.11 checks in CI ([#908](https://github.com/stac-utils/pystac/pull/908))
-- Add the optional argument timespec to datetime_to_str function in utils ([#929](https://github.com/stac-utils/pystac/pull/929))
+- Ability to only update resolved links when using `Catalog.normalize_hrefs` and `Catalog.normalize_and_save`, via a new `skip_unresolved` argument ([#900](https://github.com/stac-utils/pystac/pull/900))
+- Add the optional argument `timespec` to `utils.datetime_to_str` ([#929](https://github.com/stac-utils/pystac/pull/929))
 
 ### Removed
 

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -615,7 +615,7 @@ class Catalog(STACObject):
 
         This method mutates the entire catalog tree, unless ``skip_unresolved``
         is True, in which case only resolved links are modified. This is useful
-        in the case when you have loaded large catalog and you've added a few
+        in the case when you have loaded a large catalog and you've added a few
         items/children, and you only want to update those newly-added objects,
         not the whole tree.
 


### PR DESCRIPTION
**Related Issue(s):**
- Closes #284

**Description:**

Adds a `skip_unresolved` argument to `Catalog.normalize_hrefs` and `Catalog.normalize_and_save`. Instead of using `Catalog.get_items` and `Catalog.get_children` (which resolve their links), we re-implement with additional logic to conditionally skip unresolved links. We considered pushing `skip_unresolved` all the way down into `Link.get_stac_object`, but this seemed like overkill, since the motivating use-case for `skip_unresolved` is to avoid walking the whole tree when normalizing (#284).

Because `save` already skips unresolved links, this enables `normalize_and_save` to only touch objects that have been added to the tree or modified (and therefore resolved).

Note this isn't exactly the solution proposed by @matthewhanson in #284, since the hrefs newly-added entities aren't normalized. These changes are only confined to `normalize`.

This is a feature-adding, backwards compatible change that could be incorporated in a MINOR release.

cc @l0b0 

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
