### PR TITLE
Don't override parent link when determining hrefs #1116

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@
 - Catalog `get_item()`. Use `get_items(id)` instead ([#1075](https://github.com/stac-utils/pystac/pull/1075))
 - Catalog and Collection `get_all_items`. Use `get_items(recursive=True)` instead ([#1075](https://github.com/stac-utils/pystac/pull/1075))
 
+### Fixed
+
+- If a child catalog is linked to from two parents, the creation folder depends on the parent link instead of relying on the order of add_child calls ([#1118](https://github.com/stac-utils/pystac/pull/1118))
+- Don't override an existing parent link when determining the href's ([#1118](https://github.com/stac-utils/pystac/pull/1118))
+
 ## [v1.7.3]
 
 ### Fixed

--- a/pystac/link.py
+++ b/pystac/link.py
@@ -334,7 +334,8 @@ class Link(PathLike):
             and isinstance(self.owner, pystac.Catalog)
         ):
             assert self._target_object
-            self._target_object.set_parent(self.owner)
+            if self._target_object.get_parent() is None:
+                self._target_object.set_parent(self.owner)
 
         return self
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -264,6 +264,28 @@ class TestCatalog:
         parent2.add_item(child)
         assert child.get_parent() is parent2
 
+    def test_add_child_store_at_parent_location(self) -> None:
+        root = pystac.Catalog("root", "root")
+        left = pystac.Catalog("left", "left")
+        right = pystac.Catalog("right", "right")
+
+        root.add_child(left)
+        root.add_child(right)
+
+        child = pystac.Catalog("child", "child")
+
+        left.add_child(child)
+        right.add_child(child, keep_parent=True)
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root.normalize_and_save(
+                temporary_directory, pystac.CatalogType.ABSOLUTE_PUBLISHED
+            )
+            correct_path = os.path.join(temporary_directory, "left/child/catalog.json")
+            wrong_path = os.path.join(temporary_directory, "right/child/catalog.json")
+            assert os.path.exists(correct_path)
+            assert not os.path.exists(wrong_path)
+
     def test_add_item_keep_parent(self) -> None:
         parent1 = Catalog(id="parent1", description="test1")
         parent2 = Catalog(id="parent2", description="test2")


### PR DESCRIPTION
**Related Issue(s):**

- #1116

**Description:**

Don't override parent link when determining hrefs.
Also don't set a self href when the parent set as link is not the current parent iterating over.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [ ] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
