### PR TITLE
Raise error if writing to url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Removed documentation references to `to_dict` methods returning JSON ([#1074](https://github.com/stac-utils/pystac/pull/1074))
 - Expand support for previous extension schema URIs ([#1091](https://github.com/stac-utils/pystac/pull/1091))
 - Use `pyproject.toml` instead of `setup.py` ([#1100](https://github.com/stac-utils/pystac/pull/1100))
+- `DefaultStacIO` now raises an error if it tries to write to a non-local url ([#1107](https://github.com/stac-utils/pystac/pull/1107))
 
 ### Deprecated
 

--- a/pystac/stac_io.py
+++ b/pystac/stac_io.py
@@ -326,6 +326,8 @@ class DefaultStacIO(StacIO):
             href : The path to which the file will be written.
             txt : The string content to write to the file.
         """
+        if _is_url(href):
+            raise NotImplementedError("DefaultStacIO cannot write to urls")
         href = os.fspath(href)
         dirname = os.path.dirname(href)
         if dirname != "" and not os.path.isdir(dirname):

--- a/tests/test_stac_io.py
+++ b/tests/test_stac_io.py
@@ -2,6 +2,7 @@ import json
 import os
 import tempfile
 import unittest
+from pathlib import Path
 
 import pytest
 
@@ -142,3 +143,10 @@ def test_retry_stac_io_404() -> None:
             "https://planetarycomputer.microsoft.com"
             "/api/stac/v1/collections/not-a-collection-id"
         )
+
+
+def test_save_http_href_errors(tmp_path: Path) -> None:
+    catalog = pystac.Catalog(id="test-catalog", description="")
+    catalog.set_self_href("http://pystac.test/catalog.json")
+    with pytest.raises(NotImplementedError):
+        catalog.save_object()


### PR DESCRIPTION
**Related Issue(s):**

- Closes #1106 

**Description:**

This is in DefaultStacIO ... other StacIOs could support writing to urls, if they want. cc @constantinius.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
