### PR TITLE
Fix up README for Python 3.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ See [contributing docs](docs/contributing.rst) for details on contributing to th
 There is a quickstart and tutorials written as jupyter notebooks in the `docs/tutorials` folder.
 To run the notebooks, run a jupyter notebook with the `docs` directory as the notebook directory:
 
-```
-> PYTHONPATH=`pwd`:$PYTHONPATH jupyter notebook --ip 0.0.0.0 --port 8888 --notebook-dir=docs
+```shell
+jupyter notebook --ip 0.0.0.0 --port 8888 --notebook-dir=docs
 ```
 
 You can then navigate to the notebooks and execute them.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-## PySTAC
+# PySTAC
+
 ![Build Status](https://github.com/stac-utils/pystac/workflows/CI/badge.svg?branch=main)
 [![PyPI version](https://badge.fury.io/py/pystac.svg)](https://badge.fury.io/py/pystac)
 [![Conda (channel only)](https://img.shields.io/conda/vn/conda-forge/pystac)](https://anaconda.org/conda-forge/pystac)
@@ -34,8 +35,7 @@ PySTAC can be installed from pip or the source repository.
 
 If you would like to enable the validation feature utilizing the
 [jsonschema](https://pypi.org/project/jsonschema/) project, install with the optional
-`validation` requirements: 
-
+`validation` requirements:
 
 ```bash
 > pip install pystac[validation]
@@ -61,8 +61,8 @@ From source repository:
 > pip install .
 ```
 
+### Versions
 
-#### Versions
 To install a version of PySTAC that works with a specific versions of the STAC
 specification, install the matching version of PySTAC from the following table.
 

--- a/README.md
+++ b/README.md
@@ -21,32 +21,32 @@ after that date.
 PySTAC has a single required dependency (`python-dateutil`).
 PySTAC can be installed from pip or the source repository.
 
-```bash
-> pip install pystac
+```shell
+pip install pystac
 ```
 
 If you would like to enable the validation feature utilizing the
 [jsonschema](https://pypi.org/project/jsonschema/) project, install with the optional
 `validation` requirements:
 
-```bash
-> pip install pystac[validation]
+```shell
+pip install pystac[validation]
 ```
 
 If you would like to use the [`orjson`](https://pypi.org/project/orjson/) instead of the
 standard `json` library for JSON serialization/deserialization, install with the
 optional `orjson` requirements:
 
-```bash
-> pip install pystac[orjson]
+```shell
+pip install pystac[orjson]
 ```
 
 From source repository:
 
-```bash
-> git clone https://github.com/stac-utils/pystac.git
-> cd pystac
-> pip install .
+```shell
+git clone https://github.com/stac-utils/pystac.git
+cd pystac
+pip install .
 ```
 
 ### Versions
@@ -63,7 +63,7 @@ specification, install the matching version of PySTAC from the following table.
 
 For instance, to work with STAC v0.9.x:
 
-```bash
+```shell
 pip install pystac==0.4.0
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,14 +18,6 @@ for Python versions. This means that users can expect support for Python 3.8 to 
 removed from the `main` branch after Apr 14, 2023 and therefore from the next release
 after that date.
 
-Note that while we support Python 3.10.\*, wheels for the `orjson` library are not always immediately available for all
-platforms. If you install PySTAC with the `orjson` extra, you may need to have the Rust toolchain installed (e.g. via [rustup](https://rustup.rs/)) in order to
-build the package from source.
-
-Support for Python 3.11 should be considered experimental until further notice. There is a known issue with failing build of `orjson` on 3.11.0 alpha releases prior to alpha.6 (see
-[#765(comment)](https://github.com/stac-utils/pystac/pull/765#pullrequestreview-908908772) for
-some additional detail).
-
 PySTAC has a single required dependency (`python-dateutil`).
 PySTAC can be installed from pip or the source repository.
 
@@ -48,10 +40,6 @@ optional `orjson` requirements:
 ```bash
 > pip install pystac[orjson]
 ```
-
-> *`orjson` wheels are only available for Linux in Python 3.10. If you are using the
-> `orjson` extra with Python 3.10 you will need to have the Rust nightly toolchain
-> installed as your default toolchain in order to build the package wheel.*
 
 From source repository:
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -2,7 +2,7 @@ Contributing
 ============
 
 A list of issues and ongoing work is available on the PySTAC `issues page
-<https://github.com/azavea/pystac/issues>`_. If you want to contribute code, the best
+<https://github.com/stac-utils/pystac/issues>`_. If you want to contribute code, the best
 way is to coordinate with the core developers via an issue or pull request conversation.
 
 Development installation


### PR DESCRIPTION
**Description:**

Remove some 3.11-specific language from the README that no longer applies. Specifically, orjson wheels exist for all three os flavors for Python 3.11

Also includes a couple sidecar fixups to the README caught by my markdown linter.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
