### PR TITLE
Fix up releasing workflow and docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   release:
     types:
-      - created
+      - published
 
 jobs:
   release:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -23,7 +23,8 @@ This is a checklist to use when releasing a new PySTAC version.
 8. Once approved, merge the PR.
 9. Once the PR is merged, create a tag with the version name, e.g. `vX.Y.Z`.
    Prefer a signed tag, if possible.
-   Push the tag to Github to trigger the PyPI publish.
+   Push the tag to Github.
 10. Use the tag to finish your release notes, and publish those.
     The "auto generate" feature is your friend, here.
+    When the release is published, this will trigger the build and release on PyPI.
 11. Announced the release in [Gitter](https://matrix.to/#/#SpatioTemporal-Asset-Catalog_python:gitter.im) and on any relevant social media.


### PR DESCRIPTION
**Description:**

I didn't get the release flow quite right for https://github.com/stac-utils/pystac/releases/tag/v1.7.0, so this fixes up the docs for next time, and tweaks the workflow to run on `publish` (and not just `created`, since `created` only fires if you make a new tag).

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
