### PR TITLE
Add deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - `STACObject.remove_hierarchical_links` and `Link.is_hierarchical` ([#999](https://github.com/stac-utils/pystac/pull/999))
 - `extra_fields` to `AssetDefinition` in the item assets extension ([#1003](https://github.com/stac-utils/pystac/pull/1003))
 - `Catalog.fully_resolve` ([#1001](https://github.com/stac-utils/pystac/pull/1001))
+- A `DeprecatedWarning` when deserializing an Item or Collection to a STAC object via the `from_dict()` method ([1006](https://github.com/stac-utils/pystac/pull/1006))
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ See the [documentation page](https://pystac.readthedocs.io/en/latest/) for the l
 
 ## Developing
 
-See [contributing docs](https://pystac.readthedocs.io/en/latest/contributing.rst)
+See [contributing docs](https://pystac.readthedocs.io/en/latest/contributing.html)
 for details on contributing to this project.
 
 ## Running the quickstart and tutorials

--- a/benchmarks/item.py
+++ b/benchmarks/item.py
@@ -15,7 +15,8 @@ class ItemBench(Bench):
 
         self.stac_io = StacIO.default()
 
-        self.item_path = get_data_path("item/sample-item-asset-properties.json")
+        # using an item with many assets to better test deserialization timing
+        self.item_path = get_data_path("eo/eo-sentinel2-item.json")
         with open(self.item_path) as src:
             self.item_dict = json.load(src)
         self.item = Item.from_file(self.item_path)

--- a/pystac/__init__.py
+++ b/pystac/__init__.py
@@ -13,6 +13,7 @@ __all__ = [
     "ExtensionTypeError",
     "RequiredPropertyMissing",
     "STACValidationError",
+    "DeprecatedWarning",
     "MediaType",
     "RelType",
     "StacIO",
@@ -54,6 +55,7 @@ from pystac.errors import (
     ExtensionTypeError,
     RequiredPropertyMissing,
     STACValidationError,
+    DeprecatedWarning,
 )
 
 from pystac.version import (

--- a/pystac/errors.py
+++ b/pystac/errors.py
@@ -87,3 +87,10 @@ class STACValidationError(Exception):
     def __init__(self, message: str, source: Optional[Any] = None):
         super().__init__(message)
         self.source = source
+
+
+class DeprecatedWarning(FutureWarning):
+    """Issued when converting a dictionary to a STAC Item or Collection and the
+    version extension ``deprecated`` field is present and set to ``True``."""
+
+    pass


### PR DESCRIPTION
**Related Issue(s):**

- Closes #843 

**Description:**

- Inserts logic into the Item and Collection `from_dict()` methods that checks for the version extension and, if it exists, issues a `DeprecatedWarning` if the version extension `deprecated` field is set to `True`.
- Provides an `ignore_deprecated` context manager to suppress the `DeprecatedWarning`.

This PR originally used logic outside the version extension to check for the `deprecated` field on assets. This was removed in favor of working within the version extension's current deprecation checking ability.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
