### PR TITLE
Update PR template since precommit runs on the diff by default

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
 
 **PR Checklist:**
 
-- [ ] Code is formatted (run `pre-commit run --all-files`)
+- [ ] `pre-commit` hooks pass locally
 - [ ] Tests pass (run `scripts/test`)
 - [ ] Documentation has been updated to reflect changes, if applicable
 - [ ] This PR maintains or improves overall codebase code coverage.


### PR DESCRIPTION
**Description:**

I don't think it is good practice to encourage people to run `pre-commit run --all-files`. It kind of undermines the beauty of pre-commit which is that it runs by default on the diff on each commit. 

