### PR TITLE
Add isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,3 +41,11 @@ repos:
         stages: [commit]
         types: [python]
         require_serial: true
+
+      - id: isort
+        name: isort
+        entry: isort
+        args: []
+        language: system
+        stages: [commit]
+        types: [python]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Python 3.11 checks in CI ([#908](https://github.com/stac-utils/pystac/pull/908))
 - Ability to only update resolved links when using `Catalog.normalize_hrefs` and `Catalog.normalize_and_save`, via a new `skip_unresolved` argument ([#900](https://github.com/stac-utils/pystac/pull/900))
 - Add the optional argument `timespec` to `utils.datetime_to_str` ([#929](https://github.com/stac-utils/pystac/pull/929))
+- `isort` ([#961](https://github.com/stac-utils/pystac/pull/961))
 
 ### Removed
 

--- a/benchmarks/_util.py
+++ b/benchmarks/_util.py
@@ -1,5 +1,5 @@
 import os
-from typing import Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
     PathLike = os.PathLike[str]

--- a/benchmarks/catalog.py
+++ b/benchmarks/catalog.py
@@ -5,14 +5,15 @@ import shutil
 import tempfile
 from pathlib import Path
 from tempfile import TemporaryDirectory
+
 from pystac import (
     Catalog,
-    StacIO,
     Collection,
     Extent,
-    TemporalExtent,
-    SpatialExtent,
     Item,
+    SpatialExtent,
+    StacIO,
+    TemporalExtent,
 )
 
 from ._base import Bench

--- a/benchmarks/collection.py
+++ b/benchmarks/collection.py
@@ -2,7 +2,8 @@ import json
 import os
 import shutil
 import tempfile
-from pystac import StacIO, Collection
+
+from pystac import Collection, StacIO
 
 from ._base import Bench
 from ._util import get_data_path

--- a/benchmarks/item.py
+++ b/benchmarks/item.py
@@ -2,7 +2,8 @@ import json
 import os
 import shutil
 import tempfile
-from pystac import StacIO, Item
+
+from pystac import Item, StacIO
 
 from ._base import Bench
 from ._util import get_data_path

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,14 +13,13 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
-import sys
 import subprocess
+import sys
 from typing import Any, Dict, List
-
 
 sys.path.insert(0, os.path.abspath("."))
 sys.path.insert(0, os.path.abspath("../"))
-from pystac.version import __version__, STACVersion  # noqa:E402
+from pystac.version import STACVersion, __version__  # noqa:E402
 
 git_branch = (
     subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"])

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -59,6 +59,7 @@ PySTAC uses
 - `doc8 <https://github.com/pycqa/doc8>`__ for style checking on RST files in the docs
 - `flake8 <https://flake8.pycqa.org/en/latest/>`_ for Python style checks
 - `mypy <http://www.mypy-lang.org/>`_ for Python type annotation checks
+- `isort <https://pycqa.github.io/isort/>` to sort Python import statements
 
 Run all of these with ``pre-commit run --all-files`` or a single one using
 ``pre-commit run --all-files ID``, where ``ID`` is one of the command names above. For

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.isort]
+profile = "black"

--- a/pystac/__init__.py
+++ b/pystac/__init__.py
@@ -1,3 +1,4 @@
+# isort: skip_file
 """
 PySTAC is a library for working with SpatioTemporal Asset Catalogs (STACs)
 """

--- a/pystac/asset.py
+++ b/pystac/asset.py
@@ -1,10 +1,9 @@
-from html import escape
 from copy import copy, deepcopy
-from typing import Any, Dict, List, Optional, TYPE_CHECKING, Union
+from html import escape
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
-from pystac import common_metadata
+from pystac import common_metadata, utils
 from pystac.html.jinja_env import get_jinja_env
-from pystac import utils
 
 if TYPE_CHECKING:
     from pystac.collection import Collection as Collection_Type

--- a/pystac/cache.py
+++ b/pystac/cache.py
@@ -1,12 +1,12 @@
 from collections import ChainMap
 from copy import copy
-from typing import Any, Dict, List, Optional, TYPE_CHECKING, Tuple, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, cast
 
 import pystac
 
 if TYPE_CHECKING:
-    from pystac.stac_object import STACObject as STACObject_Type
     from pystac.collection import Collection as Collection_Type
+    from pystac.stac_object import STACObject as STACObject_Type
 
 
 def get_cache_key(stac_object: "STACObject_Type") -> Tuple[str, bool]:

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -1,35 +1,35 @@
 import os
-from html import escape
 from copy import deepcopy
-from pystac.errors import STACTypeError
-from pystac.html.jinja_env import get_jinja_env
+from html import escape
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Dict,
     Iterable,
     List,
     Optional,
-    TYPE_CHECKING,
     Tuple,
     Union,
     cast,
 )
 
 import pystac
-from pystac.stac_object import STACObject, STACObjectType
+from pystac.cache import ResolvedObjectCache
+from pystac.errors import STACTypeError
+from pystac.html.jinja_env import get_jinja_env
 from pystac.layout import (
     BestPracticesLayoutStrategy,
     HrefLayoutStrategy,
     LayoutTemplate,
 )
 from pystac.link import Link
-from pystac.cache import ResolvedObjectCache
 from pystac.serialization import (
-    identify_stac_object_type,
     identify_stac_object,
+    identify_stac_object_type,
     migrate_to_latest,
 )
+from pystac.stac_object import STACObject, STACObjectType
 from pystac.utils import (
     StringEnum,
     is_absolute_href,
@@ -39,8 +39,8 @@ from pystac.utils import (
 
 if TYPE_CHECKING:
     from pystac.asset import Asset as Asset_Type
-    from pystac.item import Item as Item_Type
     from pystac.collection import Collection as Collection_Type
+    from pystac.item import Item as Item_Type
 
 
 class CatalogType(StringEnum):

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -1,16 +1,13 @@
-from html import escape
 from copy import deepcopy
 from datetime import datetime
-
-from pystac.errors import STACTypeError
-from pystac.html.jinja_env import get_jinja_env
+from html import escape
 from typing import (
+    TYPE_CHECKING,
     Any,
     Dict,
     Iterable,
     List,
     Optional,
-    TYPE_CHECKING,
     Tuple,
     TypeVar,
     Union,
@@ -20,19 +17,21 @@ from typing import (
 from dateutil import tz
 
 import pystac
-from pystac import STACObjectType, CatalogType
+from pystac import CatalogType, STACObjectType
 from pystac.asset import Asset
 from pystac.catalog import Catalog
+from pystac.errors import STACTypeError
+from pystac.html.jinja_env import get_jinja_env
 from pystac.layout import HrefLayoutStrategy
 from pystac.link import Link
 from pystac.provider import Provider
-from pystac.utils import datetime_to_str, str_to_datetime
 from pystac.serialization import (
-    identify_stac_object_type,
     identify_stac_object,
+    identify_stac_object_type,
     migrate_to_latest,
 )
 from pystac.summaries import Summaries
+from pystac.utils import datetime_to_str, str_to_datetime
 
 if TYPE_CHECKING:
     from pystac.item import Item as Item_Type

--- a/pystac/common_metadata.py
+++ b/pystac/common_metadata.py
@@ -1,14 +1,14 @@
 from datetime import datetime as Datetime
-from pystac.errors import STACError
-from typing import Any, cast, Dict, List, Optional, Type, TYPE_CHECKING, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, TypeVar, Union, cast
 
 import pystac
 from pystac import utils
+from pystac.errors import STACError
 
 if TYPE_CHECKING:
-    from pystac.provider import Provider as Provider_Type
     from pystac.asset import Asset as Asset_Type
     from pystac.item import Item as Item_Type
+    from pystac.provider import Provider as Provider_Type
 
 
 P = TypeVar("P")

--- a/pystac/extensions/base.py
+++ b/pystac/extensions/base.py
@@ -1,15 +1,15 @@
 from abc import ABC, abstractmethod
 from typing import (
-    cast,
+    Any,
+    Dict,
     Generic,
     Iterable,
     List,
     Optional,
-    Dict,
-    Any,
     Type,
     TypeVar,
     Union,
+    cast,
 )
 
 import pystac

--- a/pystac/extensions/datacube.py
+++ b/pystac/extensions/datacube.py
@@ -4,10 +4,7 @@ from abc import ABC
 from typing import Any, Dict, Generic, List, Optional, TypeVar, Union, cast
 
 import pystac
-from pystac.extensions.base import (
-    ExtensionManagementMixin,
-    PropertiesExtension,
-)
+from pystac.extensions.base import ExtensionManagementMixin, PropertiesExtension
 from pystac.extensions.hooks import ExtensionHooks
 from pystac.utils import StringEnum, get_required, map_opt
 

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -14,15 +14,15 @@ from typing import (
 )
 
 import pystac
-from pystac.summaries import RangeSummary
+from pystac.extensions import projection, view
 from pystac.extensions.base import (
     ExtensionManagementMixin,
     PropertiesExtension,
     SummariesExtension,
 )
 from pystac.extensions.hooks import ExtensionHooks
-from pystac.extensions import view, projection
 from pystac.serialization.identify import STACJSONDescription, STACVersionID
+from pystac.summaries import RangeSummary
 from pystac.utils import get_required, map_opt
 
 T = TypeVar("T", pystac.Item, pystac.Asset)

--- a/pystac/extensions/hooks.py
+++ b/pystac/extensions/hooks.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from functools import lru_cache
-from typing import Any, Dict, Iterable, List, Optional, Set, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Set, Union
 
 import pystac
 from pystac.serialization.identify import STACJSONDescription, STACVersionID

--- a/pystac/extensions/label.py
+++ b/pystac/extensions/label.py
@@ -1,11 +1,11 @@
 """Implements the :stac-ext:`Label Extension <label>`."""
 
-from pystac.extensions.base import ExtensionManagementMixin, SummariesExtension
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Union, cast
 
 import pystac
-from pystac.serialization.identify import STACJSONDescription, STACVersionID
+from pystac.extensions.base import ExtensionManagementMixin, SummariesExtension
 from pystac.extensions.hooks import ExtensionHooks
+from pystac.serialization.identify import STACJSONDescription, STACVersionID
 from pystac.utils import StringEnum, get_required, map_opt
 
 SCHEMA_URI = "https://stac-extensions.github.io/label/v1.0.1/schema.json"

--- a/pystac/extensions/pointcloud.py
+++ b/pystac/extensions/pointcloud.py
@@ -1,5 +1,5 @@
 """Implements the :stac-ext:`Point Cloud Extension <pointcloud>`."""
-from typing import Any, Dict, Iterable, Generic, List, Optional, TypeVar, cast, Union
+from typing import Any, Dict, Generic, Iterable, List, Optional, TypeVar, Union, cast
 
 import pystac
 from pystac.extensions.base import (
@@ -9,7 +9,7 @@ from pystac.extensions.base import (
 )
 from pystac.extensions.hooks import ExtensionHooks
 from pystac.summaries import RangeSummary
-from pystac.utils import StringEnum, map_opt, get_required
+from pystac.utils import StringEnum, get_required, map_opt
 
 T = TypeVar("T", pystac.Item, pystac.Asset)
 

--- a/pystac/extensions/projection.py
+++ b/pystac/extensions/projection.py
@@ -4,12 +4,12 @@ import json
 from typing import Any, Dict, Generic, Iterable, List, Optional, TypeVar, Union, cast
 
 import pystac
-from pystac.extensions.hooks import ExtensionHooks
 from pystac.extensions.base import (
     ExtensionManagementMixin,
     PropertiesExtension,
     SummariesExtension,
 )
+from pystac.extensions.hooks import ExtensionHooks
 
 T = TypeVar("T", pystac.Item, pystac.Asset)
 

--- a/pystac/extensions/sar.py
+++ b/pystac/extensions/sar.py
@@ -1,16 +1,16 @@
 """Implements the :stac-ext:`Synthetic-Aperture Radar (SAR) Extension <sar>`."""
 
-from typing import Any, Dict, Generic, Iterable, List, Optional, TypeVar, cast, Union
+from typing import Any, Dict, Generic, Iterable, List, Optional, TypeVar, Union, cast
 
 import pystac
-from pystac.serialization.identify import STACJSONDescription, STACVersionID
-from pystac.summaries import RangeSummary
 from pystac.extensions.base import (
     ExtensionManagementMixin,
     PropertiesExtension,
     SummariesExtension,
 )
 from pystac.extensions.hooks import ExtensionHooks
+from pystac.serialization.identify import STACJSONDescription, STACVersionID
+from pystac.summaries import RangeSummary
 from pystac.utils import StringEnum, get_required, map_opt
 
 T = TypeVar("T", pystac.Item, pystac.Asset)

--- a/pystac/extensions/sat.py
+++ b/pystac/extensions/sat.py
@@ -1,8 +1,7 @@
 """Implements the :stac-ext:`Satellite Extension <sat>`."""
 
 from datetime import datetime as Datetime
-from pystac.summaries import RangeSummary
-from typing import Dict, Any, List, Iterable, Generic, Optional, TypeVar, Union, cast
+from typing import Any, Dict, Generic, Iterable, List, Optional, TypeVar, Union, cast
 
 import pystac
 from pystac.extensions.base import (
@@ -11,7 +10,8 @@ from pystac.extensions.base import (
     SummariesExtension,
 )
 from pystac.extensions.hooks import ExtensionHooks
-from pystac.utils import StringEnum, str_to_datetime, datetime_to_str, map_opt
+from pystac.summaries import RangeSummary
+from pystac.utils import StringEnum, datetime_to_str, map_opt, str_to_datetime
 
 T = TypeVar("T", pystac.Item, pystac.Asset)
 

--- a/pystac/extensions/table.py
+++ b/pystac/extensions/table.py
@@ -2,10 +2,7 @@
 from typing import Any, Dict, Generic, List, Optional, TypeVar, Union, cast
 
 import pystac
-from pystac.extensions.base import (
-    ExtensionManagementMixin,
-    PropertiesExtension,
-)
+from pystac.extensions.base import ExtensionManagementMixin, PropertiesExtension
 from pystac.extensions.hooks import ExtensionHooks
 from pystac.utils import get_required
 

--- a/pystac/extensions/timestamps.py
+++ b/pystac/extensions/timestamps.py
@@ -1,8 +1,7 @@
 """Implements the :stac-ext:`Timestamps Extension <timestamps>`."""
 
 from datetime import datetime as datetime
-from pystac.summaries import RangeSummary
-from typing import Dict, Any, Iterable, Generic, Optional, TypeVar, Union, cast
+from typing import Any, Dict, Generic, Iterable, Optional, TypeVar, Union, cast
 
 import pystac
 from pystac.extensions.base import (
@@ -11,6 +10,7 @@ from pystac.extensions.base import (
     SummariesExtension,
 )
 from pystac.extensions.hooks import ExtensionHooks
+from pystac.summaries import RangeSummary
 from pystac.utils import datetime_to_str, map_opt, str_to_datetime
 
 T = TypeVar("T", pystac.Item, pystac.Asset)

--- a/pystac/extensions/version.py
+++ b/pystac/extensions/version.py
@@ -1,14 +1,10 @@
 """Implements the :stac-ext:`Versioning Indicators Extension <version>`."""
-from pystac.utils import get_required, map_opt
 from typing import Any, Dict, Generic, List, Optional, TypeVar, Union, cast
 
 import pystac
-from pystac.utils import StringEnum
-from pystac.extensions.base import (
-    ExtensionManagementMixin,
-    PropertiesExtension,
-)
+from pystac.extensions.base import ExtensionManagementMixin, PropertiesExtension
 from pystac.extensions.hooks import ExtensionHooks
+from pystac.utils import StringEnum, get_required, map_opt
 
 T = TypeVar("T", pystac.Collection, pystac.Item)
 

--- a/pystac/extensions/view.py
+++ b/pystac/extensions/view.py
@@ -3,13 +3,13 @@
 from typing import Any, Dict, Generic, Iterable, Optional, TypeVar, Union, cast
 
 import pystac
-from pystac.summaries import RangeSummary
 from pystac.extensions.base import (
     ExtensionManagementMixin,
     PropertiesExtension,
     SummariesExtension,
 )
 from pystac.extensions.hooks import ExtensionHooks
+from pystac.summaries import RangeSummary
 
 T = TypeVar("T", pystac.Item, pystac.Asset)
 

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -1,28 +1,28 @@
-from html import escape
 from copy import copy, deepcopy
 from datetime import datetime as Datetime
-from pystac.catalog import Catalog
+from html import escape
 from typing import Any, Dict, List, Optional, Union, cast
 
 import pystac
-from pystac.html.jinja_env import get_jinja_env
 from pystac import STACError, STACObjectType
 from pystac.asset import Asset
+from pystac.catalog import Catalog
+from pystac.collection import Collection
+from pystac.html.jinja_env import get_jinja_env
 from pystac.link import Link
 from pystac.serialization import (
-    identify_stac_object_type,
     identify_stac_object,
+    identify_stac_object_type,
     migrate_to_latest,
 )
 from pystac.stac_object import STACObject
 from pystac.utils import (
+    datetime_to_str,
     is_absolute_href,
     make_absolute_href,
     make_relative_href,
-    datetime_to_str,
     str_to_datetime,
 )
-from pystac.collection import Collection
 
 
 class Item(STACObject):

--- a/pystac/item_collection.py
+++ b/pystac/item_collection.py
@@ -1,13 +1,12 @@
 from copy import deepcopy
-from pystac.errors import STACTypeError
-from typing import Any, Dict, Iterator, List, Optional, Collection, Iterable, Union
 from html import escape
+from typing import Any, Collection, Dict, Iterable, Iterator, List, Optional, Union
 
 import pystac
+from pystac.errors import STACTypeError
 from pystac.html.jinja_env import get_jinja_env
-from pystac.utils import make_absolute_href, is_absolute_href
 from pystac.serialization.identify import identify_stac_object_type
-
+from pystac.utils import is_absolute_href, make_absolute_href
 
 ItemLike = Union[pystac.Item, Dict[str, Any]]
 

--- a/pystac/layout.py
+++ b/pystac/layout.py
@@ -1,16 +1,16 @@
-from abc import abstractmethod, ABC
+from abc import ABC, abstractmethod
 from collections import OrderedDict
 from string import Formatter
-from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 import pystac
-from pystac.utils import safe_urlparse, join_path_or_url, JoinType
+from pystac.utils import JoinType, join_path_or_url, safe_urlparse
 
 if TYPE_CHECKING:
-    from pystac.stac_object import STACObject as STACObject_Type
     from pystac.catalog import Catalog as Catalog_Type
     from pystac.collection import Collection as Collection_Type
     from pystac.item import Item as Item_Type
+    from pystac.stac_object import STACObject as STACObject_Type
 
 
 class TemplateError(Exception):

--- a/pystac/link.py
+++ b/pystac/link.py
@@ -1,17 +1,17 @@
 import os
 from copy import copy
 from html import escape
-from typing import Any, Dict, Optional, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
 import pystac
 from pystac.html.jinja_env import get_jinja_env
-from pystac.utils import make_absolute_href, make_relative_href, is_absolute_href
+from pystac.utils import is_absolute_href, make_absolute_href, make_relative_href
 
 if TYPE_CHECKING:
-    from pystac.stac_object import STACObject as STACObject_Type
-    from pystac.item import Item as Item_Type
     from pystac.catalog import Catalog as Catalog_Type
     from pystac.collection import Collection as Collection_Type
+    from pystac.item import Item as Item_Type
+    from pystac.stac_object import STACObject as STACObject_Type
 
     PathLike = os.PathLike[str]
 

--- a/pystac/provider.py
+++ b/pystac/provider.py
@@ -1,5 +1,5 @@
-from typing import Any, Dict, List, Optional
 from html import escape
+from typing import Any, Dict, List, Optional
 
 from pystac.html.jinja_env import get_jinja_env
 from pystac.utils import StringEnum

--- a/pystac/serialization/__init__.py
+++ b/pystac/serialization/__init__.py
@@ -5,10 +5,10 @@ __all__ = [
     "identify_stac_object",
     "identify_stac_object_type",
 ]
+from pystac.serialization.common_properties import merge_common_properties
 from pystac.serialization.identify import (
     STACVersionRange,
     identify_stac_object,
     identify_stac_object_type,
 )
-from pystac.serialization.common_properties import merge_common_properties
 from pystac.serialization.migrate import migrate_to_latest

--- a/pystac/serialization/identify.py
+++ b/pystac/serialization/identify.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from functools import total_ordering
-from typing import Any, Dict, Optional, Set, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Set, Union
 
 import pystac
 from pystac.version import STACVersion

--- a/pystac/serialization/migrate.py
+++ b/pystac/serialization/migrate.py
@@ -1,13 +1,13 @@
 from copy import deepcopy
-from typing import Any, Callable, Dict, List, Optional, Set, TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple
 
 import pystac
-from pystac.version import STACVersion
 from pystac.serialization.identify import (
     OldExtensionShortIDs,
     STACJSONDescription,
     STACVersionID,
 )
+from pystac.version import STACVersion
 
 if TYPE_CHECKING:
     from pystac import STACObjectType as STACObjectType_Type

--- a/pystac/stac_io.py
+++ b/pystac/stac_io.py
@@ -1,29 +1,19 @@
-from abc import ABC, abstractmethod
-import os
 import json
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    TYPE_CHECKING,
-    Tuple,
-)
-
-from urllib.request import urlopen
-from urllib.request import Request
+import os
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 from urllib.error import HTTPError
+from urllib.request import Request, urlopen
 
 import pystac
 from pystac.link import HREF
-from pystac.utils import safe_urlparse
 from pystac.serialization import (
-    merge_common_properties,
-    identify_stac_object_type,
     identify_stac_object,
+    identify_stac_object_type,
+    merge_common_properties,
     migrate_to_latest,
 )
+from pystac.utils import safe_urlparse
 
 # Use orjson if available
 try:
@@ -32,8 +22,8 @@ except ImportError:
     orjson = None  # type: ignore[assignment]
 
 if TYPE_CHECKING:
-    from pystac.stac_object import STACObject as STACObject_Type
     from pystac.catalog import Catalog as Catalog_Type
+    from pystac.stac_object import STACObject as STACObject_Type
 
 
 class StacIO(ABC):

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Iterable, List, Optional, Type, cast, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Type, Union, cast
 
 import pystac
 from pystac import STACError

--- a/pystac/summaries.py
+++ b/pystac/summaries.py
@@ -1,23 +1,22 @@
-from copy import deepcopy
 import numbers
+from copy import deepcopy
 from enum import Enum
 from functools import lru_cache
-
-import pystac
-from pystac.utils import get_required
-
 from typing import (
+    TYPE_CHECKING,
     Any,
     Dict,
     Generic,
+    Iterable,
     List,
     Optional,
     Protocol,
-    Union,
     TypeVar,
-    Iterable,
-    TYPE_CHECKING,
+    Union,
 )
+
+import pystac
+from pystac.utils import get_required
 
 if TYPE_CHECKING:
     from pystac.item import Item as Item_Type

--- a/pystac/utils.py
+++ b/pystac/utils.py
@@ -1,11 +1,14 @@
 import os
 import posixpath
-from enum import Enum
-from pystac.errors import RequiredPropertyMissing
-from typing import Any, Callable, Dict, List, Optional, TypeVar, Union, cast
-from urllib.parse import urljoin, urlparse, urlunparse, ParseResult as URLParseResult
 from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Callable, Dict, List, Optional, TypeVar, Union, cast
+from urllib.parse import ParseResult as URLParseResult
+from urllib.parse import urljoin, urlparse, urlunparse
+
 import dateutil.parser
+
+from pystac.errors import RequiredPropertyMissing
 
 # Allow for modifying the path library for testability
 # (i.e. testing Windows path manipulation on non-Windows systems)

--- a/pystac/validation/__init__.py
+++ b/pystac/validation/__init__.py
@@ -1,9 +1,9 @@
-from typing import Dict, List, Any, Optional, cast, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
 
 import pystac
 from pystac.serialization.identify import STACVersionID, identify_stac_object
-from pystac.validation.schema_uri_map import OldExtensionSchemaUriMap
 from pystac.utils import make_absolute_href
+from pystac.validation.schema_uri_map import OldExtensionSchemaUriMap
 
 if TYPE_CHECKING:
     from pystac.stac_object import STACObject as STACObject_Type
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 
 # Import after above class definition
-from pystac.validation.stac_validator import STACValidator, JsonSchemaSTACValidator
+from pystac.validation.stac_validator import JsonSchemaSTACValidator, STACValidator
 
 
 def validate(stac_object: "STACObject_Type") -> List[Any]:

--- a/pystac/validation/schema_uri_map.py
+++ b/pystac/validation/schema_uri_map.py
@@ -1,10 +1,10 @@
 from abc import ABC, abstractmethod
 from functools import lru_cache
-from pystac.serialization.identify import OldExtensionShortIDs, STACVersionID
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import pystac
 from pystac.serialization import STACVersionRange
+from pystac.serialization.identify import OldExtensionShortIDs, STACVersionID
 from pystac.stac_object import STACObjectType
 
 

--- a/pystac/validation/stac_validator.py
+++ b/pystac/validation/stac_validator.py
@@ -1,16 +1,16 @@
-from abc import ABC, abstractmethod
-import logging
 import json
-from pystac.stac_object import STACObjectType
+import logging
+from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Tuple
 
 import pystac
+from pystac.stac_object import STACObjectType
 from pystac.validation.schema_uri_map import DefaultSchemaUriMap, SchemaUriMap
 
 try:
     import jsonschema
-    import jsonschema.validators
     import jsonschema.exceptions
+    import jsonschema.validators
 except ImportError:
     jsonschema = None
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,6 +5,7 @@ pytest==7.2.1
 pytest-cov==4.0.0
 pytest-mock==3.10.0
 codespell==2.2.2
+isort==5.11.4
 
 jsonschema==4.17.3
 coverage==7.0.5

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 import os
-from setuptools import setup, find_packages
 from glob import glob
-
 from os.path import basename, splitext
+
+from setuptools import find_packages, setup
 
 here = os.path.abspath(os.path.dirname(__file__))
 

--- a/tests/data-files/change_stac_version.py
+++ b/tests/data-files/change_stac_version.py
@@ -2,10 +2,10 @@
 Script to change the version property of the test files for PySTAC.
 This is used when upgrading to a new version of STAC.
 """
-import os
-import re
 import argparse
 import json
+import os
+import re
 
 import pystac
 

--- a/tests/data-files/get_examples.py
+++ b/tests/data-files/get_examples.py
@@ -2,11 +2,11 @@
 Script to download the examples from the stac-spec repository.
 This is used when upgrading to a new version of STAC.
 """
-import os
 import argparse
 import json
-from subprocess import call
+import os
 import tempfile
+from subprocess import call
 from typing import Any, Dict, List, Optional
 from urllib.error import HTTPError
 

--- a/tests/extensions/test_custom.py
+++ b/tests/extensions/test_custom.py
@@ -1,17 +1,17 @@
 """Tests creating a custom extension"""
 
-from pystac.summaries import RangeSummary
-from typing import Any, Dict, Generic, List, Optional, Set, TypeVar, Union, cast
 import unittest
+from typing import Any, Dict, Generic, List, Optional, Set, TypeVar, Union, cast
 
 import pystac
-from pystac.serialization.identify import STACJSONDescription, STACVersionID
 from pystac.extensions.base import (
     ExtensionManagementMixin,
     PropertiesExtension,
     SummariesExtension,
 )
 from pystac.extensions.hooks import ExtensionHooks
+from pystac.serialization.identify import STACJSONDescription, STACVersionID
+from pystac.summaries import RangeSummary
 
 T = TypeVar("T", pystac.Catalog, pystac.Collection, pystac.Item, pystac.Asset)
 

--- a/tests/extensions/test_datacube.py
+++ b/tests/extensions/test_datacube.py
@@ -1,8 +1,8 @@
 import unittest
+
 import pystac
 from pystac import ExtensionTypeError
 from pystac.extensions.datacube import DatacubeExtension, Variable
-
 from tests.utils import TestCases
 
 

--- a/tests/extensions/test_eo.py
+++ b/tests/extensions/test_eo.py
@@ -3,10 +3,10 @@ import unittest
 
 import pystac
 from pystac import ExtensionTypeError, Item
+from pystac.extensions.eo import Band, EOExtension
+from pystac.extensions.projection import ProjectionExtension
 from pystac.summaries import RangeSummary
 from pystac.utils import get_opt
-from pystac.extensions.eo import EOExtension, Band
-from pystac.extensions.projection import ProjectionExtension
 from tests.utils import TestCases, assert_to_from_dict
 
 

--- a/tests/extensions/test_file.py
+++ b/tests/extensions/test_file.py
@@ -3,8 +3,8 @@ import unittest
 
 import pystac
 from pystac import ExtensionTypeError
+from pystac.extensions.file import ByteOrder, FileExtension, MappingObject
 from tests.utils import TestCases, assert_to_from_dict
-from pystac.extensions.file import FileExtension, ByteOrder, MappingObject
 
 
 class ByteOrderTest(unittest.TestCase):

--- a/tests/extensions/test_grid.py
+++ b/tests/extensions/test_grid.py
@@ -3,8 +3,8 @@
 # mypy: warn_unused_ignores=False
 
 import datetime
-from typing import Any, Dict
 import unittest
+from typing import Any, Dict
 
 import pystac
 from pystac import ExtensionTypeError

--- a/tests/extensions/test_item_assets.py
+++ b/tests/extensions/test_item_assets.py
@@ -2,7 +2,6 @@ import unittest
 
 from pystac import Collection
 from pystac.extensions.item_assets import AssetDefinition, ItemAssetsExtension
-
 from tests.utils import TestCases
 
 

--- a/tests/extensions/test_label.py
+++ b/tests/extensions/test_label.py
@@ -1,23 +1,23 @@
 import json
 import os
-import unittest
 import tempfile
+import unittest
 from typing import List, Union
 
 import pystac
-from pystac import Catalog, Collection, ExtensionTypeError, Item, CatalogType
+import pystac.validation
+from pystac import Catalog, CatalogType, Collection, ExtensionTypeError, Item
 from pystac.extensions.label import (
-    LabelExtension,
     LabelClasses,
     LabelCount,
+    LabelExtension,
     LabelMethod,
     LabelOverview,
+    LabelRelType,
     LabelStatistics,
     LabelTask,
     LabelType,
-    LabelRelType,
 )
-import pystac.validation
 from pystac.utils import get_opt
 from tests.utils import TestCases, assert_to_from_dict
 

--- a/tests/extensions/test_pointcloud.py
+++ b/tests/extensions/test_pointcloud.py
@@ -1,12 +1,10 @@
 import json
-from typing import Any, Dict
 import unittest
-
-# from copy import deepcopy
+from typing import Any, Dict
 
 import pystac
 from pystac.asset import Asset
-from pystac.errors import ExtensionTypeError, STACError, RequiredPropertyMissing
+from pystac.errors import ExtensionTypeError, RequiredPropertyMissing, STACError
 from pystac.extensions.pointcloud import (
     AssetPointcloudExtension,
     PhenomenologyType,
@@ -17,6 +15,8 @@ from pystac.extensions.pointcloud import (
 )
 from pystac.summaries import RangeSummary
 from tests.utils import TestCases, assert_to_from_dict
+
+# from copy import deepcopy
 
 
 class PointcloudTest(unittest.TestCase):

--- a/tests/extensions/test_projection.py
+++ b/tests/extensions/test_projection.py
@@ -1,7 +1,7 @@
 import json
-from typing import Any, Dict
 import unittest
 from copy import deepcopy
+from typing import Any, Dict
 
 import pystac
 from pystac import ExtensionTypeError

--- a/tests/extensions/test_raster.py
+++ b/tests/extensions/test_raster.py
@@ -3,16 +3,16 @@ import unittest
 
 import pystac
 from pystac import ExtensionTypeError, Item
-from pystac.utils import get_opt
 from pystac.extensions.raster import (
+    DataType,
     Histogram,
     NoDataStrings,
-    RasterExtension,
     RasterBand,
+    RasterExtension,
     Sampling,
-    DataType,
     Statistics,
 )
+from pystac.utils import get_opt
 from tests.utils import TestCases, assert_to_from_dict
 
 

--- a/tests/extensions/test_sar.py
+++ b/tests/extensions/test_sar.py
@@ -1,11 +1,10 @@
 """Tests for pystac.extensions.sar."""
 
 import datetime
-from random import choice
-from typing import List
 import unittest
-
+from random import choice
 from string import ascii_letters
+from typing import List
 
 import pystac
 from pystac import ExtensionTypeError

--- a/tests/extensions/test_sat.py
+++ b/tests/extensions/test_sat.py
@@ -1,15 +1,15 @@
 """Tests for pystac.extensions.sat."""
 
 import datetime
-from pystac.summaries import RangeSummary
-from typing import Any, Dict
 import unittest
+from typing import Any, Dict
 
 import pystac
-from pystac.utils import str_to_datetime, datetime_to_str
 from pystac import ExtensionTypeError
 from pystac.extensions import sat
 from pystac.extensions.sat import OrbitState, SatExtension
+from pystac.summaries import RangeSummary
+from pystac.utils import datetime_to_str, str_to_datetime
 from tests.utils import TestCases
 
 

--- a/tests/extensions/test_scientific.py
+++ b/tests/extensions/test_scientific.py
@@ -1,14 +1,11 @@
 """Tests for pystac.tests.extensions.scientific."""
 
 import datetime
-
-from pystac import ExtensionTypeError
-from pystac.link import Link
-from pystac.summaries import Summaries
 import unittest
 from typing import List, Optional
 
 import pystac
+from pystac import ExtensionTypeError
 from pystac.extensions import scientific
 from pystac.extensions.scientific import (
     Publication,
@@ -16,6 +13,8 @@ from pystac.extensions.scientific import (
     ScientificRelType,
     remove_link,
 )
+from pystac.link import Link
+from pystac.summaries import Summaries
 from tests.utils import TestCases
 
 URL_TEMPLATE = "http://example.com/catalog/%s.json"

--- a/tests/extensions/test_storage.py
+++ b/tests/extensions/test_storage.py
@@ -6,7 +6,7 @@ from string import ascii_letters
 import pystac
 from pystac import ExtensionTypeError, Item
 from pystac.collection import Collection
-from pystac.extensions.storage import StorageExtension, CloudPlatform
+from pystac.extensions.storage import CloudPlatform, StorageExtension
 from tests.utils import TestCases, assert_to_from_dict
 
 

--- a/tests/extensions/test_table.py
+++ b/tests/extensions/test_table.py
@@ -1,8 +1,8 @@
 import unittest
+
 import pystac
 from pystac import ExtensionTypeError
 from pystac.extensions.table import TableExtension
-
 from tests.utils import TestCases
 
 

--- a/tests/extensions/test_timestamps.py
+++ b/tests/extensions/test_timestamps.py
@@ -4,9 +4,9 @@ from datetime import datetime
 
 import pystac
 from pystac import ExtensionTypeError
-from pystac.summaries import RangeSummary
 from pystac.extensions.timestamps import TimestampsExtension
-from pystac.utils import get_opt, str_to_datetime, datetime_to_str
+from pystac.summaries import RangeSummary
+from pystac.utils import datetime_to_str, get_opt, str_to_datetime
 from tests.utils import TestCases, assert_to_from_dict
 
 

--- a/tests/extensions/test_view.py
+++ b/tests/extensions/test_view.py
@@ -1,12 +1,11 @@
 import json
-
-from pystac import ExtensionTypeError
-from pystac.collection import Collection
 import unittest
 
 import pystac
-from pystac.summaries import RangeSummary
+from pystac import ExtensionTypeError
+from pystac.collection import Collection
 from pystac.extensions.view import ViewExtension
+from pystac.summaries import RangeSummary
 from tests.utils import TestCases, assert_to_from_dict
 
 

--- a/tests/html/test_html.py
+++ b/tests/html/test_html.py
@@ -1,7 +1,7 @@
 import sys
 
-from pytest_mock import MockerFixture
 import html5lib
+from pytest_mock import MockerFixture
 
 import pystac
 from pystac.html.jinja_env import get_jinja_env

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,9 +1,9 @@
-from typing import Any, Dict
-from pystac.utils import get_opt
 import unittest
+from typing import Any, Dict
 
 import pystac
 from pystac.cache import ResolvedObjectCache, ResolvedObjectCollectionCache
+from pystac.utils import get_opt
 from tests.utils import TestCases
 
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,38 +1,33 @@
-from copy import deepcopy
-import os
 import json
+import os
 import tempfile
-from typing import Any, Dict, List, Tuple, Union, cast
 import unittest
-from datetime import datetime
 from collections import defaultdict
+from copy import deepcopy
+from datetime import datetime
+from typing import Any, Dict, List, Tuple, Union, cast
 
 import pytest
 
 import pystac
 from pystac import (
-    Catalog,
-    Collection,
-    CatalogType,
-    Item,
-    Asset,
-    MediaType,
     HIERARCHICAL_LINKS,
+    Asset,
+    Catalog,
+    CatalogType,
+    Collection,
+    Item,
+    MediaType,
 )
 from pystac.extensions.label import LabelClasses, LabelExtension, LabelType
 from pystac.utils import (
+    JoinType,
     is_absolute_href,
     join_path_or_url,
-    JoinType,
     make_absolute_href,
     make_relative_href,
 )
-from tests.utils import (
-    TestCases,
-    ARBITRARY_GEOM,
-    ARBITRARY_BBOX,
-    MockStacIO,
-)
+from tests.utils import ARBITRARY_BBOX, ARBITRARY_GEOM, MockStacIO, TestCases
 
 
 class CatalogTypeTest(unittest.TestCase):

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -1,25 +1,26 @@
-from copy import deepcopy
-import unittest
-import os
 import json
-from datetime import datetime
-from dateutil import tz
+import os
 import tempfile
+import unittest
+from copy import deepcopy
+from datetime import datetime
+
+from dateutil import tz
 
 import pystac
-from pystac.extensions.eo import EOExtension
-from pystac.validation import validate_dict
 from pystac import (
+    CatalogType,
     Collection,
-    Item,
     Extent,
+    Item,
+    Provider,
     SpatialExtent,
     TemporalExtent,
-    CatalogType,
-    Provider,
 )
+from pystac.extensions.eo import EOExtension
 from pystac.utils import datetime_to_str, get_required, str_to_datetime
-from tests.utils import TestCases, ARBITRARY_GEOM, ARBITRARY_BBOX
+from pystac.validation import validate_dict
+from tests.utils import ARBITRARY_BBOX, ARBITRARY_GEOM, TestCases
 
 TEST_DATETIME = datetime(2020, 3, 14, 16, 32)
 

--- a/tests/test_common_metadata.py
+++ b/tests/test_common_metadata.py
@@ -2,9 +2,7 @@ import unittest
 from datetime import datetime
 from typing import Any, Dict, List
 
-from pystac import CommonMetadata, Provider, ProviderRole, Item
-from pystac import utils
-
+from pystac import CommonMetadata, Item, Provider, ProviderRole, utils
 from tests.utils import TestCases
 
 

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -1,15 +1,15 @@
-from copy import deepcopy
-import os
 import json
+import os
 import tempfile
-from typing import Any, Dict
 import unittest
+from copy import deepcopy
+from typing import Any, Dict
 
 import pystac
-from pystac import Asset, Item
-from pystac.validation import validate_dict
 import pystac.serialization.common_properties
-from pystac.utils import datetime_to_str, get_opt, str_to_datetime, is_absolute_href
+from pystac import Asset, Item
+from pystac.utils import datetime_to_str, get_opt, is_absolute_href, str_to_datetime
+from pystac.validation import validate_dict
 from tests.utils import TestCases, assert_to_from_dict
 
 

--- a/tests/test_item_collection.py
+++ b/tests/test_item_collection.py
@@ -1,11 +1,10 @@
-from copy import deepcopy
 import json
-from pystac.item_collection import ItemCollection
 import unittest
+from copy import deepcopy
 from os.path import relpath
 
 import pystac
-
+from pystac.item_collection import ItemCollection
 from tests.utils import TestCases
 from tests.utils.stac_io_mock import MockDefaultStacIO
 

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1,18 +1,18 @@
+import unittest
 from datetime import datetime, timedelta
 from typing import Callable
-from pystac.collection import Collection
-import unittest
 
 import pystac
-from pystac.utils import join_path_or_url, JoinType
+from pystac.collection import Collection
 from pystac.layout import (
-    LayoutTemplate,
-    CustomLayoutStrategy,
-    TemplateLayoutStrategy,
     BestPracticesLayoutStrategy,
+    CustomLayoutStrategy,
+    LayoutTemplate,
     TemplateError,
+    TemplateLayoutStrategy,
 )
-from tests.utils import TestCases, ARBITRARY_GEOM, ARBITRARY_BBOX
+from pystac.utils import JoinType, join_path_or_url
+from tests.utils import ARBITRARY_BBOX, ARBITRARY_GEOM, TestCases
 
 
 class LayoutTemplateTest(unittest.TestCase):

--- a/tests/test_stac_io.py
+++ b/tests/test_stac_io.py
@@ -1,10 +1,10 @@
 import json
 import os
-import unittest
 import tempfile
+import unittest
 
 import pystac
-from pystac.stac_io import StacIO, DefaultStacIO, DuplicateKeyReportingMixin
+from pystac.stac_io import DefaultStacIO, DuplicateKeyReportingMixin, StacIO
 from tests.utils import TestCases
 
 

--- a/tests/test_summaries.py
+++ b/tests/test_summaries.py
@@ -1,8 +1,8 @@
 import socket
-from typing import Any
 import unittest
+from typing import Any
 
-from pystac.summaries import RangeSummary, Summarizer, Summaries
+from pystac.summaries import RangeSummary, Summaries, Summarizer
 from tests.utils import TestCases
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,19 +1,19 @@
-from typing import Optional
-import unittest
-import os
 import json
 import ntpath
+import os
 import sys
 import time
-from datetime import datetime, timezone, timedelta
+import unittest
+from datetime import datetime, timedelta, timezone
+from typing import Optional
 
 from dateutil import tz
-from pystac import utils
 
+from pystac import utils
 from pystac.utils import (
-    make_relative_href,
-    make_absolute_href,
     is_absolute_href,
+    make_absolute_href,
+    make_relative_href,
     str_to_datetime,
 )
 from tests.utils import TestCases

--- a/tests/test_writing.py
+++ b/tests/test_writing.py
@@ -9,7 +9,6 @@ from pystac.utils import is_absolute_href, make_absolute_href
 from pystac.validation import validate_dict
 from tests.utils import TestCases
 
-
 CTYPES = [
     CatalogType.ABSOLUTE_PUBLISHED,
     CatalogType.RELATIVE_PUBLISHED,

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -5,21 +5,21 @@ __all__ = [
     "ARBITRARY_EXTENT",
     "MockStacIO",
 ]
-from typing import Any, Dict, TYPE_CHECKING, Type
 import unittest
-from tests.utils.test_cases import (
-    TestCases,
-    ARBITRARY_GEOM,
-    ARBITRARY_BBOX,
-    ARBITRARY_EXTENT,
-)
-
 from copy import deepcopy
 from datetime import datetime
+from typing import TYPE_CHECKING, Any, Dict, Type
+
 from dateutil.parser import parse
 
 import pystac
 from tests.utils.stac_io_mock import MockStacIO
+from tests.utils.test_cases import (
+    ARBITRARY_BBOX,
+    ARBITRARY_EXTENT,
+    ARBITRARY_GEOM,
+    TestCases,
+)
 
 
 def assert_to_from_dict(

--- a/tests/utils/stac_io_mock.py
+++ b/tests/utils/stac_io_mock.py
@@ -3,8 +3,8 @@ from typing import Any, AnyStr, Optional, Union
 from unittest.mock import Mock
 
 import pystac
-from pystac.stac_io import DefaultStacIO, StacIO
 from pystac.link import HREF
+from pystac.stac_io import DefaultStacIO, StacIO
 
 
 class MockStacIO(pystac.StacIO):

--- a/tests/utils/test_cases.py
+++ b/tests/utils/test_cases.py
@@ -1,24 +1,24 @@
+import csv
 import os
 from datetime import datetime
-import csv
 from typing import Any, Dict, List
 
 import pystac
 from pystac import (
+    Asset,
     Catalog,
     Collection,
-    Item,
-    Asset,
     Extent,
-    TemporalExtent,
-    SpatialExtent,
+    Item,
     MediaType,
+    SpatialExtent,
+    TemporalExtent,
 )
 from pystac.extensions.label import (
-    LabelExtension,
-    LabelOverview,
     LabelClasses,
     LabelCount,
+    LabelExtension,
+    LabelOverview,
     LabelType,
 )
 

--- a/tests/validation/test_validate.py
+++ b/tests/validation/test_validate.py
@@ -1,10 +1,9 @@
-from datetime import datetime
 import json
 import os
-from typing import Any, Dict
-from pystac.utils import get_opt
 import shutil
 import tempfile
+from datetime import datetime
+from typing import Any, Dict
 
 import jsonschema
 import pytest
@@ -13,6 +12,7 @@ import pystac
 import pystac.validation
 from pystac.cache import CollectionCache
 from pystac.serialization.common_properties import merge_common_properties
+from pystac.utils import get_opt
 from tests.utils import TestCases
 from tests.utils.test_cases import ExampleInfo
 


### PR DESCRIPTION
**Related Issue(s):**

- For some of the typing fixes needed for #862, I'm going to be doing a fair bit of import changes. Having `isort` on board will help reduce the mental load during those changes.


**Description:**

Adds isort to pre-commit and `requirements-test.txt`. There are **no functional changes**, all diffs should be either adding isort or applying isort.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
