### PR TITLE
Expand `get_items` - deprecate `get_all_items` and `Catalog.get_item` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 - `sort_links_by_id` to Catalog `get_child()` and `modify_links` to `get_stac_objects()` ([#1064](https://github.com/stac-utils/pystac/pull/1064))
+- `*ids` to Catalog and Collection `get_items()` for only including the provided ids in the iterator ([#1075](https://github.com/stac-utils/pystac/pull/1075))
+-  `recursive` to Catalog and Collection `get_items()` to walk the sub-catalogs and sub-collections ([#1075](https://github.com/stac-utils/pystac/pull/1075))
 
 ### Changed
 
@@ -13,6 +15,8 @@
 ### Deprecated
 
 - `pystac.summaries.FIELDS_JSON_URL` ([#1045](https://github.com/stac-utils/pystac/pull/1045))
+- Catalog `get_item()`. Use `get_items(id)` instead ([#1075](https://github.com/stac-utils/pystac/pull/1075))
+- Catalog and Collection `get_all_items`. Use `get_items(recursive=True)` instead ([#1075](https://github.com/stac-utils/pystac/pull/1075))
 
 ### [v1.7.1]
 

--- a/docs/quickstart.ipynb
+++ b/docs/quickstart.ipynb
@@ -149,6 +149,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -156,7 +157,7 @@
     "\n",
     "[STAC Items](https://github.com/radiantearth/stac-spec/tree/master/item-spec) are the fundamental building blocks of a STAC Catalog. Each Item represents a single spatiotemporal resource (e.g. a satellite scene).\n",
     "\n",
-    "Both Catalogs and Collections may have Items associated with them. Let's crawl our catalog, starting at the root, to see what Items we have. The [Catalog.get_all_items method](https://pystac.readthedocs.io/en/latest/api.html#pystac.Catalog.get_all_items) provides a convenient way of recursively listing all Items associated with a Catalog and all of its sub-Catalogs."
+    "Both Catalogs and Collections may have Items associated with them. Let's crawl our catalog, starting at the root, to see what Items we have. The [Catalog.get_items method](https://pystac.readthedocs.io/en/latest/api.html#pystac.Catalog.get_items) provides a convenient way of recursively listing all Items associated with a Catalog and all of its sub-Catalogs by including the `recursive=True` option."
    ]
   },
   {
@@ -177,7 +178,7 @@
     }
    ],
    "source": [
-    "items = list(root_catalog.get_all_items())\n",
+    "items = list(root_catalog.get_items(recursive=True))\n",
     "\n",
     "print(f\"Number of items: {len(items)}\")\n",
     "for item in items:\n",
@@ -214,7 +215,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "item = root_catalog.get_item(\"LC80140332018166LGN00\", recursive=True)"
+    "item = next(root_catalog.get_items(\"LC80140332018166LGN00\", recursive=True), None)"
    ]
   },
   {
@@ -1794,7 +1795,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "item_to_update = root_catalog.get_item(\"LC80140332018166LGN00\", recursive=True)\n",
+    "item_to_update = next(\n",
+    "    root_catalog.get_items(\"LC80140332018166LGN00\", recursive=True), None\n",
+    ")\n",
     "item_to_update_eo_ext = EOExtension.ext(item_to_update)\n",
     "\n",
     "# Update the cloud cover\n",
@@ -1856,7 +1859,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Catalog saved to: /tmp/tmpgdncnim0/catalog.json\n"
+      "Catalog saved to: /tmp/tmp74zztgmt/catalog.json\n"
      ]
     }
    ],

--- a/docs/quickstart.ipynb
+++ b/docs/quickstart.ipynb
@@ -193,6 +193,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -206,7 +207,7 @@
     "\n",
     "We will walk through each of these metadata categories in the following sections. \n",
     "\n",
-    "First, let's grab one of the Items using the [Catalog.get_item method](https://pystac.readthedocs.io/en/latest/api.html#pystac.Catalog.get_item). We will use `recursive=True` to recursively crawl all child Catalogs and/or Collections to find the Item."
+    "First, let's grab one of the Items using the [Catalog.get_items method](https://pystac.readthedocs.io/en/latest/api.html#pystac.Catalog.get_items). We will use `recursive=True` to recursively crawl all child Catalogs and/or Collections to find the Item."
    ]
   },
   {
@@ -1859,7 +1860,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Catalog saved to: /tmp/tmp74zztgmt/catalog.json\n"
+      "Catalog saved to: /tmp/tmpo2y1572p/catalog.json\n"
      ]
     }
    ],

--- a/docs/quickstart.ipynb
+++ b/docs/quickstart.ipynb
@@ -216,7 +216,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "item = next(root_catalog.get_items(\"LC80140332018166LGN00\", recursive=True), None)"
+    "item = next(root_catalog.get_items(\"LC80140332018166LGN00\", recursive=True))"
    ]
   },
   {
@@ -1797,7 +1797,7 @@
    "outputs": [],
    "source": [
     "item_to_update = next(\n",
-    "    root_catalog.get_items(\"LC80140332018166LGN00\", recursive=True), None\n",
+    "    root_catalog.get_items(\"LC80140332018166LGN00\", recursive=True)\n",
     ")\n",
     "item_to_update_eo_ext = EOExtension.ext(item_to_update)\n",
     "\n",

--- a/docs/tutorials/how-to-create-stac-catalogs.ipynb
+++ b/docs/tutorials/how-to-create-stac-catalogs.ipynb
@@ -24,33 +24,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Requirement already satisfied: boto3 in /Users/gadomski/.virtualenvs/pystac/lib/python3.9/site-packages (1.21.28)\n",
-      "Requirement already satisfied: rasterio in /Users/gadomski/.virtualenvs/pystac/lib/python3.9/site-packages (1.2.10)\n",
-      "Requirement already satisfied: shapely in /Users/gadomski/.virtualenvs/pystac/lib/python3.9/site-packages (1.8.1.post1)\n",
-      "Requirement already satisfied: pystac in /Users/gadomski/Code/pystac (1.3.0)\n",
-      "Requirement already satisfied: jmespath<2.0.0,>=0.7.1 in /Users/gadomski/.virtualenvs/pystac/lib/python3.9/site-packages (from boto3) (1.0.0)\n",
-      "Requirement already satisfied: botocore<1.25.0,>=1.24.28 in /Users/gadomski/.virtualenvs/pystac/lib/python3.9/site-packages (from boto3) (1.24.28)\n",
-      "Requirement already satisfied: s3transfer<0.6.0,>=0.5.0 in /Users/gadomski/.virtualenvs/pystac/lib/python3.9/site-packages (from boto3) (0.5.2)\n",
-      "Requirement already satisfied: certifi in /Users/gadomski/.virtualenvs/pystac/lib/python3.9/site-packages (from rasterio) (2021.5.30)\n",
-      "Requirement already satisfied: numpy in /Users/gadomski/.virtualenvs/pystac/lib/python3.9/site-packages (from rasterio) (1.22.3)\n",
-      "Requirement already satisfied: click-plugins in /Users/gadomski/.virtualenvs/pystac/lib/python3.9/site-packages (from rasterio) (1.1.1)\n",
-      "Requirement already satisfied: click>=4.0 in /Users/gadomski/.virtualenvs/pystac/lib/python3.9/site-packages (from rasterio) (8.0.1)\n",
-      "Requirement already satisfied: snuggs>=1.4.1 in /Users/gadomski/.virtualenvs/pystac/lib/python3.9/site-packages (from rasterio) (1.4.7)\n",
-      "Requirement already satisfied: cligj>=0.5 in /Users/gadomski/.virtualenvs/pystac/lib/python3.9/site-packages (from rasterio) (0.7.2)\n",
-      "Requirement already satisfied: affine in /Users/gadomski/.virtualenvs/pystac/lib/python3.9/site-packages (from rasterio) (2.3.1)\n",
-      "Requirement already satisfied: setuptools in /Users/gadomski/.virtualenvs/pystac/lib/python3.9/site-packages (from rasterio) (56.0.0)\n",
-      "Requirement already satisfied: attrs in /Users/gadomski/.virtualenvs/pystac/lib/python3.9/site-packages (from rasterio) (21.2.0)\n",
-      "Requirement already satisfied: python-dateutil>=2.7.0 in /Users/gadomski/.virtualenvs/pystac/lib/python3.9/site-packages (from pystac) (2.8.1)\n",
-      "Requirement already satisfied: urllib3<1.27,>=1.25.4 in /Users/gadomski/.virtualenvs/pystac/lib/python3.9/site-packages (from botocore<1.25.0,>=1.24.28->boto3) (1.26.5)\n",
-      "Requirement already satisfied: six>=1.5 in /Users/gadomski/.virtualenvs/pystac/lib/python3.9/site-packages (from python-dateutil>=2.7.0->pystac) (1.16.0)\n",
-      "Requirement already satisfied: pyparsing>=2.1.6 in /Users/gadomski/.virtualenvs/pystac/lib/python3.9/site-packages (from snuggs>=1.4.1->rasterio) (2.4.7)\n"
+      "Requirement already satisfied: boto3 in /home/jsignell/conda/envs/pystac/lib/python3.8/site-packages (1.26.104)\n",
+      "Requirement already satisfied: rasterio in /home/jsignell/conda/envs/pystac/lib/python3.8/site-packages (1.3.6)\n",
+      "Requirement already satisfied: shapely in /home/jsignell/conda/envs/pystac/lib/python3.8/site-packages (2.0.1)\n",
+      "Requirement already satisfied: pystac in /home/jsignell/pystac (1.7.0)\n",
+      "Requirement already satisfied: botocore<1.30.0,>=1.29.104 in /home/jsignell/conda/envs/pystac/lib/python3.8/site-packages (from boto3) (1.29.104)\n",
+      "Requirement already satisfied: s3transfer<0.7.0,>=0.6.0 in /home/jsignell/conda/envs/pystac/lib/python3.8/site-packages (from boto3) (0.6.0)\n",
+      "Requirement already satisfied: jmespath<2.0.0,>=0.7.1 in /home/jsignell/conda/envs/pystac/lib/python3.8/site-packages (from boto3) (1.0.1)\n",
+      "Requirement already satisfied: certifi in /home/jsignell/conda/envs/pystac/lib/python3.8/site-packages (from rasterio) (2022.12.7)\n",
+      "Requirement already satisfied: numpy>=1.18 in /home/jsignell/conda/envs/pystac/lib/python3.8/site-packages (from rasterio) (1.24.2)\n",
+      "Requirement already satisfied: cligj>=0.5 in /home/jsignell/conda/envs/pystac/lib/python3.8/site-packages (from rasterio) (0.7.2)\n",
+      "Requirement already satisfied: click-plugins in /home/jsignell/conda/envs/pystac/lib/python3.8/site-packages (from rasterio) (1.1.1)\n",
+      "Requirement already satisfied: setuptools in /home/jsignell/conda/envs/pystac/lib/python3.8/site-packages (from rasterio) (65.6.3)\n",
+      "Requirement already satisfied: snuggs>=1.4.1 in /home/jsignell/conda/envs/pystac/lib/python3.8/site-packages (from rasterio) (1.4.7)\n",
+      "Requirement already satisfied: click>=4.0 in /home/jsignell/conda/envs/pystac/lib/python3.8/site-packages (from rasterio) (8.1.3)\n",
+      "Requirement already satisfied: affine in /home/jsignell/conda/envs/pystac/lib/python3.8/site-packages (from rasterio) (2.4.0)\n",
+      "Requirement already satisfied: attrs in /home/jsignell/conda/envs/pystac/lib/python3.8/site-packages (from rasterio) (22.2.0)\n",
+      "Requirement already satisfied: python-dateutil>=2.7.0 in /home/jsignell/conda/envs/pystac/lib/python3.8/site-packages (from pystac) (2.8.2)\n",
+      "Requirement already satisfied: urllib3<1.27,>=1.25.4 in /home/jsignell/conda/envs/pystac/lib/python3.8/site-packages (from botocore<1.30.0,>=1.29.104->boto3) (1.26.14)\n",
+      "Requirement already satisfied: six>=1.5 in /home/jsignell/conda/envs/pystac/lib/python3.8/site-packages (from python-dateutil>=2.7.0->pystac) (1.16.0)\n",
+      "Requirement already satisfied: pyparsing>=2.1.6 in /home/jsignell/conda/envs/pystac/lib/python3.8/site-packages (from snuggs>=1.4.1->rasterio) (3.0.9)\n",
+      "Note: you may need to restart the kernel to use updated packages.\n"
      ]
     }
    ],
@@ -67,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -90,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -104,17 +105,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "('/var/folders/9z/lnsvqfqj4gs2d1j1nw3vynrm0000gn/T/tmpzpx86d17/image.tif',\n",
-       " <http.client.HTTPMessage at 0x10ed01ac0>)"
+       "('/tmp/tmpo7ext4tt/image.tif', <http.client.HTTPMessage at 0x7ff4f4ebfca0>)"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -137,7 +137,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -153,7 +153,7 @@
       "    Args:\n",
       "        id : Identifier for the catalog. Must be unique within the STAC.\n",
       "        description : Detailed multi-line description to fully explain the catalog.\n",
-      "            `CommonMark 0.28 syntax <https://commonmark.org/>`_ MAY be used for rich\n",
+      "            `CommonMark 0.29 syntax <https://commonmark.org/>`_ MAY be used for rich\n",
       "            text representation.\n",
       "        title : Optional short descriptive one-line title for the catalog.\n",
       "        stac_extensions : Optional list of extensions the Catalog implements.\n",
@@ -178,7 +178,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -194,7 +194,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -220,7 +220,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -240,9 +240,13 @@
       "            using either 2D or 3D geometries. The length of the array must be 2*n\n",
       "            where n is the number of dimensions. Could also be None in the case of a\n",
       "            null geometry.\n",
-      "        datetime : Datetime associated with this item. If None,\n",
-      "            a start_datetime and end_datetime must be supplied in the properties.\n",
+      "        datetime : datetime associated with this item. If None,\n",
+      "            a start_datetime and end_datetime must be supplied.\n",
       "        properties : A dictionary of additional metadata for the item.\n",
+      "        start_datetime : Optional start datetime, part of common metadata. This value\n",
+      "            will override any `start_datetime` key in properties.\n",
+      "        end_datetime : Optional end datetime, part of common metadata. This value\n",
+      "            will override any `end_datetime` key in properties.\n",
       "        stac_extensions : Optional list of extensions the Item implements.\n",
       "        href : Optional HREF for this item, which be set as the item's\n",
       "            self link's HREF.\n",
@@ -250,6 +254,9 @@
       "            belongs to.\n",
       "        extra_fields : Extra fields that are part of the top-level JSON\n",
       "            properties of the Item.\n",
+      "        assets : A dictionary mapping string keys to :class:`~pystac.Asset` objects. All\n",
+      "            :class:`~pystac.Asset` values in the dictionary will have their\n",
+      "            :attr:`~pystac.Asset.owner` attribute set to the created Item.\n",
       "    \n"
      ]
     }
@@ -267,7 +274,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -293,7 +300,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -320,7 +327,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -344,7 +351,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -353,7 +360,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -362,16 +369,210 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "\n",
+       "\n",
+       "<div class=\"jp-RenderedHTMLCommon jp-RenderedHTML jp-mod-trusted jp-OutputArea-output\">\n",
+       "    <div style=\"\n",
+       "        width: 24px;\n",
+       "        height: 24px;\n",
+       "        background-color: #E1E1E1;\n",
+       "        border: 3px solid #9D9D9D;\n",
+       "        border-radius: 5px;\n",
+       "        position: absolute;\">\n",
+       "    </div>\n",
+       "    <div>\n",
+       "        <details style=\"margin-left: 48px;\">\n",
+       "            <summary style=\"margin-bottom: 20px;\">\n",
+       "                <h3 style=\"margin-bottom: 0px; display: inline;\">\n",
+       "                    Catalog: test-catalog\n",
+       "                </h3>\n",
+       "            </summary>\n",
+       "            <table style=\"width: 100%; text-align: left;\">\n",
+       "                <tr><td style=\"text-align: left;\"><strong>id:</strong> test-catalog </td></tr>\n",
+       "                \n",
+       "                \n",
+       "                    <tr><td style=\"text-align: left;\"><strong>description:</strong> Tutorial catalog. </td></tr>\n",
+       "                \n",
+       "                 \n",
+       "                \n",
+       "            </table>\n",
+       "            \n",
+       "            \n",
+       "            \n",
+       "        <details>\n",
+       "            <summary style=\"margin-bottom: 10px; margin-top: 10px\">\n",
+       "                <h4 style=\"margin-bottom: 0px; display: inline;\">Items</h4>\n",
+       "            </summary>\n",
+       "            <i> Only the first item shown </i>\n",
+       "            \n",
+       "                \n",
+       "\n",
+       "<div class=\"jp-RenderedHTMLCommon jp-RenderedHTML jp-mod-trusted jp-OutputArea-output\">\n",
+       "    <div style=\"\n",
+       "        width: 24px;\n",
+       "        height: 24px;\n",
+       "        background-color: #DBF5FF;\n",
+       "        border: 3px solid #4CC9FF;\n",
+       "        border-radius: 5px;\n",
+       "        position: absolute;\">\n",
+       "    </div>\n",
+       "    <div>\n",
+       "        <details style=\"margin-left: 48px;\">\n",
+       "            <summary style=\"margin-bottom: 20px;\">\n",
+       "                <h3 style=\"margin-bottom: 0px; display: inline;\">Item: local-image</h3>\n",
+       "            </summary>\n",
+       "            <table style=\"width: 100%; text-align: left;\">\n",
+       "                <tr><td style=\"text-align: left;\"><strong>id:</strong> local-image </td></tr>\n",
+       "                \n",
+       "                    <tr><td style=\"text-align: left;\"><strong>bbox:</strong> [37.6616853489879, 55.73478197572927, 37.66573047610874, 55.73882710285011] </td></tr>\n",
+       "                \n",
+       "                \n",
+       "                \n",
+       "            </table>\n",
+       "            \n",
+       "            \n",
+       "            \n",
+       "        <details>\n",
+       "            <summary style=\"margin-bottom: 10px; margin-top: 10px\">\n",
+       "                <h4 style=\"margin-bottom: 0px; display: inline;\">Links</h4>\n",
+       "            </summary>\n",
+       "            \n",
+       "                \n",
+       "\n",
+       "<div class=\"jp-RenderedHTMLCommon jp-RenderedHTML jp-mod-trusted jp-OutputArea-output\">\n",
+       "    <div style=\"\n",
+       "        width: 24px;\n",
+       "        height: 24px;\n",
+       "        background-color: #FFF7E5;\n",
+       "        border: 3px solid #FF6132;\n",
+       "        border-radius: 5px;\n",
+       "        position: absolute;\">\n",
+       "    </div>\n",
+       "    <div style=\"margin-left: 48px;\">\n",
+       "        <h4 style=\"margin-bottom: 0px;\">Link: </h4>\n",
+       "        <table style=\"width: 100%; text-align: left;\">\n",
+       "            <tr><td style=\"text-align: left;\"><strong>rel:</strong> root </td></tr>\n",
+       "            <tr><td style=\"text-align: left;\"><strong>href:</strong> None </td></tr>\n",
+       "            \n",
+       "                <tr><td style=\"text-align: left;\"><strong>type:</strong> application/json </td></tr>\n",
+       "            \n",
+       "            \n",
+       "            \n",
+       "        </table>\n",
+       "        \n",
+       "    </div>\n",
+       "</div>\n",
+       "            \n",
+       "                \n",
+       "\n",
+       "<div class=\"jp-RenderedHTMLCommon jp-RenderedHTML jp-mod-trusted jp-OutputArea-output\">\n",
+       "    <div style=\"\n",
+       "        width: 24px;\n",
+       "        height: 24px;\n",
+       "        background-color: #FFF7E5;\n",
+       "        border: 3px solid #FF6132;\n",
+       "        border-radius: 5px;\n",
+       "        position: absolute;\">\n",
+       "    </div>\n",
+       "    <div style=\"margin-left: 48px;\">\n",
+       "        <h4 style=\"margin-bottom: 0px;\">Link: </h4>\n",
+       "        <table style=\"width: 100%; text-align: left;\">\n",
+       "            <tr><td style=\"text-align: left;\"><strong>rel:</strong> parent </td></tr>\n",
+       "            <tr><td style=\"text-align: left;\"><strong>href:</strong> None </td></tr>\n",
+       "            \n",
+       "                <tr><td style=\"text-align: left;\"><strong>type:</strong> application/json </td></tr>\n",
+       "            \n",
+       "            \n",
+       "            \n",
+       "        </table>\n",
+       "        \n",
+       "    </div>\n",
+       "</div>\n",
+       "            \n",
+       "        </details>\n",
+       "    \n",
+       "        </details>\n",
+       "    </div>\n",
+       "</div>\n",
+       "            \n",
+       "        </details>\n",
+       "    \n",
+       "            \n",
+       "        <details>\n",
+       "            <summary style=\"margin-bottom: 10px; margin-top: 10px\">\n",
+       "                <h4 style=\"margin-bottom: 0px; display: inline;\">Links</h4>\n",
+       "            </summary>\n",
+       "            \n",
+       "                \n",
+       "\n",
+       "<div class=\"jp-RenderedHTMLCommon jp-RenderedHTML jp-mod-trusted jp-OutputArea-output\">\n",
+       "    <div style=\"\n",
+       "        width: 24px;\n",
+       "        height: 24px;\n",
+       "        background-color: #FFF7E5;\n",
+       "        border: 3px solid #FF6132;\n",
+       "        border-radius: 5px;\n",
+       "        position: absolute;\">\n",
+       "    </div>\n",
+       "    <div style=\"margin-left: 48px;\">\n",
+       "        <h4 style=\"margin-bottom: 0px;\">Link: </h4>\n",
+       "        <table style=\"width: 100%; text-align: left;\">\n",
+       "            <tr><td style=\"text-align: left;\"><strong>rel:</strong> root </td></tr>\n",
+       "            <tr><td style=\"text-align: left;\"><strong>href:</strong> None </td></tr>\n",
+       "            \n",
+       "                <tr><td style=\"text-align: left;\"><strong>type:</strong> application/json </td></tr>\n",
+       "            \n",
+       "            \n",
+       "            \n",
+       "        </table>\n",
+       "        \n",
+       "    </div>\n",
+       "</div>\n",
+       "            \n",
+       "                \n",
+       "\n",
+       "<div class=\"jp-RenderedHTMLCommon jp-RenderedHTML jp-mod-trusted jp-OutputArea-output\">\n",
+       "    <div style=\"\n",
+       "        width: 24px;\n",
+       "        height: 24px;\n",
+       "        background-color: #FFF7E5;\n",
+       "        border: 3px solid #FF6132;\n",
+       "        border-radius: 5px;\n",
+       "        position: absolute;\">\n",
+       "    </div>\n",
+       "    <div style=\"margin-left: 48px;\">\n",
+       "        <h4 style=\"margin-bottom: 0px;\">Link: </h4>\n",
+       "        <table style=\"width: 100%; text-align: left;\">\n",
+       "            <tr><td style=\"text-align: left;\"><strong>rel:</strong> item </td></tr>\n",
+       "            <tr><td style=\"text-align: left;\"><strong>href:</strong> None </td></tr>\n",
+       "            \n",
+       "                <tr><td style=\"text-align: left;\"><strong>type:</strong> application/json </td></tr>\n",
+       "            \n",
+       "            \n",
+       "            \n",
+       "        </table>\n",
+       "        \n",
+       "    </div>\n",
+       "</div>\n",
+       "            \n",
+       "        </details>\n",
+       "    \n",
+       "             \n",
+       "        </details>\n",
+       "    </div>\n",
+       "</div>"
+      ],
       "text/plain": [
        "<Catalog id=test-catalog>"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -389,7 +590,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -416,7 +617,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -450,7 +651,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -468,7 +669,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -480,7 +681,7 @@
       "    \"stac_version\": \"1.0.0\",\n",
       "    \"id\": \"local-image\",\n",
       "    \"properties\": {\n",
-      "        \"datetime\": \"2022-03-29T12:47:45.754444Z\"\n",
+      "        \"datetime\": \"2023-03-31T20:30:16.284679Z\"\n",
       "    },\n",
       "    \"geometry\": {\n",
       "        \"type\": \"Polygon\",\n",
@@ -523,7 +724,7 @@
       "    ],\n",
       "    \"assets\": {\n",
       "        \"image\": {\n",
-      "            \"href\": \"/var/folders/9z/lnsvqfqj4gs2d1j1nw3vynrm0000gn/T/tmpzpx86d17/image.tif\",\n",
+      "            \"href\": \"/tmp/tmpo7ext4tt/image.tif\",\n",
       "            \"type\": \"image/tiff; application=geotiff\"\n",
       "        }\n",
       "    },\n",
@@ -567,7 +768,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -593,7 +794,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -609,15 +810,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/var/folders/9z/lnsvqfqj4gs2d1j1nw3vynrm0000gn/T/tmpzpx86d17/stac/catalog.json\n",
-      "/var/folders/9z/lnsvqfqj4gs2d1j1nw3vynrm0000gn/T/tmpzpx86d17/stac/local-image/local-image.json\n"
+      "/tmp/tmpo7ext4tt/stac/catalog.json\n",
+      "/tmp/tmpo7ext4tt/stac/local-image/local-image.json\n"
      ]
     }
    ],
@@ -637,7 +838,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -646,16 +847,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/var/folders/9z/lnsvqfqj4gs2d1j1nw3vynrm0000gn/T/tmpzpx86d17/stac/catalog.json\n",
+      "/tmp/tmpo7ext4tt/stac/catalog.json\n",
       "\n",
-      "/var/folders/9z/lnsvqfqj4gs2d1j1nw3vynrm0000gn/T/tmpzpx86d17/stac/local-image:\n",
+      "/tmp/tmpo7ext4tt/stac/local-image:\n",
       "local-image.json\n"
      ]
     }
@@ -666,7 +867,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -689,8 +890,7 @@
       "      \"href\": \"./local-image/local-image.json\",\n",
       "      \"type\": \"application/json\"\n",
       "    }\n",
-      "  ],\n",
-      "  \"stac_extensions\": []\n",
+      "  ]\n",
       "}\n"
      ]
     }
@@ -702,7 +902,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -714,7 +914,7 @@
       "  \"stac_version\": \"1.0.0\",\n",
       "  \"id\": \"local-image\",\n",
       "  \"properties\": {\n",
-      "    \"datetime\": \"2022-03-29T12:47:45.754444Z\"\n",
+      "    \"datetime\": \"2023-03-31T20:30:16.284679Z\"\n",
       "  },\n",
       "  \"geometry\": {\n",
       "    \"type\": \"Polygon\",\n",
@@ -757,7 +957,7 @@
       "  ],\n",
       "  \"assets\": {\n",
       "    \"image\": {\n",
-      "      \"href\": \"/var/folders/9z/lnsvqfqj4gs2d1j1nw3vynrm0000gn/T/tmpzpx86d17/image.tif\",\n",
+      "      \"href\": \"/tmp/tmpo7ext4tt/image.tif\",\n",
       "      \"type\": \"image/tiff; application=geotiff\"\n",
       "    }\n",
       "  },\n",
@@ -786,7 +986,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -802,7 +1002,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -814,7 +1014,7 @@
       "  \"stac_version\": \"1.0.0\",\n",
       "  \"id\": \"local-image\",\n",
       "  \"properties\": {\n",
-      "    \"datetime\": \"2022-03-29T12:47:45.754444Z\"\n",
+      "    \"datetime\": \"2023-03-31T20:30:16.284679Z\"\n",
       "  },\n",
       "  \"geometry\": {\n",
       "    \"type\": \"Polygon\",\n",
@@ -846,23 +1046,23 @@
       "  \"links\": [\n",
       "    {\n",
       "      \"rel\": \"root\",\n",
-      "      \"href\": \"/var/folders/9z/lnsvqfqj4gs2d1j1nw3vynrm0000gn/T/tmpzpx86d17/stac/catalog.json\",\n",
+      "      \"href\": \"/tmp/tmpo7ext4tt/stac/catalog.json\",\n",
       "      \"type\": \"application/json\"\n",
       "    },\n",
       "    {\n",
       "      \"rel\": \"parent\",\n",
-      "      \"href\": \"/var/folders/9z/lnsvqfqj4gs2d1j1nw3vynrm0000gn/T/tmpzpx86d17/stac/catalog.json\",\n",
+      "      \"href\": \"/tmp/tmpo7ext4tt/stac/catalog.json\",\n",
       "      \"type\": \"application/json\"\n",
       "    },\n",
       "    {\n",
       "      \"rel\": \"self\",\n",
-      "      \"href\": \"/var/folders/9z/lnsvqfqj4gs2d1j1nw3vynrm0000gn/T/tmpzpx86d17/stac/local-image/local-image.json\",\n",
+      "      \"href\": \"/tmp/tmpo7ext4tt/stac/local-image/local-image.json\",\n",
       "      \"type\": \"application/json\"\n",
       "    }\n",
       "  ],\n",
       "  \"assets\": {\n",
       "    \"image\": {\n",
-      "      \"href\": \"/var/folders/9z/lnsvqfqj4gs2d1j1nw3vynrm0000gn/T/tmpzpx86d17/image.tif\",\n",
+      "      \"href\": \"/tmp/tmpo7ext4tt/image.tif\",\n",
       "      \"type\": \"image/tiff; application=geotiff\"\n",
       "    }\n",
       "  },\n",
@@ -891,7 +1091,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -901,7 +1101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -913,7 +1113,7 @@
       "  \"stac_version\": \"1.0.0\",\n",
       "  \"id\": \"local-image\",\n",
       "  \"properties\": {\n",
-      "    \"datetime\": \"2022-03-29T12:47:45.754444Z\"\n",
+      "    \"datetime\": \"2023-03-31T20:30:16.284679Z\"\n",
       "  },\n",
       "  \"geometry\": {\n",
       "    \"type\": \"Polygon\",\n",
@@ -994,7 +1194,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1040,7 +1240,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1064,7 +1264,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1075,7 +1275,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
@@ -1099,7 +1299,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1118,13 +1318,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'href': '/var/folders/9z/lnsvqfqj4gs2d1j1nw3vynrm0000gn/T/tmpzpx86d17/image.tif',\n",
+       "{'href': '/tmp/tmpo7ext4tt/image.tif',\n",
        " 'type': <MediaType.GEOTIFF: 'image/tiff; application=geotiff'>,\n",
        " 'eo:bands': [{'name': 'Coastal',\n",
        "   'common_name': 'coastal',\n",
@@ -1148,7 +1348,7 @@
        "   'description': 'Near-IR2: 860 - 1040 nm'}]}"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1166,7 +1366,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
@@ -1175,7 +1375,7 @@
        "[]"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1187,7 +1387,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {
@@ -1196,7 +1396,7 @@
        "[<Item id=local-image-eo>]"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1208,7 +1408,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1227,7 +1427,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1236,7 +1436,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [
     {
@@ -1245,7 +1445,7 @@
        "[<Item id=local-image-eo>]"
       ]
      },
-     "execution_count": 42,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1257,16 +1457,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [],
    "source": [
-    "item: pystac.Item = next(catalog2.get_all_items())"
+    "item: pystac.Item = next(catalog2.get_items(recursive=True))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1275,7 +1475,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {
@@ -1304,17 +1504,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "('/var/folders/9z/lnsvqfqj4gs2d1j1nw3vynrm0000gn/T/tmpzpx86d17/image.tif',\n",
-       " <http.client.HTTPMessage at 0x114dba130>)"
+       "('/tmp/tmpo7ext4tt/image.tif', <http.client.HTTPMessage at 0x7ff4a64adb50>)"
       ]
      },
-     "execution_count": 46,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1331,7 +1530,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1347,7 +1546,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [
     {
@@ -1360,7 +1559,7 @@
       "    Args:\n",
       "        id : Identifier for the collection. Must be unique within the STAC.\n",
       "        description : Detailed multi-line description to fully explain the\n",
-      "            collection. `CommonMark 0.28 syntax <https://commonmark.org/>`_ MAY\n",
+      "            collection. `CommonMark 0.29 syntax <https://commonmark.org/>`_ MAY\n",
       "            be used for rich text representation.\n",
       "        extent : Spatial and temporal extents that describe the bounds of\n",
       "            all items contained within this Collection.\n",
@@ -1383,6 +1582,9 @@
       "            either a set of values or statistics such as a range.\n",
       "        extra_fields : Extra fields that are part of the top-level\n",
       "            JSON properties of the Collection.\n",
+      "        assets : A dictionary mapping string keys to :class:`~pystac.Asset` objects. All\n",
+      "            :class:`~pystac.Asset` values in the dictionary will have their\n",
+      "            :attr:`~pystac.Asset.owner` attribute set to the created Collection.\n",
       "    \n"
      ]
     }
@@ -1400,7 +1602,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [
     {
@@ -1433,7 +1635,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1481,7 +1683,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1494,7 +1696,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1504,7 +1706,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 51,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1513,7 +1715,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 52,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1534,7 +1736,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 53,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1543,7 +1745,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 54,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1554,7 +1756,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 55,
    "metadata": {},
    "outputs": [
     {
@@ -1574,7 +1776,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 56,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1595,7 +1797,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 57,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1627,7 +1829,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 58,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1675,7 +1877,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 59,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1708,7 +1910,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 60,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1721,7 +1923,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 61,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1748,7 +1950,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 62,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1757,7 +1959,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 63,
    "metadata": {},
    "outputs": [
     {
@@ -1775,7 +1977,7 @@
        " '1005': {'img': 's3://spacenet-dataset/spacenet/SN5_roads/train/AOI_7_Moscow/PS-MS/SN5_roads_train_AOI_7_Moscow_PS-MS_chip1005.tif'}}"
       ]
      },
-     "execution_count": 67,
+     "execution_count": 63,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1793,7 +1995,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 64,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1813,7 +2015,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": 65,
    "metadata": {},
    "outputs": [
     {
@@ -1875,7 +2077,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": 66,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1888,7 +2090,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": 67,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1898,7 +2100,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 74,
+   "execution_count": 68,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1907,7 +2109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 75,
+   "execution_count": 69,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1921,7 +2123,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": 70,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1930,7 +2132,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": 71,
    "metadata": {},
    "outputs": [
     {
@@ -1964,7 +2166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 72,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1974,7 +2176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 73,
    "metadata": {},
    "outputs": [
     {
@@ -2011,7 +2213,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": 74,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2025,7 +2227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": 75,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2044,7 +2246,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": 76,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2063,7 +2265,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": 77,
    "metadata": {},
    "outputs": [
     {
@@ -2111,15 +2313,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": 78,
    "metadata": {},
    "outputs": [],
    "source": [
     "from pystac.extensions.label import LabelType\n",
     "\n",
     "for chip_id in chip_id_to_data:\n",
-    "    img_item = collection.get_item(\"img_{}\".format(chip_id))\n",
-    "    assert img_item\n",
+    "    img_item = next(collection.get_items(\"img_{}\".format(chip_id)))\n",
     "    label_uri = chip_id_to_data[chip_id][\"label\"]\n",
     "\n",
     "    label_item = pystac.Item(\n",
@@ -2150,7 +2351,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": 79,
    "metadata": {},
    "outputs": [
     {
@@ -2189,7 +2390,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": 80,
    "metadata": {},
    "outputs": [
     {
@@ -2202,7 +2403,7 @@
        "  'label:type': <LabelType.VECTOR: 'vector'>,\n",
        "  'label:properties': None,\n",
        "  'label:tasks': ['segmentation', 'regression'],\n",
-       "  'datetime': '2022-03-29T12:58:05.404487Z'},\n",
+       "  'datetime': '2023-03-31T20:31:29.528250Z'},\n",
        " 'geometry': {'type': 'Polygon',\n",
        "  'coordinates': (((37.68191035616281, 55.73478210707574),\n",
        "    (37.68191035616281, 55.73882710285011),\n",
@@ -2227,7 +2428,7 @@
        " 'stac_extensions': ['https://stac-extensions.github.io/label/v1.0.1/schema.json']}"
       ]
      },
-     "execution_count": 87,
+     "execution_count": 80,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2254,7 +2455,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.8.15"
   }
  },
  "nbformat": 4,

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -563,7 +563,7 @@ class Catalog(STACObject):
             "get_item is deprecated and will be removed in v2",
             DeprecationWarning,
         )
-        yield from self.get_items(recursive=True)
+        return self.get_items(recursive=True)
 
     def get_item_links(self) -> List[Link]:
         """Return all item links of this catalog.

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -466,17 +466,11 @@ class Catalog(STACObject):
             Item or None: The item with the given ID, or None if not found.
         """
         warnings.warn(
-            "get_item is deprecated and will be removed in v2",
+            "get_item is deprecated and will be removed in v2. "
+            "Use next(self.get_items(id), None) instead",
             DeprecationWarning,
         )
-        if not recursive:
-            return next((i for i in self.get_items() if i.id == id), None)
-        else:
-            for root, _, _ in self.walk():
-                item = root.get_item(id, recursive=False)
-                if item is not None:
-                    return item
-            return None
+        return next(self.get_items(id, recursive=recursive), None)
 
     def get_items(self, *ids: str, recursive: bool = False) -> Iterator[Item]:
         """Return all items or specific items of this catalog.

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from itertools import chain
+import warnings
 import os
 from copy import deepcopy
 from html import escape
@@ -445,7 +447,13 @@ class Catalog(STACObject):
         self.links = new_links
 
     def get_item(self, id: str, recursive: bool = False) -> Optional[Item]:
-        """Returns an item with a given ID.
+        """
+        DEPRECATED.
+
+        .. deprecated:: 1.8
+            Use :meth:`next(pystac.Catalog.get_items(id), None)` instead.
+
+        Returns an item with a given ID.
 
         Args:
             id : The ID of the item to find.
@@ -456,6 +464,10 @@ class Catalog(STACObject):
         Return:
             Item or None: The item with the given ID, or None if not found.
         """
+        warnings.warn(
+            "get_item is deprecated and will be removed in v2",
+            DeprecationWarning,
+        )
         if not recursive:
             return next((i for i in self.get_items() if i.id == id), None)
         else:
@@ -465,15 +477,36 @@ class Catalog(STACObject):
                     return item
             return None
 
-    def get_items(self) -> Iterable[Item]:
-        """Return all items of this catalog.
+    def get_items(self, *ids: str, recursive: bool = False) -> Iterable[Item]:
+        """Return all items or specific items of this catalog.
+
+        Args:
+            *ids : The IDs of the items to include.
+            recursive : If True, search this catalog and all children for the
+                item; otherwise, only search the items of this catalog. Defaults
+                to False.
 
         Return:
-            Iterable[Item]: Generator of items whose parent is this catalog.
+            Iterable[Item]: Generator of items whose parent is this catalog, and
+                (if recursive) all catalogs or collections connected to this catalog
+                through child links.
         """
-        return map(
-            lambda x: cast(pystac.Item, x), self.get_stac_objects(pystac.RelType.ITEM)
-        )
+        items: Iterable[Item]
+        if not recursive:
+            items = map(
+                lambda x: cast(pystac.Item, x),
+                self.get_stac_objects(pystac.RelType.ITEM),
+            )
+        else:
+            items = chain(
+                self.get_items(recursive=False),
+                *(child.get_items(recursive=True) for child in self.get_children()),
+            )
+
+        if ids:
+            return (i for i in items if i.id in ids)
+
+        return items
 
     def clear_items(self) -> None:
         """Removes all items from this catalog.
@@ -511,7 +544,13 @@ class Catalog(STACObject):
         self.links = new_links
 
     def get_all_items(self) -> Iterable[Item]:
-        """Get all items from this catalog and all subcatalogs. Will traverse
+        """
+        DEPRECATED.
+
+        .. deprecated:: 1.8
+            Use :meth:`pystac.Catalog.get_items(recursive=True)` instead.
+
+        Get all items from this catalog and all subcatalogs. Will traverse
         any subcatalogs recursively.
 
         Returns:
@@ -519,6 +558,10 @@ class Catalog(STACObject):
                 catalogs or collections connected to this catalog through
                 child links.
         """
+        warnings.warn(
+            "get_item is deprecated and will be removed in v2",
+            DeprecationWarning,
+        )
         yield from self.get_items()
         for child in self.get_children():
             yield from child.get_all_items()

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -504,9 +504,9 @@ class Catalog(STACObject):
             )
 
         if ids:
-            return (i for i in items if i.id in ids)
-
-        return items
+            yield from (i for i in items if i.id in ids)
+        else:
+            yield from items
 
     def clear_items(self) -> None:
         """Removes all items from this catalog.
@@ -562,9 +562,7 @@ class Catalog(STACObject):
             "get_item is deprecated and will be removed in v2",
             DeprecationWarning,
         )
-        yield from self.get_items()
-        for child in self.get_children():
-            yield from child.get_all_items()
+        yield from self.get_items(recursive=True)
 
     def get_item_links(self) -> List[Link]:
         """Return all item links of this catalog.

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -11,6 +11,7 @@ from typing import (
     Callable,
     Dict,
     Iterable,
+    Iterator,
     List,
     Optional,
     Tuple,
@@ -477,7 +478,7 @@ class Catalog(STACObject):
                     return item
             return None
 
-    def get_items(self, *ids: str, recursive: bool = False) -> Iterable[Item]:
+    def get_items(self, *ids: str, recursive: bool = False) -> Iterator[Item]:
         """Return all items or specific items of this catalog.
 
         Args:
@@ -487,11 +488,11 @@ class Catalog(STACObject):
                 to False.
 
         Return:
-            Iterable[Item]: Generator of items whose parent is this catalog, and
+            Iterator[Item]: Generator of items whose parent is this catalog, and
                 (if recursive) all catalogs or collections connected to this catalog
                 through child links.
         """
-        items: Iterable[Item]
+        items: Iterator[Item]
         if not recursive:
             items = map(
                 lambda x: cast(pystac.Item, x),

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -706,14 +706,7 @@ class Collection(Catalog):
         Return:
             Item or None: The item with the given ID, or None if not found.
         """
-        if not recursive:
-            return next((i for i in self.get_items() if i.id == id), None)
-        else:
-            for root, _, _ in self.walk():
-                item = root.get_item(id, recursive=False)
-                if item is not None:
-                    return item
-            return None
+        return next(self.get_items(id, recursive=recursive), None)
 
     def get_assets(
         self,

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -694,6 +694,35 @@ class Collection(Catalog):
 
         return collection
 
+    def get_item(self, id: str, recursive: Optional[bool] = None) -> Optional[Item]:
+        """Returns an item with a given ID.
+
+        Args:
+            id : The ID of the item to find.
+            recursive (deprecated) : If True, search this collection and all children
+                for the item; otherwise, only search the items of this collection.
+                Defaults to False.
+
+        Return:
+            Item or None: The item with the given ID, or None if not found.
+        """
+        if recursive is not None:
+            warnings.warn(
+                "recursive is deprecated and will be removed in v2",
+                DeprecationWarning,
+            )
+        else:
+            recursive = False
+
+        if not recursive:
+            return next((i for i in self.get_items() if i.id == id), None)
+        else:
+            for root, _, _ in self.walk():
+                item = root.get_item(id, recursive=False)
+                if item is not None:
+                    return item
+            return None
+
     def get_assets(
         self,
         media_type: Optional[Union[str, pystac.MediaType]] = None,

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -694,26 +694,18 @@ class Collection(Catalog):
 
         return collection
 
-    def get_item(self, id: str, recursive: Optional[bool] = None) -> Optional[Item]:
+    def get_item(self, id: str, recursive: bool = False) -> Optional[Item]:
         """Returns an item with a given ID.
 
         Args:
             id : The ID of the item to find.
-            recursive (deprecated) : If True, search this collection and all children
-                for the item; otherwise, only search the items of this collection.
-                Defaults to False.
+            recursive : If True, search this collection and all children for the
+                item; otherwise, only search the items of this collection. Defaults
+                to False.
 
         Return:
             Item or None: The item with the given ID, or None if not found.
         """
-        if recursive is not None:
-            warnings.warn(
-                "recursive is deprecated and will be removed in v2",
-                DeprecationWarning,
-            )
-        else:
-            recursive = False
-
         if not recursive:
             return next((i for i in self.get_items() if i.id == id), None)
         else:
@@ -764,7 +756,7 @@ class Collection(Catalog):
         """
         Update datetime and bbox based on all items to a single bbox and time window.
         """
-        self.extent = Extent.from_items(self.get_all_items())
+        self.extent = Extent.from_items(self.get_items(recursive=True))
 
     def full_copy(
         self, root: Optional["Catalog"] = None, parent: Optional["Catalog"] = None

--- a/pystac/summaries.py
+++ b/pystac/summaries.py
@@ -195,7 +195,7 @@ class Summarizer:
         """Creates summaries from items"""
         summaries = Summaries.empty()
         if isinstance(source, pystac.Collection):
-            for item in source.get_all_items():
+            for item in source.get_items(recursive=True):
                 self._update_with_item(summaries, item)
         else:
             for item in source:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,6 @@
 [metadata]
 version = attr: pystac.version.__version__
+
+[tool:pytest]
+filterwarnings =
+    error:::pystac[.*]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,3 +27,8 @@ def item() -> Item:
 @pytest.fixture
 def test_case_1_catalog() -> Catalog:
     return TestCases.case_1()
+
+
+@pytest.fixture
+def test_case_8_collection() -> Collection:
+    return TestCases.case_8()

--- a/tests/extensions/test_label.py
+++ b/tests/extensions/test_label.py
@@ -156,8 +156,9 @@ class LabelTest(unittest.TestCase):
             catalog.normalize_and_save(cat_dir, catalog_type=CatalogType.SELF_CONTAINED)
 
             cat_read = Catalog.from_file(os.path.join(cat_dir, "catalog.json"))
-            label_item_read = cat_read.get_item("area-2-2-labels", recursive=True)
-            assert label_item_read is not None
+            label_item_read = next(
+                cat_read.get_items("area-2-2-labels", recursive=True)
+            )
             label_item_read.validate()
 
     def test_read_label_item_owns_asset(self) -> None:

--- a/tests/extensions/test_label.py
+++ b/tests/extensions/test_label.py
@@ -134,7 +134,7 @@ class LabelTest(unittest.TestCase):
     def test_get_sources(self) -> None:
         cat = TestCases.case_1()
 
-        items = list(cat.get_all_items())
+        items = list(cat.get_items(recursive=True))
         item_ids = set([i.id for i in items])
 
         for li in items:
@@ -164,7 +164,7 @@ class LabelTest(unittest.TestCase):
     def test_read_label_item_owns_asset(self) -> None:
         item = next(
             x
-            for x in TestCases.case_2().get_all_items()
+            for x in TestCases.case_2().get_items(recursive=True)
             if LabelExtension.has_extension(x)
         )
         assert len(item.assets) > 0

--- a/tests/extensions/test_pointcloud.py
+++ b/tests/extensions/test_pointcloud.py
@@ -33,7 +33,7 @@ class PointcloudTest(unittest.TestCase):
         assert_to_from_dict(self, pystac.Item, d)
 
     def test_apply(self) -> None:
-        item = next(iter(TestCases.case_2().get_all_items()))
+        item = next(TestCases.case_2().get_items(recursive=True))
 
         self.assertFalse(PointcloudExtension.has_extension(item))
 

--- a/tests/extensions/test_projection.py
+++ b/tests/extensions/test_projection.py
@@ -84,7 +84,7 @@ class ProjectionTest(unittest.TestCase):
         assert_to_from_dict(self, pystac.Item, d)
 
     def test_apply(self) -> None:
-        item = next(iter(TestCases.case_2().get_all_items()))
+        item = next(TestCases.case_2().get_items(recursive=True))
         self.assertFalse(ProjectionExtension.has_extension(item))
 
         ProjectionExtension.add_to(item)

--- a/tests/extensions/test_timestamps.py
+++ b/tests/extensions/test_timestamps.py
@@ -25,7 +25,7 @@ class TimestampsTest(unittest.TestCase):
         assert_to_from_dict(self, pystac.Item, self.item_dict)
 
     def test_apply(self) -> None:
-        item = next(iter(TestCases.case_2().get_all_items()))
+        item = next(TestCases.case_2().get_items(recursive=True))
         self.assertFalse(TimestampsExtension.has_extension(item))
 
         TimestampsExtension.add_to(item)

--- a/tests/extensions/test_version.py
+++ b/tests/extensions/test_version.py
@@ -143,11 +143,8 @@ class ItemVersionExtensionTest(unittest.TestCase):
         cat = TestCases.case_1()
 
         # Fetch two items from the catalog
-        item1 = cat.get_item("area-1-1-imagery", recursive=True)
-        item2 = cat.get_item("area-2-2-imagery", recursive=True)
-
-        assert item1 is not None
-        assert item2 is not None
+        item1 = next(cat.get_items("area-1-1-imagery", recursive=True))
+        item2 = next(cat.get_items("area-2-2-imagery", recursive=True))
 
         # Enable the version extension on each, and link them
         # as if they are different versions of the same Item
@@ -161,10 +158,8 @@ class ItemVersionExtensionTest(unittest.TestCase):
         cat_copy = cat.full_copy()
 
         # Retrieve the copied version of the items
-        item1_copy = cat_copy.get_item("area-1-1-imagery", recursive=True)
-        assert item1_copy is not None
-        item2_copy = cat_copy.get_item("area-2-2-imagery", recursive=True)
-        assert item2_copy is not None
+        item1_copy = next(cat_copy.get_items("area-1-1-imagery", recursive=True))
+        item2_copy = next(cat_copy.get_items("area-2-2-imagery", recursive=True))
 
         # Check to see if the version links point to the instances of the
         # item objects as they should.

--- a/tests/extensions/test_view.py
+++ b/tests/extensions/test_view.py
@@ -20,7 +20,7 @@ class ViewTest(unittest.TestCase):
         assert_to_from_dict(self, pystac.Item, d)
 
     def test_apply(self) -> None:
-        item = next(iter(TestCases.case_2().get_all_items()))
+        item = next(TestCases.case_2().get_items(recursive=True))
         self.assertFalse(ViewExtension.has_extension(item))
 
         ViewExtension.add_to(item)

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1490,3 +1490,9 @@ def test_fully_resolve(tmp_path: Path, test_case_1_catalog: Catalog) -> None:
     test_case_1_catalog.fully_resolve()
     test_case_1_catalog.save(dest_href=str(tmp_path / "after"))
     assert len(list((tmp_path / "after").glob("**/*.json"))) == 15
+
+
+def test_get_items_with_multiple_ids(test_case_1_catalog: Catalog) -> None:
+    cat = test_case_1_catalog
+    items = cat.get_items("area-2-1-imagery", "area-1-1-labels", recursive=True)
+    assert len(list(items)) == 2

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -88,7 +88,7 @@ class TestCatalog:
             collections = catalog.get_children()
             assert len(list(collections)) == 2
 
-            items = read_catalog.get_all_items()
+            items = read_catalog.get_items(recursive=True)
 
             assert len(list(items)) == 8
 
@@ -138,7 +138,7 @@ class TestCatalog:
         )
         subcat.add_item(item)
 
-        items = list(catalog.get_all_items())
+        items = list(catalog.get_items(recursive=True))
         assert len(items) == 1
         assert items[0].properties["key"] == "one"
 
@@ -152,7 +152,7 @@ class TestCatalog:
         )
         subcat.add_item(item)
 
-        items = list(catalog.get_all_items())
+        items = list(catalog.get_items(recursive=True))
         assert len(items) == 1
         assert items[0].properties["key"] == "two"
 
@@ -166,7 +166,7 @@ class TestCatalog:
         )
         subcat.add_item(item)
 
-        items = list(catalog.get_all_items())
+        items = list(catalog.get_items(recursive=True))
         assert len(items) == 1
         assert items[0].properties["key"] == "three"
 
@@ -218,7 +218,7 @@ class TestCatalog:
 
     def test_add_child_throws_if_item(self) -> None:
         cat = TestCases.case_1()
-        item = next(iter(cat.get_all_items()))
+        item = next(cat.get_items(recursive=True))
         with pytest.raises(pystac.STACError):
             cat.add_child(item)  # type:ignore
 
@@ -244,6 +244,13 @@ class TestCatalog:
         with pytest.warns(DeprecationWarning):
             item = cat.get_item("thisshouldnotbeanitemid", recursive=True)
             assert item is None
+
+    def test_get_all_items_is_deprecated_but_still_works(self) -> None:
+        cat = TestCases.case_1()
+        with pytest.warns(DeprecationWarning):
+            all_items = cat.get_all_items()
+        items = cat.get_items(recursive=True)
+        assert all(a == i for a, i in zip(all_items, items))
 
     def test_get_items_returns_empty_generator_if_not_found(self) -> None:
         cat = TestCases.case_1()
@@ -427,7 +434,7 @@ class TestCatalog:
                 ), f"{expected_child_path} is not a file."
 
             # Check each item
-            for item in catalog.get_all_items():
+            for item in catalog.get_items(recursive=True):
                 relative_path = make_relative_href(
                     item.self_href, catalog.self_href, start_is_dir=False
                 )
@@ -553,7 +560,8 @@ class TestCatalog:
         catalog = TestCases.case_7()
 
         item_counts = {
-            cat.id: len(list(cat.get_all_items())) for cat in catalog.get_children()
+            cat.id: len(list(cat.get_items(recursive=True)))
+            for cat in catalog.get_children()
         }
 
         catalog.generate_subcatalogs("${year}/${day}")
@@ -564,7 +572,7 @@ class TestCatalog:
 
             cat2 = pystac.Catalog.from_file(os.path.join(tmp_dir, "catalog.json"))
             for child in cat2.get_children():
-                actual = len(list(child.get_all_items()))
+                actual = len(list(child.get_items(recursive=True)))
                 expected = item_counts[child.id]
                 assert actual == expected, " for child '{}'".format(child.id)
 
@@ -598,13 +606,13 @@ class TestCatalog:
         _ = catalog.generate_subcatalogs("${year}/${month}")
         catalog.normalize_hrefs("/tmp")
         expected_hrefs = {
-            item.id: item.get_self_href() for item in catalog.get_all_items()
+            item.id: item.get_self_href() for item in catalog.get_items(recursive=True)
         }
 
         result = catalog.generate_subcatalogs("${year}/${month}")
         assert len(result) == 0
         catalog.normalize_hrefs("/tmp")
-        for item in catalog.get_all_items():
+        for item in catalog.get_items(recursive=True):
             assert (
                 item.get_self_href() == expected_hrefs[item.id]
             ), " for item '{}'".format(item.id)
@@ -690,7 +698,7 @@ class TestCatalog:
         assert len(result) == 6
 
         catalog.normalize_hrefs("/")
-        for item in catalog.get_all_items():
+        for item in catalog.get_items(recursive=True):
             item_parent = item.get_parent()
             assert item_parent is not None
             parent_href = item_parent.self_href
@@ -713,10 +721,10 @@ class TestCatalog:
 
             result_cat = Catalog.from_file(os.path.join(tmp_dir, "cat", "catalog.json"))
 
-            for item in result_cat.get_all_items():
+            for item in result_cat.get_items(recursive=True):
                 assert "ITEM_MAPPER" in item.properties
 
-            for item in catalog.get_all_items():
+            for item in catalog.get_items(recursive=True):
                 assert "ITEM_MAPPER" not in item.properties
 
     def test_map_items_multiple(self) -> None:
@@ -729,7 +737,7 @@ class TestCatalog:
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             catalog = TestCases.case_1()
-            catalog_items = list(catalog.get_all_items())
+            catalog_items = list(catalog.get_items(recursive=True))
 
             new_cat = catalog.map_items(item_mapper)
 
@@ -737,7 +745,7 @@ class TestCatalog:
             new_cat.save(catalog_type=CatalogType.ABSOLUTE_PUBLISHED)
 
             result_cat = Catalog.from_file(os.path.join(tmp_dir, "cat", "catalog.json"))
-            result_items = list(result_cat.get_all_items())
+            result_items = list(result_cat.get_items(recursive=True))
 
             assert len(catalog_items) * 2 == len(result_items)
 
@@ -754,7 +762,7 @@ class TestCatalog:
 
             assert ones == twos
 
-            for item in catalog.get_all_items():
+            for item in catalog.get_items(recursive=True):
                 assert ("ITEM_MAPPER_1" not in item.properties) and (
                     "ITEM_MAPPER_2" not in item.properties
                 )
@@ -818,7 +826,7 @@ class TestCatalog:
         c = c.map_items(create_label_item)
         new_catalog = c
 
-        items = new_catalog.get_all_items()
+        items = new_catalog.get_items(recursive=True)
         assert len(list(items)) == 4
 
     def test_map_assets_single(self) -> None:
@@ -841,7 +849,7 @@ class TestCatalog:
             result_cat = Catalog.from_file(os.path.join(tmp_dir, "cat", "catalog.json"))
 
             found = False
-            for item in result_cat.get_all_items():
+            for item in result_cat.get_items(recursive=True):
                 for key, asset in item.assets.items():
                     if key == changed_asset:
                         found = True
@@ -875,7 +883,7 @@ class TestCatalog:
 
             found = False
             not_found = False
-            for item in result_cat.get_all_items():
+            for item in result_cat.get_items(recursive=True):
                 for key, asset in item.assets.items():
                     if key.replace("-modified", "") in changed_assets:
                         found = True
@@ -916,7 +924,7 @@ class TestCatalog:
             found1 = False
             found2 = False
             not_found = False
-            for item in result_cat.get_all_items():
+            for item in result_cat.get_items(recursive=True):
                 for key, asset in item.assets.items():
                     if key.replace("-mod-1", "") in changed_assets:
                         found1 = True
@@ -1086,7 +1094,7 @@ class TestCatalog:
         # Modify the datetimes
         year = 2004
         month = 2
-        for item in catalog.get_all_items():
+        for item in catalog.get_items(recursive=True):
             assert item.datetime is not None
             item.datetime = item.datetime.replace(year=year, month=month)
             year += 1
@@ -1169,7 +1177,7 @@ class TestCatalog:
 
         # Iterate over the items. This was causing failure in
         # in the later iterations as per issue #88
-        for item in cat.get_all_items():
+        for item in cat.get_items(recursive=True):
             pass
 
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -1180,7 +1188,7 @@ class TestCatalog:
             # Open the local copy and iterate over it.
             cat2 = Catalog.from_file(os.path.join(new_stac_uri, "catalog.json"))
 
-            for item in cat2.get_all_items():
+            for item in cat2.get_items(recursive=True):
                 # Iterate again over the items. This would fail in #88
                 pass
 
@@ -1201,7 +1209,7 @@ class TestCatalog:
         cat = pystac.Catalog.from_file(
             TestCases.get_path("data-files/invalid/shared-id/catalog.json")
         )
-        items = list(cat.get_all_items())
+        items = list(cat.get_items(recursive=True))
 
         assert len(items) == 1
 

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -64,7 +64,7 @@ class CollectionTest(unittest.TestCase):
 
     def test_read_eo_items_are_heritable(self) -> None:
         cat = TestCases.case_5()
-        item = next(iter(cat.get_all_items()))
+        item = next(cat.get_items(recursive=True))
 
         self.assertTrue(EOExtension.has_extension(item))
 

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -565,3 +565,22 @@ def test_get_child_sort_links_by_id_is_configurable(
     child_links = [link for link in cat1.links if link.rel == pystac.RelType.CHILD]
     for link in child_links:
         assert link.is_resolved()
+
+
+def test_get_item_returns_none_if_not_found(
+    test_case_8_collection: Collection,
+) -> None:
+    col8 = test_case_8_collection
+    item = col8.get_item("notarealitem")
+    assert item is None
+
+
+def test_get_item_is_not_recursive_by_default(
+    test_case_8_collection: Collection,
+) -> None:
+    col8 = test_case_8_collection
+    item = col8.get_item("20170831_162740_ssc1d1")
+    assert item is None
+
+    item = col8.get_item("20170831_162740_ssc1d1", recursive=True)
+    assert item is not None

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -58,7 +58,7 @@ class ItemTest(unittest.TestCase):
 
     def test_set_self_href_does_not_break_asset_hrefs(self) -> None:
         cat = TestCases.case_2()
-        for item in cat.get_all_items():
+        for item in cat.get_items(recursive=True):
             for asset in item.assets.values():
                 if is_absolute_href(asset.href):
                     asset.href = f"./{os.path.basename(asset.href)}"
@@ -68,7 +68,7 @@ class ItemTest(unittest.TestCase):
 
     def test_set_self_href_none_ignores_relative_asset_hrefs(self) -> None:
         cat = TestCases.case_2()
-        for item in cat.get_all_items():
+        for item in cat.get_items(recursive=True):
             for asset in item.assets.values():
                 if is_absolute_href(asset.href):
                     asset.href = f"./{os.path.basename(asset.href)}"
@@ -121,7 +121,7 @@ class ItemTest(unittest.TestCase):
     def test_clearing_collection(self) -> None:
         collection = TestCases.case_4().get_child("acc")
         assert isinstance(collection, pystac.Collection)
-        item = next(iter(collection.get_all_items()))
+        item = next(collection.get_items(recursive=True))
         self.assertEqual(item.collection_id, collection.id)
         item.set_collection(None)
         self.assertIsNone(item.collection_id)
@@ -245,7 +245,7 @@ class ItemTest(unittest.TestCase):
         )
 
     def test_read_eo_item_owns_asset(self) -> None:
-        item = next(iter(TestCases.case_1().get_all_items()))
+        item = next(TestCases.case_1().get_items(recursive=True))
         assert len(item.assets) > 0
         for asset_key in item.assets:
             self.assertEqual(item.assets[asset_key].owner, item)
@@ -281,7 +281,7 @@ class ItemTest(unittest.TestCase):
 
     def test_clone_preserves_assets(self) -> None:
         cat = TestCases.case_2()
-        original_item = next(iter(cat.get_all_items()))
+        original_item = next(cat.get_items(recursive=True))
         assert len(original_item.assets) > 0
         assert all(
             asset.owner is original_item for asset in original_item.assets.values()
@@ -299,7 +299,7 @@ class ItemTest(unittest.TestCase):
 
     def test_make_asset_href_relative_is_noop_on_relative_hrefs(self) -> None:
         cat = TestCases.case_2()
-        item = next(iter(cat.get_all_items()))
+        item = next(cat.get_items(recursive=True))
         asset = list(item.assets.values())[0]
         assert not is_absolute_href(asset.href)
         original_href = asset.get_absolute_href()
@@ -455,7 +455,7 @@ def test_item_from_dict_with_missing_type_raises_useful_error() -> None:
 def test_remove_hierarchical_links(
     test_case_1_catalog: Catalog, add_canonical: bool
 ) -> None:
-    item = list(test_case_1_catalog.get_all_items())[0]
+    item = next(test_case_1_catalog.get_items(recursive=True))
     item.remove_hierarchical_links(add_canonical=add_canonical)
     for link in item.links:
         assert not link.is_hierarchical()

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -82,7 +82,7 @@ class LayoutTemplateTest(unittest.TestCase):
 
         collection = TestCases.case_4().get_child("acc")
         assert collection is not None
-        item = next(iter(collection.get_all_items()))
+        item = next(collection.get_items())
         assert item.collection_id is not None
 
         parts = template.get_template_values(item)
@@ -98,7 +98,7 @@ class LayoutTemplateTest(unittest.TestCase):
 
         collection = TestCases.case_4().get_child("acc")
         assert collection is not None
-        item = next(iter(collection.get_all_items()))
+        item = next(collection.get_items())
         item.set_collection(None)
         assert item.collection_id is None
 
@@ -259,7 +259,7 @@ class CustomLayoutStrategyTest(unittest.TestCase):
     def test_produces_layout_for_item(self) -> None:
         strategy = CustomLayoutStrategy(item_func=self.get_custom_item_func())
         collection = TestCases.case_8()
-        item = next(iter(collection.get_all_items()))
+        item = next(collection.get_items(recursive=True))
         href = strategy.get_href(item, parent_dir="http://example.com")
         self.assertEqual(href, "http://example.com/item/{}.json".format(item.id))
 
@@ -271,7 +271,7 @@ class CustomLayoutStrategyTest(unittest.TestCase):
             fallback_strategy=fallback,
         )
         collection = TestCases.case_8()
-        item = next(iter(collection.get_all_items()))
+        item = next(collection.get_items(recursive=True))
         href = strategy.get_href(item, parent_dir="http://example.com")
         expected = fallback.get_href(item, parent_dir="http://example.com")
         self.assertEqual(href, expected)
@@ -352,7 +352,7 @@ class TemplateLayoutStrategyTest(unittest.TestCase):
     def test_produces_layout_for_item(self) -> None:
         strategy = TemplateLayoutStrategy(item_template=self.TEST_ITEM_TEMPLATE)
         collection = self._get_collection()
-        item = next(iter(collection.get_all_items()))
+        item = next(collection.get_items())
         href = strategy.get_href(item, parent_dir="http://example.com")
         self.assertEqual(
             href,
@@ -363,7 +363,7 @@ class TemplateLayoutStrategyTest(unittest.TestCase):
         template = "item/${collection}"
         strategy = TemplateLayoutStrategy(item_template=template)
         collection = self._get_collection()
-        item = next(iter(collection.get_all_items()))
+        item = next(collection.get_items())
         href = strategy.get_href(item, parent_dir="http://example.com")
         self.assertEqual(
             href,
@@ -378,7 +378,7 @@ class TemplateLayoutStrategyTest(unittest.TestCase):
             fallback_strategy=fallback,
         )
         collection = self._get_collection()
-        item = next(iter(collection.get_all_items()))
+        item = next(collection.get_items())
         href = strategy.get_href(item, parent_dir="http://example.com")
         expected = fallback.get_href(item, parent_dir="http://example.com")
         self.assertEqual(href, expected)
@@ -416,7 +416,7 @@ class BestPracticesLayoutStrategyTest(unittest.TestCase):
 
     def test_produces_layout_for_item(self) -> None:
         collection = TestCases.case_8()
-        item = next(iter(collection.get_all_items()))
+        item = next(collection.get_items(recursive=True))
         href = self.strategy.get_href(item, parent_dir="http://example.com")
         expected = "http://example.com/{}/{}.json".format(item.id, item.id)
         self.assertEqual(href, expected)
@@ -451,7 +451,7 @@ class AsIsLayoutStrategyTest(unittest.TestCase):
 
     def test_item(self) -> None:
         collection = TestCases.case_8()
-        item = next(iter(collection.get_all_items()))
+        item = next(collection.get_items(recursive=True))
         item.set_self_href(None)
         with self.assertRaises(ValueError):
             self.strategy.get_href(item, parent_dir="http://example.com")

--- a/tests/test_summaries.py
+++ b/tests/test_summaries.py
@@ -9,14 +9,14 @@ from tests.utils import TestCases
 class SummariesTest(unittest.TestCase):
     def test_summary(self) -> None:
         coll = TestCases.case_5()
-        summaries = Summarizer().summarize(coll.get_all_items())
+        summaries = Summarizer().summarize(coll.get_items(recursive=True))
         summaries_dict = summaries.to_dict()
         self.assertEqual(len(summaries_dict["eo:bands"]), 4)
         self.assertEqual(len(summaries_dict["proj:epsg"]), 1)
 
     def test_summary_limit(self) -> None:
         coll = TestCases.case_5()
-        summaries = Summarizer().summarize(coll.get_all_items())
+        summaries = Summarizer().summarize(coll.get_items(recursive=True))
         summaries.maxcount = 2
         summaries_dict = summaries.to_dict()
         self.assertIsNone(summaries_dict.get("eo:bands"))
@@ -25,7 +25,7 @@ class SummariesTest(unittest.TestCase):
     def test_summary_custom_fields_file(self) -> None:
         coll = TestCases.case_5()
         path = TestCases.get_path("data-files/summaries/fields_no_bands.json")
-        summaries = Summarizer(path).summarize(coll.get_all_items())
+        summaries = Summarizer(path).summarize(coll.get_items(recursive=True))
         summaries_dict = summaries.to_dict()
         self.assertIsNone(summaries_dict.get("eo:bands"))
         self.assertEqual(len(summaries_dict["proj:epsg"]), 1)
@@ -33,7 +33,7 @@ class SummariesTest(unittest.TestCase):
     def test_summary_wrong_custom_fields_file(self) -> None:
         coll = TestCases.case_5()
         with self.assertRaises(FileNotFoundError) as context:
-            Summarizer("wrong/path").summarize(coll.get_all_items())
+            Summarizer("wrong/path").summarize(coll.get_items(recursive=True))
         self.assertTrue("No such file or directory" in str(context.exception))
 
     def test_can_open_fields_file_even_with_no_nework(self) -> None:
@@ -56,12 +56,12 @@ class SummariesTest(unittest.TestCase):
 
     def test_summary_not_empty(self) -> None:
         coll = TestCases.case_5()
-        summaries = Summarizer().summarize(coll.get_all_items())
+        summaries = Summarizer().summarize(coll.get_items(recursive=True))
         self.assertFalse(summaries.is_empty())
 
     def test_clone_summary(self) -> None:
         coll = TestCases.case_5()
-        summaries = Summarizer().summarize(coll.get_all_items())
+        summaries = Summarizer().summarize(coll.get_items(recursive=True))
         summaries_dict = summaries.to_dict()
         self.assertEqual(len(summaries_dict["eo:bands"]), 4)
         self.assertEqual(len(summaries_dict["proj:epsg"]), 1)

--- a/tests/validation/test_validate.py
+++ b/tests/validation/test_validate.py
@@ -64,8 +64,7 @@ class TestValidate:
     def test_validate_error_contains_href(self) -> None:
         # Test that the exception message contains the HREF of the object if available.
         cat = TestCases.case_1()
-        item = cat.get_item("area-1-1-labels", recursive=True)
-        assert item is not None
+        item = next(cat.get_items("area-1-1-labels", recursive=True))
         assert item.get_self_href() is not None
 
         item.geometry = {"type": "INVALID"}


### PR DESCRIPTION
**Related Issue(s):**

- #585

**Description:**

Instead of using `get_all_items` people should use `get_items(recursive=True)` and instead of `Catalog.get_item(id)` people should use `next(Catalog.get_items(id), None)`

**TO DO:**

- [x] make tests fail on deprecation warnings
- [x] refactor code to not use deprecated methods
- [x] add new tests
- [x] explicitly expect warnings in specific tests
- [x] refactor examples to not use deprecated methods

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
