### PR TITLE
`Link.to_dict()` should only contain strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Use `pyproject.toml` instead of `setup.py` ([#1100](https://github.com/stac-utils/pystac/pull/1100))
 - `DefaultStacIO` now raises an error if it tries to write to a non-local url ([#1107](https://github.com/stac-utils/pystac/pull/1107))
 - Allow instantiation of pystac objects even with `"stac_extensions": null` ([#1109](https://github.com/stac-utils/pystac/pull/1109))
+- Make `Link.to_dict()` only contain strings ([#1114](https://github.com/stac-utils/pystac/pull/1114))
 
 ### Deprecated
 

--- a/pystac/link.py
+++ b/pystac/link.py
@@ -67,7 +67,7 @@ class Link(PathLike):
     """The relation of the link (e.g. 'child', 'item'). Registered rel Types are
     preferred. See :class:`~pystac.RelType` for common media types."""
 
-    media_type: Optional[str]
+    media_type: Optional[Union[str, pystac.MediaType]]
     """Optional description of the media type. Registered Media Types are preferred.
     See :class:`~pystac.MediaType` for common media types."""
 
@@ -88,7 +88,7 @@ class Link(PathLike):
         self,
         rel: Union[str, pystac.RelType],
         target: Union[str, STACObject],
-        media_type: Optional[str] = None,
+        media_type: Optional[Union[str, pystac.MediaType]] = None,
         title: Optional[str] = None,
         extra_fields: Optional[Dict[str, Any]] = None,
     ) -> None:
@@ -372,12 +372,12 @@ class Link(PathLike):
         """
 
         d: Dict[str, Any] = {
-            "rel": self.rel,
+            "rel": str(self.rel),
             "href": self.get_href(transform_href=transform_href),
         }
 
         if self.media_type is not None:
-            d["type"] = self.media_type
+            d["type"] = str(self.media_type)
 
         if self.title is not None:
             d["title"] = self.title

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -205,8 +205,8 @@ class LinkTest(unittest.TestCase):
         link = pystac.Link(pystac.RelType.SELF, href, pystac.MediaType.JSON, title)
         link_dict = link.to_dict()
 
-        self.assertEqual(str(link_dict["rel"]), "self")
-        self.assertEqual(str(link_dict["type"]), "application/json")
+        self.assertEqual(link_dict["rel"], "self")
+        self.assertEqual(link_dict["type"], "application/json")
         self.assertEqual(link_dict["title"], title)
         self.assertEqual(link_dict["href"], href)
 


### PR DESCRIPTION
**Related Issue(s):**
I know this issue is closed, but I think this PR does what the OP intended.
- #652

**Description:**

I just encountered this recently when checking how a dict roundtrips. This is what I was doing:

```python
import pystac
import requests

response = requests.get("https://staging-stac.delta-backend.com/collections/no2-monthly-diff")
collection_dict = response.json()
collection_dict["links"]
```
```python
[{'rel': 'items',
  'type': 'application/geo+json',
  'href': 'https://staging-stac.delta-backend.com/collections/no2-monthly-diff/items'},
 {'rel': 'parent',
  'type': 'application/json',
  'href': 'https://staging-stac.delta-backend.com/'},
 {'rel': 'root',
  'type': 'application/json',
  'href': 'https://staging-stac.delta-backend.com/'},
 {'rel': 'self',
  'type': 'application/json',
  'href': 'https://staging-stac.delta-backend.com/collections/no2-monthly-diff'}]
```

```python
collection = pystac.Collection.from_dict(collection_dict)
collection.validate()
collection.to_dict()["links"]
```

**Before this PR**
```python
[{'rel': 'items',
  'href': 'https://staging-stac.delta-backend.com/collections/no2-monthly-diff/items',
  'type': 'application/geo+json'},
 {'rel': 'parent',
  'href': 'https://staging-stac.delta-backend.com/',
  'type': 'application/json'},
 {'rel': <RelType.ROOT: 'root'>,
  'href': 'https://staging-stac.delta-backend.com/',
  'type': <MediaType.JSON: 'application/json'>,
  'title': 'veda-stac'},
 {'rel': 'self',
  'href': 'https://staging-stac.delta-backend.com/collections/no2-monthly-diff',
  'type': 'application/json'}]
```

**After this PR**
```python
[{'rel': 'items',
  'href': 'https://staging-stac.delta-backend.com/collections/no2-monthly-diff/items',
  'type': 'application/geo+json'},
 {'rel': 'parent',
  'href': 'https://staging-stac.delta-backend.com/',
  'type': 'application/json'},
 {'rel': 'root',
  'href': 'https://staging-stac.delta-backend.com/',
  'type': 'application/json',
  'title': 'veda-stac'},
 {'rel': 'self',
  'href': 'https://staging-stac.delta-backend.com/collections/no2-monthly-diff',
  'type': 'application/json'}]
```
**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x]  This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
