### PR TITLE
Make `layout_strategy` default value consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `isort` ([#961](https://github.com/stac-utils/pystac/pull/961))
 - `AsIsLayoutStrategy` ([#919](https://github.com/stac-utils/pystac/pull/919))
 - `__geo_interface__` for items ([#885](https://github.com/stac-utils/pystac/pull/885))
+- Optional `strategy` parameter to `catalog.add_items()` ([#967](https://github.com/stac-utils/pystac/pull/967))
 
 ### Removed
 

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -240,7 +240,8 @@ class Catalog(STACObject):
             child : The child to add.
             title : Optional title to give to the :class:`~pystac.Link`
             strategy : The layout strategy to use for setting the
-                self href of the child.
+                self href of the child. If not provided, defaults to
+                :class:`~pystac.layout.BestPracticesLayoutStrategy`.
         """
 
         # Prevent typo confusion
@@ -287,6 +288,9 @@ class Catalog(STACObject):
         Args:
             item : The item to add.
             title : Optional title to give to the :class:`~pystac.Link`
+            strategy : The layout strategy to use for setting the
+                self href of the item. If not provided, defaults to
+                :class:`~pystac.layout.BestPracticesLayoutStrategy`.
         """
 
         # Prevent typo confusion
@@ -307,16 +311,23 @@ class Catalog(STACObject):
 
         self.add_link(Link.item(item, title=title))
 
-    def add_items(self, items: Iterable["Item_Type"]) -> None:
-        """Adds links to multiple :class:`~pystac.Item` s.
+    def add_items(
+        self,
+        items: Iterable["Item_Type"],
+        strategy: Optional[HrefLayoutStrategy] = None,
+    ) -> None:
+        """Adds links to multiple :class:`~pystac.Item`s.
         This method will set each item's parent to this object, and their root to
         this Catalog's root.
 
         Args:
             items : The items to add.
+            strategy : The layout strategy to use for setting the
+                self href of the items. If not provided, defaults to
+                :class:`~pystac.layout.BestPracticesLayoutStrategy`.
         """
         for item in items:
-            self.add_item(item)
+            self.add_item(item, strategy=strategy)
 
     def get_child(
         self, id: str, recursive: bool = False
@@ -588,7 +599,7 @@ class Catalog(STACObject):
                 Defaults to the root catalog.catalog_type or the current catalog
                 catalog_type if there is no root catalog.
             strategy : The layout strategy to use in setting the
-                HREFS for this catalog. Defaults to
+                HREFS for this catalog. If not provided, defaults to
                 :class:`~pystac.layout.BestPracticesLayoutStrategy`
             stac_io : Optional instance of :class:`~pystac.StacIO` to use. If not
                 provided, will use the instance set while reading in the catalog,
@@ -622,7 +633,7 @@ class Catalog(STACObject):
         Args:
             root_href : The absolute HREF that all links will be normalized against.
             strategy : The layout strategy to use in setting the HREFS
-                for this catalog. Defaults to
+                for this catalog. If not provided, defaults to
                 :class:`~pystac.layout.BestPracticesLayoutStrategy`
             skip_unresolved : Skip unresolved links when normalizing the tree.
                 Defaults to False.

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -85,7 +85,7 @@ class CatalogType(StringEnum):
 
         Returns:
             Optional[CatalogType]: The catalog type of the catalog or collection.
-                Will return None if it cannot be determined.
+            Will return None if it cannot be determined.
         """
         self_link = None
         relative = False

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -230,7 +230,7 @@ class Catalog(STACObject):
         self,
         child: Union["Catalog", "Collection_Type"],
         title: Optional[str] = None,
-        strategy: Optional[HrefLayoutStrategy] = None,
+        strategy: HrefLayoutStrategy = BestPracticesLayoutStrategy(),
     ) -> None:
         """Adds a link to a child :class:`~pystac.Catalog` or
         :class:`~pystac.Collection`. This method will set the child's parent to this
@@ -240,15 +240,13 @@ class Catalog(STACObject):
             child : The child to add.
             title : Optional title to give to the :class:`~pystac.Link`
             strategy : The layout strategy to use for setting the
-                self href of the child.
+                self href of the child. Defaults to
+                :class:`~pystac.layout.BestPracticesLayoutStrategy`
         """
 
         # Prevent typo confusion
         if isinstance(child, pystac.Item):
             raise pystac.STACError("Cannot add item as child. Use add_item instead.")
-
-        if strategy is None:
-            strategy = BestPracticesLayoutStrategy()
 
         child.set_root(self.get_root())
         child.set_parent(self)
@@ -278,7 +276,7 @@ class Catalog(STACObject):
         self,
         item: "Item_Type",
         title: Optional[str] = None,
-        strategy: Optional[HrefLayoutStrategy] = None,
+        strategy: HrefLayoutStrategy = BestPracticesLayoutStrategy(),
     ) -> None:
         """Adds a link to an :class:`~pystac.Item`.
         This method will set the item's parent to this object, and its root to
@@ -286,15 +284,14 @@ class Catalog(STACObject):
 
         Args:
             item : The item to add.
-            title : Optional title to give to the :class:`~pystac.Link`
+            title : Optional title to give to the :class:`~pystac.Link`.
+            strategy : The layout strategy to use for setting the self href of
+                the item. Defaults to
+                :class:`~pystac.layout.BestPracticesLayoutStrategy`.
         """
-
         # Prevent typo confusion
         if isinstance(item, pystac.Catalog):
             raise pystac.STACError("Cannot add catalog as item. Use add_child instead.")
-
-        if strategy is None:
-            strategy = BestPracticesLayoutStrategy()
 
         item.set_root(self.get_root())
         item.set_parent(self)
@@ -307,16 +304,23 @@ class Catalog(STACObject):
 
         self.add_link(Link.item(item, title=title))
 
-    def add_items(self, items: Iterable["Item_Type"]) -> None:
-        """Adds links to multiple :class:`~pystac.Item` s.
+    def add_items(
+        self,
+        items: Iterable["Item_Type"],
+        strategy: HrefLayoutStrategy = BestPracticesLayoutStrategy(),
+    ) -> None:
+        """Adds links to multiple :class:`~pystac.Item`s.
         This method will set each item's parent to this object, and their root to
         this Catalog's root.
 
         Args:
             items : The items to add.
+            strategy : The layout strategy to use for setting the self href of
+                the item. Defaults to
+                :class:`~pystac.layout.BestPracticesLayoutStrategy`.
         """
         for item in items:
-            self.add_item(item)
+            self.add_item(item, strategy=strategy)
 
     def get_child(
         self, id: str, recursive: bool = False
@@ -570,7 +574,7 @@ class Catalog(STACObject):
         self,
         root_href: str,
         catalog_type: Optional[CatalogType] = None,
-        strategy: Optional[HrefLayoutStrategy] = None,
+        strategy: HrefLayoutStrategy = BestPracticesLayoutStrategy(),
         stac_io: Optional[pystac.StacIO] = None,
         skip_unresolved: bool = False,
     ) -> None:
@@ -606,7 +610,7 @@ class Catalog(STACObject):
     def normalize_hrefs(
         self,
         root_href: str,
-        strategy: Optional[HrefLayoutStrategy] = None,
+        strategy: HrefLayoutStrategy = BestPracticesLayoutStrategy(),
         skip_unresolved: bool = False,
     ) -> None:
         """Normalize HREFs will regenerate all link HREFs based on
@@ -631,11 +635,6 @@ class Catalog(STACObject):
             :stac-spec:`STAC best practices document <best-practices.md#catalog-layout>`
             for the canonical layout of a STAC.
         """
-        if strategy is None:
-            _strategy: HrefLayoutStrategy = BestPracticesLayoutStrategy()
-        else:
-            _strategy = strategy
-
         # Normalizing requires an absolute path
         if not is_absolute_href(root_href):
             root_href = make_absolute_href(root_href, os.getcwd(), start_is_dir=True)
@@ -644,7 +643,7 @@ class Catalog(STACObject):
             if not skip_unresolved:
                 item.resolve_links()
 
-            new_self_href = _strategy.get_href(item, _root_href)
+            new_self_href = strategy.get_href(item, _root_href)
 
             def fn() -> None:
                 item.set_self_href(new_self_href)
@@ -659,7 +658,7 @@ class Catalog(STACObject):
             if not skip_unresolved:
                 cat.resolve_links()
 
-            new_self_href = _strategy.get_href(cat, _root_href, is_root)
+            new_self_href = strategy.get_href(cat, _root_href, is_root)
             new_root = os.path.dirname(new_self_href)
 
             for link in cat.get_links():

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -22,7 +22,7 @@ from pystac.asset import Asset
 from pystac.catalog import Catalog
 from pystac.errors import STACTypeError
 from pystac.html.jinja_env import get_jinja_env
-from pystac.layout import HrefLayoutStrategy
+from pystac.layout import BestPracticesLayoutStrategy, HrefLayoutStrategy
 from pystac.link import Link
 from pystac.provider import Provider
 from pystac.serialization import (
@@ -545,7 +545,7 @@ class Collection(Catalog):
         self,
         item: "Item_Type",
         title: Optional[str] = None,
-        strategy: Optional[HrefLayoutStrategy] = None,
+        strategy: HrefLayoutStrategy = BestPracticesLayoutStrategy(),
     ) -> None:
         super().add_item(item, title, strategy)
         item.set_collection(self)

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -358,7 +358,7 @@ class Extent:
 
         Returns:
             Extent: An Extent that spatially and temporally covers all of the
-                given items.
+            given items.
         """
         bounds_values: List[List[float]] = [
             [float("inf")],
@@ -689,7 +689,7 @@ class Collection(Catalog):
 
         Returns:
             Dict[str, Asset]: A dictionary of assets that match ``media_type``
-                and/or ``role`` if set or else all of this collection's assets.
+            and/or ``role`` if set or else all of this collection's assets.
         """
         if media_type is None and role is None:
             return dict(self.assets.items())

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -22,7 +22,7 @@ from pystac.asset import Asset
 from pystac.catalog import Catalog
 from pystac.errors import STACTypeError
 from pystac.html.jinja_env import get_jinja_env
-from pystac.layout import BestPracticesLayoutStrategy, HrefLayoutStrategy
+from pystac.layout import HrefLayoutStrategy
 from pystac.link import Link
 from pystac.provider import Provider
 from pystac.serialization import (
@@ -545,7 +545,7 @@ class Collection(Catalog):
         self,
         item: "Item_Type",
         title: Optional[str] = None,
-        strategy: HrefLayoutStrategy = BestPracticesLayoutStrategy(),
+        strategy: Optional[HrefLayoutStrategy] = None,
     ) -> None:
         super().add_item(item, title, strategy)
         item.set_collection(self)

--- a/pystac/layout.py
+++ b/pystac/layout.py
@@ -272,6 +272,56 @@ class HrefLayoutStrategy(ABC):
         raise NotImplementedError
 
 
+class BestPracticesLayoutStrategy(HrefLayoutStrategy):
+    """Layout strategy that represents the catalog layout described
+    in the :stac-spec:`STAC Best Practices documentation
+    <best-practices.md>`
+
+    For a root catalog or collection, this will use the filename 'catalog.json'
+    or 'collection.json' to the given directory. For a non-root catalog or collection,
+    the ID will be used as a subdirectory, e.g. ``${id}/catalog.json`` or
+    ``${id}/collection.json``. For items, a subdirectory with a name of the item
+    ID will be made, and the item ID will be used in the filename, i.e.
+    ``${id}/${id}.json``
+
+    All paths are appended to the parent directory.
+    """
+
+    def get_catalog_href(
+        self, cat: "Catalog_Type", parent_dir: str, is_root: bool
+    ) -> str:
+        parsed_parent_dir = safe_urlparse(parent_dir)
+        join_type = JoinType.from_parsed_uri(parsed_parent_dir)
+
+        if is_root:
+            cat_root = parent_dir
+        else:
+            cat_root = join_path_or_url(join_type, parent_dir, "{}".format(cat.id))
+
+        return join_path_or_url(join_type, cat_root, cat.DEFAULT_FILE_NAME)
+
+    def get_collection_href(
+        self, col: "Collection_Type", parent_dir: str, is_root: bool
+    ) -> str:
+        parsed_parent_dir = safe_urlparse(parent_dir)
+        join_type = JoinType.from_parsed_uri(parsed_parent_dir)
+
+        if is_root:
+            col_root = parent_dir
+        else:
+            col_root = join_path_or_url(join_type, parent_dir, "{}".format(col.id))
+
+        return join_path_or_url(join_type, col_root, col.DEFAULT_FILE_NAME)
+
+    def get_item_href(self, item: "Item_Type", parent_dir: str) -> str:
+        parsed_parent_dir = safe_urlparse(parent_dir)
+        join_type = JoinType.from_parsed_uri(parsed_parent_dir)
+
+        item_root = join_path_or_url(join_type, parent_dir, "{}".format(item.id))
+
+        return join_path_or_url(join_type, item_root, "{}.json".format(item.id))
+
+
 class CustomLayoutStrategy(HrefLayoutStrategy):
     """Layout strategy that allows users to supply functions to dictate
     stac object paths.
@@ -316,13 +366,11 @@ class CustomLayoutStrategy(HrefLayoutStrategy):
         catalog_func: Optional[Callable[["Catalog_Type", str, bool], str]] = None,
         collection_func: Optional[Callable[["Collection_Type", str, bool], str]] = None,
         item_func: Optional[Callable[["Item_Type", str], str]] = None,
-        fallback_strategy: Optional[HrefLayoutStrategy] = None,
+        fallback_strategy: HrefLayoutStrategy = BestPracticesLayoutStrategy(),
     ):
         self.item_func = item_func
         self.collection_func = collection_func
         self.catalog_func = catalog_func
-        if fallback_strategy is None:
-            fallback_strategy = BestPracticesLayoutStrategy()
         self.fallback_strategy = fallback_strategy
 
     def get_catalog_href(
@@ -397,7 +445,7 @@ class TemplateLayoutStrategy(HrefLayoutStrategy):
         catalog_template: Optional[str] = None,
         collection_template: Optional[str] = None,
         item_template: Optional[str] = None,
-        fallback_strategy: Optional[HrefLayoutStrategy] = None,
+        fallback_strategy: HrefLayoutStrategy = BestPracticesLayoutStrategy(),
     ):
         self.catalog_template = (
             LayoutTemplate(catalog_template) if catalog_template is not None else None
@@ -411,8 +459,6 @@ class TemplateLayoutStrategy(HrefLayoutStrategy):
             LayoutTemplate(item_template) if item_template is not None else None
         )
 
-        if fallback_strategy is None:
-            fallback_strategy = BestPracticesLayoutStrategy()
         self.fallback_strategy = fallback_strategy
 
     def get_catalog_href(
@@ -463,56 +509,6 @@ class TemplateLayoutStrategy(HrefLayoutStrategy):
                 )
 
             return join_path_or_url(join_type, parent_dir, template_path)
-
-
-class BestPracticesLayoutStrategy(HrefLayoutStrategy):
-    """Layout strategy that represents the catalog layout described
-    in the :stac-spec:`STAC Best Practices documentation
-    <best-practices.md>`
-
-    For a root catalog or collection, this will use the filename 'catalog.json'
-    or 'collection.json' to the given directory. For a non-root catalog or collection,
-    the ID will be used as a subdirectory, e.g. ``${id}/catalog.json`` or
-    ``${id}/collection.json``. For items, a subdirectory with a name of the item
-    ID will be made, and the item ID will be used in the filename, i.e.
-    ``${id}/${id}.json``
-
-    All paths are appended to the parent directory.
-    """
-
-    def get_catalog_href(
-        self, cat: "Catalog_Type", parent_dir: str, is_root: bool
-    ) -> str:
-        parsed_parent_dir = safe_urlparse(parent_dir)
-        join_type = JoinType.from_parsed_uri(parsed_parent_dir)
-
-        if is_root:
-            cat_root = parent_dir
-        else:
-            cat_root = join_path_or_url(join_type, parent_dir, "{}".format(cat.id))
-
-        return join_path_or_url(join_type, cat_root, cat.DEFAULT_FILE_NAME)
-
-    def get_collection_href(
-        self, col: "Collection_Type", parent_dir: str, is_root: bool
-    ) -> str:
-        parsed_parent_dir = safe_urlparse(parent_dir)
-        join_type = JoinType.from_parsed_uri(parsed_parent_dir)
-
-        if is_root:
-            col_root = parent_dir
-        else:
-            col_root = join_path_or_url(join_type, parent_dir, "{}".format(col.id))
-
-        return join_path_or_url(join_type, col_root, col.DEFAULT_FILE_NAME)
-
-    def get_item_href(self, item: "Item_Type", parent_dir: str) -> str:
-        parsed_parent_dir = safe_urlparse(parent_dir)
-        join_type = JoinType.from_parsed_uri(parsed_parent_dir)
-
-        item_root = join_path_or_url(join_type, parent_dir, "{}".format(item.id))
-
-        return join_path_or_url(join_type, item_root, "{}.json".format(item.id))
 
 
 class AsIsLayoutStrategy(HrefLayoutStrategy):

--- a/pystac/layout.py
+++ b/pystac/layout.py
@@ -201,8 +201,8 @@ class LayoutTemplate:
 
         Returns:
             [dict]: A dictionary with keys being the template variables
-                and values being the respective values based on the given
-                stac object.
+            and values being the respective values based on the given
+            stac object.
 
         Raises:
             TemplateError: If a value for a template variable cannot be
@@ -224,8 +224,8 @@ class LayoutTemplate:
 
         Returns:
             str: The original template supplied to this LayoutTemplate
-                with template variables replaced by the values derived
-                from this stac object.
+            with template variables replaced by the values derived
+            from this stac object.
 
         Raises:
             TemplateError: If a value for a template variable cannot be

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -97,8 +97,8 @@ class STACObject(ABC):
 
         Returns:
             Optional[:class:`~pystac.Link`]: First link that matches ``rel``
-                and/or ``media_type``, or else the first link associated with
-                this object.
+            and/or ``media_type``, or else the first link associated with
+            this object.
         """
         if rel is None and media_type is None:
             return next(iter(self.links), None)
@@ -127,8 +127,8 @@ class STACObject(ABC):
 
         Returns:
             List[:class:`~pystac.Link`]: A list of links that match ``rel`` and/
-                or ``media_type`` if set, or else all links associated with this
-                object.
+            or ``media_type`` if set, or else all links associated with this
+            object.
         """
         if rel is None and media_type is None:
             return self.links
@@ -389,7 +389,7 @@ class STACObject(ABC):
 
         Returns:
             STACObject: A full copy of this object, as well as any objects this object
-                links to.
+            links to.
         """
         clone = self.clone()
 


### PR DESCRIPTION
**Related Issue(s):** #
- Closes #965 

**Description:**
- Updates docstrings to make users aware of the default layout strategy.
- Adds an optional `strategy` parameter to the catalog `add_items()` method.
- Updates docstring formatting in several places to correct rendering in the API docs.


**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
