### PR TITLE
Don't transform hrefs in one test

### DIFF
--- a/tests/test_item_collection.py
+++ b/tests/test_item_collection.py
@@ -72,7 +72,7 @@ class TestItemCollection(unittest.TestCase):
         self.assertEqual(d.get("custom_field"), "My value")
 
     def test_item_collection_from_dict(self) -> None:
-        features = [item.to_dict() for item in self.items]
+        features = [item.to_dict(transform_hrefs=False) for item in self.items]
         d = {
             "type": "FeatureCollection",
             "features": features,


### PR DESCRIPTION
**Related Issue(s):**

- Until #960 is fixed, the default behavior is to hit the network when serializing items.

**Description:**

We often have intermittent test failures due to an inability to hit CMR, e.g. https://github.com/stac-utils/pystac/actions/runs/4306838650/jobs/7511161952#step:5:321. In this case, the network request is unnecessary for the test that is running, so we diable the network request by setting `transform_hrefs=False` when serializing items.

I'm sure there's other spots where we could improve things by setting `transform_hrefs=False`, but rather than do a complete audit, I'd like to fix them as we find them from failed test runs.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
