### PR TITLE
Add timespec to datetime_to_str util function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Update Grid Extension support to v1.1.0 and fix issue with grid:code prefix validation ([#925](https://github.com/stac-utils/pystac/pull/925))
 - Adds custom `header` support to `DefaultStacIO` ([#889](https://github.com/stac-utils/pystac/pull/889))
 - Python 3.11 checks in CI ([#908](https://github.com/stac-utils/pystac/pull/908))
+- Add the optional argument timespec to datetime_to_str function in utils ([#929](https://github.com/stac-utils/pystac/pull/929))
 
 ### Removed
 

--- a/pystac/utils.py
+++ b/pystac/utils.py
@@ -299,7 +299,7 @@ def is_absolute_href(href: str) -> bool:
     return parsed.scheme != "" or _pathlib.isabs(parsed.path)
 
 
-def datetime_to_str(dt: datetime) -> str:
+def datetime_to_str(dt: datetime, timespec: str = "auto") -> str:
     """Converts a :class:`datetime.datetime` instance to an ISO8601 string in the
     `RFC 3339, section 5.6
     <https://datatracker.ietf.org/doc/html/rfc3339#section-5.6>`__ format required by
@@ -314,7 +314,7 @@ def datetime_to_str(dt: datetime) -> str:
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)
 
-    timestamp = dt.isoformat()
+    timestamp = dt.isoformat(timespec=timespec)
     zulu = "+00:00"
     if timestamp.endswith(zulu):
         timestamp = "{}Z".format(timestamp[: -len(zulu)])

--- a/pystac/utils.py
+++ b/pystac/utils.py
@@ -307,6 +307,10 @@ def datetime_to_str(dt: datetime, timespec: str = "auto") -> str:
 
     Args:
         dt : The datetime to convert.
+        timespec: An optional argument that specifies the number of additional
+        terms of the time to include. Valid options are 'auto', 'hours',
+        'minutes', 'seconds', 'milliseconds' and 'microseconds'. The default value
+        is 'auto'.
 
     Returns:
         str: The ISO8601 (RFC 3339) formatted string representing the datetime.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -280,7 +280,7 @@ class UtilsTest(unittest.TestCase):
             with self.subTest(title=title):
                 got = utils.datetime_to_str(dt)
                 self.assertEqual(expected, got)
-    
+
     def test_datetime_to_str_with_microseconds_timespec(self) -> None:
         cases = (
             (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -280,6 +280,30 @@ class UtilsTest(unittest.TestCase):
             with self.subTest(title=title):
                 got = utils.datetime_to_str(dt)
                 self.assertEqual(expected, got)
+    
+    def test_datetime_to_str_with_microseconds_timespec(self) -> None:
+        cases = (
+            (
+                "timezone naive, assume utc",
+                datetime(2000, 1, 1, 0, 0, 0, 0),
+                "2000-01-01T00:00:00.000000Z",
+            ),
+            (
+                "timezone aware, utc",
+                datetime(2000, 1, 1, 0, 0, 0, 0, tzinfo=timezone.utc),
+                "2000-01-01T00:00:00.000000Z",
+            ),
+            (
+                "timezone aware, utc -7",
+                datetime(2000, 1, 1, 0, 0, 0, 0, tzinfo=timezone(timedelta(hours=-7))),
+                "2000-01-01T00:00:00.000000-07:00",
+            ),
+        )
+
+        for title, dt, expected in cases:
+            with self.subTest(title=title):
+                got = utils.datetime_to_str(dt, timespec="microseconds")
+                self.assertEqual(expected, got)
 
     def test_str_to_datetime(self) -> None:
         def _set_tzinfo(tz_str: Optional[str]) -> None:


### PR DESCRIPTION
**Related Issue(s):** #

- Helps fix https://github.com/stac-utils/pystac/issues/927

**Description:**
Currently `datetime_to_str` function in `utils` truncates all microseconds if the microsecond in `datetime` object is equal to zero.
I've added an optional input (`timespec`) to control this ability. The default behavior is like before, but If users want to retrieve the result with `microseconds`, they can pass `timespec = "microseconds"` to the `datetime_to_str` function, and the result with microseconds will return.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
