### PR TITLE
Always use ``from datetime import datetime``

### DIFF
--- a/benchmarks/catalog.py
+++ b/benchmarks/catalog.py
@@ -1,8 +1,8 @@
-import datetime
 import json
 import os
 import shutil
 import tempfile
+from datetime import datetime
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -108,12 +108,12 @@ def make_large_catalog() -> Catalog:
     catalog = Catalog("an-id", "a description")
     extent = Extent(
         SpatialExtent([[-180.0, -90.0, 180.0, 90.0]]),
-        TemporalExtent([[datetime.datetime(2023, 1, 1), None]]),
+        TemporalExtent([[datetime(2023, 1, 1), None]]),
     )
     for i in range(0, 10):
         collection = Collection(f"collection-{i}", f"Collection {i}", extent)
         for j in range(0, 100):
-            item = Item(f"item-{i}-{j}", None, None, datetime.datetime.now(), {})
+            item = Item(f"item-{i}-{j}", None, None, datetime.now(), {})
             collection.add_item(item)
         catalog.add_child(collection)
     return catalog

--- a/benchmarks/extensions/projection.py
+++ b/benchmarks/extensions/projection.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime
 
 from pystac import Item
 from pystac.extensions.projection import ProjectionExtension
@@ -8,7 +8,7 @@ from .._base import Bench
 
 class ProjectionBench(Bench):
     def setup(self) -> None:
-        self.item = Item("an-id", None, None, datetime.datetime.now(), {})
+        self.item = Item("an-id", None, None, datetime.now(), {})
 
     def time_add_projection_extension(self) -> None:
         _ = ProjectionExtension.ext(self.item, add_if_missing=True)

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -131,3 +131,22 @@ few steps:
 
 For more information on changelogs and how to write a good entry, see `keep a changelog
 <https://keepachangelog.com/en/1.0.0/>`_.
+
+
+Style
+^^^^^
+
+In an effort to maintain a consistent codebase, PySTAC conforms to the following rules:
+
+.. code-block:: python
+
+   # DO
+   from datetime import datetime
+
+   # DON't
+   import datetime
+   import datetime as dt
+
+The exception to this rule is when ``datetime`` is only imported for type checking and
+using the class directly interferes with another variable name. In this case, in the
+TYPE_CHECKING block you should do ``from datetime import datetime as Datetime``.

--- a/pystac/common_metadata.py
+++ b/pystac/common_metadata.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime as Datetime
+from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, TypeVar, Union, cast
 
 import pystac
@@ -84,25 +84,25 @@ class CommonMetadata:
 
     # Date and Time Range
     @property
-    def start_datetime(self) -> Optional[Datetime]:
+    def start_datetime(self) -> Optional[datetime]:
         """Get or set the object's start_datetime."""
         return utils.map_opt(
             utils.str_to_datetime, self._get_field("start_datetime", str)
         )
 
     @start_datetime.setter
-    def start_datetime(self, v: Optional[Datetime]) -> None:
+    def start_datetime(self, v: Optional[datetime]) -> None:
         self._set_field("start_datetime", utils.map_opt(utils.datetime_to_str, v))
 
     @property
-    def end_datetime(self) -> Optional[Datetime]:
+    def end_datetime(self) -> Optional[datetime]:
         """Get or set the item's end_datetime."""
         return utils.map_opt(
             utils.str_to_datetime, self._get_field("end_datetime", str)
         )
 
     @end_datetime.setter
-    def end_datetime(self, v: Optional[Datetime]) -> None:
+    def end_datetime(self, v: Optional[datetime]) -> None:
         self._set_field("end_datetime", utils.map_opt(utils.datetime_to_str, v))
 
     # License
@@ -179,7 +179,7 @@ class CommonMetadata:
 
     # Metadata
     @property
-    def created(self) -> Optional[Datetime]:
+    def created(self) -> Optional[datetime]:
         """Get or set the metadata file's creation date. All datetime attributes have
         setters that can take either a string or a datetime, but always stores
         the attribute as a string.
@@ -193,11 +193,11 @@ class CommonMetadata:
         return utils.map_opt(utils.str_to_datetime, self._get_field("created", str))
 
     @created.setter
-    def created(self, v: Optional[Datetime]) -> None:
+    def created(self, v: Optional[datetime]) -> None:
         self._set_field("created", utils.map_opt(utils.datetime_to_str, v))
 
     @property
-    def updated(self) -> Optional[Datetime]:
+    def updated(self) -> Optional[datetime]:
         """Get or set the metadata file's update date. All datetime attributes have
         setters that can take either a string or a datetime, but always stores
         the attribute as a string
@@ -211,5 +211,5 @@ class CommonMetadata:
         return utils.map_opt(utils.str_to_datetime, self._get_field("updated", str))
 
     @updated.setter
-    def updated(self, v: Optional[Datetime]) -> None:
+    def updated(self, v: Optional[datetime]) -> None:
         self._set_field("updated", utils.map_opt(utils.datetime_to_str, v))

--- a/pystac/extensions/sat.py
+++ b/pystac/extensions/sat.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime as Datetime
+from datetime import datetime
 from typing import Any, Dict, Generic, Iterable, List, Optional, TypeVar, Union, cast
 
 import pystac
@@ -61,7 +61,7 @@ class SatExtension(
         relative_orbit: Optional[int] = None,
         absolute_orbit: Optional[int] = None,
         platform_international_designator: Optional[str] = None,
-        anx_datetime: Optional[Datetime] = None,
+        anx_datetime: Optional[datetime] = None,
     ) -> None:
         """Applies ext extension properties to the extended :class:`~pystac.Item` or
         class:`~pystac.Asset`.
@@ -123,11 +123,11 @@ class SatExtension(
         self._set_property(RELATIVE_ORBIT_PROP, v)
 
     @property
-    def anx_datetime(self) -> Optional[Datetime]:
+    def anx_datetime(self) -> Optional[datetime]:
         return map_opt(str_to_datetime, self._get_property(ANX_DATETIME_PROP, str))
 
     @anx_datetime.setter
-    def anx_datetime(self, v: Optional[Datetime]) -> None:
+    def anx_datetime(self, v: Optional[datetime]) -> None:
         self._set_property(ANX_DATETIME_PROP, map_opt(datetime_to_str, v))
 
     @classmethod
@@ -268,7 +268,7 @@ class SummariesSatExtension(SummariesExtension):
         self._set_summary(RELATIVE_ORBIT_PROP, v)
 
     @property
-    def anx_datetime(self) -> Optional[RangeSummary[Datetime]]:
+    def anx_datetime(self) -> Optional[RangeSummary[datetime]]:
         return map_opt(
             lambda s: RangeSummary(
                 str_to_datetime(s.minimum), str_to_datetime(s.maximum)
@@ -277,7 +277,7 @@ class SummariesSatExtension(SummariesExtension):
         )
 
     @anx_datetime.setter
-    def anx_datetime(self, v: Optional[RangeSummary[Datetime]]) -> None:
+    def anx_datetime(self, v: Optional[RangeSummary[datetime]]) -> None:
         self._set_summary(
             ANX_DATETIME_PROP,
             map_opt(

--- a/pystac/extensions/timestamps.py
+++ b/pystac/extensions/timestamps.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime as datetime
+from datetime import datetime
 from typing import Any, Dict, Generic, Iterable, Optional, TypeVar, Union, cast
 
 import pystac

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -28,6 +28,7 @@ from pystac.utils import (
 T = TypeVar("T", bound="Item")
 
 if TYPE_CHECKING:
+    # avoids conflicts since there are also kwargs and attrs called `datetime`
     from datetime import datetime as Datetime
 
 

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 from copy import copy, deepcopy
-from datetime import datetime as Datetime
 from html import escape
-from typing import Any, Dict, List, Optional, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, TypeVar, Union, cast
 
 import pystac
 from pystac import STACError, STACObjectType
@@ -28,6 +27,9 @@ from pystac.utils import (
 
 T = TypeVar("T", bound="Item")
 
+if TYPE_CHECKING:
+    from datetime import datetime as Datetime
+
 
 class Item(STACObject):
     """An Item is the core granular entity in a STAC, containing the core metadata
@@ -43,7 +45,7 @@ class Item(STACObject):
             using either 2D or 3D geometries. The length of the array must be 2*n
             where n is the number of dimensions. Could also be None in the case of a
             null geometry.
-        datetime : Datetime associated with this item. If None,
+        datetime : datetime associated with this item. If None,
             a start_datetime and end_datetime must be supplied.
         properties : A dictionary of additional metadata for the item.
         start_datetime : Optional start datetime, part of common metadata. This value

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-import datetime
+from datetime import datetime
 
 import pytest
 
@@ -19,6 +19,4 @@ def test_collection() -> Catalog:
 
 @pytest.fixture
 def test_item() -> Item:
-    return Item(
-        "test-item", ARBITRARY_GEOM, ARBITRARY_BBOX, datetime.datetime.now(), {}
-    )
+    return Item("test-item", ARBITRARY_GEOM, ARBITRARY_BBOX, datetime.now(), {})

--- a/tests/extensions/test_custom.py
+++ b/tests/extensions/test_custom.py
@@ -1,7 +1,7 @@
 """Tests creating a custom extension"""
 
-import datetime
 import unittest
+from datetime import datetime
 from typing import Any, Dict, Generic, Optional, Set, TypeVar, Union, cast
 
 import pytest
@@ -130,7 +130,7 @@ class CustomExtensionTest(unittest.TestCase):
         pystac.EXTENSION_HOOKS.remove_extension_hooks(SCHEMA_URI)
 
     def test_add_to_item_asset(self) -> None:
-        item = Item("an-id", None, None, datetime.datetime.now(), {})
+        item = Item("an-id", None, None, datetime.now(), {})
         item.add_asset("foo", Asset("http://pystac.test/asset.tif"))
         custom = CustomExtension.ext(item.assets["foo"], add_if_missing=True)
         assert CustomExtension.has_extension(item)
@@ -139,7 +139,7 @@ class CustomExtensionTest(unittest.TestCase):
         assert item_as_dict["assets"]["foo"]["test:prop"] == "bar"
 
     def test_add_to_item(self) -> None:
-        item = Item("an-id", None, None, datetime.datetime.now(), {})
+        item = Item("an-id", None, None, datetime.now(), {})
         custom = CustomExtension.ext(item, add_if_missing=True)
         assert CustomExtension.has_extension(item)
         custom.test_prop = "foo"
@@ -160,7 +160,7 @@ class CustomExtensionTest(unittest.TestCase):
             "a description",
             extent=Extent(
                 spatial=SpatialExtent([-180.0, -90.0, 180.0, 90.0]),
-                temporal=TemporalExtent([[datetime.datetime.now(), None]]),
+                temporal=TemporalExtent([[datetime.now(), None]]),
             ),
         )
         custom = CustomExtension.ext(collection, add_if_missing=True)
@@ -175,7 +175,7 @@ class CustomExtensionTest(unittest.TestCase):
             "a description",
             extent=Extent(
                 spatial=SpatialExtent([-180.0, -90.0, 180.0, 90.0]),
-                temporal=TemporalExtent([[datetime.datetime.now(), None]]),
+                temporal=TemporalExtent([[datetime.now(), None]]),
             ),
         )
         collection.add_asset("foo", Asset("http://pystac.test/asset.tif"))
@@ -190,7 +190,7 @@ class CustomExtensionTest(unittest.TestCase):
             CustomExtension.ext({})  # type: ignore
 
     def test_migrates(self) -> None:
-        item = Item("an-id", None, None, datetime.datetime.now(), {})
+        item = Item("an-id", None, None, datetime.now(), {})
         item_as_dict = item.to_dict()
         item_as_dict["stac_version"] = "1.0.0-rc.1"
         item_as_dict["stac_extensions"] = [

--- a/tests/extensions/test_grid.py
+++ b/tests/extensions/test_grid.py
@@ -2,8 +2,8 @@
 # This is for the type checking on GridTest.test_clear_code
 # mypy: warn_unused_ignores=False
 
-import datetime
 import unittest
+from datetime import datetime
 from typing import Any, Dict
 
 import pystac
@@ -18,7 +18,7 @@ code = "MGRS-4CFJ"
 def make_item() -> pystac.Item:
     """Create basic test items that are only slightly different."""
     asset_id = "an/asset"
-    start = datetime.datetime(2018, 1, 2)
+    start = datetime(2018, 1, 2)
     item = pystac.Item(
         id=asset_id, geometry=None, bbox=None, datetime=start, properties={}
     )

--- a/tests/extensions/test_sar.py
+++ b/tests/extensions/test_sar.py
@@ -1,7 +1,7 @@
 """Tests for pystac.extensions.sar."""
 
-import datetime
 import unittest
+from datetime import datetime
 from random import choice
 from string import ascii_letters
 from typing import List
@@ -21,7 +21,7 @@ from tests.utils import TestCases
 
 def make_item() -> pystac.Item:
     asset_id = "my/items/2011"
-    start = datetime.datetime(2020, 11, 7)
+    start = datetime(2020, 11, 7)
     item = pystac.Item(
         id=asset_id, geometry=None, bbox=None, datetime=start, properties={}
     )

--- a/tests/extensions/test_sat.py
+++ b/tests/extensions/test_sat.py
@@ -1,7 +1,7 @@
 """Tests for pystac.extensions.sat."""
 
-import datetime
 import unittest
+from datetime import datetime
 from typing import Any, Dict
 
 import pystac
@@ -16,7 +16,7 @@ from tests.utils import TestCases
 def make_item() -> pystac.Item:
     """Create basic test items that are only slightly different."""
     asset_id = "an/asset"
-    start = datetime.datetime(2018, 1, 2)
+    start = datetime(2018, 1, 2)
     item = pystac.Item(
         id=asset_id, geometry=None, bbox=None, datetime=start, properties={}
     )

--- a/tests/extensions/test_scientific.py
+++ b/tests/extensions/test_scientific.py
@@ -1,7 +1,7 @@
 """Tests for pystac.tests.extensions.scientific."""
 
-import datetime
 import unittest
+from datetime import datetime, timedelta
 from typing import List, Optional
 
 import pystac
@@ -39,7 +39,7 @@ PUBLICATIONS = [
 
 def make_item() -> pystac.Item:
     asset_id = "USGS/GAP/CONUS/2011"
-    start = datetime.datetime(2011, 1, 2)
+    start = datetime(2011, 1, 2)
     item = pystac.Item(
         id=asset_id, geometry=None, bbox=None, datetime=start, properties={}
     )
@@ -229,11 +229,11 @@ class ItemScientificExtensionTest(unittest.TestCase):
 
 def make_collection() -> pystac.Collection:
     asset_id = "my/thing"
-    start = datetime.datetime(2018, 8, 24)
-    end = start + datetime.timedelta(5, 4, 3, 2, 1)
+    start = datetime(2018, 8, 24)
+    end = start + timedelta(5, 4, 3, 2, 1)
     bboxes = [[-180.0, -90.0, 180.0, 90.0]]
     spatial_extent = pystac.SpatialExtent(bboxes)
-    intervals: List[List[Optional[datetime.datetime]]] = [[start, end]]
+    intervals: List[List[Optional[datetime]]] = [[start, end]]
     temporal_extent = pystac.TemporalExtent(intervals)
     extent = pystac.Extent(spatial_extent, temporal_extent)
     collection = pystac.Collection(asset_id, "desc", extent)

--- a/tests/extensions/test_version.py
+++ b/tests/extensions/test_version.py
@@ -1,7 +1,7 @@
 """Tests for pystac.extensions.version."""
 
-import datetime
 import unittest
+from datetime import datetime
 from typing import List, Optional
 
 import pystac
@@ -16,7 +16,7 @@ URL_TEMPLATE: str = "http://example.com/catalog/%s.json"
 def make_item(year: int) -> pystac.Item:
     """Create basic test items that are only slightly different."""
     asset_id = f"USGS/GAP/CONUS/{year}"
-    start = datetime.datetime(year, 1, 2)
+    start = datetime(year, 1, 2)
 
     item = pystac.Item(
         id=asset_id, geometry=None, bbox=None, datetime=start, properties={}
@@ -252,11 +252,11 @@ class ItemVersionExtensionTest(unittest.TestCase):
 
 def make_collection(year: int) -> pystac.Collection:
     asset_id = f"my/collection/of/things/{year}"
-    start = datetime.datetime(2014, 8, 10)
-    end = datetime.datetime(year, 1, 3, 4, 5)
+    start = datetime(2014, 8, 10)
+    end = datetime(year, 1, 3, 4, 5)
     bboxes = [[-180.0, -90.0, 180.0, 90.0]]
     spatial_extent = pystac.SpatialExtent(bboxes)
-    intervals: List[List[Optional[datetime.datetime]]] = [[start, end]]
+    intervals: List[List[Optional[datetime]]] = [[start, end]]
     temporal_extent = pystac.TemporalExtent(intervals)
     extent = pystac.Extent(spatial_extent, temporal_extent)
 

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -1,7 +1,7 @@
-import datetime
 import json
 import os
 import unittest
+from datetime import datetime
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Dict, List
@@ -10,7 +10,7 @@ import pystac
 from pystac import Collection, Item, Link
 from tests.utils.test_cases import ARBITRARY_EXTENT
 
-TEST_DATETIME: datetime.datetime = datetime.datetime(2020, 3, 14, 16, 32)
+TEST_DATETIME: datetime = datetime(2020, 3, 14, 16, 32)
 
 
 class LinkTest(unittest.TestCase):
@@ -312,7 +312,7 @@ class LinkInheritanceTest(unittest.TestCase):
 
 def test_relative_self_link(tmp_path: Path) -> None:
     # https://github.com/stac-utils/pystac/issues/801
-    item = Item("an-id", None, None, datetime.datetime.now(), {})
+    item = Item("an-id", None, None, datetime.now(), {})
     item_as_dict = item.to_dict(include_self_link=False)
     item_as_dict["links"] = [{"href": "item.json", "rel": "self"}]
     item_as_dict["assets"] = {"data": {"href": "asset.tif"}}


### PR DESCRIPTION
**Description:** 
Just a minor tidy. The datetime import varied across the codebase so I took the opportunity to consolidate around `from datetime import datetime`. 


**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
