### PR TITLE
Windows paths should be written as posix

### DIFF
--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import posixpath
 from copy import deepcopy
 from html import escape
 from typing import (
@@ -263,7 +264,7 @@ class Catalog(STACObject):
         # set self link
         self_href = self.get_self_href()
         if self_href:
-            child_href = strategy.get_href(child, os.path.dirname(self_href))
+            child_href = strategy.get_href(child, posixpath.dirname(self_href))
             child.set_self_href(child_href)
 
         self.add_link(Link.child(child, title=title))
@@ -310,7 +311,7 @@ class Catalog(STACObject):
         # set self link
         self_href = self.get_self_href()
         if self_href:
-            item_href = strategy.get_href(item, os.path.dirname(self_href))
+            item_href = strategy.get_href(item, posixpath.dirname(self_href))
             item.set_self_href(item_href)
 
         self.add_link(Link.item(item, title=title))
@@ -676,7 +677,7 @@ class Catalog(STACObject):
                 cat.resolve_links()
 
             new_self_href = _strategy.get_href(cat, _root_href, is_root)
-            new_root = os.path.dirname(new_self_href)
+            new_root = posixpath.dirname(new_self_href)
 
             for link in cat.get_links():
                 if skip_unresolved and not link.is_resolved():
@@ -839,7 +840,7 @@ class Catalog(STACObject):
                         rel_href, dest_href, start_is_dir=True
                     )
                     child.save(
-                        dest_href=os.path.dirname(child_dest_href),
+                        dest_href=posixpath.dirname(child_dest_href),
                         stac_io=stac_io,
                     )
                 else:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,4 @@
 import json
-import ntpath
 import os
 import sys
 import time
@@ -83,60 +82,59 @@ class UtilsTest(unittest.TestCase):
             actual = make_relative_href(source_href, start_href)
             self.assertEqual(actual, expected)
 
+    @unittest.skipIf(
+        sys.platform not in ("win32", "cygwin"), reason="Paths are specific to windows"
+    )
     def test_make_relative_href_windows(self) -> None:
-        utils._pathlib = ntpath
-        try:
-            # Test cases of (source_href, start_href, expected)
-            test_cases = [
-                (
-                    "C:\\a\\b\\c\\d\\catalog.json",
-                    "C:\\a\\b\\c\\catalog.json",
-                    ".\\d\\catalog.json",
-                ),
-                (
-                    "C:\\a\\b\\catalog.json",
-                    "C:\\a\\b\\c\\catalog.json",
-                    "..\\catalog.json",
-                ),
-                (
-                    "C:\\a\\catalog.json",
-                    "C:\\a\\b\\c\\catalog.json",
-                    "..\\..\\catalog.json",
-                ),
-                ("a\\b\\c\\catalog.json", "a\\b\\catalog.json", ".\\c\\catalog.json"),
-                ("a\\b\\catalog.json", "a\\b\\c\\catalog.json", "..\\catalog.json"),
-                (
-                    "http://stacspec.org/a/b/c/d/catalog.json",
-                    "http://stacspec.org/a/b/c/catalog.json",
-                    "./d/catalog.json",
-                ),
-                (
-                    "http://stacspec.org/a/b/catalog.json",
-                    "http://stacspec.org/a/b/c/catalog.json",
-                    "../catalog.json",
-                ),
-                (
-                    "http://stacspec.org/a/catalog.json",
-                    "http://stacspec.org/a/b/c/catalog.json",
-                    "../../catalog.json",
-                ),
-                (
-                    "http://stacspec.org/a/catalog.json",
-                    "http://cogeo.org/a/b/c/catalog.json",
-                    "http://stacspec.org/a/catalog.json",
-                ),
-                (
-                    "http://stacspec.org/a/catalog.json",
-                    "https://stacspec.org/a/b/c/catalog.json",
-                    "http://stacspec.org/a/catalog.json",
-                ),
-            ]
+        # Test cases of (source_href, start_href, expected)
+        test_cases = [
+            (
+                "C:\\a\\b\\c\\d\\catalog.json",
+                "C:\\a\\b\\c\\catalog.json",
+                "./d/catalog.json",
+            ),
+            (
+                "C:\\a\\b\\catalog.json",
+                "C:\\a\\b\\c\\catalog.json",
+                "../catalog.json",
+            ),
+            (
+                "C:\\a\\catalog.json",
+                "C:\\a\\b\\c\\catalog.json",
+                "../../catalog.json",
+            ),
+            ("a\\b\\c\\catalog.json", "a\\b\\catalog.json", "./c/catalog.json"),
+            ("a\\b\\catalog.json", "a\\b\\c\\catalog.json", "../catalog.json"),
+            (
+                "http://stacspec.org/a/b/c/d/catalog.json",
+                "http://stacspec.org/a/b/c/catalog.json",
+                "./d/catalog.json",
+            ),
+            (
+                "http://stacspec.org/a/b/catalog.json",
+                "http://stacspec.org/a/b/c/catalog.json",
+                "../catalog.json",
+            ),
+            (
+                "http://stacspec.org/a/catalog.json",
+                "http://stacspec.org/a/b/c/catalog.json",
+                "../../catalog.json",
+            ),
+            (
+                "http://stacspec.org/a/catalog.json",
+                "http://cogeo.org/a/b/c/catalog.json",
+                "http://stacspec.org/a/catalog.json",
+            ),
+            (
+                "http://stacspec.org/a/catalog.json",
+                "https://stacspec.org/a/b/c/catalog.json",
+                "http://stacspec.org/a/catalog.json",
+            ),
+        ]
 
-            for source_href, start_href, expected in test_cases:
-                actual = make_relative_href(source_href, start_href)
-                self.assertEqual(actual, expected)
-        finally:
-            utils._pathlib = os.path
+        for source_href, start_href, expected in test_cases:
+            actual = make_relative_href(source_href, start_href)
+            self.assertEqual(actual, expected)
 
     @unittest.skipIf(
         sys.platform in ("win32", "cygwin"), reason="Paths are specific to posix"
@@ -185,46 +183,45 @@ class UtilsTest(unittest.TestCase):
 
         self.assertEqual(expected, make_absolute_href(rel_path, cat_path))
 
+    @unittest.skipIf(
+        sys.platform not in ("win32", "cygwin"), reason="Paths are specific to windows"
+    )
     def test_make_absolute_href_windows(self) -> None:
-        utils._pathlib = ntpath
-        try:
-            # Test cases of (source_href, start_href, expected)
-            test_cases = [
-                ("item.json", "C:\\a\\b\\c\\catalog.json", "C:\\a\\b\\c\\item.json"),
-                (".\\item.json", "C:\\a\\b\\c\\catalog.json", "C:\\a\\b\\c\\item.json"),
-                (
-                    ".\\z\\item.json",
-                    "Z:\\a\\b\\c\\catalog.json",
-                    "Z:\\a\\b\\c\\z\\item.json",
-                ),
-                ("..\\item.json", "a:\\a\\b\\c\\catalog.json", "a:\\a\\b\\item.json"),
-                (
-                    "item.json",
-                    "HTTPS://stacspec.org/a/b/c/catalog.json",
-                    "https://stacspec.org/a/b/c/item.json",
-                ),
-                (
-                    "./item.json",
-                    "https://stacspec.org/a/b/c/catalog.json",
-                    "https://stacspec.org/a/b/c/item.json",
-                ),
-                (
-                    "./z/item.json",
-                    "https://stacspec.org/a/b/c/catalog.json",
-                    "https://stacspec.org/a/b/c/z/item.json",
-                ),
-                (
-                    "../item.json",
-                    "https://stacspec.org/a/b/c/catalog.json",
-                    "https://stacspec.org/a/b/item.json",
-                ),
-            ]
+        # Test cases of (source_href, start_href, expected)
+        test_cases = [
+            ("item.json", "C:\\a\\b\\c\\catalog.json", "c:/a/b/c/item.json"),
+            (".\\item.json", "C:\\a\\b\\c\\catalog.json", "c:/a/b/c/item.json"),
+            (
+                ".\\z\\item.json",
+                "Z:\\a\\b\\c\\catalog.json",
+                "z:/a/b/c/z/item.json",
+            ),
+            ("..\\item.json", "a:\\a\\b\\c\\catalog.json", "a:/a/b/item.json"),
+            (
+                "item.json",
+                "HTTPS://stacspec.org/a/b/c/catalog.json",
+                "https://stacspec.org/a/b/c/item.json",
+            ),
+            (
+                "./item.json",
+                "https://stacspec.org/a/b/c/catalog.json",
+                "https://stacspec.org/a/b/c/item.json",
+            ),
+            (
+                "./z/item.json",
+                "https://stacspec.org/a/b/c/catalog.json",
+                "https://stacspec.org/a/b/c/z/item.json",
+            ),
+            (
+                "../item.json",
+                "https://stacspec.org/a/b/c/catalog.json",
+                "https://stacspec.org/a/b/item.json",
+            ),
+        ]
 
-            for source_href, start_href, expected in test_cases:
-                actual = make_absolute_href(source_href, start_href)
-                self.assertEqual(actual, expected)
-        finally:
-            utils._pathlib = os.path
+        for source_href, start_href, expected in test_cases:
+            actual = make_absolute_href(source_href, start_href)
+            self.assertEqual(actual, expected)
 
     def test_is_absolute_href(self) -> None:
         # Test cases of (href, expected)
@@ -240,23 +237,22 @@ class UtilsTest(unittest.TestCase):
             actual = is_absolute_href(href)
             self.assertEqual(actual, expected)
 
+    @unittest.skipIf(
+        sys.platform not in ("win32", "cygwin"), reason="Paths are specific to windows"
+    )
     def test_is_absolute_href_windows(self) -> None:
-        utils._pathlib = ntpath
-        try:
-            # Test cases of (href, expected)
-            test_cases = [
-                ("item.json", False),
-                (".\\item.json", False),
-                ("..\\item.json", False),
-                ("c:\\item.json", True),
-                ("http://stacspec.org/item.json", True),
-            ]
+        # Test cases of (href, expected)
+        test_cases = [
+            ("item.json", False),
+            (".\\item.json", False),
+            ("..\\item.json", False),
+            ("c:\\item.json", True),
+            ("http://stacspec.org/item.json", True),
+        ]
 
-            for href, expected in test_cases:
-                actual = is_absolute_href(href)
-                self.assertEqual(actual, expected)
-        finally:
-            utils._pathlib = os.path
+        for href, expected in test_cases:
+            actual = is_absolute_href(href)
+            self.assertEqual(actual, expected)
 
     def test_datetime_to_str(self) -> None:
         cases = (


### PR DESCRIPTION
**Related Issue(s):** #619


**Description:**

Based on https://github.com/stac-utils/pystac/issues/619#issuecomment-1437217155 the goal of this PR is that regardless of operating system all paths are written using posix-style paths. 

There is more cleanup that I can do since this means that all path joins should use `/` but I'm opening this for now to see how the tests do on windows.


**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [ ] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [ ] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
