### PR TITLE
return all validation issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Allow instantiation of pystac objects even with `"stac_extensions": null` ([#1109](https://github.com/stac-utils/pystac/pull/1109))
 - Make `Link.to_dict()` only contain strings ([#1114](https://github.com/stac-utils/pystac/pull/1114))
 - Updated raster extension to work with the item_assets extension's AssetDefinition objects ([#1110](https://github.com/stac-utils/pystac/pull/1110))
+- Return all validation errors from validation methods of `JsonSchemaSTACValidator` ([#1120](https://github.com/stac-utils/pystac/pull/1120))
 
 ### Deprecated
 

--- a/tests/validation/test_validate.py
+++ b/tests/validation/test_validate.py
@@ -58,7 +58,8 @@ class TestValidate:
                 try:
                     pystac.validation.validate_dict(stac_json)
                 except pystac.STACValidationError as e:
-                    assert isinstance(e.source, jsonschema.ValidationError)
+                    assert isinstance(e.source, list)
+                    assert isinstance(e.source[0], jsonschema.ValidationError)
                     raise e
 
     def test_validate_error_contains_href(self) -> None:


### PR DESCRIPTION
**Related Issue(s):**

- #887

**Description:**

Closes #887 by returning all issues found during validation in the source parameter of the `STACValidationError`

**PR Checklist:**

- [X] `pre-commit` hooks pass locally
- [X] Tests pass (run `scripts/test`)
- [X] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
