### PR TITLE
Always create `/`-delimited hrefs, even on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - Allow subclasses in a few more `clone` methods ([#983](https://github.com/stac-utils/pystac/pull/983))
 - Pass `href` from `Item.from_dict` to constructor ([#984](https://github.com/stac-utils/pystac/pull/984))
 - Serializing the table extension ([#992](https://github.com/stac-utils/pystac/pull/992))
+- Use `as_posix` when storing the href when reading STAC objects with a StacIO ([#1008](https://github.com/stac-utils/pystac/pull/1008))
 
 ## [v1.6.1]
 

--- a/pystac/stac_io.py
+++ b/pystac/stac_io.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
@@ -149,7 +150,7 @@ class StacIO(ABC):
                 parameter. Set to ``False`` when possible to avoid the performance
                 hit of a deepcopy.
         """
-        href_str = None if href is None else str(os.fspath(href))
+        href_str = None if href is None else Path(os.fspath(href)).as_posix()
         if identify_stac_object_type(d) == pystac.STACObjectType.ITEM:
             collection_cache = None
             if root is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 # TODO move all test case code to this file
 
 from datetime import datetime
+from pathlib import Path
 
 import pytest
 
@@ -27,3 +28,8 @@ def item() -> Item:
 @pytest.fixture
 def test_case_1_catalog() -> Catalog:
     return TestCases.case_1()
+
+
+@pytest.fixture
+def data_files() -> Path:
+    return Path(__file__).parent / "data-files"

--- a/tests/test_stac_io.py
+++ b/tests/test_stac_io.py
@@ -1,7 +1,9 @@
 import json
 import os
+import sys
 import tempfile
 import unittest
+from pathlib import Path
 
 import pytest
 
@@ -142,3 +144,21 @@ def test_retry_stac_io_404() -> None:
             "https://planetarycomputer.microsoft.com"
             "/api/stac/v1/collections/not-a-collection-id"
         )
+
+
+def test_convert_windows_separators_on_read_path(data_files: Path) -> None:
+    item = pystac.read_file(href=data_files / "item" / "sample-item.json")
+    href = item.get_self_href()
+    assert href
+    assert href.endswith("/item/sample-item.json")
+
+
+@pytest.mark.skipif(
+    sys.platform != "win32", reason="testing windows path construction with strings"
+)
+def test_convert_windows_separators_on_read_str(data_files: Path) -> None:
+    path = os.fspath(data_files) + r"\item\sample-item.json"
+    item = pystac.read_file(href=path)
+    href = item.get_self_href()
+    assert href
+    assert href.endswith("/item/sample-item.json")


### PR DESCRIPTION
**Related Issue(s):**

- Closes #619 
- Closes (as superseding) #1002 

**Description:**

Simply use `Path.as_posix` when reading STAC objects. I _think_ this is enough to solve OP's issue?

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
