### PR TITLE
Add extra_fields to AssetDefinition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - `start_datetime` and `end_datetime` arguments to the `Item` constructor ([#918](https://github.com/stac-utils/pystac/pull/918))
 - `RetryStacIO` ([#986](https://github.com/stac-utils/pystac/pull/986))
 - `STACObject.remove_hierarchical_links` and `Link.is_hierarchical` ([#999](https://github.com/stac-utils/pystac/pull/999))
+- `extra_fields` to `AssetDefinition` in the item assets extension ([#1003](https://github.com/stac-utils/pystac/pull/1003))
 
 ### Removed
 

--- a/pystac/extensions/item_assets.py
+++ b/pystac/extensions/item_assets.py
@@ -45,6 +45,7 @@ class AssetDefinition:
         description: Optional[str],
         media_type: Optional[str],
         roles: Optional[List[str]],
+        extra_fields: Optional[Dict[str, Any]] = None,
     ) -> AssetDefinition:
         """
         Creates a new asset definition.
@@ -61,10 +62,16 @@ class AssetDefinition:
             roles : `semantic roles
                 <https://github.com/radiantearth/stac-spec/tree/v1.0.0/item-spec/item-spec.md#asset-role-types>`__
                 of the asset, similar to the use of rel in links.
+            extra_fields : Additional fields on the asset definition, e.g. from
+                extensions.
         """
         asset_defn = cls({})
         asset_defn.apply(
-            title=title, description=description, media_type=media_type, roles=roles
+            title=title,
+            description=description,
+            media_type=media_type,
+            roles=roles,
+            extra_fields=extra_fields,
         )
         return asset_defn
 
@@ -74,6 +81,7 @@ class AssetDefinition:
         description: Optional[str],
         media_type: Optional[str],
         roles: Optional[List[str]],
+        extra_fields: Optional[Dict[str, Any]] = None,
     ) -> None:
         """
         Sets the properties for this asset definition.
@@ -90,7 +98,11 @@ class AssetDefinition:
             roles : `semantic roles
                 <https://github.com/radiantearth/stac-spec/tree/v1.0.0/item-spec/item-spec.md#asset-role-types>`__
                 of the asset, similar to the use of rel in links.
+            extra_fields : Additional fields on the asset definition, e.g. from
+                extensions.
         """
+        if extra_fields:
+            self.properties.update(extra_fields)
         self.title = title
         self.description = description
         self.media_type = media_type

--- a/tests/extensions/test_item_assets.py
+++ b/tests/extensions/test_item_assets.py
@@ -93,3 +93,19 @@ class TestAssetDefinition(unittest.TestCase):
 
         self.assertEqual(asset_defn.roles, roles)
         self.assertEqual(asset_defn.to_dict()["roles"], roles)
+
+
+def test_extra_fields(collection: Collection) -> None:
+    asset_definition = AssetDefinition.create(
+        title=None,
+        description=None,
+        media_type=None,
+        roles=None,
+        extra_fields={"raster:bands": [{"nodata": 42}]},
+    )
+    item_assets = ItemAssetsExtension.ext(collection, add_if_missing=True)
+    item_assets.item_assets = {"data": asset_definition}
+    collection_as_dict = collection.to_dict()
+    assert collection_as_dict["item_assets"]["data"]["raster:bands"] == [{"nodata": 42}]
+    asset = asset_definition.create_asset("asset.tif")
+    assert asset.extra_fields["raster:bands"] == [{"nodata": 42}]


### PR DESCRIPTION
**Related Issue(s):**
- Closes #855

**Description:**

Pretty simple.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
