### PR TITLE
Fix twice consumed iterators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Creating dictionaries from Catalogs and Collections without root hrefs now creates valid STAC ([#896](https://github.com/stac-utils/pystac/pull/896))
 - Dependency resolution when installing `requirements-dev.txt` ([#897](https://github.com/stac-utils/pystac/pull/897))
 - Serializing optional Collection attributes ([#916](https://github.com/stac-utils/pystac/pull/916))
+- A couple non-running tests ([#912](https://github.com/stac-utils/pystac/pull/912))
 
 ## [v1.6.1]
 

--- a/tests/extensions/test_label.py
+++ b/tests/extensions/test_label.py
@@ -134,7 +134,7 @@ class LabelTest(unittest.TestCase):
     def test_get_sources(self) -> None:
         cat = TestCases.case_1()
 
-        items = cat.get_all_items()
+        items = list(cat.get_all_items())
         item_ids = set([i.id for i in items])
 
         for li in items:

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -717,7 +717,7 @@ class TestCatalog:
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             catalog = TestCases.case_1()
-            catalog_items = catalog.get_all_items()
+            catalog_items = list(catalog.get_all_items())
 
             new_cat = catalog.map_items(item_mapper)
 
@@ -725,9 +725,9 @@ class TestCatalog:
             new_cat.save(catalog_type=CatalogType.ABSOLUTE_PUBLISHED)
 
             result_cat = Catalog.from_file(os.path.join(tmp_dir, "cat", "catalog.json"))
-            result_items = result_cat.get_all_items()
+            result_items = list(result_cat.get_all_items())
 
-            assert len(list(catalog_items)) * 2 == len(list(result_items))
+            assert len(catalog_items) * 2 == len(result_items)
 
             ones, twos = 0, 0
             for item in result_items:
@@ -1125,7 +1125,7 @@ class TestCatalog:
                     )
                     self_href = item.get_self_href()
                     assert self_href is not None
-                    self_href.endswith(end), "{} does not end with {}".format(
+                    assert self_href.endswith(end), "{} does not end with {}".format(
                         self_href, end
                     )
 


### PR DESCRIPTION
**Related Issue(s):**

- Closes #502 
- Depends on #909 

**Description:**

Fixes two tests that looped through iterators twice.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
