### PR TITLE
[WIP] Simpler extensions interface

### DIFF
--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -21,6 +21,7 @@ from pystac.extensions.base import (
     ExtensionManagementMixin,
     PropertiesExtension,
     SummariesExtension,
+    register_extension,
 )
 from pystac.extensions.hooks import ExtensionHooks
 from pystac.serialization.identify import STACJSONDescription, STACVersionID
@@ -275,6 +276,7 @@ class Band:
         return None
 
 
+@register_extension("eo", pystac.Item)
 class EOExtension(
     Generic[T],
     PropertiesExtension,

--- a/pystac/extensions/projection.py
+++ b/pystac/extensions/projection.py
@@ -6,10 +6,12 @@ import json
 from typing import Any, Dict, Generic, Iterable, List, Optional, TypeVar, Union, cast
 
 import pystac
+
 from pystac.extensions.base import (
     ExtensionManagementMixin,
     PropertiesExtension,
     SummariesExtension,
+    register_extension,
 )
 from pystac.extensions.hooks import ExtensionHooks
 
@@ -29,6 +31,7 @@ SHAPE_PROP: str = PREFIX + "shape"
 TRANSFORM_PROP: str = PREFIX + "transform"
 
 
+@register_extension("proj", pystac.Item)
 class ProjectionExtension(
     Generic[T],
     PropertiesExtension,


### PR DESCRIPTION
**Related Issue(s):**

- POC for #1051

**Example**:
```python
In [1]: import pystac
   ...: 
   ...: PROJ_EXT_EXAMPLE_URL = "https://raw.githubusercontent.com/stac-extensions/projection/v1.1.0/examples/item.json"
   ...: item = pystac.Item.from_file(PROJ_EXT_EXAMPLE_URL)
   ...: 
   ...: item.proj.epsg
Out[1]: 32659

In [2]: item.proj.epsg = 4326

In [3]: item.properties
Out[3]: 
{'datetime': '2020-12-11T22:38:32.125Z',
 'created': '2020-12-12T01:48:13.725Z',
 'updated': '2020-12-12T01:48:13.725Z',
 'platform': 'cool_sat2',
 'instruments': ['cool_sensor_v1'],
 'gsd': 0.66,
 'proj:epsg': 4326,
 'proj:shape': [5558, 9559],
 'proj:transform': [0.5, 0, 712710, 0, -0.5, 151406, 0, 0, 1]}

In [4]: item.eo
---------------------------------------------------------------------------
ExtensionNotImplemented                   Traceback (most recent call last)
Cell In[4], line 1
----> 1 item.eo

File ~/pystac/pystac/extensions/base.py:57, in _CachedExtension.__get__(self, obj, cls)
     52 except pystac.ExtensionNotImplemented as e:
     53     e.args = (
     54         f"{e.args[0]}\nHint: to add a new extension to this pystac object use:"
     55         f"``{self._extension.__name__}.add_to(obj)``",
     56     )
---> 57     raise e
     58 except AttributeError:
     59     # __getattr__ on data object will swallow any AttributeErrors
     60     # raised when initializing the extension, so we need to raise as
     61     # something else:
     62     raise RuntimeError(f"error initializing {self._name!r} extension.")

File ~/pystac/pystac/extensions/base.py:51, in _CachedExtension.__get__(self, obj, cls)
     48     pass
     50 try:
---> 51     extension_obj = self._extension.ext(obj)
     52 except pystac.ExtensionNotImplemented as e:
     53     e.args = (
     54         f"{e.args[0]}\nHint: to add a new extension to this pystac object use:"
     55         f"``{self._extension.__name__}.add_to(obj)``",
     56     )

File ~/pystac/pystac/extensions/eo.py:367, in EOExtension.ext(cls, obj, add_if_missing)
    356 """Extends the given STAC Object with properties from the
    357 :stac-ext:`Electro-Optical Extension <eo>`.
    358 
   (...)
    364     pystac.ExtensionTypeError : If an invalid object type is passed.
    365 """
    366 if isinstance(obj, pystac.Item):
--> 367     cls.validate_has_extension(obj, add_if_missing)
    368     return cast(EOExtension[T], ItemEOExtension(obj))
    369 elif isinstance(obj, pystac.Asset):

File ~/pystac/pystac/extensions/base.py:251, in ExtensionManagementMixin.validate_has_extension(cls, obj, add_if_missing)
    248     cls.add_to(obj)
    250 if cls.get_schema_uri() not in obj.stac_extensions:
--> 251     raise pystac.ExtensionNotImplemented(
    252         f"Could not find extension schema URI {cls.get_schema_uri()} in object."
    253     )

ExtensionNotImplemented: Could not find extension schema URI https://stac-extensions.github.io/eo/v1.0.0/schema.json in object.
Hint: to add a new extension to this pystac object use:``EOExtension.add_to(obj)``

In [5]: from pystac.extensions.eo import EOExtension
   ...: 
   ...: EOExtension.add_to(item)

In [6]: item.eo.cloud_cover = .7

In [7]: item.properties
Out[7]: 
{'datetime': '2020-12-11T22:38:32.125Z',
 'created': '2020-12-12T01:48:13.725Z',
 'updated': '2020-12-12T01:48:13.725Z',
 'platform': 'cool_sat2',
 'instruments': ['cool_sensor_v1'],
 'gsd': 0.66,
 'proj:epsg': 4326,
 'proj:shape': [5558, 9559],
 'proj:transform': [0.5, 0, 712710, 0, -0.5, 151406, 0, 0, 1],
 'eo:cloud_cover': 0.7}

```


**PR Checklist:**

- [ ] `pre-commit` hooks pass locally
- [ ] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [ ] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
