### PR TITLE
Filter links with only media_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Serializing optional Collection attributes ([#916](https://github.com/stac-utils/pystac/pull/916))
 - A couple non-running tests ([#912](https://github.com/stac-utils/pystac/pull/912))
 - Support relative stac extension paths via `make_absolute_href` ([#884](https://github.com/stac-utils/pystac/pull/884))
+- Filtering on `media_type` only in `get_links()` ([#966](https://github.com/stac-utils/pystac/pull/966))
 
 ## [v1.6.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 - Serializing optional Collection attributes ([#916](https://github.com/stac-utils/pystac/pull/916))
 - A couple non-running tests ([#912](https://github.com/stac-utils/pystac/pull/912))
 - Support relative stac extension paths via `make_absolute_href` ([#884](https://github.com/stac-utils/pystac/pull/884))
-- Filtering on `media_type` only in `get_links()` ([#966](https://github.com/stac-utils/pystac/pull/966))
+- Filtering on `media_type` in `get_links()` and `get_single_link()` ([#966](https://github.com/stac-utils/pystac/pull/966))
 
 ## [v1.6.1]
 

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -83,23 +83,30 @@ class STACObject(ABC):
 
     def get_single_link(
         self,
-        rel: Union[str, pystac.RelType],
+        rel: Optional[Union[str, pystac.RelType]] = None,
         media_type: Optional[Union[str, pystac.MediaType]] = None,
     ) -> Optional[Link]:
-        """Get single link that matches the given ``rel`` and, optionally,
-        ``media_type``. If ``media_type`` is ``None``, then the link is
-        matched only on the ``rel`` value.
+        """Get a single :class:`~pystac.Link` instance associated with this
+        object.
 
         Args:
-             rel : The :class:`~pystac.Link` ``rel`` to match on.
-             media_type: The :class:`~pystack.MediaType` ``media_type`` to match on
-        """
+            rel : If set, filter links such that only those
+                matching this relationship are returned.
+            media_type: If set, filter the links such that only
+                those matching media_type are returned
 
+        Returns:
+            Optional[:class:`~pystac.Link`]: First link that matches ``rel``
+                and/or ``media_type``, or else the first link associated with
+                this object.
+        """
+        if rel is None and media_type is None:
+            return next(iter(self.links), None)
         return next(
             (
                 link
                 for link in self.links
-                if link.rel == rel
+                if (rel is None or link.rel == rel)
                 and (media_type is None or link.media_type == media_type)
             ),
             None,

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -86,7 +86,7 @@ class STACObject(ABC):
         rel: Union[str, pystac.RelType],
         media_type: Optional[Union[str, pystac.MediaType]] = None,
     ) -> Optional[Link]:
-        """Get single link that match the given ``rel`` and, optionally,
+        """Get single link that matches the given ``rel`` and, optionally,
         ``media_type``. If ``media_type`` is ``None``, then the link is
         matched only on the ``rel`` value.
 
@@ -119,16 +119,17 @@ class STACObject(ABC):
                 those matching media_type are returned
 
         Returns:
-            List[:class:`~pystac.Link`]: A list of links that match ``rel`` if set,
-                or else all links associated with this object.
+            List[:class:`~pystac.Link`]: A list of links that match ``rel`` and/
+                or ``media_type`` if set, or else all links associated with this
+                object.
         """
-        if rel is None:
+        if rel is None and media_type is None:
             return self.links
         else:
             return [
                 link
                 for link in self.links
-                if link.rel == rel
+                if (rel is None or link.rel == rel)
                 and (media_type is None or link.media_type == media_type)
             ]
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1245,7 +1245,7 @@ class TestCatalog:
         assert json_link is not None
         assert json_link.href == "./search.json"
 
-    def test_get_links_media_type(self) -> None:
+    def test_get_links(self) -> None:
         catalog = TestCases.case_1()
 
         catalog.links.append(
@@ -1256,7 +1256,13 @@ class TestCatalog:
                 rel="search", target="./search.json", media_type="application/geo+json"
             )
         )
-        assert len(catalog.get_links("search", media_type="application/geo+json")) == 1
+        assert (
+            len(catalog.get_links(rel="search", media_type="application/geo+json")) == 1
+        )
+        assert len(catalog.get_links(media_type="text/html")) == 1
+        assert len(catalog.get_links(rel="search")) == 2
+        assert len(catalog.get_links(rel="via")) == 0
+        assert len(catalog.get_links()) == 6
 
     def test_to_dict_no_self_href(self) -> None:
         catalog = Catalog(id="an-id", description="A test Catalog")

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1238,12 +1238,22 @@ class TestCatalog:
             )
         )
 
-        html_link = catalog.get_single_link("search")
+        html_link = catalog.get_single_link(rel="search")
         assert html_link is not None
         assert html_link.href == "./search.html"
-        json_link = catalog.get_single_link("search", media_type="application/geo+json")
+        html_link = catalog.get_single_link(media_type="text/html")
+        assert html_link is not None
+        assert html_link.href == "./search.html"
+        json_link = catalog.get_single_link(
+            rel="search", media_type="application/geo+json"
+        )
         assert json_link is not None
         assert json_link.href == "./search.json"
+        no_link = catalog.get_single_link(rel="via")
+        assert no_link is None
+        first_link = catalog.get_single_link()
+        assert first_link is not None
+        assert first_link.rel == "self"
 
     def test_get_links(self) -> None:
         catalog = TestCases.case_1()


### PR DESCRIPTION
**Related Issue(s):**
- Closes #937 

**Description:**
Enables filtering with `get_links()` on either `rel`, `media_type`, or both.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
