### PR TITLE
Replace flake8 and isort with ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-max-line-length = 88
-extend-ignore = E203, W503, E731, E722
-per-file-ignores = __init__.py:F401

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,13 @@
 repos:
   - repo: local
     hooks:
+      - id: ruff
+        name: ruff
+        entry: ruff
+        language: system
+        stages: [commit]
+        types: [python]
+
       - id: black
         name: black
         entry: black
@@ -26,13 +33,6 @@ repos:
         files: \.rst$
         require_serial: true
 
-      - id: flake8
-        name: flake8
-        entry: flake8
-        language: system
-        stages: [commit]
-        types: [python]
-
       - id: mypy
         name: mypy
         entry: mypy
@@ -41,11 +41,3 @@ repos:
         stages: [commit]
         types: [python]
         require_serial: true
-
-      - id: isort
-        name: isort
-        entry: isort
-        args: []
-        language: system
-        stages: [commit]
-        types: [python]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Use [ruff](https://github.com/charliermarsh/ruff) instead of **isort** and **flake8** ([#1034](https://github.com/stac-utils/pystac/pull/1034))
+
 ## [v1.7.0]
 
 ### Added
@@ -230,7 +234,7 @@
 - Added `Collections` as a type that can be extended for extensions whose fields can appear in collection summaries ([#547](https://github.com/stac-utils/pystac/pull/547))
 - Allow resolved self links when getting an object's self href ([#555](https://github.com/stac-utils/pystac/pull/555))
 - Fixed type annotation on SummariesLabelExtension.label_properties setter ([#562](https://github.com/stac-utils/pystac/pull/562))
-- Allow comparable types with alternate parameter naming of __lt__ method to pass structural type linting for RangeSummary ([#562](https://github.com/stac-utils/pystac/pull/562))
+- Allow comparable types with alternate parameter naming of **lt** method to pass structural type linting for RangeSummary ([#562](https://github.com/stac-utils/pystac/pull/562))
 
 ## [v1.0.0-rc.3]
 
@@ -592,7 +596,7 @@ documentation for more information on the new way to use extensions.
 - Dropped support for Python 3.5 [#108](https://github.com/azavea/pystac/pull/108)
 
 - Extension classes for label, eo and single-file-stac were moved to the `pystac.extensions` package.
-- the eo and label extensions changed from being a subclass of Item to wrapping items. __Note__: This is a major change in the API for dealing with extensions. See the note below for more information.
+- the eo and label extensions changed from being a subclass of Item to wrapping items. **Note**: This is a major change in the API for dealing with extensions. See the note below for more information.
 - Renamed the class that enumerates extension names from `Extension` to `Extensions`
 - Asset properties always return a dict instead of being None for Assets that have non-core properties.
 - The `Band` constructor in the EO extension changed to taking a dict. To create a band from property values,

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -54,12 +54,11 @@ tl;dr: Run ``pre-commit install --overwrite`` to perform checks when committing,
 
 PySTAC uses
 
+- `ruff <https://github.com/charliermarsh/ruff>`_ for Python code linting
 - `black <https://github.com/psf/black>`_ for Python code formatting
 - `codespell <https://github.com/codespell-project/codespell/>`_ to check code for common misspellings
 - `doc8 <https://github.com/pycqa/doc8>`__ for style checking on RST files in the docs
-- `flake8 <https://flake8.pycqa.org/en/latest/>`_ for Python style checks
 - `mypy <http://www.mypy-lang.org/>`_ for Python type annotation checks
-- `isort <https://pycqa.github.io/isort/>` to sort Python import statements
 
 Run all of these with ``pre-commit run --all-files`` or a single one using
 ``pre-commit run --all-files ID``, where ``ID`` is one of the command names above. For

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,0 @@
-[tool.isort]
-profile = "black"

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,9 +2,7 @@ black==23.1.0
 codespell==2.2.2
 coverage==7.2.1
 doc8==1.1.1
-flake8==6.0.0
 html5lib==1.1
-isort==5.12.0
 jinja2<4.0
 jsonschema==4.17.3
 mypy==1.1.1
@@ -14,6 +12,7 @@ pytest-cov==4.0.0
 pytest-mock==3.10.0
 pytest-vcr==1.0.2
 pytest==7.2.2
+ruff==0.0.254
 types-html5lib==1.1.11.12
 types-orjson==3.6.2
 types-python-dateutil==2.8.19.10


### PR DESCRIPTION
**Related Issue(s):**

- Closes #1030

**Description:**

[ruff](https://github.com/charliermarsh/ruff) is fast and has [good momentum](https://github.com/charliermarsh/ruff#whos-using-ruff). See https://beta.ruff.rs/docs/faq/#which-tools-does-ruff-replace for the list of tools that **ruff** can replace.

**PR Checklist:**

- [x] Code is formatted (run `pre-commit run --all-files`)
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
