### PR TITLE
Fix serializing optional Collection attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Fixed
 
 - Dependency resolution when installing `requirements-dev.txt` ([#897](https://github.com/stac-utils/pystac/pull/897))
+- Serializing optional Collection attributes ([#916](https://github.com/stac-utils/pystac/pull/916))
 
 ## [v1.6.1]
 

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -510,7 +510,7 @@ class Catalog(STACObject):
             "links": [link.to_dict(transform_href=transform_hrefs) for link in links],
         }
 
-        if self.stac_extensions is not None:
+        if self.stac_extensions:
             d["stac_extensions"] = self.stac_extensions
 
         for key in self.extra_fields:

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -559,11 +559,11 @@ class Collection(Catalog):
         )
         d["extent"] = self.extent.to_dict()
         d["license"] = self.license
-        if self.stac_extensions is not None:
+        if self.stac_extensions:
             d["stac_extensions"] = self.stac_extensions
-        if self.keywords is not None:
+        if self.keywords:
             d["keywords"] = self.keywords
-        if self.providers is not None:
+        if self.providers:
             d["providers"] = list(map(lambda x: x.to_dict(), self.providers))
         if not self.summaries.is_empty():
             d["summaries"] = self.summaries.to_dict()
@@ -629,19 +629,19 @@ class Collection(Catalog):
         description = d.pop("description")
         license = d.pop("license")
         extent = Extent.from_dict(d.pop("extent"))
-        title = d.get("title")
-        stac_extensions = d.get("stac_extensions")
-        keywords = d.get("keywords")
-        providers = d.get("providers")
+        title = d.pop("title", None)
+        stac_extensions = d.pop("stac_extensions", None)
+        keywords = d.pop("keywords", None)
+        providers = d.pop("providers", None)
         if providers is not None:
             providers = list(map(lambda x: pystac.Provider.from_dict(x), providers))
-        summaries = d.get("summaries")
+        summaries = d.pop("summaries", None)
         if summaries is not None:
             summaries = Summaries(summaries)
 
-        assets: Optional[Dict[str, Any]] = {
-            k: Asset.from_dict(v) for k, v in d.get("assets", {}).items()
-        }
+        assets = d.pop("assets", None)
+        if assets:
+            assets = {k: Asset.from_dict(v) for k, v in assets.items()}
         links = d.pop("links")
 
         d.pop("stac_version")

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -226,6 +226,43 @@ class CollectionTest(unittest.TestCase):
         collection = pystac.Collection.from_dict(data)
         collection.validate()
 
+    def test_removing_optional_attributes(self) -> None:
+        path = TestCases.get_path("data-files/collections/with-assets.json")
+        with open(path, "r") as file:
+            data = json.load(file)
+        data["title"] = "dummy title"
+        data["stac_extensions"] = ["dummy extension"]
+        data["keywords"] = ["key", "word"]
+        data["providers"] = [{"name": "pystac"}]
+        collection = pystac.Collection.from_dict(data)
+
+        # Assert we have everything set
+        assert collection.title
+        assert collection.stac_extensions
+        assert collection.keywords
+        assert collection.providers
+        assert collection.summaries
+        assert collection.assets
+
+        # Remove all of the optional stuff
+        collection.title = None
+        collection.stac_extensions = []
+        collection.keywords = []
+        collection.providers = []
+        collection.summaries = pystac.Summaries({})
+        collection.assets = {}
+
+        collection_as_dict = collection.to_dict()
+        for key in (
+            "title",
+            "stac_extensions",
+            "keywords",
+            "providers",
+            "summaries",
+            "assets",
+        ):
+            assert key not in collection_as_dict
+
     def test_from_dict_preserves_dict(self) -> None:
         path = TestCases.get_path("data-files/collections/with-assets.json")
         with open(path) as f:


### PR DESCRIPTION
**Description:**

The underlying problem is that, when creating a Collection from a dict, some values are pulled out to Collection-level attributes, e.g. https://github.com/stac-utils/pystac/blob/114b1a192051972cf155c36c362ad5628572215a/pystac/collection.py#L644-L646

However, those values are _not_ removed from the original dictionary `d`, and that original dictionary is used to populate `extra_fields`: https://github.com/stac-utils/pystac/blob/114b1a192051972cf155c36c362ad5628572215a/pystac/collection.py#L657

This means that the `assets` attribute of a Collection isn't the only place where assets (and other attributes) are stored, and in fact when a collection is turned back into a dictionary, those assets are re-populated from `extra_fields`: https://github.com/stac-utils/pystac/blob/114b1a192051972cf155c36c362ad5628572215a/pystac/catalog.py#L516-L517

This fixes the issue by popping these optional attributes out of the source dictionary, and by checking for these attributes' presence in a better way (i.e. before we were checking if lists were not None 😞).


**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
