### PR TITLE
Use `from __future__ import annotations`

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,6 +10,7 @@ on:
       - "1.0"
       - "2.0"
   pull_request:
+  merge_group:
 
 jobs:
   test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 ### Changed
 
 - Switch to pytest ([#939](https://github.com/stac-utils/pystac/pull/939))
+- Use `from __future__ import annotations` for type signatures ([#962](https://github.com/stac-utils/pystac/pull/962))
 
 ### Fixed
 

--- a/pystac/__init__.py
+++ b/pystac/__init__.py
@@ -41,7 +41,7 @@ __all__ = [
 ]
 
 import os
-from typing import Any, AnyStr, Dict, Optional, Union
+from typing import Any, Dict, Optional
 
 from pystac.errors import (
     STACError,

--- a/pystac/asset.py
+++ b/pystac/asset.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from copy import copy, deepcopy
 from html import escape
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
@@ -6,9 +8,9 @@ from pystac import common_metadata, utils
 from pystac.html.jinja_env import get_jinja_env
 
 if TYPE_CHECKING:
-    from pystac.collection import Collection as Collection_Type
-    from pystac.common_metadata import CommonMetadata as CommonMetadata_Type
-    from pystac.item import Item as Item_Type
+    from pystac.collection import Collection
+    from pystac.common_metadata import CommonMetadata
+    from pystac.item import Item
 
 
 class Asset:
@@ -50,7 +52,7 @@ class Asset:
     """Optional, Semantic roles (i.e. thumbnail, overview, data, metadata) of the
     asset."""
 
-    owner: Optional[Union["Item_Type", "Collection_Type"]]
+    owner: Optional[Union[Item, Collection]]
     """The :class:`~pystac.Item` or :class:`~pystac.Collection` that this asset belongs
     to, or ``None`` if it has no owner."""
 
@@ -77,7 +79,7 @@ class Asset:
         # The Item which owns this Asset.
         self.owner = None
 
-    def set_owner(self, obj: Union["Collection_Type", "Item_Type"]) -> None:
+    def set_owner(self, obj: Union[Collection, Item]) -> None:
         """Sets the owning item of this Asset.
 
         The owning item will be used to resolve relative HREFs of this asset.
@@ -134,7 +136,7 @@ class Asset:
 
         return d
 
-    def clone(self) -> "Asset":
+    def clone(self) -> Asset:
         """Clones this asset. Makes a ``deepcopy`` of the
         :attr:`~pystac.Asset.extra_fields`.
 
@@ -166,7 +168,7 @@ class Asset:
             return role in self.roles
 
     @property
-    def common_metadata(self) -> "CommonMetadata_Type":
+    def common_metadata(self) -> CommonMetadata:
         """Access the asset's common metadata fields as a
         :class:`~pystac.CommonMetadata` object."""
         return common_metadata.CommonMetadata(self)
@@ -183,7 +185,7 @@ class Asset:
             return escape(repr(self))
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> "Asset":
+    def from_dict(cls, d: Dict[str, Any]) -> Asset:
         """Constructs an Asset from a dict.
 
         Returns:

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from copy import deepcopy
 from datetime import datetime
 from html import escape
@@ -34,8 +36,7 @@ from pystac.summaries import Summaries
 from pystac.utils import datetime_to_str, str_to_datetime
 
 if TYPE_CHECKING:
-    from pystac.item import Item as Item_Type
-    from pystac.provider import Provider as Provider_Type
+    from pystac.item import Item
 
 T = TypeVar("T")
 TemporalIntervals = Union[List[List[datetime]], List[List[Optional[datetime]]]]
@@ -90,7 +91,7 @@ class SpatialExtent:
         d = {"bbox": self.bboxes, **self.extra_fields}
         return d
 
-    def clone(self) -> "SpatialExtent":
+    def clone(self) -> SpatialExtent:
         """Clones this object.
 
         Returns:
@@ -101,7 +102,7 @@ class SpatialExtent:
         )
 
     @staticmethod
-    def from_dict(d: Dict[str, Any]) -> "SpatialExtent":
+    def from_dict(d: Dict[str, Any]) -> SpatialExtent:
         """Constructs a SpatialExtent from a dict.
 
         Returns:
@@ -114,7 +115,7 @@ class SpatialExtent:
     @staticmethod
     def from_coordinates(
         coordinates: List[Any], extra_fields: Optional[Dict[str, Any]] = None
-    ) -> "SpatialExtent":
+    ) -> SpatialExtent:
         """Constructs a SpatialExtent from a set of coordinates.
 
         This method will only produce a single bbox that covers all points
@@ -228,7 +229,7 @@ class TemporalExtent:
         d = {"interval": encoded_intervals, **self.extra_fields}
         return d
 
-    def clone(self) -> "TemporalExtent":
+    def clone(self) -> TemporalExtent:
         """Clones this object.
 
         Returns:
@@ -239,7 +240,7 @@ class TemporalExtent:
         )
 
     @staticmethod
-    def from_dict(d: Dict[str, Any]) -> "TemporalExtent":
+    def from_dict(d: Dict[str, Any]) -> TemporalExtent:
         """Constructs an TemporalExtent from a dict.
 
         Returns:
@@ -262,7 +263,7 @@ class TemporalExtent:
         )
 
     @staticmethod
-    def from_now() -> "TemporalExtent":
+    def from_now() -> TemporalExtent:
         """Constructs an TemporalExtent with a single open interval that has
         the start time as the current time.
 
@@ -318,7 +319,7 @@ class Extent:
 
         return d
 
-    def clone(self) -> "Extent":
+    def clone(self) -> Extent:
         """Clones this object.
 
         Returns:
@@ -331,7 +332,7 @@ class Extent:
         )
 
     @staticmethod
-    def from_dict(d: Dict[str, Any]) -> "Extent":
+    def from_dict(d: Dict[str, Any]) -> Extent:
         """Constructs an Extent from a dict.
 
         Returns:
@@ -347,8 +348,8 @@ class Extent:
 
     @staticmethod
     def from_items(
-        items: Iterable["Item_Type"], extra_fields: Optional[Dict[str, Any]] = None
-    ) -> "Extent":
+        items: Iterable[Item], extra_fields: Optional[Dict[str, Any]] = None
+    ) -> Extent:
         """Create an Extent based on the datetimes and bboxes of a list of items.
 
         Args:
@@ -504,7 +505,7 @@ class Collection(Catalog):
         catalog_type: Optional[CatalogType] = None,
         license: str = "proprietary",
         keywords: Optional[List[str]] = None,
-        providers: Optional[List["Provider_Type"]] = None,
+        providers: Optional[List[Provider]] = None,
         summaries: Optional[Summaries] = None,
         assets: Optional[Dict[str, Asset]] = None,
     ):
@@ -543,7 +544,7 @@ class Collection(Catalog):
 
     def add_item(
         self,
-        item: "Item_Type",
+        item: Item,
         title: Optional[str] = None,
         strategy: Optional[HrefLayoutStrategy] = None,
     ) -> None:
@@ -571,7 +572,7 @@ class Collection(Catalog):
 
         return d
 
-    def clone(self) -> "Collection":
+    def clone(self) -> Collection:
         cls = self.__class__
         clone = cls(
             id=self.id,
@@ -611,7 +612,7 @@ class Collection(Catalog):
         root: Optional[Catalog] = None,
         migrate: bool = False,
         preserve_dict: bool = True,
-    ) -> "Collection":
+    ) -> Collection:
         if migrate:
             info = identify_stac_object(d)
             d = migrate_to_latest(d, info)
@@ -719,13 +720,13 @@ class Collection(Catalog):
 
     def full_copy(
         self, root: Optional["Catalog"] = None, parent: Optional["Catalog"] = None
-    ) -> "Collection":
+    ) -> Collection:
         return cast(Collection, super().full_copy(root, parent))
 
     @classmethod
     def from_file(
         cls, href: str, stac_io: Optional[pystac.StacIO] = None
-    ) -> "Collection":
+    ) -> Collection:
         result = super().from_file(href, stac_io)
         if not isinstance(result, Collection):
             raise pystac.STACTypeError(f"{result} is not a {Collection}.")

--- a/pystac/extensions/datacube.py
+++ b/pystac/extensions/datacube.py
@@ -1,5 +1,7 @@
 """Implements the :stac-ext:`Datacube Extension <datacube>`."""
 
+from __future__ import annotations
+
 from abc import ABC
 from typing import Any, Dict, Generic, List, Optional, TypeVar, Union, cast
 
@@ -102,7 +104,7 @@ class Dimension(ABC):
         return self.properties
 
     @staticmethod
-    def from_dict(d: Dict[str, Any]) -> "Dimension":
+    def from_dict(d: Dict[str, Any]) -> Dimension:
         dim_type: str = get_required(
             d.get(DIM_TYPE_PROP), "cube_dimension", DIM_TYPE_PROP
         )
@@ -500,7 +502,7 @@ class Variable:
             self.properties[VAR_UNIT_PROP] = v
 
     @staticmethod
-    def from_dict(d: Dict[str, Any]) -> "Variable":
+    def from_dict(d: Dict[str, Any]) -> Variable:
         return Variable(d)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -579,7 +581,7 @@ class DatacubeExtension(
         return SCHEMA_URI
 
     @classmethod
-    def ext(cls, obj: T, add_if_missing: bool = False) -> "DatacubeExtension[T]":
+    def ext(cls, obj: T, add_if_missing: bool = False) -> DatacubeExtension[T]:
         """Extends the given STAC Object with properties from the :stac-ext:`Datacube
         Extension <datacube>`.
 

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -1,5 +1,7 @@
 """Implements the :stac-ext:`Electro-Optical Extension <eo>`."""
 
+from __future__ import annotations
+
 from typing import (
     Any,
     Dict,
@@ -86,7 +88,7 @@ class Band:
         center_wavelength: Optional[float] = None,
         full_width_half_max: Optional[float] = None,
         solar_illumination: Optional[float] = None,
-    ) -> "Band":
+    ) -> Band:
         """
         Creates a new band.
 
@@ -348,7 +350,7 @@ class EOExtension(
         return SCHEMA_URI
 
     @classmethod
-    def ext(cls, obj: T, add_if_missing: bool = False) -> "EOExtension[T]":
+    def ext(cls, obj: T, add_if_missing: bool = False) -> EOExtension[T]:
         """Extends the given STAC Object with properties from the
         :stac-ext:`Electro-Optical Extension <eo>`.
 
@@ -373,7 +375,7 @@ class EOExtension(
     @classmethod
     def summaries(
         cls, obj: pystac.Collection, add_if_missing: bool = False
-    ) -> "SummariesEOExtension":
+    ) -> SummariesEOExtension:
         """Returns the extended summaries object for the given collection."""
         cls.validate_has_extension(obj, add_if_missing)
         return SummariesEOExtension(obj)

--- a/pystac/extensions/file.py
+++ b/pystac/extensions/file.py
@@ -1,5 +1,7 @@
 """Implements the :stac-ext:`File Info Extension <file>`."""
 
+from __future__ import annotations
+
 from typing import Any, Dict, Iterable, List, Optional, Union
 
 import pystac
@@ -50,7 +52,7 @@ class MappingObject:
         self.summary = summary
 
     @classmethod
-    def create(cls, values: List[Any], summary: str) -> "MappingObject":
+    def create(cls, values: List[Any], summary: str) -> MappingObject:
         """Creates a new :class:`~MappingObject` instance.
 
         Args:
@@ -81,7 +83,7 @@ class MappingObject:
         self.properties["summary"] = v
 
     @classmethod
-    def from_dict(cls, d: Dict[str, Any]) -> "MappingObject":
+    def from_dict(cls, d: Dict[str, Any]) -> MappingObject:
         return cls.create(**d)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -215,7 +217,7 @@ class FileExtension(
         return SCHEMA_URI
 
     @classmethod
-    def ext(cls, obj: pystac.Asset, add_if_missing: bool = False) -> "FileExtension":
+    def ext(cls, obj: pystac.Asset, add_if_missing: bool = False) -> FileExtension:
         """Extends the given STAC Object with properties from the :stac-ext:`File Info
         Extension <file>`.
 

--- a/pystac/extensions/grid.py
+++ b/pystac/extensions/grid.py
@@ -1,5 +1,7 @@
 """Implements the :stac-ext:`Grid Extension <grid>`."""
 
+from __future__ import annotations
+
 import re
 from typing import Any, Dict, Optional, Pattern, Set, Union
 
@@ -79,7 +81,7 @@ class GridExtension(
         return SCHEMA_URI
 
     @classmethod
-    def ext(cls, obj: pystac.Item, add_if_missing: bool = False) -> "GridExtension":
+    def ext(cls, obj: pystac.Item, add_if_missing: bool = False) -> GridExtension:
         """Extends the given STAC Object with properties from the :stac-ext:`Grid
         Extension <grid>`.
 

--- a/pystac/extensions/hooks.py
+++ b/pystac/extensions/hooks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Set, Union
@@ -6,7 +8,7 @@ import pystac
 from pystac.serialization.identify import STACJSONDescription, STACVersionID
 
 if TYPE_CHECKING:
-    from pystac.stac_object import STACObject as STACObject_Type
+    from pystac.stac_object import STACObject
 
 
 class ExtensionHooks(ABC):
@@ -38,7 +40,7 @@ class ExtensionHooks(ABC):
         return set([x.value for x in self.stac_object_types])
 
     def get_object_links(
-        self, obj: "STACObject_Type"
+        self, obj: STACObject
     ) -> Optional[List[Union[str, pystac.RelType]]]:
         return None
 
@@ -83,7 +85,7 @@ class RegisteredExtensionHooks:
             del self.hooks[extension_id]
 
     def get_extended_object_links(
-        self, obj: "STACObject_Type"
+        self, obj: STACObject
     ) -> List[Union[str, pystac.RelType]]:
         result: Optional[List[Union[str, pystac.RelType]]] = None
         for ext in obj.stac_extensions:

--- a/pystac/extensions/item_assets.py
+++ b/pystac/extensions/item_assets.py
@@ -1,5 +1,7 @@
 """Implements the :stac-ext:`Item Assets Definition Extension <item-assets>`."""
 
+from __future__ import annotations
+
 from copy import deepcopy
 from typing import Any, Dict, List, Optional
 
@@ -43,7 +45,7 @@ class AssetDefinition:
         description: Optional[str],
         media_type: Optional[str],
         roles: Optional[List[str]],
-    ) -> "AssetDefinition":
+    ) -> AssetDefinition:
         """
         Creates a new asset definition.
 
@@ -206,7 +208,7 @@ class ItemAssetsExtension(ExtensionManagementMixin[pystac.Collection]):
     @classmethod
     def ext(
         cls, obj: pystac.Collection, add_if_missing: bool = False
-    ) -> "ItemAssetsExtension":
+    ) -> ItemAssetsExtension:
         """Extends the given :class:`~pystac.Collection` with properties from the
         :stac-ext:`Item Assets Extension <item-assets>`.
 

--- a/pystac/extensions/label.py
+++ b/pystac/extensions/label.py
@@ -1,5 +1,7 @@
 """Implements the :stac-ext:`Label Extension <label>`."""
 
+from __future__ import annotations
+
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Union, cast
 
 import pystac
@@ -90,7 +92,7 @@ class LabelClasses:
         cls,
         classes: Sequence[Union[str, int, float]],
         name: Optional[str] = None,
-    ) -> "LabelClasses":
+    ) -> LabelClasses:
         """Creates a new :class:`~LabelClasses` instance.
 
         Args:
@@ -165,7 +167,7 @@ class LabelCount:
         self.count = count
 
     @classmethod
-    def create(cls, name: str, count: int) -> "LabelCount":
+    def create(cls, name: str, count: int) -> LabelCount:
         """Creates a :class:`LabelCount` instance.
 
         Args:
@@ -230,7 +232,7 @@ class LabelStatistics:
         self.value = value
 
     @classmethod
-    def create(cls, name: str, value: float) -> "LabelStatistics":
+    def create(cls, name: str, value: float) -> LabelStatistics:
         """Creates a new :class:`LabelStatistics` instance.
 
         Args:
@@ -315,7 +317,7 @@ class LabelOverview:
         property_key: Optional[str],
         counts: Optional[List[LabelCount]] = None,
         statistics: Optional[List[LabelStatistics]] = None,
-    ) -> "LabelOverview":
+    ) -> LabelOverview:
         """Creates a new instance.
 
         Either ``counts`` or ``statistics``, or both, can be placed in an overview;
@@ -381,7 +383,7 @@ class LabelOverview:
         else:
             self.properties["statistics"] = [s.to_dict() for s in v]
 
-    def merge_counts(self, other: "LabelOverview") -> "LabelOverview":
+    def merge_counts(self, other: "LabelOverview") -> LabelOverview:
         """Merges the counts associated with this overview with another overview.
         Creates a new instance.
 
@@ -690,7 +692,7 @@ class LabelExtension(ExtensionManagementMixin[Union[pystac.Item, pystac.Collecti
         return SCHEMA_URI
 
     @classmethod
-    def ext(cls, obj: pystac.Item, add_if_missing: bool = False) -> "LabelExtension":
+    def ext(cls, obj: pystac.Item, add_if_missing: bool = False) -> LabelExtension:
         """Extends the given STAC Object with properties from the :stac-ext:`Label
         Extension <label>`.
 
@@ -707,7 +709,7 @@ class LabelExtension(ExtensionManagementMixin[Union[pystac.Item, pystac.Collecti
     @classmethod
     def summaries(
         cls, obj: pystac.Collection, add_if_missing: bool = False
-    ) -> "SummariesLabelExtension":
+    ) -> SummariesLabelExtension:
         """Returns the extended summaries object for the given collection."""
         cls.validate_has_extension(obj, add_if_missing)
         return SummariesLabelExtension(obj)

--- a/pystac/extensions/pointcloud.py
+++ b/pystac/extensions/pointcloud.py
@@ -1,4 +1,7 @@
 """Implements the :stac-ext:`Point Cloud Extension <pointcloud>`."""
+
+from __future__ import annotations
+
 from typing import Any, Dict, Generic, Iterable, List, Optional, TypeVar, Union, cast
 
 import pystac
@@ -70,7 +73,7 @@ class Schema:
         self.properties["type"] = type
 
     @classmethod
-    def create(cls, name: str, size: int, type: SchemaType) -> "Schema":
+    def create(cls, name: str, size: int, type: SchemaType) -> Schema:
         """Creates a new Schema.
 
         Args:
@@ -180,7 +183,7 @@ class Statistic:
         minimum: Optional[float] = None,
         stddev: Optional[float] = None,
         variance: Optional[float] = None,
-    ) -> "Statistic":
+    ) -> Statistic:
         """Creates a new Statistic class.
 
         Args:
@@ -433,7 +436,7 @@ class PointcloudExtension(
         return SCHEMA_URI
 
     @classmethod
-    def ext(cls, obj: T, add_if_missing: bool = False) -> "PointcloudExtension[T]":
+    def ext(cls, obj: T, add_if_missing: bool = False) -> PointcloudExtension[T]:
         """Extends the given STAC Object with properties from the :stac-ext:`Point Cloud
         Extension <pointcloud>`.
 
@@ -462,7 +465,7 @@ class PointcloudExtension(
     @classmethod
     def summaries(
         cls, obj: pystac.Collection, add_if_missing: bool = False
-    ) -> "SummariesPointcloudExtension":
+    ) -> SummariesPointcloudExtension:
         cls.validate_has_extension(obj, add_if_missing)
         return SummariesPointcloudExtension(obj)
 

--- a/pystac/extensions/projection.py
+++ b/pystac/extensions/projection.py
@@ -1,5 +1,7 @@
 """Implements the :stac-ext:`Projection Extension <projection>`."""
 
+from __future__ import annotations
+
 import json
 from typing import Any, Dict, Generic, Iterable, List, Optional, TypeVar, Union, cast
 
@@ -258,7 +260,7 @@ class ProjectionExtension(
         return SCHEMA_URI
 
     @classmethod
-    def ext(cls, obj: T, add_if_missing: bool = False) -> "ProjectionExtension[T]":
+    def ext(cls, obj: T, add_if_missing: bool = False) -> ProjectionExtension[T]:
         """Extends the given STAC Object with properties from the :stac-ext:`Projection
         Extension <projection>`.
 
@@ -283,7 +285,7 @@ class ProjectionExtension(
     @classmethod
     def summaries(
         cls, obj: pystac.Collection, add_if_missing: bool = False
-    ) -> "SummariesProjectionExtension":
+    ) -> SummariesProjectionExtension:
         """Returns the extended summaries object for the given collection."""
         cls.validate_has_extension(obj, add_if_missing)
         return SummariesProjectionExtension(obj)

--- a/pystac/extensions/raster.py
+++ b/pystac/extensions/raster.py
@@ -1,5 +1,7 @@
 """Implements the :stac-ext:`Raster Extension <raster>`."""
 
+from __future__ import annotations
+
 from typing import Any, Dict, Iterable, List, Optional, Union
 
 import pystac
@@ -88,7 +90,7 @@ class Statistics:
         mean: Optional[float] = None,
         stddev: Optional[float] = None,
         valid_percent: Optional[float] = None,
-    ) -> "Statistics":
+    ) -> Statistics:
         """
         Creates a new band.
 
@@ -198,7 +200,7 @@ class Statistics:
         return self.properties
 
     @staticmethod
-    def from_dict(d: Dict[str, Any]) -> "Statistics":
+    def from_dict(d: Dict[str, Any]) -> Statistics:
         """Constructs an Statistics from a dict.
 
         Returns:
@@ -250,7 +252,7 @@ class Histogram:
         min: float,
         max: float,
         buckets: List[int],
-    ) -> "Histogram":
+    ) -> Histogram:
         """
         Creates a new band.
 
@@ -334,7 +336,7 @@ class Histogram:
         return self.properties
 
     @staticmethod
-    def from_dict(d: Dict[str, Any]) -> "Histogram":
+    def from_dict(d: Dict[str, Any]) -> Histogram:
         """Constructs an Histogram from a dict.
 
         Returns:
@@ -417,7 +419,7 @@ class RasterBand:
         scale: Optional[float] = None,
         offset: Optional[float] = None,
         histogram: Optional[Histogram] = None,
-    ) -> "RasterBand":
+    ) -> RasterBand:
         """
         Creates a new band.
 
@@ -705,7 +707,7 @@ class RasterExtension(
         return SCHEMA_URI
 
     @classmethod
-    def ext(cls, obj: pystac.Asset, add_if_missing: bool = False) -> "RasterExtension":
+    def ext(cls, obj: pystac.Asset, add_if_missing: bool = False) -> RasterExtension:
         """Extends the given STAC Object with properties from the :stac-ext:`Raster
         Extension <raster>`.
 
@@ -726,7 +728,7 @@ class RasterExtension(
     @classmethod
     def summaries(
         cls, obj: pystac.Collection, add_if_missing: bool = False
-    ) -> "SummariesRasterExtension":
+    ) -> SummariesRasterExtension:
         cls.validate_has_extension(obj, add_if_missing)
         return SummariesRasterExtension(obj)
 

--- a/pystac/extensions/sar.py
+++ b/pystac/extensions/sar.py
@@ -1,5 +1,7 @@
 """Implements the :stac-ext:`Synthetic-Aperture Radar (SAR) Extension <sar>`."""
 
+from __future__ import annotations
+
 from typing import Any, Dict, Generic, Iterable, List, Optional, TypeVar, Union, cast
 
 import pystac
@@ -298,7 +300,7 @@ class SarExtension(
         return SCHEMA_URI
 
     @classmethod
-    def ext(cls, obj: T, add_if_missing: bool = False) -> "SarExtension[T]":
+    def ext(cls, obj: T, add_if_missing: bool = False) -> SarExtension[T]:
         """Extends the given STAC Object with properties from the :stac-ext:`SAR
         Extension <sar>`.
 
@@ -327,7 +329,7 @@ class SarExtension(
     @classmethod
     def summaries(
         cls, obj: pystac.Collection, add_if_missing: bool = False
-    ) -> "SummariesSarExtension":
+    ) -> SummariesSarExtension:
         """Returns the extended summaries object for the given collection."""
         cls.validate_has_extension(obj, add_if_missing)
         return SummariesSarExtension(obj)

--- a/pystac/extensions/sat.py
+++ b/pystac/extensions/sat.py
@@ -1,5 +1,7 @@
 """Implements the :stac-ext:`Satellite Extension <sat>`."""
 
+from __future__ import annotations
+
 from datetime import datetime as Datetime
 from typing import Any, Dict, Generic, Iterable, List, Optional, TypeVar, Union, cast
 
@@ -133,7 +135,7 @@ class SatExtension(
         return SCHEMA_URI
 
     @classmethod
-    def ext(cls, obj: T, add_if_missing: bool = False) -> "SatExtension[T]":
+    def ext(cls, obj: T, add_if_missing: bool = False) -> SatExtension[T]:
         """Extends the given STAC Object with properties from the :stac-ext:`Satellite
         Extension <sat>`.
 
@@ -158,7 +160,7 @@ class SatExtension(
     @classmethod
     def summaries(
         cls, obj: pystac.Collection, add_if_missing: bool = False
-    ) -> "SummariesSatExtension":
+    ) -> SummariesSatExtension:
         """Returns the extended summaries object for the given collection."""
         cls.validate_has_extension(obj, add_if_missing)
         return SummariesSatExtension(obj)

--- a/pystac/extensions/scientific.py
+++ b/pystac/extensions/scientific.py
@@ -5,6 +5,8 @@ For a description of Digital Object Identifiers (DOIs), see the DOI Handbook:
 https://doi.org/10.1000/182
 """
 
+from __future__ import annotations
+
 import copy
 from typing import Any, Dict, Generic, List, Optional, TypeVar, Union, cast
 from urllib import parse
@@ -72,7 +74,7 @@ class Publication:
         return copy.deepcopy({"doi": self.doi, "citation": self.citation})
 
     @staticmethod
-    def from_dict(d: Dict[str, str]) -> "Publication":
+    def from_dict(d: Dict[str, str]) -> Publication:
         return Publication(d.get("doi"), d.get("citation"))
 
     def get_link(self) -> Optional[pystac.Link]:
@@ -224,7 +226,7 @@ class ScientificExtension(
         return SCHEMA_URI
 
     @classmethod
-    def ext(cls, obj: T, add_if_missing: bool = False) -> "ScientificExtension[T]":
+    def ext(cls, obj: T, add_if_missing: bool = False) -> ScientificExtension[T]:
         """Extends the given STAC Object with properties from the :stac-ext:`Scientific
         Extension <scientific>`.
 
@@ -249,7 +251,7 @@ class ScientificExtension(
     @classmethod
     def summaries(
         cls, obj: pystac.Collection, add_if_missing: bool = False
-    ) -> "SummariesScientificExtension":
+    ) -> SummariesScientificExtension:
         """Returns the extended summaries object for the given collection."""
         cls.validate_has_extension(obj, add_if_missing)
         return SummariesScientificExtension(obj)

--- a/pystac/extensions/storage.py
+++ b/pystac/extensions/storage.py
@@ -3,6 +3,8 @@
 https://github.com/stac-extensions/storage
 """
 
+from __future__ import annotations
+
 from typing import (
     Any,
     Dict,
@@ -135,7 +137,7 @@ class StorageExtension(
         return SCHEMA_URI
 
     @classmethod
-    def ext(cls, obj: T, add_if_missing: bool = False) -> "StorageExtension[T]":
+    def ext(cls, obj: T, add_if_missing: bool = False) -> StorageExtension[T]:
         """Extends the given STAC Object with properties from the :stac-ext:`Storage
         Extension <storage>`.
 
@@ -160,7 +162,7 @@ class StorageExtension(
     @classmethod
     def summaries(
         cls, obj: pystac.Collection, add_if_missing: bool = False
-    ) -> "SummariesStorageExtension":
+    ) -> SummariesStorageExtension:
         """Returns the extended summaries object for the given collection."""
         cls.validate_has_extension(obj, add_if_missing)
         return SummariesStorageExtension(obj)

--- a/pystac/extensions/table.py
+++ b/pystac/extensions/table.py
@@ -1,4 +1,7 @@
 """Implements the :stac-ext:`Table Extension <table>`."""
+
+from __future__ import annotations
+
 from typing import Any, Dict, Generic, List, Optional, TypeVar, Union, cast
 
 import pystac
@@ -138,7 +141,7 @@ class TableExtension(
         return SCHEMA_URI
 
     @classmethod
-    def ext(cls, obj: T, add_if_missing: bool = False) -> "TableExtension[T]":
+    def ext(cls, obj: T, add_if_missing: bool = False) -> TableExtension[T]:
         """Extend the given STAC Object with properties from the
         :stac-ext:`Table Extension <table>`.
 

--- a/pystac/extensions/timestamps.py
+++ b/pystac/extensions/timestamps.py
@@ -1,5 +1,7 @@
 """Implements the :stac-ext:`Timestamps Extension <timestamps>`."""
 
+from __future__ import annotations
+
 from datetime import datetime as datetime
 from typing import Any, Dict, Generic, Iterable, Optional, TypeVar, Union, cast
 
@@ -114,7 +116,7 @@ class TimestampsExtension(
         return SCHEMA_URI
 
     @classmethod
-    def ext(cls, obj: T, add_if_missing: bool = False) -> "TimestampsExtension[T]":
+    def ext(cls, obj: T, add_if_missing: bool = False) -> TimestampsExtension[T]:
         """Extends the given STAC Object with properties from the :stac-ext:`Timestamps
         Extension <timestamps>`.
 
@@ -139,7 +141,7 @@ class TimestampsExtension(
     @classmethod
     def summaries(
         cls, obj: pystac.Collection, add_if_missing: bool = False
-    ) -> "SummariesTimestampsExtension":
+    ) -> SummariesTimestampsExtension:
         """Returns the extended summaries object for the given collection."""
         cls.validate_has_extension(obj, add_if_missing)
         return SummariesTimestampsExtension(obj)

--- a/pystac/extensions/version.py
+++ b/pystac/extensions/version.py
@@ -1,4 +1,7 @@
 """Implements the :stac-ext:`Versioning Indicators Extension <version>`."""
+
+from __future__ import annotations
+
 from typing import Any, Dict, Generic, List, Optional, TypeVar, Union, cast
 
 import pystac
@@ -186,7 +189,7 @@ class VersionExtension(
         return SCHEMA_URI
 
     @classmethod
-    def ext(cls, obj: T, add_if_missing: bool = False) -> "VersionExtension[T]":
+    def ext(cls, obj: T, add_if_missing: bool = False) -> VersionExtension[T]:
         """Extends the given STAC Object with properties from the :stac-ext:`Versioning
         Indicators Extension <version>`.
 

--- a/pystac/extensions/view.py
+++ b/pystac/extensions/view.py
@@ -1,5 +1,7 @@
 """Implement the :stac-ext:`View Geometry Extension <view>`."""
 
+from __future__ import annotations
+
 from typing import Any, Dict, Generic, Iterable, Optional, TypeVar, Union, cast
 
 import pystac
@@ -143,7 +145,7 @@ class ViewExtension(
         return SCHEMA_URI
 
     @classmethod
-    def ext(cls, obj: T, add_if_missing: bool = False) -> "ViewExtension[T]":
+    def ext(cls, obj: T, add_if_missing: bool = False) -> ViewExtension[T]:
         """Extends the given STAC Object with properties from the :stac-ext:`View
         Geometry Extension <scientific>`.
 
@@ -168,7 +170,7 @@ class ViewExtension(
     @classmethod
     def summaries(
         cls, obj: pystac.Collection, add_if_missing: bool = False
-    ) -> "SummariesViewExtension":
+    ) -> SummariesViewExtension:
         """Returns the extended summaries object for the given collection."""
         cls.validate_has_extension(obj, add_if_missing)
         return SummariesViewExtension(obj)

--- a/pystac/serialization/identify.py
+++ b/pystac/serialization/identify.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from enum import Enum
 from functools import total_ordering
 from typing import TYPE_CHECKING, Any, Dict, Optional, Set, Union
@@ -6,7 +8,7 @@ import pystac
 from pystac.version import STACVersion
 
 if TYPE_CHECKING:
-    from pystac.stac_object import STACObjectType as STACObjectType_Type
+    from pystac.stac_object import STACObjectType
 
 
 class OldExtensionShortIDs(Enum):
@@ -156,13 +158,13 @@ class STACJSONDescription:
             object implements
     """
 
-    object_type: "STACObjectType_Type"
+    object_type: STACObjectType
     version_range: STACVersionRange
     extensions: Set[str]
 
     def __init__(
         self,
-        object_type: "STACObjectType_Type",
+        object_type: STACObjectType,
         version_range: STACVersionRange,
         extensions: Set[str],
     ) -> None:
@@ -176,9 +178,7 @@ class STACJSONDescription:
         )
 
 
-def identify_stac_object_type(
-    json_dict: Dict[str, Any]
-) -> Optional["STACObjectType_Type"]:
+def identify_stac_object_type(json_dict: Dict[str, Any]) -> Optional[STACObjectType]:
     """Determines the STACObjectType of the provided JSON dict. If the JSON dict does
     not represent a STAC object, returns ``None``.
 

--- a/pystac/serialization/migrate.py
+++ b/pystac/serialization/migrate.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple
 
@@ -10,7 +12,7 @@ from pystac.serialization.identify import (
 from pystac.version import STACVersion
 
 if TYPE_CHECKING:
-    from pystac import STACObjectType as STACObjectType_Type
+    from pystac import STACObjectType
 
 
 def _migrate_catalog(
@@ -93,7 +95,7 @@ def _get_removed_extension_migrations() -> (
     Dict[
         str,
         Tuple[
-            Optional[List["STACObjectType_Type"]],
+            Optional[List[STACObjectType]],
             Optional[
                 Callable[
                     [Dict[str, Any], STACVersionID, STACJSONDescription],

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Type, Union, cast
 
@@ -7,7 +9,7 @@ from pystac.link import Link
 from pystac.utils import StringEnum, is_absolute_href, make_absolute_href
 
 if TYPE_CHECKING:
-    from pystac.catalog import Catalog as Catalog_Type
+    from pystac.catalog import Catalog
 
 
 class STACObjectType(StringEnum):
@@ -217,7 +219,7 @@ class STACObject(ABC):
         if root_link is not None and root_link.is_resolved():
             cast(pystac.Catalog, root_link.target)._resolved_objects.cache(self)
 
-    def get_root(self) -> Optional["Catalog_Type"]:
+    def get_root(self) -> Optional[Catalog]:
         """Get the :class:`~pystac.Catalog` or :class:`~pystac.Collection` to
         the root for this object. The root is represented by a
         :class:`~pystac.Link` with ``rel == 'root'``.
@@ -236,7 +238,7 @@ class STACObject(ABC):
         else:
             return None
 
-    def set_root(self, root: Optional["Catalog_Type"]) -> None:
+    def set_root(self, root: Optional[Catalog]) -> None:
         """Sets the root :class:`~pystac.Catalog` or :class:`~pystac.Collection`
         for this object.
 
@@ -272,7 +274,7 @@ class STACObject(ABC):
                 self.add_link(new_root_link)
             root._resolved_objects.cache(self)
 
-    def get_parent(self) -> Optional["Catalog_Type"]:
+    def get_parent(self) -> Optional[Catalog]:
         """Get the :class:`~pystac.Catalog` or :class:`~pystac.Collection` to
         the parent for this object. The root is represented by a
         :class:`~pystac.Link` with ``rel == 'parent'``.
@@ -288,7 +290,7 @@ class STACObject(ABC):
         else:
             return None
 
-    def set_parent(self, parent: Optional["Catalog_Type"]) -> None:
+    def set_parent(self, parent: Optional[Catalog]) -> None:
         """Sets the parent :class:`~pystac.Catalog` or :class:`~pystac.Collection`
         for this object.
 
@@ -302,8 +304,8 @@ class STACObject(ABC):
             self.add_link(Link.parent(parent))
 
     def get_stac_objects(
-        self, rel: Union[str, pystac.RelType], typ: Optional[Type["STACObject"]] = None
-    ) -> Iterable["STACObject"]:
+        self, rel: Union[str, pystac.RelType], typ: Optional[Type[STACObject]] = None
+    ) -> Iterable[STACObject]:
         """Gets the :class:`~pystac.STACObject` instances that are linked to
         by links with their ``rel`` property matching the passed in argument.
 
@@ -324,7 +326,7 @@ class STACObject(ABC):
             if link.rel == rel:
                 link.resolve_stac_object(root=self.get_root())
                 if typ is None or isinstance(link.target, typ):
-                    yield cast("STACObject", link.target)
+                    yield cast(STACObject, link.target)
 
     def save_object(
         self,
@@ -375,9 +377,9 @@ class STACObject(ABC):
 
     def full_copy(
         self,
-        root: Optional["Catalog_Type"] = None,
-        parent: Optional["Catalog_Type"] = None,
-    ) -> "STACObject":
+        root: Optional[Catalog] = None,
+        parent: Optional[Catalog] = None,
+    ) -> STACObject:
         """Create a full copy of this STAC object and any stac objects linked to by
         this object.
 
@@ -478,7 +480,7 @@ class STACObject(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def clone(self) -> "STACObject":
+    def clone(self) -> STACObject:
         """Clones this object.
 
         Cloning an object will make a copy of all properties and links of the object;
@@ -494,7 +496,7 @@ class STACObject(ABC):
     @classmethod
     def from_file(
         cls, href: str, stac_io: Optional[pystac.StacIO] = None
-    ) -> "STACObject":
+    ) -> STACObject:
         """Reads a STACObject implementation from a file.
 
         Args:
@@ -536,10 +538,10 @@ class STACObject(ABC):
         cls,
         d: Dict[str, Any],
         href: Optional[str] = None,
-        root: Optional["Catalog_Type"] = None,
+        root: Optional[Catalog] = None,
         migrate: bool = False,
         preserve_dict: bool = True,
-    ) -> "STACObject":
+    ) -> STACObject:
         """Parses this STACObject from the passed in dictionary.
 
         Args:

--- a/pystac/validation/__init__.py
+++ b/pystac/validation/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, cast
 
 import pystac
@@ -6,15 +8,14 @@ from pystac.utils import make_absolute_href
 from pystac.validation.schema_uri_map import OldExtensionSchemaUriMap
 
 if TYPE_CHECKING:
-    from pystac.stac_object import STACObject as STACObject_Type
-    from pystac.stac_object import STACObjectType as STACObjectType_Type
+    from pystac.stac_object import STACObject, STACObjectType
 
 
 # Import after above class definition
 from pystac.validation.stac_validator import JsonSchemaSTACValidator, STACValidator
 
 
-def validate(stac_object: "STACObject_Type") -> List[Any]:
+def validate(stac_object: STACObject) -> List[Any]:
     """Validates a :class:`~pystac.STACObject`.
 
     Args:
@@ -39,7 +40,7 @@ def validate(stac_object: "STACObject_Type") -> List[Any]:
 
 def validate_dict(
     stac_dict: Dict[str, Any],
-    stac_object_type: Optional["STACObjectType_Type"] = None,
+    stac_object_type: Optional[STACObjectType] = None,
     stac_version: Optional[str] = None,
     extensions: Optional[List[str]] = None,
     href: Optional[str] = None,


### PR DESCRIPTION
**Related Issue(s):**

- Supports #862

**Tl;dr:**

Switch to using `from __future__ import annotations` to give us slightly cleaner type signatures.

**Description:**

As described in the [mypy documentation](https://mypy.readthedocs.io/en/stable/runtime_troubles.html), there are three tools at our disposal when resolving runtime typing issues:

- `from __future__ import annotations`
- String types
- `typing.TYPE_CHECKING`

Currently, **pystac** uses string types and `typing.TYPE_CHECKING`. This works fine, but does lead to a bit of clutter in the typing namespace, e.g.: https://github.com/stac-utils/pystac/blob/f44de3ca86a8bc1cc1af19add4ac220fd0300365/pystac/asset.py#L8-L11

`"Item_Type"` and friends work fine for the purposes of defining our type signatures, but (IMO) they feel like a workaround and are a little awkward. Additionally, names like `"Item_Type"` will be confusing when combined with the names required to fix #862, e.g.:

```python
TItem = TypeVar("TItem", bound=Item)
if typing.TYPE_CHECKING:
    from pystac.item import Item as Item_Type

# We now have both `TItem` and `Item_Type` in scope, and that feels confusing

class Item:
    def from_dict(d: Dict[str, Any]) -> TItem:
        ....
```

This PR removes the `*_Type` names, and uses `from __future__ import annotations` throughout the library to simplify some type signatures. I don't believe this is a risky change, because (a) it's recommended by mypy as a potential solution to typing issues, and (b) this _may_ become the default Python behavior in the future, in which case we're setting ourselves up for success later.

There are no functional changes to behavior in this PR, this is purely a typing change. Also, because names like `Item_Type` are only used internally, I believe this PR is a non-breaking change.

As a sidecar fix, I also removed two unused imports in the top-level `__init__.py`.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
