### PR TITLE
When instantiating ItemCollections clone items by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Use `from __future__ import annotations` for type signatures ([#962](https://github.com/stac-utils/pystac/pull/962))
 - Use `TypeVar` for alternate constructors ([#983](https://github.com/stac-utils/pystac/pull/983))
 - Behavior when required fields are missing in `Item.from_dict` ([#994](https://github.com/stac-utils/pystac/pull/994))
+- By default, `ItemCollection` now clones items in iterator (`clone_items=True`) ([#1016](https://github.com/stac-utils/pystac/pull/1016))
 - `TemplateError` in `layout.py` deprecated in favor of duplicate in `errors.py` ([#1018](https://github.com/stac-utils/pystac/pull/1018))
 
 ### Fixed

--- a/pystac/item_collection.py
+++ b/pystac/item_collection.py
@@ -48,9 +48,9 @@ class ItemCollection(Collection[pystac.Item]):
             :class:`~ItemCollection`.
         clone_items : Optional flag indicating whether :class:`~pystac.Item` instances
             should be cloned before storing in the :class:`~ItemCollection`. Setting to
-            ``True`` ensures that changes made to :class:`~pystac.Item` instances in
-            the :class:`~ItemCollection` will not mutate the original ``Item``, but
-            will result in slower instantiation. Defaults to ``False``.
+            ``False`` will result in faster instantiation, but changes made to
+            :class:`~pystac.Item` instances in the :class:`~ItemCollection` will mutate
+            the original ``Item``. Defaults to ``True``.
 
     Examples:
 
@@ -71,7 +71,7 @@ class ItemCollection(Collection[pystac.Item]):
         object equality (i.e. ``item_1 is item_2``).
 
         >>> item: Item = ...
-        >>> item_collection = ItemCollection(items=[item])
+        >>> item_collection = ItemCollection(items=[item], clone_items=False)
         >>> assert item in item_collection
 
         Combine :class:`~ItemCollection` instances
@@ -97,7 +97,7 @@ class ItemCollection(Collection[pystac.Item]):
         self,
         items: Iterable[ItemLike],
         extra_fields: Optional[Dict[str, Any]] = None,
-        clone_items: bool = False,
+        clone_items: bool = True,
     ):
         def map_item(item_or_dict: ItemLike) -> pystac.Item:
             # Converts dicts to pystac.Items and clones if necessary
@@ -125,12 +125,8 @@ class ItemCollection(Collection[pystac.Item]):
         if not isinstance(other, ItemCollection):
             return NotImplemented
 
-        combined = []
-        for item in self.items + other.items:
-            if item not in combined:
-                combined.append(item)
-
-        return ItemCollection(items=combined, clone_items=False)
+        combined = [*self.items, *other.items]
+        return ItemCollection(items=combined)
 
     def to_dict(self, transform_hrefs: bool = False) -> Dict[str, Any]:
         """Serializes an :class:`ItemCollection` instance to a JSON-like dictionary.

--- a/pystac/item_collection.py
+++ b/pystac/item_collection.py
@@ -82,8 +82,8 @@ class ItemCollection(Collection[pystac.Item]):
         >>> item_collection_1 = ItemCollection(items=[item_1, item_2])
         >>> item_collection_2 = ItemCollection(items=[item_2, item_3])
         >>> combined = item_collection_1 + item_collection_2
-        >>> assert len(combined) == 3
-        # If an item is present in both ItemCollections it will only be added once
+        >>> assert len(combined) == 4
+        # If an item is present in both ItemCollections it will occur twice
     """
 
     items: List[pystac.Item]

--- a/tests/test_item_collection.py
+++ b/tests/test_item_collection.py
@@ -50,7 +50,7 @@ class TestItemCollection(unittest.TestCase):
 
     def test_item_collection_contains(self) -> None:
         item = pystac.Item.from_file(self.SIMPLE_ITEM)
-        item_collection = pystac.ItemCollection(items=[item])
+        item_collection = pystac.ItemCollection(items=[item], clone_items=False)
 
         self.assertIn(item, item_collection)
 
@@ -126,7 +126,7 @@ class TestItemCollection(unittest.TestCase):
 
         combined = item_collection_1 + item_collection_2
 
-        self.assertEqual(len(combined), 3)
+        self.assertEqual(len(combined), 4)
 
     def test_add_other_raises_error(self) -> None:
         item_collection = pystac.ItemCollection.from_file(self.ITEM_COLLECTION)


### PR DESCRIPTION
**Related Issue(s):**

- closes #859 

**Description:**

NOTE this PR changes the behavior when adding item collections. After this PR adding item collections will no longer dedupe items. 

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
