### PR TITLE
Remove duplicate self links on items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Duplicate `self` links in Items ([#1103](https://github.com/stac-utils/pystac/pull/1103))
+
 ## [v1.7.2]
 
 ### Fixed

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -6,7 +6,7 @@ from html import escape
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, TypeVar, Union, cast
 
 import pystac
-from pystac import STACError, STACObjectType
+from pystac import RelType, STACError, STACObjectType
 from pystac.asset import Asset
 from pystac.catalog import Catalog
 from pystac.collection import Collection
@@ -476,13 +476,9 @@ class Item(STACObject):
             assets={k: Asset.from_dict(v) for k, v in assets.items()},
         )
 
-        has_self_link = False
         for link in links:
-            has_self_link |= link["rel"] == pystac.RelType.SELF
-            item.add_link(Link.from_dict(link))
-
-        if not has_self_link and href is not None:
-            item.add_link(Link.self_href(href))
+            if href is None or link.get("rel", None) != RelType.SELF:
+                item.add_link(Link.from_dict(link))
 
         if root:
             item.set_root(root)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,3 +33,8 @@ def test_case_1_catalog() -> Catalog:
 def projection_landsat8_item() -> Item:
     path = TestCases.get_path("data-files/projection/example-landsat8.json")
     return Item.from_file(path)
+
+
+@pytest.fixture
+def sample_item() -> Item:
+    return Item.from_file(TestCases.get_path("data-files/item/sample-item.json"))

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -5,6 +5,7 @@ import os
 import tempfile
 import unittest
 from copy import deepcopy
+from pathlib import Path
 from typing import Any, Dict, Optional
 
 import dateutil.relativedelta
@@ -468,3 +469,12 @@ def test_geo_interface() -> None:
         item.to_dict(include_self_link=False, transform_hrefs=False)
         == item.__geo_interface__
     )
+
+
+def test_duplicate_self_links(tmp_path: Path, sample_item: pystac.Item) -> None:
+    # https://github.com/stac-utils/pystac/issues/1102
+    assert len(sample_item.get_links(rel="self")) == 1
+    path = tmp_path / "item.json"
+    sample_item.save_object(include_self_link=True, dest_href=str(path))
+    sample_item = Item.from_file(str(path))
+    assert len(sample_item.get_links(rel="self")) == 1


### PR DESCRIPTION
**Related Issue(s):**

- Fixes #1102

**Description:**

The `self` link is set in the constructor, so `from_dict` doesn't need to add the link again. This PR is against the v1.7 branch so we can use it to release a bugfix v1.7.3.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
