### PR TITLE
Simplify installation section of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,30 @@ PySTAC is a library for working with [SpatioTemporal Asset Catalog](https://stac
 pip install pystac
 ```
 
+If you would like to enable the validation feature utilizing the
+[jsonschema](https://pypi.org/project/jsonschema/) project, install with the optional
+`validation` requirements:
+
+```shell
+pip install pystac[validation]
+```
+
+If you would like to use the [`orjson`](https://pypi.org/project/orjson/) instead of the
+standard `json` library for JSON serialization/deserialization, install with the
+optional `orjson` requirements:
+
+```shell
+pip install pystac[orjson]
+```
+
+### Install from source:
+
+```shell
+git clone https://github.com/stac-utils/pystac.git
+cd pystac
+pip install .
+```
+
 See the [installation page](https://pystac.readthedocs.io/en/latest/installation.html)
 for more options.
 

--- a/README.md
+++ b/README.md
@@ -12,62 +12,14 @@ PySTAC is a library for working with [SpatioTemporal Asset Catalog](https://stac
 
 ## Installation
 
-PySTAC requires Python >= 3.8. This project follows the recommendations of
-[NEP-29](https://numpy.org/neps/nep-0029-deprecation_policy.html) in deprecating support
-for Python versions. This means that users can expect support for Python 3.8 to be
-removed from the `main` branch after Apr 14, 2023 and therefore from the next release
-after that date.
-
-PySTAC has a single required dependency (`python-dateutil`).
-PySTAC can be installed from pip or the source repository.
+### Install from PyPi (recommended)
 
 ```shell
 pip install pystac
 ```
 
-If you would like to enable the validation feature utilizing the
-[jsonschema](https://pypi.org/project/jsonschema/) project, install with the optional
-`validation` requirements:
-
-```shell
-pip install pystac[validation]
-```
-
-If you would like to use the [`orjson`](https://pypi.org/project/orjson/) instead of the
-standard `json` library for JSON serialization/deserialization, install with the
-optional `orjson` requirements:
-
-```shell
-pip install pystac[orjson]
-```
-
-From source repository:
-
-```shell
-git clone https://github.com/stac-utils/pystac.git
-cd pystac
-pip install .
-```
-
-### Versions
-
-To install a version of PySTAC that works with a specific versions of the STAC
-specification, install the matching version of PySTAC from the following table.
-
-| PySTAC | STAC  |
-| ------ | ----- |
-| 1.x    | 1.0.x |
-| 0.5.x  | 1.0.0-beta.* |
-| 0.4.x  | 0.9.x |
-| 0.3.x  | 0.8.x |
-
-For instance, to work with STAC v0.9.x:
-
-```shell
-pip install pystac==0.4.0
-```
-
-STAC spec versions below 0.8 are not supported by PySTAC.
+See the [installation page](https://pystac.readthedocs.io/en/latest/installation.html)
+for more options.
 
 ## Documentation
 
@@ -75,7 +27,8 @@ See the [documentation page](https://pystac.readthedocs.io/en/latest/) for the l
 
 ## Developing
 
-See [contributing docs](docs/contributing.rst) for details on contributing to this project.
+See [contributing docs](https://pystac.readthedocs.io/en/latest/contributing.rst)
+for details on contributing to this project.
 
 ## Running the quickstart and tutorials
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -25,7 +25,13 @@ Install from source
 .. _installation_dependencies:
 
 Dependencies
-=============
+============
+
+PySTAC requires Python >= 3.8. This project follows the recommendations of
+`NEP-29 <https://numpy.org/neps/nep-0029-deprecation_policy.html>`__ in deprecating support
+for Python versions. This means that users can expect support for Python 3.8 to be
+removed from the ``main`` branch after Apr 14, 2023 and therefore from the next release
+after that date.
 
 As a foundational component of the Python STAC ecosystem used in a number of downstream
 libraries, PySTAC aims to minimize its dependencies. As a result, the only dependency
@@ -59,3 +65,33 @@ additional functionality:
   .. code-block:: bash
 
       pip install pystac[orjson]
+
+Versions
+========
+
+To install a version of PySTAC that works with a specific versions of the STAC
+specification, install the matching version of PySTAC from the following table.
+
+.. list-table:: Versions
+   :widths: 50 50
+   :header-rows: 1
+
+   * - PySTAC
+     - STAC
+   * - 1.x
+     - 1.0.x
+   * - 0.5.x
+     - 1.0.0-beta.*
+   * - 0.4.x
+     - 0.9.x
+   * - 0.3.x
+     - 0.8.x
+
+For instance, to work with STAC v0.9.x:
+
+   .. code-block:: bash
+
+      pip install pystac==0.4.0
+
+
+STAC spec versions below 0.8 are not supported by PySTAC.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -72,7 +72,7 @@ Versions
 To install a version of PySTAC that works with a specific versions of the STAC
 specification, install the matching version of PySTAC from the following table.
 
-.. list-table:: Versions
+.. list-table::
    :widths: 50 50
    :header-rows: 1
 


### PR DESCRIPTION
**Related Issue(s):** #917 


**Description:** I copied the pypi installation section and then pointed to the installation docs to avoid duplication. In this PR I just deleted the NEP-29 information, but I think it would also fit nicely in the contributing doc if you think it's important to keep around.


**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
