### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To reproduce**
+Steps to reproduce the behavior:
+
+> Ex.
+>
+> 1. Install stactools
+> 2. Run `scripts/test`
+> 3. See error
+
+Include OS, Python version, and PySTAC version.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots and shell session dumps**
+If applicable, add session dumps and/or screenshots to help explain your problem.
+
+> ex. `scripts/lint >> lint_errors.txt`
+
+**Additional context**
+Add any other context about the problem here.
+
+**Issue Checklist**
+
+- [ ] OS, Python version, PySTAC version are included.
+- [ ] Existing issues were reviewed to prevent duplicate submission.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,14 @@
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen. Ex. I would like to use PySTAC to do [...]
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**PySTAC version**
+Include your PySTAC version in case a similar feature already exists in a newer or pre-release version.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
**Related Issue(s):**
- Closes #437

**Description:**
Adds Bug Report and Feature Request templates using a select mashup of @duckontheweb's list and GitHub's default recommendations.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
