### PR TITLE
Allow nullable `stac_extensions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Expand support for previous extension schema URIs ([#1091](https://github.com/stac-utils/pystac/pull/1091))
 - Use `pyproject.toml` instead of `setup.py` ([#1100](https://github.com/stac-utils/pystac/pull/1100))
 - `DefaultStacIO` now raises an error if it tries to write to a non-local url ([#1107](https://github.com/stac-utils/pystac/pull/1107))
+- Allow instantiation of pystac objects even with `"stac_extensions": null` ([#1109](https://github.com/stac-utils/pystac/pull/1109))
 
 ### Deprecated
 

--- a/pystac/serialization/migrate.py
+++ b/pystac/serialization/migrate.py
@@ -184,15 +184,10 @@ def migrate_to_latest(
 
     if version != STACVersion.DEFAULT_STAC_VERSION:
         object_migrations[info.object_type](result, version, info)
-        if "stac_extensions" not in result:
-            # Force stac_extensions property, as it makes
-            # downstream migration less complex
-            result["stac_extensions"] = []
         result["stac_version"] = STACVersion.DEFAULT_STAC_VERSION
-    else:
-        # Ensure stac_extensions property for consistency
-        if "stac_extensions" not in result:
-            result["stac_extensions"] = []
+
+    # Ensure stac_extensions property for consistency
+    result["stac_extensions"] = result.get("stac_extensions", None) or []
 
     pystac.EXTENSION_HOOKS.migrate(result, version, info)
     for ext in result["stac_extensions"][:]:

--- a/tests/serialization/test_migrate.py
+++ b/tests/serialization/test_migrate.py
@@ -99,3 +99,13 @@ class TestMigrate:
             match=r"^Item Assets extension does not apply to type 'object'$",
         ):
             ItemAssetsExtension.ext(object())  # type: ignore
+
+
+def test_migrate_works_even_if_stac_extensions_is_null(
+    test_case_1_catalog: pystac.Catalog,
+) -> None:
+    collection = list(test_case_1_catalog.get_all_collections())[0]
+    collection_dict = collection.to_dict()
+    collection_dict["stac_extensions"] = None
+
+    pystac.Collection.from_dict(collection_dict, migrate=True)


### PR DESCRIPTION
**Description:** I noticed recently while working on VEDA (https://staging-stac.delta-backend.com/) that if `stac_extensions` is set to null, with https://github.com/stac-utils/pystac/pull/1091 the collection can't be opened so as not to break people who might have have this mild invalidity in their catalogs. 

NOTE: I none of these collections with `stac_extensions` set to null fail validation because by the time you have created a collection from a dict and then dumped it back to a dict null has been stripped out.

**Example:**

```python
from pystac import Catalog

catalog = Catalog.from_file('https://staging-stac.delta-backend.com/')
failed = []
for c in catalog.get_collections():
    try:
        c.validate()
    except:
        failed.append(c)
```

```python-traceback
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[1], line 5
      3 catalog = Catalog.from_file('https://staging-stac.delta-backend.com/')
      4 failed = []
----> 5 for c in catalog.get_collections():
      6     try:
      7         c.validate()

File ~/pystac/pystac/stac_object.py:379, in STACObject.get_stac_objects(self, rel, typ, modify_links)
    377 link = links[i]
    378 if link.rel == rel:
--> 379     link.resolve_stac_object(root=self.get_root())
    380     if typ is None or isinstance(link.target, typ):
    381         yield cast(STACObject, link.target)

File ~/pystac/pystac/link.py:322, in Link.resolve_stac_object(self, root)
    319     if stac_io is None:
    320         stac_io = pystac.StacIO.default()
--> 322 obj = stac_io.read_stac_object(target_href, root=root)
    323 obj.set_self_href(target_href)
    324 if root is not None:

File ~/pystac/pystac/stac_io.py:236, in StacIO.read_stac_object(self, source, root, *args, **kwargs)
    216 """Read a STACObject from a JSON file at the given source.
    217 
    218 See :func:`StacIO.read_text <pystac.StacIO.read_text>` for usage of
   (...)
    233     contained in the file at the given uri.
    234 """
    235 d = self.read_json(source, *args, **kwargs)
--> 236 return self.stac_object_from_dict(
    237     d, href=source, root=root, preserve_dict=False
    238 )

File ~/pystac/pystac/stac_io.py:168, in StacIO.stac_object_from_dict(self, d, href, root, preserve_dict)
    163     merge_common_properties(
    164         d, json_href=href_str, collection_cache=collection_cache
    165     )
    167 info = identify_stac_object(d)
--> 168 d = migrate_to_latest(d, info)
    170 if info.object_type == pystac.STACObjectType.CATALOG:
    171     result = pystac.Catalog.from_dict(
    172         d, href=href_str, root=root, migrate=False, preserve_dict=preserve_dict
    173     )

File ~/pystac/pystac/serialization/migrate.py:198, in migrate_to_latest(json_dict, info)
    195         result["stac_extensions"] = []
    197 pystac.EXTENSION_HOOKS.migrate(result, version, info)
--> 198 for ext in result["stac_extensions"][:]:
    199     if ext in removed_extension_migrations:
    200         object_types, migration_fn = removed_extension_migrations[ext]

TypeError: 'NoneType' object is not subscriptable
```

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
