### PR TITLE
Allow multiple proj versions

### DIFF
--- a/pystac/extensions/base.py
+++ b/pystac/extensions/base.py
@@ -119,7 +119,7 @@ class ExtensionManagementMixin(Generic[S], ABC):
         not already present."""
         if obj.stac_extensions is None:
             obj.stac_extensions = [cls.get_schema_uri()]
-        elif cls.get_schema_uri() not in obj.stac_extensions:
+        elif cls.has_extension(obj):
             obj.stac_extensions.append(cls.get_schema_uri())
 
     @classmethod
@@ -176,7 +176,7 @@ class ExtensionManagementMixin(Generic[S], ABC):
         if add_if_missing:
             cls.add_to(obj)
 
-        if cls.get_schema_uri() not in obj.stac_extensions:
+        if not cls.has_extension(obj):
             raise pystac.ExtensionNotImplemented(
                 f"Could not find extension schema URI {cls.get_schema_uri()} in object."
             )

--- a/pystac/extensions/projection.py
+++ b/pystac/extensions/projection.py
@@ -16,6 +16,10 @@ from pystac.extensions.hooks import ExtensionHooks
 T = TypeVar("T", pystac.Item, pystac.Asset)
 
 SCHEMA_URI: str = "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+SCHEMA_URIS: List[str] = [
+    "https://stac-extensions.github.io/projection/v1.0.0/schema.json",
+    SCHEMA_URI,
+]
 PREFIX: str = "proj:"
 
 # Field names
@@ -289,6 +293,15 @@ class ProjectionExtension(
         """Returns the extended summaries object for the given collection."""
         cls.validate_has_extension(obj, add_if_missing)
         return SummariesProjectionExtension(obj)
+
+    @classmethod
+    def has_extension(cls, obj: Union[pystac.Item, pystac.Collection]) -> bool:
+        if isinstance(obj, pystac.Item) or isinstance(obj, pystac.Collection):
+            return obj.stac_extensions is not None and any(
+                uri in obj.stac_extensions for uri in SCHEMA_URIS
+            )
+        else:
+            return False
 
 
 class ItemProjectionExtension(ProjectionExtension[pystac.Item]):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,3 +32,9 @@ def test_case_1_catalog() -> Catalog:
 @pytest.fixture
 def test_case_8_collection() -> Collection:
     return TestCases.case_8()
+
+
+@pytest.fixture
+def projection_landsat8_item() -> Item:
+    path = TestCases.get_path("data-files/projection/example-landsat8.json")
+    return Item.from_file(path)

--- a/tests/extensions/test_projection.py
+++ b/tests/extensions/test_projection.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 from typing import Any, Dict
 
 import pystac
-from pystac import ExtensionTypeError
+from pystac import ExtensionTypeError, Item
 from pystac.extensions.projection import ProjectionExtension
 from pystac.utils import get_opt
 from tests.utils import TestCases, assert_to_from_dict
@@ -536,3 +536,19 @@ class ProjectionSummariesTest(unittest.TestCase):
 
         ProjectionExtension.remove_from(col)
         self.assertNotIn(ProjectionExtension.get_schema_uri(), col.stac_extensions)
+
+
+def test_older_extension_version(projection_landsat8_item: Item) -> None:
+    stac_extensions = set(projection_landsat8_item.stac_extensions)
+    stac_extensions.remove(
+        "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+    )
+    stac_extensions.add(
+        "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
+    )
+    item_as_dict = projection_landsat8_item.to_dict(
+        include_self_link=False, transform_hrefs=False
+    )
+    item_as_dict["stac_extensions"] = stac_extensions
+    item = Item.from_dict(item_as_dict)
+    assert ProjectionExtension.has_extension(item)


### PR DESCRIPTION
**Related Issue(s):**

- Bandaid that we need until we sort out #448 
- Should fix issues like https://github.com/opendatacube/odc-stac/issues/105

**Description:**

When we [updated the projection extension version](https://github.com/stac-utils/pystac/pull/989), we inadvertantly broke any downstreams that used the `ProjectionExtension` class on items w/ v1.0.0 of the extension. That was bad. This fixes that problem, and provides a pattern that we can use when we do future extension upgrades.

This really is a kludgy bandaid, but might be all that we can do until v2.

Since we have feature-adding changes on **main**, once we merge this PR, we should backport it to a v1.7 feature branch and released w/o those feature-adding changes.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
