### PR TITLE
Add debug logging on GET

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `*ids` to Catalog and Collection `get_items()` for only including the provided ids in the iterator ([#1075](https://github.com/stac-utils/pystac/pull/1075))
 - `recursive` to Catalog and Collection `get_items()` to walk the sub-catalogs and sub-collections ([#1075](https://github.com/stac-utils/pystac/pull/1075))
 - MGRS Extension ([#1088](https://github.com/stac-utils/pystac/pull/1088))
+- All HTTP requests are logged when level is set to `logging.DEBUG` ([#1096](https://github.com/stac-utils/pystac/pull/1096))
 
 ### Changed
 

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -273,6 +273,16 @@ It is possible provide auth headers (or any other customer headers) to the
 
   catalog = Catalog.from_file("<URI-requiring-auth>", stac_io=stac_io)
 
+You can double check that requests PySTAC is making by adjusting logging level so
+that you see all API calls.
+
+.. code-block:: python
+
+   import logging
+
+   logging.basicConfig()
+   logger = logging.getLogger('pystac')
+   logger.setLevel(logging.DEBUG)
 
 If you require more custom logic for I/O operations or would like to use a
 3rd-party library for I/O operations (e.g. ``requests``),

--- a/pystac/stac_io.py
+++ b/pystac/stac_io.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
@@ -34,6 +35,9 @@ else:
 if TYPE_CHECKING:
     from pystac.catalog import Catalog
     from pystac.stac_object import STACObject
+
+
+logger = logging.getLogger(__name__)
 
 
 class StacIO(ABC):
@@ -292,6 +296,7 @@ class DefaultStacIO(StacIO):
         href_contents: str
         if _is_url(href):
             try:
+                logger.debug(f"GET {href} Headers: {self.headers}")
                 req = Request(href, headers=self.headers)
                 with urlopen(req) as f:
                     href_contents = f.read().decode("utf-8")


### PR DESCRIPTION
**Description:**

I was running through the examples on pystac-client and came across some where you turn on logging and get to see all the requests that are being made. This seems like a nice way to increase visibility into what pystac is doing:

```python 
from pystac import Catalog

# set pystac_client logger to DEBUG to see API calls
import logging
logging.basicConfig()
logger = logging.getLogger('pystac')
logger.setLevel(logging.DEBUG)

Catalog.from_file('https://planetarycomputer.microsoft.com/api/stac/v1')
```

![image](https://user-images.githubusercontent.com/4806877/232541143-6411507d-80e0-4d0b-bd01-e8371794214f.png)


**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
