### PR TITLE
Preserve relative links when using `from_file`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,15 +8,15 @@ from .utils import ARBITRARY_BBOX, ARBITRARY_EXTENT, ARBITRARY_GEOM
 
 
 @pytest.fixture
-def test_catalog() -> Catalog:
+def catalog() -> Catalog:
     return Catalog("test-catalog", "A test catalog")
 
 
 @pytest.fixture
-def test_collection() -> Catalog:
+def collection() -> Catalog:
     return Collection("test-collection", "A test collection", ARBITRARY_EXTENT)
 
 
 @pytest.fixture
-def test_item() -> Item:
+def item() -> Item:
     return Item("test-item", ARBITRARY_GEOM, ARBITRARY_BBOX, datetime.now(), {})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,54 @@
 from datetime import datetime
 
 import pytest
+from pytest import FixtureRequest
 
 from pystac import Catalog, Collection, Item
 
-from .utils import ARBITRARY_BBOX, ARBITRARY_EXTENT, ARBITRARY_GEOM
+from .utils import ARBITRARY_BBOX, ARBITRARY_EXTENT, ARBITRARY_GEOM, TestCases
 
 
 @pytest.fixture
 def catalog() -> Catalog:
     return Catalog("test-catalog", "A test catalog")
+
+
+@pytest.fixture
+def prebuilt_catalog_1() -> Catalog:
+    path = TestCases.get_path("data-files/catalogs/test-case-1/catalog.json")
+    return Catalog.from_file(path)
+
+
+@pytest.fixture
+def prebuilt_catalog_2() -> Catalog:
+    path = TestCases.get_path("data-files/catalogs/test-case-2/catalog.json")
+    return Catalog.from_file(path)
+
+
+@pytest.fixture
+def prebuilt_catalog_4() -> Catalog:
+    path = TestCases.get_path("data-files/catalogs/test-case-4/catalog.json")
+    return Catalog.from_file(path)
+
+
+@pytest.fixture
+def prebuilt_catalog_5() -> Catalog:
+    path = TestCases.get_path("data-files/catalogs/test-case-5/catalog.json")
+    return Catalog.from_file(path)
+
+
+@pytest.fixture
+def prebuilt_catalog_6() -> Catalog:
+    path = TestCases.get_path("data-files/catalogs/test-case-6/catalog.json")
+    return Catalog.from_file(path)
+
+
+@pytest.fixture(params=["1", "2", "4", "5", "6"])
+def prebuilt_catalog(request: FixtureRequest) -> Catalog:
+    path = TestCases.get_path(
+        f"data-files/catalogs/test-case-{request.param}/catalog.json"
+    )
+    return Catalog.from_file(path)
 
 
 @pytest.fixture

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1444,7 +1444,7 @@ class CatalogSubClassTest(unittest.TestCase):
         self.assertIsInstance(cloned_catalog, self.BasicCustomCatalog)
 
 
-def test_custom_catalog_from_dict(test_catalog: Catalog) -> None:
+def test_custom_catalog_from_dict(catalog: Catalog) -> None:
     # https://github.com/stac-utils/pystac/issues/862
     class CustomCatalog(Catalog):
         @classmethod
@@ -1458,4 +1458,4 @@ def test_custom_catalog_from_dict(test_catalog: Catalog) -> None:
         ) -> CustomCatalog:
             return super().from_dict(d)
 
-    _ = CustomCatalog.from_dict(test_catalog.to_dict())
+    _ = CustomCatalog.from_dict(catalog.to_dict())

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -514,7 +514,7 @@ class CollectionSubClassTest(unittest.TestCase):
         self.assertIsInstance(cloned_collection, self.BasicCustomCollection)
 
 
-def test_custom_collection_from_dict(test_collection: Collection) -> None:
+def test_custom_collection_from_dict(collection: Collection) -> None:
     # https://github.com/stac-utils/pystac/issues/862
     class CustomCollection(Collection):
         @classmethod
@@ -528,4 +528,4 @@ def test_custom_collection_from_dict(test_collection: Collection) -> None:
         ) -> CustomCollection:
             return super().from_dict(d)
 
-    _ = CustomCollection.from_dict(test_collection.to_dict())
+    _ = CustomCollection.from_dict(collection.to_dict())

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -422,7 +422,7 @@ class AssetSubClassTest(unittest.TestCase):
         self.assertIsInstance(cloned_asset, self.CustomAsset)
 
 
-def test_custom_item_from_dict(test_item: Item) -> None:
+def test_custom_item_from_dict(item: Item) -> None:
     # https://github.com/stac-utils/pystac/issues/862
     class CustomItem(Item):
         @classmethod
@@ -436,7 +436,7 @@ def test_custom_item_from_dict(test_item: Item) -> None:
         ) -> CustomItem:
             return super().from_dict(d)
 
-    _ = CustomItem.from_dict(test_item.to_dict())
+    _ = CustomItem.from_dict(item.to_dict())
 
 
 def test_item_from_dict_raises_useful_error() -> None:


### PR DESCRIPTION
**Related Issue(s):**
- Closes #838 

**Description:**

When reading Catalogs/Collections from files, a user should be able to preserve any relative links e.g. to children. Otherwise, re-saving the Catalog/Collection may produce surprising results (e.g. filesystem-absolute links where previously they were relative, breaking portability).

This is currently a draft PR demonstrating the problem. The fix will likely be adding a `catalog_type` argument to `from_file`, but we should explore other options as well, since adding a new argument to such a widely used classmethod is not ideal.

**PR Checklist:**

- [ ] Code is formatted (run `pre-commit run --all-files`)
- [ ] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [ ] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
