### PR TITLE
Remove `experimental` from CI matrix

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,7 +21,6 @@ jobs:
   test:
     name: test
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.experimental }}
     strategy:
       # Allow other matrix jobs to complete if 1 fails
       fail-fast: false
@@ -35,8 +34,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
           - macos-latest
-        experimental:
-          - false
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
**Description:**

This was used to test future python versions, but IMO this can be handled w/o adding a new matrix dimension.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
