### PR TITLE
Ruff import sorting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
         language: system
         stages: [commit]
         types: [python]
+        args: [--fix, --exit-non-zero-on-fix]
 
       - id: black
         name: black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,10 @@ exclude = ["tests*", "benchmarks*"]
 [tool.setuptools.dynamic]
 version = { attr = "pystac.version.__version__" }
 
+[tool.ruff]
+line-length = 88
+select = ["E", "F", "I"]
+
 [tool.pytest]
 filterwarnings = "error:::pystac[.*]"
 

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from itertools import chain
-import warnings
 import os
+import warnings
 from copy import deepcopy
 from html import escape
+from itertools import chain
 from typing import (
     TYPE_CHECKING,
     Any,

--- a/pystac/extensions/raster.py
+++ b/pystac/extensions/raster.py
@@ -16,13 +16,13 @@ from typing import (
 )
 
 import pystac
+import pystac.extensions.item_assets as item_assets
 from pystac.extensions.base import (
     ExtensionManagementMixin,
     PropertiesExtension,
     SummariesExtension,
 )
 from pystac.extensions.hooks import ExtensionHooks
-import pystac.extensions.item_assets as item_assets
 from pystac.utils import StringEnum, get_opt, get_required, map_opt
 
 T = TypeVar("T", pystac.Asset, item_assets.AssetDefinition)

--- a/tests/extensions/test_grid.py
+++ b/tests/extensions/test_grid.py
@@ -7,12 +7,13 @@ from datetime import datetime
 from typing import Any, Dict
 
 import pytest
+
 import pystac
 from pystac import ExtensionTypeError
 from pystac.extensions import grid
 from pystac.extensions.grid import GridExtension
-from tests.utils import TestCases
 from tests.conftest import get_data_file
+from tests.utils import TestCases
 
 code = "MGRS-4CFJ"
 

--- a/tests/extensions/test_label.py
+++ b/tests/extensions/test_label.py
@@ -4,6 +4,8 @@ import tempfile
 import unittest
 from typing import List, Union
 
+import pytest
+
 import pystac
 import pystac.validation
 from pystac import Catalog, CatalogType, Collection, ExtensionTypeError, Item
@@ -19,9 +21,8 @@ from pystac.extensions.label import (
     LabelType,
 )
 from pystac.utils import get_opt
-from tests.utils import TestCases, assert_to_from_dict
 from tests.conftest import get_data_file
-import pytest
+from tests.utils import TestCases, assert_to_from_dict
 
 
 class LabelTypeTest(unittest.TestCase):

--- a/tests/extensions/test_mgrs.py
+++ b/tests/extensions/test_mgrs.py
@@ -1,10 +1,10 @@
 """Tests for pystac.tests.extensions.mgrs"""
 import json
+
 import pytest
+
 import pystac
 from pystac.extensions.mgrs import MgrsExtension
-
-
 from tests.conftest import get_data_file
 
 

--- a/tests/extensions/test_raster.py
+++ b/tests/extensions/test_raster.py
@@ -2,6 +2,7 @@ import json
 import unittest
 
 import pytest
+
 import pystac
 from pystac import ExtensionTypeError, Item
 from pystac.extensions.item_assets import ItemAssetsExtension
@@ -15,8 +16,8 @@ from pystac.extensions.raster import (
     Statistics,
 )
 from pystac.utils import get_opt
-from tests.utils import TestCases, assert_to_from_dict
 from tests.conftest import get_data_file
+from tests.utils import TestCases, assert_to_from_dict
 
 
 class RasterTest(unittest.TestCase):


### PR DESCRIPTION
**Related Issue(s):**

- Closes #1119 

**Description:**
Enables and applies Ruff's import sorting feature

**PR Checklist:**

- [X] `pre-commit` hooks pass locally
- [X] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [X] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
