### PR TITLE
Always write `/`-delimited paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - All HTTP requests are logged when level is set to `logging.DEBUG` ([#1096](https://github.com/stac-utils/pystac/pull/1096))
 - `keep_parent` to Catalog `add_item` and `add_child` to avoid overriding existing parents ([#1117](https://github.com/stac-utils/pystac/pull/1117))
 - `owner` attribute to `AssetDefinition` in the item-assets extension ([#1110](https://github.com/stac-utils/pystac/pull/1110))
+- Windows `\\` path delimiters are converted to POSIX style `/` delimiters ([#1125](https://github.com/stac-utils/pystac/pull/1125))
 
 ### Changed
 

--- a/pystac/__init__.py
+++ b/pystac/__init__.py
@@ -67,7 +67,7 @@ from pystac.media_type import MediaType
 from pystac.rel_type import RelType
 from pystac.stac_io import StacIO
 from pystac.stac_object import STACObject, STACObjectType
-from pystac.link import Link, HIERARCHICAL_LINKS, HREF
+from pystac.link import Link, HIERARCHICAL_LINKS
 from pystac.catalog import Catalog, CatalogType
 from pystac.collection import (
     Collection,
@@ -81,6 +81,7 @@ from pystac.asset import Asset
 from pystac.item import Item
 from pystac.item_collection import ItemCollection
 from pystac.provider import ProviderRole, Provider
+from pystac.utils import HREF
 import pystac.validation
 
 import pystac.extensions.hooks

--- a/pystac/asset.py
+++ b/pystac/asset.py
@@ -71,7 +71,7 @@ class Asset:
         roles: Optional[List[str]] = None,
         extra_fields: Optional[Dict[str, Any]] = None,
     ) -> None:
-        self.href = href
+        self.href = utils.make_posix_style(href)
         self.title = title
         self.description = description
         self.media_type = media_type

--- a/pystac/layout.py
+++ b/pystac/layout.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import posixpath
 import warnings
 from abc import ABC, abstractmethod
 from collections import OrderedDict
@@ -7,7 +8,6 @@ from string import Formatter
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 import pystac
-from pystac.utils import JoinType, join_path_or_url, safe_urlparse
 
 if TYPE_CHECKING:
     from pystac.catalog import Catalog
@@ -426,51 +426,36 @@ class TemplateLayoutStrategy(HrefLayoutStrategy):
         self.fallback_strategy = fallback_strategy
 
     def get_catalog_href(self, cat: Catalog, parent_dir: str, is_root: bool) -> str:
-        parsed_parent_dir = safe_urlparse(parent_dir)
-        join_type = JoinType.from_parsed_uri(parsed_parent_dir)
-
         if is_root or self.catalog_template is None:
             return self.fallback_strategy.get_catalog_href(cat, parent_dir, is_root)
         else:
             template_path = self.catalog_template.substitute(cat)
             if not template_path.endswith(".json"):
-                template_path = join_path_or_url(
-                    join_type, template_path, cat.DEFAULT_FILE_NAME
-                )
+                template_path = posixpath.join(template_path, cat.DEFAULT_FILE_NAME)
 
-            return join_path_or_url(join_type, parent_dir, template_path)
+            return posixpath.join(parent_dir, template_path)
 
     def get_collection_href(
         self, col: Collection, parent_dir: str, is_root: bool
     ) -> str:
-        parsed_parent_dir = safe_urlparse(parent_dir)
-        join_type = JoinType.from_parsed_uri(parsed_parent_dir)
-
         if is_root or self.collection_template is None:
             return self.fallback_strategy.get_collection_href(col, parent_dir, is_root)
         else:
             template_path = self.collection_template.substitute(col)
             if not template_path.endswith(".json"):
-                template_path = join_path_or_url(
-                    join_type, template_path, col.DEFAULT_FILE_NAME
-                )
+                template_path = posixpath.join(template_path, col.DEFAULT_FILE_NAME)
 
-            return join_path_or_url(join_type, parent_dir, template_path)
+            return posixpath.join(parent_dir, template_path)
 
     def get_item_href(self, item: Item, parent_dir: str) -> str:
-        parsed_parent_dir = safe_urlparse(parent_dir)
-        join_type = JoinType.from_parsed_uri(parsed_parent_dir)
-
         if self.item_template is None:
             return self.fallback_strategy.get_item_href(item, parent_dir)
         else:
             template_path = self.item_template.substitute(item)
             if not template_path.endswith(".json"):
-                template_path = join_path_or_url(
-                    join_type, template_path, "{}.json".format(item.id)
-                )
+                template_path = posixpath.join(template_path, "{}.json".format(item.id))
 
-            return join_path_or_url(join_type, parent_dir, template_path)
+            return posixpath.join(parent_dir, template_path)
 
 
 class BestPracticesLayoutStrategy(HrefLayoutStrategy):
@@ -489,36 +474,27 @@ class BestPracticesLayoutStrategy(HrefLayoutStrategy):
     """
 
     def get_catalog_href(self, cat: Catalog, parent_dir: str, is_root: bool) -> str:
-        parsed_parent_dir = safe_urlparse(parent_dir)
-        join_type = JoinType.from_parsed_uri(parsed_parent_dir)
-
         if is_root:
             cat_root = parent_dir
         else:
-            cat_root = join_path_or_url(join_type, parent_dir, "{}".format(cat.id))
+            cat_root = posixpath.join(parent_dir, "{}".format(cat.id))
 
-        return join_path_or_url(join_type, cat_root, cat.DEFAULT_FILE_NAME)
+        return posixpath.join(cat_root, cat.DEFAULT_FILE_NAME)
 
     def get_collection_href(
         self, col: Collection, parent_dir: str, is_root: bool
     ) -> str:
-        parsed_parent_dir = safe_urlparse(parent_dir)
-        join_type = JoinType.from_parsed_uri(parsed_parent_dir)
-
         if is_root:
             col_root = parent_dir
         else:
-            col_root = join_path_or_url(join_type, parent_dir, "{}".format(col.id))
+            col_root = posixpath.join(parent_dir, "{}".format(col.id))
 
-        return join_path_or_url(join_type, col_root, col.DEFAULT_FILE_NAME)
+        return posixpath.join(col_root, col.DEFAULT_FILE_NAME)
 
     def get_item_href(self, item: Item, parent_dir: str) -> str:
-        parsed_parent_dir = safe_urlparse(parent_dir)
-        join_type = JoinType.from_parsed_uri(parsed_parent_dir)
+        item_root = posixpath.join(parent_dir, "{}".format(item.id))
 
-        item_root = join_path_or_url(join_type, parent_dir, "{}".format(item.id))
-
-        return join_path_or_url(join_type, item_root, "{}.json".format(item.id))
+        return posixpath.join(item_root, "{}.json".format(item.id))
 
 
 class AsIsLayoutStrategy(HrefLayoutStrategy):

--- a/pystac/link.py
+++ b/pystac/link.py
@@ -7,7 +7,13 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Type, TypeVar, Union
 
 import pystac
 from pystac.html.jinja_env import get_jinja_env
-from pystac.utils import is_absolute_href, make_absolute_href, make_relative_href
+from pystac.utils import (
+    HREF,
+    is_absolute_href,
+    make_absolute_href,
+    make_posix_style,
+    make_relative_href,
+)
 
 if TYPE_CHECKING:
     from pystac.catalog import Catalog
@@ -21,8 +27,6 @@ else:
     PathLike = os.PathLike
 
 L = TypeVar("L", bound="Link")
-
-HREF = Union[str, os.PathLike]
 
 #: Hierarchical links provide structure to STAC catalogs.
 HIERARCHICAL_LINKS = [
@@ -97,7 +101,7 @@ class Link(PathLike):
             if rel == pystac.RelType.SELF:
                 self._target_href = make_absolute_href(target)
             else:
-                self._target_href = target
+                self._target_href = make_posix_style(target)
             self._target_object = None
         else:
             self._target_href = None

--- a/pystac/stac_io.py
+++ b/pystac/stac_io.py
@@ -9,14 +9,13 @@ from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
 import pystac
-from pystac.link import HREF
 from pystac.serialization import (
     identify_stac_object,
     identify_stac_object_type,
     merge_common_properties,
     migrate_to_latest,
 )
-from pystac.utils import safe_urlparse
+from pystac.utils import HREF, safe_urlparse
 
 # Use orjson if available
 try:

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -18,7 +18,12 @@ from typing import (
 import pystac
 from pystac import STACError
 from pystac.link import Link
-from pystac.utils import StringEnum, is_absolute_href, make_absolute_href
+from pystac.utils import (
+    StringEnum,
+    is_absolute_href,
+    make_absolute_href,
+    make_posix_style,
+)
 
 if TYPE_CHECKING:
     from pystac.catalog import Catalog
@@ -563,6 +568,8 @@ class STACObject(ABC):
         if cls == STACObject:
             return cast(S, pystac.read_file(href))
 
+        href = make_posix_style(href)
+
         if stac_io is None:
             stac_io = pystac.StacIO.default()
 
@@ -571,10 +578,6 @@ class STACObject(ABC):
 
         d = stac_io.read_json(href)
         o = cls.from_dict(d, href=href, migrate=True, preserve_dict=False)
-
-        # Set the self HREF, if it's not already set to something else.
-        if o.get_self_href() is None:
-            o.set_self_href(href)
 
         # If this is a root catalog, set the root to the catalog instance.
         root_link = o.get_root_link()

--- a/tests/data-files/windows_hrefs/catalog.json
+++ b/tests/data-files/windows_hrefs/catalog.json
@@ -1,0 +1,18 @@
+{
+  "type": "Catalog",
+  "id": "test-catalaog",
+  "stac_version": "1.0.0",
+  "description": "A test catalog",
+  "links": [
+    {
+      "rel": "root",
+      "href": ".\\catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "child",
+      "href": ".\\test-collection\\collection.json",
+      "type": "application/json"
+    }
+  ]
+}

--- a/tests/data-files/windows_hrefs/test-collection/collection.json
+++ b/tests/data-files/windows_hrefs/test-collection/collection.json
@@ -1,0 +1,44 @@
+{
+  "type": "Collection",
+  "id": "test-collection",
+  "stac_version": "1.0.0",
+  "description": "A test collection",
+  "links": [
+    {
+      "rel": "root",
+      "href": "..\\catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "item",
+      "href": ".\\test-item\\test-item.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "parent",
+      "href": "..\\catalog.json",
+      "type": "application/json"
+    }
+  ],
+  "extent": {
+    "spatial": {
+      "bbox": [
+        [
+          -2.5048828125,
+          3.8916575492899987,
+          -1.9610595703125,
+          4.275202171119132
+        ]
+      ]
+    },
+    "temporal": {
+      "interval": [
+        [
+          "2023-05-11T21:35:17Z",
+          null
+        ]
+      ]
+    }
+  },
+  "license": "proprietary"
+}

--- a/tests/data-files/windows_hrefs/test-collection/test-item/test-item.json
+++ b/tests/data-files/windows_hrefs/test-collection/test-item/test-item.json
@@ -1,0 +1,66 @@
+{
+  "type": "Feature",
+  "stac_version": "1.0.0",
+  "id": "test-item",
+  "properties": {
+    "datetime": "2023-05-11T17:35:17.490116Z"
+  },
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          -2.5048828125,
+          3.8916575492899987
+        ],
+        [
+          -1.9610595703125,
+          3.8916575492899987
+        ],
+        [
+          -1.9610595703125,
+          4.275202171119132
+        ],
+        [
+          -2.5048828125,
+          4.275202171119132
+        ],
+        [
+          -2.5048828125,
+          3.8916575492899987
+        ]
+      ]
+    ]
+  },
+  "links": [
+    {
+      "rel": "root",
+      "href": "..\\..\\catalog.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "collection",
+      "href": "..\\collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "parent",
+      "href": "..\\collection.json",
+      "type": "application/json"
+    }
+  ],
+  "assets": {
+    "test-asset": {
+      "href": ".\\test-asset.txt",
+      "type": "text/plain"
+    }
+  },
+  "bbox": [
+    -2.5048828125,
+    3.8916575492899987,
+    -1.9610595703125,
+    3.8916575492899987
+  ],
+  "stac_extensions": [],
+  "collection": "test-collection"
+}

--- a/tests/posix_paths/test_posix_paths.py
+++ b/tests/posix_paths/test_posix_paths.py
@@ -1,0 +1,199 @@
+import json
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+import pystac
+from tests.conftest import get_data_file
+from tests.utils import ARBITRARY_BBOX, ARBITRARY_EXTENT, ARBITRARY_GEOM
+
+
+def check_link(link: Optional[pystac.Link]) -> None:
+    assert link is not None
+    href = link.get_target_str()
+    assert href is not None
+    assert "\\" not in href
+
+
+def test_create_item_from_absolute_posix_href() -> None:
+    absolute_href = get_data_file("item/sample-item.json")
+    absolute_posix_href = absolute_href.replace("\\", "/")
+    pystac.Item.from_file(absolute_posix_href)
+    pystac.read_file(absolute_posix_href)
+
+
+def test_create_item_from_relative_posix_href() -> None:
+    absolute_href = get_data_file("item/sample-item.json")
+    relative_href = os.path.relpath(absolute_href)
+    relative_posix_href = relative_href.replace("\\", "/")
+    pystac.Item.from_file(relative_posix_href)
+    pystac.read_file(relative_posix_href)
+
+
+def test_create_item_containing_posix_hrefs(tmp_path: Path) -> None:
+    collection = pystac.Collection(
+        "test-collection", "A test collection", ARBITRARY_EXTENT
+    )
+    item = pystac.Item("test-item", ARBITRARY_GEOM, ARBITRARY_BBOX, datetime.now(), {})
+    collection.add_item(item)
+    collection.normalize_and_save(
+        str(tmp_path), catalog_type=pystac.CatalogType.ABSOLUTE_PUBLISHED
+    )
+
+    item_href = str(tmp_path / "test-item/test-item.json")
+    item_dict = pystac.Item.from_file(item_href).to_dict()
+    for link in item_dict["links"]:
+        link["href"] = str(link["href"]).replace("\\\\", "/").replace("\\", "/")
+    with open(item_href, "w") as f:
+        json.dump(item_dict, f)
+
+    collection_href = str(tmp_path / "collection.json")
+    collection_dict = pystac.Collection.from_file(collection_href).to_dict()
+    for link in collection_dict["links"]:
+        link["href"] = str(link["href"]).replace("\\\\", "/").replace("\\", "/")
+    with open(collection_href, "w") as f:
+        json.dump(collection_dict, f)
+
+    item_href = item_href.replace("\\", "/")
+    pystac.Item.from_file(item_href)
+    pystac.read_file(item_href)
+
+    collection_href = collection_href.replace("\\", "/")
+    pystac.Collection.from_file(collection_href)
+    pystac.read_file(collection_href)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="windows only test")
+def test_posix_self_link_from_absolute_href(tmp_path: Path) -> None:
+    # Check that we convert to a windows style (\\) absolute href to posix style
+    # in the self link
+    absolute_windows_href = get_data_file("item/sample-item.json")
+    assert "\\" in absolute_windows_href
+    item = pystac.Item.from_file(absolute_windows_href)
+    check_link(item.get_single_link(rel="self"))
+    item2 = pystac.read_file(absolute_windows_href)
+    check_link(item2.get_single_link(rel="self"))
+
+    absolute_windows_href = get_data_file("collections/multi-extent.json")
+    assert "\\" in absolute_windows_href
+    collection = pystac.Collection.from_file(absolute_windows_href)
+    check_link(collection.get_single_link(rel="self"))
+    collection2 = pystac.read_file(absolute_windows_href)
+    check_link(collection2.get_single_link(rel="self"))
+
+    absolute_windows_href = get_data_file("catalogs/test-case-1/catalog.json")
+    assert "\\" in absolute_windows_href
+    catalog = pystac.Catalog.from_file(absolute_windows_href)
+    check_link(catalog.get_single_link(rel="self"))
+    catalog2 = pystac.read_file(absolute_windows_href)
+    check_link(catalog2.get_single_link(rel="self"))
+
+    # check that we retain a posix style (/) absolute href in the self link
+    absolute_windows_href = get_data_file("item/sample-item.json")
+    assert "\\" in absolute_windows_href
+    absolute_posix_href = absolute_windows_href.replace("\\", "/")
+    item = pystac.Item.from_file(absolute_posix_href)
+    check_link(item.get_single_link(rel="self"))
+    item2 = pystac.read_file(absolute_posix_href)
+    check_link(item2.get_single_link(rel="self"))
+
+    absolute_windows_href = get_data_file("collections/multi-extent.json")
+    assert "\\" in absolute_windows_href
+    absolute_posix_href = absolute_windows_href.replace("\\", "/")
+    collection = pystac.Collection.from_file(absolute_posix_href)
+    check_link(collection.get_single_link(rel="self"))
+    collection2 = pystac.read_file(absolute_posix_href)
+    check_link(collection2.get_single_link(rel="self"))
+
+    absolute_windows_href = get_data_file("collections/multi-extent.json")
+    assert "\\" in absolute_windows_href
+    absolute_posix_href = absolute_windows_href.replace("\\", "/")
+    catalog = pystac.Collection.from_file(absolute_posix_href)
+    check_link(catalog.get_single_link(rel="self"))
+    catalog2 = pystac.read_file(absolute_posix_href)
+    check_link(catalog2.get_single_link(rel="self"))
+
+
+@pytest.mark.skipif(os.name != "nt", reason="windows only test")
+def test_posix_self_link_from_relative_href(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # check that we convert a windows style (\\) relative href to posix style
+    # in the self link (which is always converted to an absolute href)
+    test_item = pystac.Item(
+        "test-item", ARBITRARY_GEOM, ARBITRARY_BBOX, datetime.now(), {}
+    )
+    (tmp_path / "subdirectory").mkdir()
+    test_item_href = str(tmp_path / "subdirectory" / "test-item.json")
+    assert "\\" in test_item_href
+    test_item.save_object(include_self_link=False, dest_href=test_item_href)
+
+    monkeypatch.chdir(tmp_path)
+    item = pystac.Item.from_file("subdirectory\\test-item.json")
+    check_link(item.get_single_link(rel="self"))
+    item2 = pystac.read_file("subdirectory\\test-item.json")
+    check_link(item2.get_single_link(rel="self"))
+
+
+def test_all_generated_links_have_posix_hrefs(tmp_path: Path) -> None:
+    asset_href = Path(tmp_path / "test-asset-file.txt")
+    asset_href.touch()
+    asset = pystac.Asset(str(asset_href), media_type=pystac.MediaType.TEXT)
+
+    item = pystac.Item("test-item", ARBITRARY_GEOM, ARBITRARY_BBOX, datetime.now(), {})
+    item.add_asset("test-asset", asset)
+
+    collection = pystac.Collection(
+        "test-collection", "A test collection", ARBITRARY_EXTENT
+    )
+    collection.add_item(item)
+    collection.normalize_hrefs(str(tmp_path))
+
+    for link in collection.links:
+        check_link(link)
+    for link in item.links:
+        check_link(link)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="windows only test")
+def test_all_existing_links_converted_to_posix_hrefs() -> None:
+    href = get_data_file("windows_hrefs/test-collection/test-item/test-item.json")
+    item = pystac.Item.from_file(href)
+    for link in item.links:
+        check_link(link)
+    with open(href, "r") as f:
+        item_dict = json.load(f)
+    item2 = pystac.Item.from_dict(item_dict)
+    for link in item2.links:
+        check_link(link)
+
+    href = get_data_file("windows_hrefs/test-collection/collection.json")
+    collection = pystac.Collection.from_file(href)
+    for link in collection.links:
+        check_link(link)
+    with open(href, "r") as f:
+        collection_dict = json.load(f)
+    collection2 = pystac.Collection.from_dict(collection_dict)
+    for link in collection2.links:
+        check_link(link)
+
+    href = get_data_file("windows_hrefs/catalog.json")
+    catalog = pystac.Catalog.from_file(href)
+    for link in catalog.links:
+        check_link(link)
+    with open(href, "r") as f:
+        catalog_dict = json.load(f)
+    catalog2 = pystac.Catalog.from_dict(catalog_dict)
+    for link in catalog2.links:
+        check_link(link)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="windows only test")
+def test_existing_asset_hrefs_converted_to_posix() -> None:
+    href = get_data_file("windows_hrefs/test-collection/test-item/test-item.json")
+    item = pystac.Item.from_file(href)
+    for asset in item.get_assets().values():
+        assert "\\" not in asset.href

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import posixpath
 import tempfile
 import unittest
 from collections import defaultdict
@@ -24,10 +25,9 @@ from pystac import (
 )
 from pystac.extensions.label import LabelClasses, LabelExtension, LabelType
 from pystac.utils import (
-    JoinType,
     is_absolute_href,
-    join_path_or_url,
     make_absolute_href,
+    make_posix_style,
     make_relative_href,
 )
 from tests.utils import ARBITRARY_BBOX, ARBITRARY_GEOM, MockStacIO, TestCases
@@ -539,7 +539,7 @@ class TestCatalog:
     def test_normalize_hrefs_makes_absolute_href(self) -> None:
         catalog = TestCases.case_1()
         catalog.normalize_hrefs("./relativepath")
-        abspath = os.path.abspath("./relativepath")
+        abspath = make_posix_style(os.path.abspath("./relativepath"))
         self_href = catalog.get_self_href()
         assert self_href is not None
         assert self_href.startswith(abspath)
@@ -763,7 +763,7 @@ class TestCatalog:
             assert item_parent is not None
             parent_href = item_parent.self_href
             path_to_parent, _ = os.path.split(parent_href)
-            subcats = [el for el in path_to_parent.split(os.sep) if el]
+            subcats = [el for el in path_to_parent.split("/") if el]
             assert len(subcats) == 2, " for item '{}'".format(item.id)
 
     def test_map_items(self) -> None:
@@ -1187,16 +1187,17 @@ class TestCatalog:
             for root, _, items in read_catalog.walk():
                 parent = root.get_parent()
                 if parent is None:
-                    assert root.get_self_href() == os.path.join(tmp_dir, "catalog.json")
+                    assert root.get_self_href() == make_posix_style(
+                        os.path.join(tmp_dir, "catalog.json")
+                    )
                 else:
                     d = os.path.dirname(parent.self_href)
-                    assert root.get_self_href() == os.path.join(
-                        d, root.id, root.DEFAULT_FILE_NAME
+                    assert root.get_self_href() == make_posix_style(
+                        os.path.join(d, root.id, root.DEFAULT_FILE_NAME)
                     )
                 for item in items:
                     assert item.datetime is not None
-                    end = join_path_or_url(
-                        JoinType.PATH,
+                    end = posixpath.join(
                         "{}-{}".format(item.datetime.year, item.datetime.month),
                         "{}.json".format(item.id),
                     )

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -14,7 +14,13 @@ import pytest
 import pystac
 import pystac.serialization.common_properties
 from pystac import Asset, Catalog, Item
-from pystac.utils import datetime_to_str, get_opt, is_absolute_href, str_to_datetime
+from pystac.utils import (
+    datetime_to_str,
+    get_opt,
+    is_absolute_href,
+    make_posix_style,
+    str_to_datetime,
+)
 from pystac.validation import validate_dict
 from tests.utils import TestCases, assert_to_from_dict
 
@@ -84,8 +90,8 @@ class ItemTest(unittest.TestCase):
         item.set_self_href(item_path)
         rel_asset = Asset("./data.geojson")
         rel_asset.set_owner(item)
-        expected_href = os.path.abspath(
-            os.path.join(os.path.dirname(item_path), "./data.geojson")
+        expected_href = make_posix_style(
+            os.path.abspath(os.path.join(os.path.dirname(item_path), "./data.geojson"))
         )
         actual_href = rel_asset.get_absolute_href()
         self.assertEqual(expected_href, actual_href)

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1,3 +1,4 @@
+import posixpath
 import unittest
 from datetime import datetime, timedelta
 from typing import Callable
@@ -11,7 +12,6 @@ from pystac.layout import (
     LayoutTemplate,
     TemplateLayoutStrategy,
 )
-from pystac.utils import JoinType, join_path_or_url
 from tests.utils import ARBITRARY_BBOX, ARBITRARY_GEOM, TestCases
 
 
@@ -186,11 +186,7 @@ class LayoutTemplateTest(unittest.TestCase):
 class CustomLayoutStrategyTest(unittest.TestCase):
     def get_custom_catalog_func(self) -> Callable[[pystac.Catalog, str, bool], str]:
         def fn(cat: pystac.Catalog, parent_dir: str, is_root: bool) -> str:
-            # Use JoinType.URL since we always use this in cases where we are using
-            # URLs
-            return join_path_or_url(
-                JoinType.URL, parent_dir, "cat/{}/{}.json".format(is_root, cat.id)
-            )
+            return posixpath.join(parent_dir, "cat/{}/{}.json".format(is_root, cat.id))
 
         return fn
 
@@ -198,21 +194,13 @@ class CustomLayoutStrategyTest(unittest.TestCase):
         self,
     ) -> Callable[[pystac.Collection, str, bool], str]:
         def fn(col: pystac.Collection, parent_dir: str, is_root: bool) -> str:
-            # Use JoinType.URL since we always use this in cases where we are using
-            # URLs
-            return join_path_or_url(
-                JoinType.URL, parent_dir, "col/{}/{}.json".format(is_root, col.id)
-            )
+            return posixpath.join(parent_dir, "col/{}/{}.json".format(is_root, col.id))
 
         return fn
 
     def get_custom_item_func(self) -> Callable[[pystac.Item, str], str]:
         def fn(item: pystac.Item, parent_dir: str) -> str:
-            # Use JoinType.URL since we always use this in cases where we are using
-            # URLs
-            return join_path_or_url(
-                JoinType.URL, parent_dir, "item/{}.json".format(item.id)
-            )
+            return posixpath.join(parent_dir, "item/{}.json".format(item.id))
 
         return fn
 

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -11,6 +11,7 @@ import pytest
 import pystac
 from pystac import Collection, Item, Link
 from pystac.link import HIERARCHICAL_LINKS
+from pystac.utils import make_posix_style
 from tests.utils.test_cases import ARBITRARY_EXTENT
 
 TEST_DATETIME: datetime = datetime(2020, 3, 14, 16, 32)
@@ -33,7 +34,7 @@ class LinkTest(unittest.TestCase):
         target = os.path.abspath("../elsewhere")
         link = pystac.Link(rel, target)
 
-        self.assertEqual(os.fspath(link), target)
+        self.assertEqual(os.fspath(link), make_posix_style(target))
 
     def test_minimal(self) -> None:
         rel = "my rel"
@@ -106,7 +107,7 @@ class LinkTest(unittest.TestCase):
             link = catalog.get_single_link(pystac.RelType.SELF)
             assert link
             link.resolve_stac_object()
-            self.assertEqual(link.get_absolute_href(), path)
+            self.assertEqual(link.get_absolute_href(), make_posix_style(path))
 
     def test_target_getter_setter(self) -> None:
         link = pystac.Link("my rel", target="./foo/bar.json")
@@ -236,7 +237,7 @@ class StaticLinkTest(unittest.TestCase):
             d2 = pystac.Link.from_dict(d).to_dict()
             self.assertEqual(d, d2)
         d = {"rel": "self", "href": "t"}
-        d2 = {"rel": "self", "href": os.path.join(os.getcwd(), "t")}
+        d2 = {"rel": "self", "href": make_posix_style(os.path.join(os.getcwd(), "t"))}
         self.assertEqual(pystac.Link.from_dict(d).to_dict(), d2)
 
     def test_from_dict_failures(self) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,5 @@
 import json
-import ntpath
 import os
-import sys
 import time
 import unittest
 from datetime import datetime, timedelta, timezone
@@ -12,20 +10,20 @@ from dateutil import tz
 
 from pystac import utils
 from pystac.utils import (
+    JoinType,
     is_absolute_href,
+    join_path_or_url,
     make_absolute_href,
     make_relative_href,
     now_in_utc,
     now_to_rfc3339_str,
+    safe_urlparse,
     str_to_datetime,
 )
 from tests.utils import TestCases
 
 
 class UtilsTest(unittest.TestCase):
-    @unittest.skipIf(
-        sys.platform in ("win32", "cygwin"), reason="Paths are specific to posix"
-    )
     def test_make_relative_href(self) -> None:
         # Test cases of (source_href, start_href, expected)
         test_cases = [
@@ -84,63 +82,56 @@ class UtilsTest(unittest.TestCase):
             self.assertEqual(actual, expected)
 
     def test_make_relative_href_windows(self) -> None:
-        utils._pathlib = ntpath
-        try:
-            # Test cases of (source_href, start_href, expected)
-            test_cases = [
-                (
-                    "C:\\a\\b\\c\\d\\catalog.json",
-                    "C:\\a\\b\\c\\catalog.json",
-                    ".\\d\\catalog.json",
-                ),
-                (
-                    "C:\\a\\b\\catalog.json",
-                    "C:\\a\\b\\c\\catalog.json",
-                    "..\\catalog.json",
-                ),
-                (
-                    "C:\\a\\catalog.json",
-                    "C:\\a\\b\\c\\catalog.json",
-                    "..\\..\\catalog.json",
-                ),
-                ("a\\b\\c\\catalog.json", "a\\b\\catalog.json", ".\\c\\catalog.json"),
-                ("a\\b\\catalog.json", "a\\b\\c\\catalog.json", "..\\catalog.json"),
-                (
-                    "http://stacspec.org/a/b/c/d/catalog.json",
-                    "http://stacspec.org/a/b/c/catalog.json",
-                    "./d/catalog.json",
-                ),
-                (
-                    "http://stacspec.org/a/b/catalog.json",
-                    "http://stacspec.org/a/b/c/catalog.json",
-                    "../catalog.json",
-                ),
-                (
-                    "http://stacspec.org/a/catalog.json",
-                    "http://stacspec.org/a/b/c/catalog.json",
-                    "../../catalog.json",
-                ),
-                (
-                    "http://stacspec.org/a/catalog.json",
-                    "http://cogeo.org/a/b/c/catalog.json",
-                    "http://stacspec.org/a/catalog.json",
-                ),
-                (
-                    "http://stacspec.org/a/catalog.json",
-                    "https://stacspec.org/a/b/c/catalog.json",
-                    "http://stacspec.org/a/catalog.json",
-                ),
-            ]
+        # Test cases of (source_href, start_href, expected)
+        test_cases = [
+            (
+                "C:\\a\\b\\c\\d\\catalog.json",
+                "C:\\a\\b\\c\\catalog.json",
+                "./d/catalog.json",
+            ),
+            (
+                "C:\\a\\b\\catalog.json",
+                "C:\\a\\b\\c\\catalog.json",
+                "../catalog.json",
+            ),
+            (
+                "C:\\a\\catalog.json",
+                "C:\\a\\b\\c\\catalog.json",
+                "../../catalog.json",
+            ),
+            ("a\\b\\c\\catalog.json", "a\\b\\catalog.json", "./c/catalog.json"),
+            ("a\\b\\catalog.json", "a\\b\\c\\catalog.json", "../catalog.json"),
+            (
+                "http://stacspec.org/a/b/c/d/catalog.json",
+                "http://stacspec.org/a/b/c/catalog.json",
+                "./d/catalog.json",
+            ),
+            (
+                "http://stacspec.org/a/b/catalog.json",
+                "http://stacspec.org/a/b/c/catalog.json",
+                "../catalog.json",
+            ),
+            (
+                "http://stacspec.org/a/catalog.json",
+                "http://stacspec.org/a/b/c/catalog.json",
+                "../../catalog.json",
+            ),
+            (
+                "http://stacspec.org/a/catalog.json",
+                "http://cogeo.org/a/b/c/catalog.json",
+                "http://stacspec.org/a/catalog.json",
+            ),
+            (
+                "http://stacspec.org/a/catalog.json",
+                "https://stacspec.org/a/b/c/catalog.json",
+                "http://stacspec.org/a/catalog.json",
+            ),
+        ]
 
-            for source_href, start_href, expected in test_cases:
-                actual = make_relative_href(source_href, start_href)
-                self.assertEqual(actual, expected)
-        finally:
-            utils._pathlib = os.path
+        for source_href, start_href, expected in test_cases:
+            actual = make_relative_href(source_href, start_href)
+            self.assertEqual(actual, expected)
 
-    @unittest.skipIf(
-        sys.platform in ("win32", "cygwin"), reason="Paths are specific to posix"
-    )
     def test_make_absolute_href(self) -> None:
         # Test cases of (source_href, start_href, expected)
         test_cases = [
@@ -173,11 +164,9 @@ class UtilsTest(unittest.TestCase):
 
         for source_href, start_href, expected in test_cases:
             actual = make_absolute_href(source_href, start_href)
+            _, actual = os.path.splitdrive(actual)
             self.assertEqual(actual, expected)
 
-    @unittest.skipIf(
-        sys.platform in ("win32", "cygwin"), reason="Paths are specific to posix"
-    )
     def test_make_absolute_href_on_vsitar(self) -> None:
         rel_path = "some/item.json"
         cat_path = "/vsitar//tmp/catalog.tar/catalog.json"
@@ -185,46 +174,43 @@ class UtilsTest(unittest.TestCase):
 
         self.assertEqual(expected, make_absolute_href(rel_path, cat_path))
 
+    @pytest.mark.skipif(os.name != "nt", reason="Windows only test")
     def test_make_absolute_href_windows(self) -> None:
-        utils._pathlib = ntpath
-        try:
-            # Test cases of (source_href, start_href, expected)
-            test_cases = [
-                ("item.json", "C:\\a\\b\\c\\catalog.json", "C:\\a\\b\\c\\item.json"),
-                (".\\item.json", "C:\\a\\b\\c\\catalog.json", "C:\\a\\b\\c\\item.json"),
-                (
-                    ".\\z\\item.json",
-                    "Z:\\a\\b\\c\\catalog.json",
-                    "Z:\\a\\b\\c\\z\\item.json",
-                ),
-                ("..\\item.json", "a:\\a\\b\\c\\catalog.json", "a:\\a\\b\\item.json"),
-                (
-                    "item.json",
-                    "HTTPS://stacspec.org/a/b/c/catalog.json",
-                    "https://stacspec.org/a/b/c/item.json",
-                ),
-                (
-                    "./item.json",
-                    "https://stacspec.org/a/b/c/catalog.json",
-                    "https://stacspec.org/a/b/c/item.json",
-                ),
-                (
-                    "./z/item.json",
-                    "https://stacspec.org/a/b/c/catalog.json",
-                    "https://stacspec.org/a/b/c/z/item.json",
-                ),
-                (
-                    "../item.json",
-                    "https://stacspec.org/a/b/c/catalog.json",
-                    "https://stacspec.org/a/b/item.json",
-                ),
-            ]
+        # Test cases of (source_href, start_href, expected)
+        test_cases = [
+            ("item.json", "C:\\a\\b\\c\\catalog.json", "C:/a/b/c/item.json"),
+            (".\\item.json", "C:\\a\\b\\c\\catalog.json", "C:/a/b/c/item.json"),
+            (
+                ".\\z\\item.json",
+                "Z:\\a\\b\\c\\catalog.json",
+                "Z:/a/b/c/z/item.json",
+            ),
+            ("..\\item.json", "a:\\a\\b\\c\\catalog.json", "a:/a/b/item.json"),
+            (
+                "item.json",
+                "HTTPS://stacspec.org/a/b/c/catalog.json",
+                "https://stacspec.org/a/b/c/item.json",
+            ),
+            (
+                "./item.json",
+                "https://stacspec.org/a/b/c/catalog.json",
+                "https://stacspec.org/a/b/c/item.json",
+            ),
+            (
+                "./z/item.json",
+                "https://stacspec.org/a/b/c/catalog.json",
+                "https://stacspec.org/a/b/c/z/item.json",
+            ),
+            (
+                "../item.json",
+                "https://stacspec.org/a/b/c/catalog.json",
+                "https://stacspec.org/a/b/item.json",
+            ),
+        ]
 
-            for source_href, start_href, expected in test_cases:
-                actual = make_absolute_href(source_href, start_href)
-                self.assertEqual(actual, expected)
-        finally:
-            utils._pathlib = os.path
+        for source_href, start_href, expected in test_cases:
+            actual = make_absolute_href(source_href, start_href)
+            self.assertEqual(actual, expected)
 
     def test_is_absolute_href(self) -> None:
         # Test cases of (href, expected)
@@ -240,23 +226,20 @@ class UtilsTest(unittest.TestCase):
             actual = is_absolute_href(href)
             self.assertEqual(actual, expected)
 
+    @pytest.mark.skipif(os.name != "nt", reason="Windows only test")
     def test_is_absolute_href_windows(self) -> None:
-        utils._pathlib = ntpath
-        try:
-            # Test cases of (href, expected)
-            test_cases = [
-                ("item.json", False),
-                (".\\item.json", False),
-                ("..\\item.json", False),
-                ("c:\\item.json", True),
-                ("http://stacspec.org/item.json", True),
-            ]
+        # Test cases of (href, expected)
+        test_cases = [
+            ("item.json", False),
+            (".\\item.json", False),
+            ("..\\item.json", False),
+            ("c:\\item.json", True),
+            ("http://stacspec.org/item.json", True),
+        ]
 
-            for href, expected in test_cases:
-                actual = is_absolute_href(href)
-                self.assertEqual(actual, expected)
-        finally:
-            utils._pathlib = os.path
+        for href, expected in test_cases:
+            actual = is_absolute_href(href)
+            self.assertEqual(actual, expected)
 
     def test_datetime_to_str(self) -> None:
         cases = (
@@ -428,3 +411,37 @@ def test_now_functions() -> None:
     assert now1.tzinfo == timezone.utc
 
     assert str_to_datetime(now_to_rfc3339_str())
+
+
+@pytest.mark.parametrize(
+    "test_href,expected",
+    [
+        ("https://some/address/page.html", JoinType.URL),
+        ("C:\\some\\windows\\path\\file.json", JoinType.PATH),
+        ("some\\windows\\path\\file.json", JoinType.PATH),
+        (".\\some\\windows\\path\\file.json", JoinType.PATH),
+        ("C:/some/windows/path/file.json", JoinType.PATH),
+        ("/some/posix/path/file.json", JoinType.PATH),
+        ("./some/posix/path/file.json", JoinType.PATH),
+        ("posix/path/file.json", JoinType.PATH),
+    ],
+)
+def test_join_type(test_href: str, expected: JoinType) -> None:
+    parsed = safe_urlparse(test_href)
+    with pytest.warns(DeprecationWarning):
+        assert JoinType.from_parsed_uri(parsed) == expected
+
+
+def test_join_path_or_url() -> None:
+    path_args = ["some", "path", "file.json"]
+    with pytest.warns(DeprecationWarning):
+        joined_path = join_path_or_url(JoinType.PATH, *path_args)
+    if os.name != "nt":
+        assert joined_path == "some/path/file.json"
+    else:
+        assert joined_path == "some\\path\\file.json"
+
+    url_args = ["https://some", "page", "file.html"]
+    with pytest.warns(DeprecationWarning):
+        joined_url = join_path_or_url(JoinType.URL, *url_args)
+    assert joined_url == "https://some/page/file.html"

--- a/tests/utils/stac_io_mock.py
+++ b/tests/utils/stac_io_mock.py
@@ -3,8 +3,8 @@ from typing import Any, AnyStr, Optional, Union
 from unittest.mock import Mock
 
 import pystac
-from pystac.link import HREF
 from pystac.stac_io import DefaultStacIO, StacIO
+from pystac.utils import HREF
 
 
 class MockStacIO(pystac.StacIO):


### PR DESCRIPTION
**Related Issue(s):**

- Closes #619 
- Closes #215 

**Description:**

- Link and asset HREFs are now always written with POSIX-style (`/`) delimiters whether on a POSIX or Windows system. This better aligns with the STAC specification (see [Matthias's comment](https://github.com/stac-utils/pystac/issues/619#issuecomment-1017926035)). 
- Addresses #215 by removing `_pathlib = os.path` from `utils.py`. Monkey patching `os.path` to behave as if on a Windows machine for testing is no longer needed since the full suite of tests now runs on Windows in CI.

Notes:
- Even though it is no longer used, I left the `JoinType` class and the associated `join_path_or_url` function in `utils.py` since users may be relying on them for other purposes. However, I also marked them as deprecated for eventual removal.
- I added a small utility function `make_posix_style` that converts windows path `\\` and `\` delimiters to `/` delimiters using string manipulation. I endeavored to use it sparingly.
    - Note that when on a Windows machine, both `ntpath.abspath` and `posixpath.abspath` will return a path containing `\\` delimiters. All calls to `os.path.abspath` are therefore wrapped in `make_posix_style`.
- `posixpath.relpath` doesn't play well with Windows drive letters, so we continue to use `os.path.relpath` (which will use `ntpath.relpath` on Windows machines) and accept the fact that existing STAC containing Windows paths should only be manipulated on Windows machines.

**Performance:**

- **POSIX:** Running `./scripts/bench` is flaky on WSL on a Windows machine. Sometimes I get `PERFORMANCE INCREASED` for certain benchmarks, other times decreased. On a Mac, the result is consistently `BENCHMARKS NOT SIGNIFICANTLY CHANGED`.
- **Windows:** Looks good, benchmark script command reports `BENCHMARKS NOT SIGNIFICANTLY CHANGED`.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
