### PR TITLE
Return deepcopy of `assets` from `get_assets`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Changed
 
 - Include a copy of the `fields.json` file (for summaries) with each distribution of PySTAC ([#1045](https://github.com/stac-utils/pystac/pull/1045))
+- Make Catalog, Collection `.get_assets()` return a deepcopy ([#1087](https://github.com/stac-utils/pystac/pull/1087))
 - Removed documentation references to `to_dict` methods returning JSON ([#1074](https://github.com/stac-utils/pystac/pull/1074))
 
 ### Deprecated

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -725,15 +725,12 @@ class Collection(Catalog):
             Dict[str, Asset]: A dictionary of assets that match ``media_type``
             and/or ``role`` if set or else all of this collection's assets.
         """
-        if media_type is None and role is None:
-            return dict(self.assets.items())
-        assets = dict()
-        for key, asset in self.assets.items():
-            if (media_type is None or asset.media_type == media_type) and (
-                role is None or asset.has_role(role)
-            ):
-                assets[key] = asset
-        return assets
+        return {
+            k: deepcopy(v)
+            for k, v in self.assets.items()
+            if (media_type is None or v.media_type == media_type)
+            and (role is None or v.has_role(role))
+        }
 
     def add_asset(self, key: str, asset: Asset) -> None:
         """Adds an Asset to this item.

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -256,15 +256,12 @@ class Item(STACObject):
             Dict[str, Asset]: A dictionary of assets that match ``media_type``
                 and/or ``role`` if set or else all of this item's assets.
         """
-        if media_type is None and role is None:
-            return dict(self.assets.items())
-        assets = dict()
-        for key, asset in self.assets.items():
-            if (media_type is None or asset.media_type == media_type) and (
-                role is None or asset.has_role(role)
-            ):
-                assets[key] = asset
-        return assets
+        return {
+            k: deepcopy(v)
+            for k, v in self.assets.items()
+            if (media_type is None or v.media_type == media_type)
+            and (role is None or v.has_role(role))
+        }
 
     def add_asset(self, key: str, asset: Asset) -> None:
         """Adds an Asset to this item.

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -246,7 +246,11 @@ class CollectionTest(unittest.TestCase):
         self.assertCountEqual(multi_filter.keys(), ["thumbnail"])
 
         no_filter = collection.get_assets()
+        self.assertIsNot(no_filter, collection.assets)
         self.assertCountEqual(no_filter.keys(), ["thumbnail"])
+        no_filter["thumbnail"].description = "foo"
+        assert collection.assets["thumbnail"].description != "foo"
+
         no_assets = collection.get_assets(media_type=pystac.MediaType.HDF)
         self.assertEqual(no_assets, {})
 

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -179,6 +179,8 @@ class ItemTest(unittest.TestCase):
             media_type=pystac.MediaType.PNG, role="thumbnail"
         )
         self.assertCountEqual(multi_filter.keys(), ["thumbnail"])
+        multi_filter["thumbnail"].description = "foo"
+        assert item.assets["thumbnail"].description != "foo"
 
         no_filter = item.get_assets()
         self.assertCountEqual(no_filter.keys(), ["analytic", "thumbnail"])


### PR DESCRIPTION
**Related Issue(s):**

- #541

**Description:**

~Instead of making a shallow copy, just return the object itself.~ Always create a new dict and deepcopy all values

I grepped around for other places where `dict` or `.copy` are used, and this was all I found

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
