### PR TITLE
 Expand support for multiple extension uris

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Include a copy of the `fields.json` file (for summaries) with each distribution of PySTAC ([#1045](https://github.com/stac-utils/pystac/pull/1045))
 - Removed documentation references to `to_dict` methods returning JSON ([#1074](https://github.com/stac-utils/pystac/pull/1074))
+- Expand support for previous extension schema URIs ([#1091](https://github.com/stac-utils/pystac/pull/1091))
 
 ### Deprecated
 

--- a/pystac/__init__.py
+++ b/pystac/__init__.py
@@ -87,10 +87,12 @@ import pystac.extensions.hooks
 import pystac.extensions.datacube
 import pystac.extensions.eo
 import pystac.extensions.file
+import pystac.extensions.grid
 import pystac.extensions.item_assets
 import pystac.extensions.label
 import pystac.extensions.pointcloud
 import pystac.extensions.projection
+import pystac.extensions.raster
 import pystac.extensions.sar
 import pystac.extensions.sat
 import pystac.extensions.scientific
@@ -105,10 +107,12 @@ EXTENSION_HOOKS = pystac.extensions.hooks.RegisteredExtensionHooks(
         pystac.extensions.datacube.DATACUBE_EXTENSION_HOOKS,
         pystac.extensions.eo.EO_EXTENSION_HOOKS,
         pystac.extensions.file.FILE_EXTENSION_HOOKS,
+        pystac.extensions.grid.GRID_EXTENSION_HOOKS,
         pystac.extensions.item_assets.ITEM_ASSETS_EXTENSION_HOOKS,
         pystac.extensions.label.LABEL_EXTENSION_HOOKS,
         pystac.extensions.pointcloud.POINTCLOUD_EXTENSION_HOOKS,
         pystac.extensions.projection.PROJECTION_EXTENSION_HOOKS,
+        pystac.extensions.raster.RASTER_EXTENSION_HOOKS,
         pystac.extensions.sar.SAR_EXTENSION_HOOKS,
         pystac.extensions.sat.SAT_EXTENSION_HOOKS,
         pystac.extensions.scientific.SCIENTIFIC_EXTENSION_HOOKS,

--- a/pystac/extensions/base.py
+++ b/pystac/extensions/base.py
@@ -113,6 +113,11 @@ class ExtensionManagementMixin(Generic[S], ABC):
         raise NotImplementedError
 
     @classmethod
+    def get_schema_uris(cls) -> List[str]:
+        """Gets a list of schema URIs associated with this extension."""
+        return [cls.get_schema_uri()]
+
+    @classmethod
     def add_to(cls, obj: S) -> None:
         """Add the schema URI for this extension to the
         :attr:`~pystac.STACObject.stac_extensions` list for the given object, if it is
@@ -135,9 +140,8 @@ class ExtensionManagementMixin(Generic[S], ABC):
     def has_extension(cls, obj: S) -> bool:
         """Check if the given object implements this extension by checking
         :attr:`pystac.STACObject.stac_extensions` for this extension's schema URI."""
-        return (
-            obj.stac_extensions is not None
-            and cls.get_schema_uri() in obj.stac_extensions
+        return obj.stac_extensions is not None and any(
+            uri in obj.stac_extensions for uri in cls.get_schema_uris()
         )
 
     @classmethod

--- a/pystac/extensions/grid.py
+++ b/pystac/extensions/grid.py
@@ -3,13 +3,17 @@
 from __future__ import annotations
 
 import re
-from typing import Any, Dict, Optional, Pattern, Set, Union
+from typing import Any, Dict, List, Optional, Pattern, Set, Union
 
 import pystac
 from pystac.extensions.base import ExtensionManagementMixin, PropertiesExtension
 from pystac.extensions.hooks import ExtensionHooks
 
 SCHEMA_URI: str = "https://stac-extensions.github.io/grid/v1.1.0/schema.json"
+SCHEMA_URIS: List[str] = [
+    "https://stac-extensions.github.io/grid/v1.0.0/schema.json",
+    SCHEMA_URI,
+]
 PREFIX: str = "grid:"
 
 # Field names
@@ -81,6 +85,10 @@ class GridExtension(
         return SCHEMA_URI
 
     @classmethod
+    def get_schema_uris(cls) -> List[str]:
+        return SCHEMA_URIS
+
+    @classmethod
     def ext(cls, obj: pystac.Item, add_if_missing: bool = False) -> GridExtension:
         """Extends the given STAC Object with properties from the :stac-ext:`Grid
         Extension <grid>`.
@@ -102,8 +110,8 @@ class GridExtension(
 
 class GridExtensionHooks(ExtensionHooks):
     schema_uri: str = SCHEMA_URI
-    prev_extension_ids: Set[str] = set()
+    prev_extension_ids: Set[str] = {*[uri for uri in SCHEMA_URIS if uri != SCHEMA_URI]}
     stac_object_types = {pystac.STACObjectType.ITEM}
 
 
-Grid_EXTENSION_HOOKS: ExtensionHooks = GridExtensionHooks()
+GRID_EXTENSION_HOOKS: ExtensionHooks = GridExtensionHooks()

--- a/pystac/extensions/label.py
+++ b/pystac/extensions/label.py
@@ -11,7 +11,10 @@ from pystac.serialization.identify import STACJSONDescription, STACVersionID
 from pystac.utils import StringEnum, get_required, map_opt
 
 SCHEMA_URI = "https://stac-extensions.github.io/label/v1.0.1/schema.json"
-
+SCHEMA_URIS = [
+    "https://stac-extensions.github.io/label/v1.0.0/schema.json",
+    SCHEMA_URI,
+]
 PREFIX = "label:"
 
 PROPERTIES_PROP = PREFIX + "properties"
@@ -692,6 +695,10 @@ class LabelExtension(ExtensionManagementMixin[Union[pystac.Item, pystac.Collecti
         return SCHEMA_URI
 
     @classmethod
+    def get_schema_uris(cls) -> List[str]:
+        return SCHEMA_URIS
+
+    @classmethod
     def ext(cls, obj: pystac.Item, add_if_missing: bool = False) -> LabelExtension:
         """Extends the given STAC Object with properties from the :stac-ext:`Label
         Extension <label>`.
@@ -791,7 +798,7 @@ class LabelExtensionHooks(ExtensionHooks):
     schema_uri: str = SCHEMA_URI
     prev_extension_ids = {
         "label",
-        "https://stac-extensions.github.io/label/v1.0.0/schema.json",
+        *[uri for uri in SCHEMA_URIS if uri != SCHEMA_URI],
     }
     stac_object_types = {pystac.STACObjectType.ITEM}
 

--- a/pystac/extensions/projection.py
+++ b/pystac/extensions/projection.py
@@ -264,6 +264,10 @@ class ProjectionExtension(
         return SCHEMA_URI
 
     @classmethod
+    def get_schema_uris(cls) -> List[str]:
+        return SCHEMA_URIS
+
+    @classmethod
     def ext(cls, obj: T, add_if_missing: bool = False) -> ProjectionExtension[T]:
         """Extends the given STAC Object with properties from the :stac-ext:`Projection
         Extension <projection>`.
@@ -293,15 +297,6 @@ class ProjectionExtension(
         """Returns the extended summaries object for the given collection."""
         cls.validate_has_extension(obj, add_if_missing)
         return SummariesProjectionExtension(obj)
-
-    @classmethod
-    def has_extension(cls, obj: Union[pystac.Item, pystac.Collection]) -> bool:
-        if isinstance(obj, pystac.Item) or isinstance(obj, pystac.Collection):
-            return obj.stac_extensions is not None and any(
-                uri in obj.stac_extensions for uri in SCHEMA_URIS
-            )
-        else:
-            return False
 
 
 class ItemProjectionExtension(ProjectionExtension[pystac.Item]):
@@ -376,7 +371,11 @@ class SummariesProjectionExtension(SummariesExtension):
 
 class ProjectionExtensionHooks(ExtensionHooks):
     schema_uri: str = SCHEMA_URI
-    prev_extension_ids = {"proj", "projection"}
+    prev_extension_ids = {
+        "proj",
+        "projection",
+        *[uri for uri in SCHEMA_URIS if uri != SCHEMA_URI],
+    }
     stac_object_types = {pystac.STACObjectType.ITEM}
 
 

--- a/pystac/extensions/raster.py
+++ b/pystac/extensions/raster.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Iterable, List, Optional, Union
+from typing import Any, Dict, Iterable, List, Optional, Set, Union
 
 import pystac
 from pystac.extensions.base import (
@@ -10,10 +10,14 @@ from pystac.extensions.base import (
     PropertiesExtension,
     SummariesExtension,
 )
+from pystac.extensions.hooks import ExtensionHooks
 from pystac.utils import StringEnum, get_opt, get_required, map_opt
 
 SCHEMA_URI = "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
-
+SCHEMA_URIS = [
+    "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+    SCHEMA_URI,
+]
 BANDS_PROP = "raster:bands"
 
 
@@ -707,6 +711,10 @@ class RasterExtension(
         return SCHEMA_URI
 
     @classmethod
+    def get_schema_uris(cls) -> List[str]:
+        return SCHEMA_URIS
+
+    @classmethod
     def ext(cls, obj: pystac.Asset, add_if_missing: bool = False) -> RasterExtension:
         """Extends the given STAC Object with properties from the :stac-ext:`Raster
         Extension <raster>`.
@@ -752,3 +760,12 @@ class SummariesRasterExtension(SummariesExtension):
     @bands.setter
     def bands(self, v: Optional[List[RasterBand]]) -> None:
         self._set_summary(BANDS_PROP, map_opt(lambda x: [b.to_dict() for b in x], v))
+
+
+class RasterExtensionHooks(ExtensionHooks):
+    schema_uri: str = SCHEMA_URI
+    prev_extension_ids: Set[str] = {*[uri for uri in SCHEMA_URIS if uri != SCHEMA_URI]}
+    stac_object_types = {pystac.STACObjectType.ITEM, pystac.STACObjectType.COLLECTION}
+
+
+RASTER_EXTENSION_HOOKS: ExtensionHooks = RasterExtensionHooks()

--- a/pystac/serialization/migrate.py
+++ b/pystac/serialization/migrate.py
@@ -188,20 +188,19 @@ def migrate_to_latest(
             # Force stac_extensions property, as it makes
             # downstream migration less complex
             result["stac_extensions"] = []
-        pystac.EXTENSION_HOOKS.migrate(result, version, info)
-
-        for ext in result["stac_extensions"][:]:
-            if ext in removed_extension_migrations:
-                object_types, migration_fn = removed_extension_migrations[ext]
-                if object_types is None or info.object_type in object_types:
-                    if migration_fn:
-                        migration_fn(result, version, info)
-                    result["stac_extensions"].remove(ext)
-
         result["stac_version"] = STACVersion.DEFAULT_STAC_VERSION
     else:
         # Ensure stac_extensions property for consistency
         if "stac_extensions" not in result:
             result["stac_extensions"] = []
+
+    pystac.EXTENSION_HOOKS.migrate(result, version, info)
+    for ext in result["stac_extensions"][:]:
+        if ext in removed_extension_migrations:
+            object_types, migration_fn = removed_extension_migrations[ext]
+            if object_types is None or info.object_type in object_types:
+                if migration_fn:
+                    migration_fn(result, version, info)
+                result["stac_extensions"].remove(ext)
 
     return result

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 # TODO move all test case code to this file
 
+from pathlib import Path
 from datetime import datetime
 
 import pytest
@@ -7,6 +8,9 @@ import pytest
 from pystac import Catalog, Collection, Item
 
 from .utils import ARBITRARY_BBOX, ARBITRARY_EXTENT, ARBITRARY_GEOM, TestCases
+
+
+here = Path(__file__).resolve().parent
 
 
 @pytest.fixture
@@ -38,3 +42,7 @@ def test_case_8_collection() -> Collection:
 def projection_landsat8_item() -> Item:
     path = TestCases.get_path("data-files/projection/example-landsat8.json")
     return Item.from_file(path)
+
+
+def get_data_file(rel_path: str) -> str:
+    return str(here / "data-files" / rel_path)

--- a/tests/extensions/test_label.py
+++ b/tests/extensions/test_label.py
@@ -20,6 +20,8 @@ from pystac.extensions.label import (
 )
 from pystac.utils import get_opt
 from tests.utils import TestCases, assert_to_from_dict
+from tests.conftest import get_data_file
+import pytest
 
 
 class LabelTypeTest(unittest.TestCase):
@@ -576,3 +578,27 @@ class LabelSummariesTest(unittest.TestCase):
             LabelExtension.ext,
             object(),
         )
+
+
+@pytest.fixture
+def ext_item() -> pystac.Item:
+    ext_item_uri = get_data_file("label/label-example-1.json")
+    return pystac.Item.from_file(ext_item_uri)
+
+
+def test_older_extension_version(ext_item: pystac.Item) -> None:
+    old = "https://stac-extensions.github.io/label/v1.0.0/schema.json"
+    new = "https://stac-extensions.github.io/label/v1.0.1/schema.json"
+
+    stac_extensions = set(ext_item.stac_extensions)
+    stac_extensions.remove(new)
+    stac_extensions.add(old)
+    item_as_dict = ext_item.to_dict(include_self_link=False, transform_hrefs=False)
+    item_as_dict["stac_extensions"] = list(stac_extensions)
+    item = pystac.Item.from_dict(item_as_dict)
+    assert LabelExtension.has_extension(item)
+    assert old in item.stac_extensions
+
+    migrated_item = pystac.Item.from_dict(item_as_dict, migrate=True)
+    assert LabelExtension.has_extension(migrated_item)
+    assert new in migrated_item.stac_extensions


### PR DESCRIPTION
**Related Issue(s):**

- #1084

**Description:**

From issue: 
> In https://github.com/stac-utils/pystac/pull/1081 we added support for older schema URIs to the `ProjectionExtension`. This behavior should be generalized so other extensions can use it easily. Ideas:
> 
> - Add `get_schema_uris()` to the base mixin
> - Refactor the base `has_extension()` to check against `get_schema_uris()` instead of `get_schema_uri()`
> - Backport any extensions that have older-but-compatible schema uris (thinking maybe `label` at least?)
> 
> This doesn't solve the problem, it's more of a band-aid -- if a newer version of an extension is incompatible with the Python structure, we don't have a mechanism to "migrate".
> 
> xref #448 which is our tracking issue for the general problem of extension versions.

I looked over the merged PRs from the last year or so to try to get a sense of which extensions had gotten updates recently. 

I also added the previous versions to the `prev_extension_ids` in the `ExtensionHooks`. This means that when the item is migrated, the extension schema uri gets updated as well. Note: It looks like there _is_ a mechanism for migrating per-extension. You can see it in `LabelExtensionHooks.migrate`

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
