### PR TITLE
Remove text around to_dict and JSON

### DIFF
--- a/pystac/asset.py
+++ b/pystac/asset.py
@@ -112,10 +112,10 @@ class Asset:
             return None
 
     def to_dict(self) -> Dict[str, Any]:
-        """Generate a dictionary representing the JSON of this Asset.
+        """Returns this Asset as a dictionary.
 
         Returns:
-            dict: A serialization of the Asset that can be written out as JSON.
+            dict: A serialization of the Asset.
         """
 
         d: Dict[str, Any] = {"href": self.href}

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -86,10 +86,10 @@ class SpatialExtent:
         self.extra_fields = extra_fields or {}
 
     def to_dict(self) -> Dict[str, Any]:
-        """Generate a dictionary representing the JSON of this SpatialExtent.
+        """Returns this spatial extent as a dictionary.
 
         Returns:
-            dict: A serialization of the SpatialExtent that can be written out as JSON.
+            dict: A serialization of the SpatialExtent.
         """
         d = {"bbox": self.bboxes, **self.extra_fields}
         return d
@@ -212,10 +212,10 @@ class TemporalExtent:
         self.extra_fields = extra_fields or {}
 
     def to_dict(self) -> Dict[str, Any]:
-        """Generate a dictionary representing the JSON of this TemporalExtent.
+        """Returns this temporal extent as a dictionary.
 
         Returns:
-            dict: A serialization of the TemporalExtent that can be written out as JSON.
+            dict: A serialization of the TemporalExtent.
         """
         encoded_intervals: List[List[Optional[str]]] = []
         for i in self.intervals:
@@ -311,10 +311,10 @@ class Extent:
         self.extra_fields = extra_fields or {}
 
     def to_dict(self) -> Dict[str, Any]:
-        """Generate a dictionary representing the JSON of this Extent.
+        """Returns this extent as a dictionary.
 
         Returns:
-            dict: A serialization of the Extent that can be written out as JSON.
+            dict: A serialization of the Extent.
         """
         d = {
             "spatial": self.spatial.to_dict(),

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -217,10 +217,10 @@ class Band:
         return "<Band name={}>".format(self.name)
 
     def to_dict(self) -> Dict[str, Any]:
-        """Returns the dictionary representing the JSON of this Band.
+        """Returns this band as a dictionary.
 
         Returns:
-            dict: The wrapped dict of the Band that can be written out as JSON.
+            dict: The serialization of this Band.
         """
         return self.properties
 

--- a/pystac/extensions/item_assets.py
+++ b/pystac/extensions/item_assets.py
@@ -163,7 +163,7 @@ class AssetDefinition:
             self.properties[ASSET_ROLES_PROP] = v
 
     def to_dict(self) -> Dict[str, Any]:
-        """Returns a JSON-like dictionary representing this ``AssetDefinition``."""
+        """Returns a dictionary representing this ``AssetDefinition``."""
         return deepcopy(self.properties)
 
     def create_asset(self, href: str) -> pystac.Asset:

--- a/pystac/extensions/label.py
+++ b/pystac/extensions/label.py
@@ -141,7 +141,7 @@ class LabelClasses:
         return self.to_dict() == o
 
     def to_dict(self) -> Dict[str, Any]:
-        """Returns the dictionary representing the JSON of this instance."""
+        """Returns this label classes object as a dictionary."""
         return self.properties
 
 
@@ -197,7 +197,7 @@ class LabelCount:
         self.properties["count"] = v
 
     def to_dict(self) -> Dict[str, Any]:
-        """Returns the dictionary representing the JSON of this instance."""
+        """Returns this label count object as a dictionary."""
         return self.properties
 
     def __eq__(self, o: object) -> bool:
@@ -262,7 +262,7 @@ class LabelStatistics:
         self.properties["value"] = v
 
     def to_dict(self) -> Dict[str, Any]:
-        """Returns the dictionary representing the JSON of this LabelStatistics."""
+        """Returns this label statistics object as a dictionary."""
         return self.properties
 
     def __eq__(self, o: object) -> bool:
@@ -417,7 +417,7 @@ class LabelOverview:
         return LabelOverview.create(self.property_key, counts=new_counts)
 
     def to_dict(self) -> Dict[str, Any]:
-        """Returns the dictionary representing the JSON of this LabelOverview."""
+        """Returns this label overview as a dictionary."""
         return self.properties
 
     def __eq__(self, o: object) -> bool:

--- a/pystac/extensions/pointcloud.py
+++ b/pystac/extensions/pointcloud.py
@@ -125,7 +125,7 @@ class Schema:
         )
 
     def to_dict(self) -> Dict[str, Any]:
-        """Returns a JSON-like dictionary representing this ``Schema``."""
+        """Returns this schema as a dictionary."""
         return self.properties
 
 
@@ -309,7 +309,7 @@ class Statistic:
         return "<Statistic statistics={}>".format(str(self.properties))
 
     def to_dict(self) -> Dict[str, Any]:
-        """Returns a JSON-like dictionary representing this ``Statistic``."""
+        """Returns this statistic as a dictionary."""
         return self.properties
 
     def __eq__(self, o: object) -> bool:

--- a/pystac/extensions/raster.py
+++ b/pystac/extensions/raster.py
@@ -192,10 +192,10 @@ class Statistics:
             self.properties.pop("valid_percent", None)
 
     def to_dict(self) -> Dict[str, Any]:
-        """Returns the dictionary representing the JSON of those Statistics.
+        """Returns these statistics as a dictionary.
 
         Returns:
-            dict: The wrapped dict of the Statistics that can be written out as JSON.
+            dict: The serialization of the Statistics.
         """
         return self.properties
 
@@ -328,10 +328,10 @@ class Histogram:
         self.properties["buckets"] = v
 
     def to_dict(self) -> Dict[str, Any]:
-        """Returns the dictionary representing the JSON of this histogram.
+        """Returns this histogram as a dictionary.
 
         Returns:
-            dict: The wrapped dict of the Histogram that can be written out as JSON.
+            dict: The serialization of the Histogram.
         """
         return self.properties
 
@@ -631,10 +631,10 @@ class RasterBand:
         return "<Raster Band>"
 
     def to_dict(self) -> Dict[str, Any]:
-        """Returns the dictionary representing the JSON of this Band.
+        """Returns this band as a dictionary.
 
         Returns:
-            dict: The wrapped dict of the Band that can be written out as JSON.
+            dict: The serialization of the Band.
         """
         return self.properties
 

--- a/pystac/extensions/table.py
+++ b/pystac/extensions/table.py
@@ -76,7 +76,7 @@ class Column:
             self.properties[COL_TYPE_PROP] = v
 
     def to_dict(self) -> Dict[str, Any]:
-        """Returns a JSON-like dictionary representing this ``Column``."""
+        """Returns a dictionary representing this ``Column``."""
         return self.properties
 
 
@@ -111,7 +111,7 @@ class Table:
             self.properties[COL_DESCRIPTION_PROP] = v
 
     def to_dict(self) -> Dict[str, Any]:
-        """Returns a JSON-like dictionary representing this ``Table``."""
+        """Returns a dictionary representing this ``Table``."""
         return self.properties
 
 

--- a/pystac/item_collection.py
+++ b/pystac/item_collection.py
@@ -129,7 +129,7 @@ class ItemCollection(Collection[pystac.Item]):
         return ItemCollection(items=combined)
 
     def to_dict(self, transform_hrefs: bool = False) -> Dict[str, Any]:
-        """Serializes an :class:`ItemCollection` instance to a JSON-like dictionary.
+        """Serializes an :class:`ItemCollection` instance to a dictionary.
 
         Args:
             transform_hrefs: If True, transform the HREF of hierarchical links

--- a/pystac/link.py
+++ b/pystac/link.py
@@ -359,7 +359,7 @@ class Link(PathLike):
         return self.rel in HIERARCHICAL_LINKS
 
     def to_dict(self, transform_href: bool = True) -> Dict[str, Any]:
-        """Generate a dictionary representing the JSON of this serialized Link.
+        """Returns this link as a dictionary.
 
         Args:
             transform_href : If ``True``, transform the HREF based on the type of
@@ -368,7 +368,7 @@ class Link(PathLike):
                 the HREF will be transformed to be relative to the catalog root
                 if this is a hierarchical link relation.
         Returns:
-            dict : A serialization of the Link that can be written out as JSON.
+            dict : A serialization of the Link.
         """
 
         d: Dict[str, Any] = {

--- a/pystac/provider.py
+++ b/pystac/provider.py
@@ -81,10 +81,10 @@ class Provider:
             return escape(repr(self))
 
     def to_dict(self) -> Dict[str, Any]:
-        """Generate a dictionary representing the JSON of this Provider.
+        """Returns this provider as a dictionary.
 
         Returns:
-            dict: A serialization of the Provider that can be written out as JSON.
+            dict: A serialization of the Provider.
         """
         d: Dict[str, Any] = {"name": self.name}
         if self.description is not None:

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -515,7 +515,7 @@ class STACObject(ABC):
     def to_dict(
         self, include_self_link: bool = True, transform_hrefs: bool = True
     ) -> Dict[str, Any]:
-        """Generate a dictionary representing the JSON of this serialized object.
+        """Returns this object as a dictionary.
 
         Args:
             include_self_link : If True, the dict will contain a self link
@@ -527,7 +527,7 @@ class STACObject(ABC):
                 hierarchical link HREFs will be transformed to be relative to the
                 catalog root.
 
-            dict: A serialization of the object that can be written out as JSON.
+            dict: A serialization of the object.
         """
         raise NotImplementedError
 


### PR DESCRIPTION
**Related Issue(s):**

- Closes #1047

**Description:**

Our `to_dict` methods do not always return objects that are strictly valid as JSON, e.g. they may contain tuples instead of lists. This PR updates all docstrings to remove references to returning valid JSON.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
- [ ] (once approved) Create a new issue to capture the useful discussion in #1047 around (de)serialization libraries
