### PR TITLE
Add start and end datetimes to `Item.__init__`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `AsIsLayoutStrategy` ([#919](https://github.com/stac-utils/pystac/pull/919))
 - `__geo_interface__` for items ([#885](https://github.com/stac-utils/pystac/pull/885))
 - Optional `strategy` parameter to `catalog.add_items()` ([#967](https://github.com/stac-utils/pystac/pull/967))
+- `start_datetime` and `end_datetime` arguments to the `Item` constructor ([#918](https://github.com/stac-utils/pystac/pull/918))
 
 ### Removed
 

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -40,8 +40,12 @@ class Item(STACObject):
             where n is the number of dimensions. Could also be None in the case of a
             null geometry.
         datetime : Datetime associated with this item. If None,
-            a start_datetime and end_datetime must be supplied in the properties.
+            a start_datetime and end_datetime must be supplied.
         properties : A dictionary of additional metadata for the item.
+        start_datetime : Optional start datetime, part of common metadata. This value
+            will override any `start_datetime` key in properties.
+        end_datetime : Optional end datetime, part of common metadata. This value
+            will override any `end_datetime` key in properties.
         stac_extensions : Optional list of extensions the Item implements.
         href : Optional HREF for this item, which be set as the item's
             self link's HREF.
@@ -104,6 +108,8 @@ class Item(STACObject):
         bbox: Optional[List[float]],
         datetime: Optional[Datetime],
         properties: Dict[str, Any],
+        start_datetime: Optional[Datetime] = None,
+        end_datetime: Optional[Datetime] = None,
         stac_extensions: Optional[List[str]] = None,
         href: Optional[str] = None,
         collection: Optional[Union[str, Collection]] = None,
@@ -124,13 +130,16 @@ class Item(STACObject):
         self.assets: Dict[str, Asset] = {}
 
         self.datetime: Optional[Datetime] = None
+        if start_datetime:
+            properties["start_datetime"] = datetime_to_str(start_datetime)
+        if end_datetime:
+            properties["end_datetime"] = datetime_to_str(end_datetime)
         if datetime is None:
             if "start_datetime" not in properties or "end_datetime" not in properties:
                 raise STACError(
                     "Invalid Item: If datetime is None, "
                     "a start_datetime and end_datetime "
-                    "must be supplied in "
-                    "the properties."
+                    "must be supplied."
                 )
             self.datetime = None
         else:

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -5,6 +5,8 @@ import unittest
 from copy import deepcopy
 from typing import Any, Dict
 
+import dateutil.relativedelta
+
 import pystac
 import pystac.serialization.common_properties
 from pystac import Asset, Item
@@ -179,6 +181,40 @@ class ItemTest(unittest.TestCase):
         self.assertCountEqual(no_filter.keys(), ["analytic", "thumbnail"])
         no_assets = item.get_assets(media_type=pystac.MediaType.HDF)
         self.assertEqual(no_assets, {})
+
+    def test_null_datetime_constructor(self) -> None:
+        item = pystac.Item.from_file(
+            TestCases.get_path("data-files/item/sample-item.json")
+        )
+        with self.assertRaises(pystac.STACError):
+            Item(
+                "test",
+                geometry=item.geometry,
+                bbox=item.bbox,
+                datetime=None,
+                end_datetime=item.datetime,
+                properties={},
+            )
+        with self.assertRaises(pystac.STACError):
+            Item(
+                "test",
+                geometry=item.geometry,
+                bbox=item.bbox,
+                datetime=None,
+                start_datetime=item.datetime,
+                properties={},
+            )
+        assert item.datetime
+        null_dt_item = Item(
+            "test",
+            geometry=item.geometry,
+            bbox=item.bbox,
+            datetime=None,
+            start_datetime=item.datetime,
+            end_datetime=item.datetime + dateutil.relativedelta.relativedelta(days=1),
+            properties={},
+        )
+        null_dt_item.validate()
 
     def test_get_set_asset_datetime(self) -> None:
         item = pystac.Item.from_file(
@@ -379,4 +415,5 @@ class AssetSubClassTest(unittest.TestCase):
         asset = self.CustomAsset.from_dict(self.asset_dict)
         cloned_asset = asset.clone()
 
+        self.assertIsInstance(cloned_asset, self.CustomAsset)
         self.assertIsInstance(cloned_asset, self.CustomAsset)


### PR DESCRIPTION
**Related Issue(s):** 

- Closes #905 
- Closes #710 (though with a different solution than the one proposed there)

**Description:**

It's pretty awkward to provide `start_datetime` and `end_datetime` as strings in `properties`, when you can provide a datetime object as `datetime`. This PR adds two optional arguments to set `start_datetime` and `end_datetime` in the constructor. These values will override anything set in `properties`.


**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
