### PR TITLE
Cancel running jobs on github actions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,7 +9,6 @@ on:
       - "0.5"
       - "1.0"
       - "2.0"
-      - cancel-running-jobs
   pull_request:
   merge_group:
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,8 +9,14 @@ on:
       - "0.5"
       - "1.0"
       - "2.0"
+      - cancel-running-jobs
   pull_request:
   merge_group:
+
+concurrency:
+  # Cancel running job if another commit is pushed to the branch
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:


### PR DESCRIPTION
**Description:**
This is a minor workflow improvement where github actions are automatically cancelled if you push another commit to the branch. It can help with speeding up CI runs.

Example: https://github.com/jsignell/pystac/actions/runs/4186696525

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
