### PR TITLE
Update layout to make within page links stick on the right

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -5,7 +5,7 @@
   {% set content_col_class = "col-md-9 col-xl-7" %}
 {% else %}
   {# This customization to the no-sidebars case is why we override docs_main #}
-  {% set content_col_class = "col-md-12" %}
+  {% set content_col_class = "col-md-9 col-xl-10" %}
 {% endif %}
 <main class="col-12 {{ content_col_class }} py-md-5 pl-md-5 pr-md-4 bd-content" role="main">
     {% block docs_body %}


### PR DESCRIPTION
**Related Issue(s):**

- Closes #1013

**Demo:**
![Screenshot from 2023-02-28 13-15-24](https://user-images.githubusercontent.com/4806877/221943628-101bca39-0458-447a-bb2d-3572d272a6ac.png)
![Screenshot from 2023-02-28 13-15-28](https://user-images.githubusercontent.com/4806877/221943644-984889c4-036d-4d9f-8234-cb819ecddf06.png)

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
