### PR TITLE
Remove structural links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Optional `strategy` parameter to `catalog.add_items()` ([#967](https://github.com/stac-utils/pystac/pull/967))
 - `start_datetime` and `end_datetime` arguments to the `Item` constructor ([#918](https://github.com/stac-utils/pystac/pull/918))
 - `RetryStacIO` ([#986](https://github.com/stac-utils/pystac/pull/986))
+- `STACObject.remove_hierarchical_links` and `Link.is_hierarchical` ([#999](https://github.com/stac-utils/pystac/pull/999))
 
 ### Removed
 

--- a/pystac/link.py
+++ b/pystac/link.py
@@ -24,6 +24,7 @@ L = TypeVar("L", bound="Link")
 
 HREF = Union[str, os.PathLike]
 
+#: Hierarchical links provide structure to STAC catalogs.
 HIERARCHICAL_LINKS = [
     pystac.RelType.ROOT,
     pystac.RelType.CHILD,
@@ -350,7 +351,7 @@ class Link(PathLike):
 
         Hierarchical links are used to build relationships in STAC, e.g.
         "parent", "child", "item", etc. For a complete list of hierarchical
-        relation types, see `:py:const:HIERARCHICAL_LINKS`.
+        relation types, see :py:const:`HIERARCHICAL_LINKS`.
 
         Returns:
             bool: True if the link's rel type is hierarchical.

--- a/pystac/link.py
+++ b/pystac/link.py
@@ -345,6 +345,18 @@ class Link(PathLike):
         """
         return self._target_object is not None
 
+    def is_hierarchical(self) -> bool:
+        """Returns true if this link's rel type is hierarchical.
+
+        Hierarchical links are used to build relationships in STAC, e.g.
+        "parent", "child", "item", etc. For a complete list of hierarchical
+        relation types, see `:py:const:HIERARCHICAL_LINKS`.
+
+        Returns:
+            bool: True if the link's rel type is hierarchical.
+        """
+        return self.rel in HIERARCHICAL_LINKS
+
     def to_dict(self, transform_href: bool = True) -> Dict[str, Any]:
         """Generate a dictionary representing the JSON of this serialized Link.
 

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -96,6 +96,35 @@ class STACObject(ABC):
 
         self.links = [link for link in self.links if link.rel != rel]
 
+    def remove_hierarchical_links(self, add_canonical: bool = False) -> List[Link]:
+        """Removes all hierarchical links from this object.
+
+        See :py:const:`pystac.link.HIERARCHICAL_LINKS` for a list of all
+        hierarchical links. If the object has a ``self`` href and
+        ``add_canonical`` is True, a link with ``rel="canonical"`` is added.
+
+        Args:
+            add_canonical : If true, and this item has a ``self`` href, that
+                href is used to build a ``canonical`` link.
+
+        Returns:
+            List[Link]: All removed links
+        """
+        keep = list()
+        self_href = self.get_self_href()
+        if add_canonical and self_href is not None:
+            keep.append(
+                Link("canonical", self_href, media_type=pystac.MediaType.GEOJSON)
+            )
+        remove = list()
+        for link in self.links:
+            if link.is_hierarchical():
+                remove.append(link)
+            else:
+                keep.append(link)
+        self.links = keep
+        return remove
+
     def get_single_link(
         self,
         rel: Optional[Union[str, pystac.RelType]] = None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,15 +8,15 @@ from .utils import ARBITRARY_BBOX, ARBITRARY_EXTENT, ARBITRARY_GEOM
 
 
 @pytest.fixture
-def test_catalog() -> Catalog:
+def catalog() -> Catalog:
     return Catalog("test-catalog", "A test catalog")
 
 
 @pytest.fixture
-def test_collection() -> Catalog:
+def collection() -> Catalog:
     return Collection("test-collection", "A test collection", ARBITRARY_EXTENT)
 
 
 @pytest.fixture
-def test_item() -> Item:
+def item() -> Item:
     return Item("test-item", ARBITRARY_GEOM, ARBITRARY_BBOX, datetime.now(), {})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,12 @@
+# TODO move all test case code to this file
+
 from datetime import datetime
 
 import pytest
 
 from pystac import Catalog, Collection, Item
 
-from .utils import ARBITRARY_BBOX, ARBITRARY_EXTENT, ARBITRARY_GEOM
+from .utils import ARBITRARY_BBOX, ARBITRARY_EXTENT, ARBITRARY_GEOM, TestCases
 
 
 @pytest.fixture
@@ -20,3 +22,8 @@ def collection() -> Catalog:
 @pytest.fixture
 def item() -> Item:
     return Item("test-item", ARBITRARY_GEOM, ARBITRARY_BBOX, datetime.now(), {})
+
+
+@pytest.fixture
+def label_catalog() -> Catalog:
+    return TestCases.case_1()

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1444,7 +1444,7 @@ class CatalogSubClassTest(unittest.TestCase):
         self.assertIsInstance(cloned_catalog, self.BasicCustomCatalog)
 
 
-def test_custom_catalog_from_dict(test_catalog: Catalog) -> None:
+def test_custom_catalog_from_dict(catalog: Catalog) -> None:
     # https://github.com/stac-utils/pystac/issues/862
     class CustomCatalog(Catalog):
         @classmethod
@@ -1458,4 +1458,4 @@ def test_custom_catalog_from_dict(test_catalog: Catalog) -> None:
         ) -> CustomCatalog:
             return super().from_dict(d)
 
-    _ = CustomCatalog.from_dict(test_catalog.to_dict())
+    _ = CustomCatalog.from_dict(catalog.to_dict())

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1459,3 +1459,11 @@ def test_custom_catalog_from_dict(catalog: Catalog) -> None:
             return super().from_dict(d)
 
     _ = CustomCatalog.from_dict(catalog.to_dict())
+
+
+@pytest.mark.parametrize("add_canonical", (True, False))
+def test_remove_hierarchical_links(label_catalog: Catalog, add_canonical: bool) -> None:
+    label_catalog.remove_hierarchical_links(add_canonical=add_canonical)
+    for link in label_catalog.links:
+        assert not link.is_hierarchical()
+    assert bool(label_catalog.get_single_link("canonical")) == add_canonical

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -8,6 +8,7 @@ from copy import deepcopy
 from datetime import datetime
 from typing import Any, Dict, Optional
 
+import pytest
 from dateutil import tz
 
 import pystac
@@ -529,3 +530,12 @@ def test_custom_collection_from_dict(collection: Collection) -> None:
             return super().from_dict(d)
 
     _ = CustomCollection.from_dict(collection.to_dict())
+
+
+@pytest.mark.parametrize("add_canonical", (True, False))
+def test_remove_hierarchical_links(label_catalog: Catalog, add_canonical: bool) -> None:
+    collection = list(label_catalog.get_all_collections())[0]
+    collection.remove_hierarchical_links(add_canonical=add_canonical)
+    for link in collection.links:
+        assert not link.is_hierarchical()
+    assert bool(collection.get_single_link("canonical")) == add_canonical

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -514,7 +514,7 @@ class CollectionSubClassTest(unittest.TestCase):
         self.assertIsInstance(cloned_collection, self.BasicCustomCollection)
 
 
-def test_custom_collection_from_dict(test_collection: Collection) -> None:
+def test_custom_collection_from_dict(collection: Collection) -> None:
     # https://github.com/stac-utils/pystac/issues/862
     class CustomCollection(Collection):
         @classmethod
@@ -528,4 +528,4 @@ def test_custom_collection_from_dict(test_collection: Collection) -> None:
         ) -> CustomCollection:
             return super().from_dict(d)
 
-    _ = CustomCollection.from_dict(test_collection.to_dict())
+    _ = CustomCollection.from_dict(collection.to_dict())

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -455,3 +455,12 @@ def test_item_from_dict_with_missing_type_raises_useful_error() -> None:
     item_dict = {"stac_version": "0.8.0", "id": "lalalalala"}
     with pytest.raises(pystac.STACTypeError, match="'type' is missing"):
         Item.from_dict(item_dict)
+
+
+@pytest.mark.parametrize("add_canonical", (True, False))
+def test_remove_hierarchical_links(label_catalog: Catalog, add_canonical: bool) -> None:
+    item = list(label_catalog.get_all_items())[0]
+    item.remove_hierarchical_links(add_canonical=add_canonical)
+    for link in item.links:
+        assert not link.is_hierarchical()
+    assert bool(item.get_single_link("canonical")) == add_canonical

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -422,7 +422,7 @@ class AssetSubClassTest(unittest.TestCase):
         self.assertIsInstance(cloned_asset, self.CustomAsset)
 
 
-def test_custom_item_from_dict(test_item: Item) -> None:
+def test_custom_item_from_dict(item: Item) -> None:
     # https://github.com/stac-utils/pystac/issues/862
     class CustomItem(Item):
         @classmethod
@@ -436,7 +436,7 @@ def test_custom_item_from_dict(test_item: Item) -> None:
         ) -> CustomItem:
             return super().from_dict(d)
 
-    _ = CustomItem.from_dict(test_item.to_dict())
+    _ = CustomItem.from_dict(item.to_dict())
 
 
 def test_item_from_dict_raises_useful_error() -> None:

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -6,8 +6,11 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Dict, List
 
+import pytest
+
 import pystac
 from pystac import Collection, Item, Link
+from pystac.link import HIERARCHICAL_LINKS
 from tests.utils.test_cases import ARBITRARY_EXTENT
 
 TEST_DATETIME: datetime = datetime(2020, 3, 14, 16, 32)
@@ -330,3 +333,15 @@ def test_relative_self_link(tmp_path: Path) -> None:
     asset_href = read_item.assets["data"].get_absolute_href()
     assert asset_href
     assert Path(asset_href).exists()
+
+
+@pytest.mark.parametrize("rel", HIERARCHICAL_LINKS)
+def test_is_hierarchical(rel: str) -> None:
+    assert Link(rel, "a-target").is_hierarchical()
+
+
+@pytest.mark.parametrize(
+    "rel", ["canonical", "derived_from", "alternate", "via", "prev", "next", "preview"]
+)
+def test_is_not_hierarchical(rel: str) -> None:
+    assert not Link(rel, "a-target").is_hierarchical()


### PR DESCRIPTION
**Related Issue(s):**

- Closes #179 
- Begins adding fixtures for #948, and changes fixture names as recommended in https://github.com/stac-utils/pystac/issues/948#issuecomment-1433176507

**Description:**

- Adds `remove_hierarchical_links` to `STACObject`
- Adds `Links.is_hierarchical`

I personally prefer the term "structural", but "hierarchical" was already in use so I stuck with that: https://github.com/stac-utils/pystac/blob/a573835eb49f1ba9c9ccdf06fa105ad1a7500624/pystac/link.py#L27-L34

Includes the first pytest fixture for the test cases. I went for a more descriptive catalog name (`label_catalog`) instead of `test_case_1` -- my thought is that it'll be nicer to depend on a well-named fixture rather than some arbitrary numbering scheme. I also followed @jsignell's recommendation and remove the `test_` prefix from some existing fixtures.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
