### PR TITLE
Fix benchmarks to build w/ pyproject.toml

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -169,4 +169,4 @@ jobs:
       - name: Set asv machine
         run: asv machine --yes
       - name: Check benchmarks
-        run: asv dev -a repeat=1 -a rounds=1 --strict
+        run: asv run -a repeat=1 -a rounds=1 --strict HEAD

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -20,5 +20,10 @@
     "benchmark_dir": "benchmarks",
     "env_dir": ".asv/env",
     "results_dir": ".asv/results",
-    "html_dir": ".asv/html"
+    "html_dir": ".asv/html",
+    "build_command": [
+        "pip install build",
+        "python -m build",
+        "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
+    ]
 }


### PR DESCRIPTION
**Related issues:**

- Closes #1121 

**Description:**

**asv** expects `setup.py` so we need to customize the build commands. We also were surprised by CI _not_ catching this problem, so updates CI to actual do builds.

No CHANGELOG entry needed IMO.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
