### PR TITLE
Fix __geo_interface__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Use [ruff](https://github.com/charliermarsh/ruff) instead of **isort** and **flake8** ([#1034](https://github.com/stac-utils/pystac/pull/1034))
 
+### Fixed
+
+- Item `__geo_interface__` now correctly returns a Feature, rather than only the Geometry ([#1049](https://github.com/stac-utils/pystac/pull/1049))
+
 ## [v1.7.0]
 
 ### Added

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -531,12 +531,14 @@ class Item(STACObject):
         return identify_stac_object_type(d) == STACObjectType.ITEM
 
     @property
-    def __geo_interface__(self) -> Optional[Dict[str, Any]]:
-        """Returns this item's geometry.
+    def __geo_interface__(self) -> Dict[str, Any]:
+        """Returns this item as a dictionary.
+
+        This just calls `to_dict` without self links or transforming any hrefs.
 
         https://gist.github.com/sgillies/2217756
 
         Returns:
-            Dict[str, Any]: The Item's geometry
+            Dict[str, Any]: This item as a dictionary.
         """
-        return deepcopy(self.geometry)
+        return self.to_dict(include_self_link=False, transform_hrefs=False)

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -315,12 +315,6 @@ class ItemTest(unittest.TestCase):
         with self.assertRaises(pystac.STACTypeError):
             _ = pystac.Item.from_dict(catalog_dict)
 
-    def test_geo_interface(self) -> None:
-        item = pystac.Item.from_file(
-            TestCases.get_path("data-files/item/sample-item.json")
-        )
-        self.assertEqual(item.geometry, item.__geo_interface__)
-
     def test_relative_extension_path(self) -> None:
         item = pystac.Item.from_file(
             TestCases.get_path(
@@ -466,3 +460,11 @@ def test_remove_hierarchical_links(
     for link in item.links:
         assert not link.is_hierarchical()
     assert bool(item.get_single_link("canonical")) == add_canonical
+
+
+def test_geo_interface() -> None:
+    item = pystac.Item.from_file(TestCases.get_path("data-files/item/sample-item.json"))
+    assert (
+        item.to_dict(include_self_link=False, transform_hrefs=False)
+        == item.__geo_interface__
+    )


### PR DESCRIPTION
**Related Issue(s):**

- Closes #1048 

**Description:**

`__geo_interface__` should be the feature, not just the geometry. I misread the protocol on my first implementation. I made the choice to just call `to_dict` with all the dials set to no to make it as quick and light as possible. An alternative implementation would be to build a new dict with only the `__geo_interface__` required fields (`type`, `bbox`, `properties`, `geometry`, `coordinates`).

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
