### PR TITLE
Release v1.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [v1.7.3]
+
 ### Fixed
 
 - Duplicate `self` links in Items ([#1103](https://github.com/stac-utils/pystac/pull/1103))
@@ -680,7 +682,8 @@ use `Band.create`
 
 Initial release.
 
-[Unreleased]: <https://github.com/stac-utils/pystac/compare/v1.7.2..main>
+[Unreleased]: <https://github.com/stac-utils/pystac/compare/v1.7.3..main>
+[v1.7.3]: <https://github.com/stac-utils/pystac/compare/v1.7.2..v1.7.3>
 [v1.7.2]: <https://github.com/stac-utils/pystac/compare/v1.7.1..v1.7.2>
 [v1.7.1]: <https://github.com/stac-utils/pystac/compare/v1.7.0..v1.7.1>
 [v1.7.0]: <https://github.com/stac-utils/pystac/compare/v1.6.1..v1.7.0>

--- a/pystac/version.py
+++ b/pystac/version.py
@@ -1,7 +1,7 @@
 import os
 from typing import Optional
 
-__version__ = "1.7.2"
+__version__ = "1.7.3"
 """Library version"""
 
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     author="stac-utils",
     author_email="stac@radiant.earth",
     url="https://github.com/stac-utils/pystac",
-    packages=find_packages(exclude=["tests*"]),
+    packages=find_packages(exclude=["tests*", "benchmarks*"]),
     package_data={"": ["py.typed", "*.jinja2"]},
     py_modules=[splitext(basename(path))[0] for path in glob("pystac/*.py")],
     python_requires=">=3.8",


### PR DESCRIPTION
**Description:**

Bugfix release to get #1103 out. Includes a small backport to fix #1085 for the 1.7 lineage. After this PR is merged, the **1.7** branch should be manually merged into main.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
