### PR TITLE
Add defaults to all the `Item.from_dict` pops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Switch to pytest ([#939](https://github.com/stac-utils/pystac/pull/939))
 - Use `from __future__ import annotations` for type signatures ([#962](https://github.com/stac-utils/pystac/pull/962))
 - Use `TypeVar` for alternate constructors ([#983](https://github.com/stac-utils/pystac/pull/983))
+- Behavior when required fields are missing in `Item.from_dict` ([#994](https://github.com/stac-utils/pystac/pull/994))
 
 ### Fixed
 

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -8,6 +8,7 @@ from copy import deepcopy
 from typing import Any, Dict, Optional
 
 import dateutil.relativedelta
+import pytest
 
 import pystac
 import pystac.serialization.common_properties
@@ -44,10 +45,10 @@ class ItemTest(unittest.TestCase):
         # test that the parameter is preserved
         self.assertEqual(param_dict, item_dict)
 
-        # assert that the parameter is not preserved with
-        # non-default parameter
+        # assert that the parameter is preserved regardless of
+        # preserve_dict
         _ = Item.from_dict(param_dict, preserve_dict=False)
-        self.assertNotEqual(param_dict, item_dict)
+        self.assertEqual(param_dict, item_dict)
 
     def test_from_dict_set_root(self) -> None:
         item_dict = self.get_example_item_dict()
@@ -436,3 +437,21 @@ def test_custom_item_from_dict(test_item: Item) -> None:
             return super().from_dict(d)
 
     _ = CustomItem.from_dict(test_item.to_dict())
+
+
+def test_item_from_dict_raises_useful_error() -> None:
+    item_dict = {"type": "Feature", "stac_version": "1.0.0", "id": "lalalalala"}
+    with pytest.raises(pystac.STACError, match="Invalid Item: "):
+        Item.from_dict(item_dict)
+
+
+def test_item_from_dict_with_missing_stac_version_raises_useful_error() -> None:
+    item_dict = {"type": "Feature", "id": "lalalalala"}
+    with pytest.raises(pystac.STACTypeError, match="'stac_version' is missing"):
+        Item.from_dict(item_dict)
+
+
+def test_item_from_dict_with_missing_type_raises_useful_error() -> None:
+    item_dict = {"stac_version": "0.8.0", "id": "lalalalala"}
+    with pytest.raises(pystac.STACTypeError, match="'type' is missing"):
+        Item.from_dict(item_dict)

--- a/tests/test_item_collection.py
+++ b/tests/test_item_collection.py
@@ -165,10 +165,10 @@ class TestItemCollection(unittest.TestCase):
         _ = ItemCollection.from_dict(param_dict)
         self.assertEqual(param_dict, self.item_collection_dict)
 
-        # assert that the parameter is not preserved with
-        # non-default parameter
+        # assert that the parameter is preserved regardless of
+        # preserve_dict
         _ = ItemCollection.from_dict(param_dict, preserve_dict=False)
-        self.assertNotEqual(param_dict, self.item_collection_dict)
+        self.assertEqual(param_dict, self.item_collection_dict)
 
     def test_from_dict_sets_root(self) -> None:
         param_dict = deepcopy(self.item_collection_dict)


### PR DESCRIPTION
**Related Issue(s):** #831


**Description:**
The easy solution to better error handling is to just defer until the init. So I added pop defaults to all the dict fields _even if they are required_

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
