### PR TITLE
Add `get/add/remove_derived_from` to  pystac.Item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Windows `\\` path delimiters are converted to POSIX style `/` delimiters ([#1125](https://github.com/stac-utils/pystac/pull/1125))
 - Updated raster extension to work with the item_assets extension's AssetDefinition objects ([#1110](https://github.com/stac-utils/pystac/pull/1110))
 - Classification extension ([#1093](https://github.com/stac-utils/pystac/pull/1093)), with support for adding classification information to item_assets' `AssetDefinition`s and raster's `RasterBand` objects.
-- `get_derived_from` and `set_derived_from` to Items ([#1136](https://github.com/stac-utils/pystac/pull/1136))
+- `get_derived_from`, `add_derived_from` and `remove_derived_from` to Items ([#1136](https://github.com/stac-utils/pystac/pull/1136))
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Windows `\\` path delimiters are converted to POSIX style `/` delimiters ([#1125](https://github.com/stac-utils/pystac/pull/1125))
 - Updated raster extension to work with the item_assets extension's AssetDefinition objects ([#1110](https://github.com/stac-utils/pystac/pull/1110))
 - Classification extension ([#1093](https://github.com/stac-utils/pystac/pull/1093)), with support for adding classification information to item_assets' `AssetDefinition`s and raster's `RasterBand` objects.
+- `get_derived_from` and `set_derived_from` to Items ([#1136](https://github.com/stac-utils/pystac/pull/1136))
 
 ### Changed
 

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -352,6 +352,36 @@ class Item(STACObject):
         else:
             return cast(Collection, collection_link.resolve_stac_object().target)
 
+    def set_derived_from(self, item: Optional[Item]) -> Item:
+        """Set the item that this is derived from.
+
+        This method will replace any existing "derived_from" link.
+
+        Args:
+            item : The item to set as this
+                item's derived_from link. If None, will clear derived_from.
+
+        Returns:
+            Item: self
+        """
+        self.remove_links(pystac.RelType.DERIVED_FROM)
+        if item is not None:
+            self.add_link(Link.derived_from(item))
+        return self
+
+    def get_derived_from(self) -> Optional[Item]:
+        """Gets the item that this is derived_from if one exists.
+
+        Returns:
+            Item or None: If this item is derived from an item, returns
+            a reference to the item. Otherwise returns None.
+        """
+        item_link = self.get_single_link(pystac.RelType.DERIVED_FROM)
+        if item_link is None:
+            return None
+        else:
+            return cast(Item, item_link.resolve_stac_object().target)
+
     def to_dict(
         self, include_self_link: bool = True, transform_hrefs: bool = True
     ) -> Dict[str, Any]:

--- a/pystac/link.py
+++ b/pystac/link.py
@@ -472,7 +472,9 @@ class Link(PathLike):
         )
 
     @classmethod
-    def derived_from(cls: Type[L], item: Item, title: Optional[str] = None) -> L:
+    def derived_from(
+        cls: Type[L], item: Union[Item, str], title: Optional[str] = None
+    ) -> L:
         """Creates a link to a derived_from Item."""
         return cls(
             pystac.RelType.DERIVED_FROM,

--- a/pystac/link.py
+++ b/pystac/link.py
@@ -472,6 +472,16 @@ class Link(PathLike):
         )
 
     @classmethod
+    def derived_from(cls: Type[L], item: Item, title: Optional[str] = None) -> L:
+        """Creates a link to a derived_from Item."""
+        return cls(
+            pystac.RelType.DERIVED_FROM,
+            item,
+            title=title,
+            media_type=pystac.MediaType.JSON,
+        )
+
+    @classmethod
     def canonical(
         cls: Type[L],
         item_or_collection: Union[Item, Collection],

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -490,34 +490,37 @@ def test_duplicate_self_links(tmp_path: Path, sample_item: pystac.Item) -> None:
 
 def test_get_derived_from_when_none_exists(test_case_1_catalog: Catalog) -> None:
     item = next(test_case_1_catalog.get_items(recursive=True))
-    assert item.get_derived_from() is None
+    assert item.get_derived_from() == []
     for link in item.links:
         assert link.rel != pystac.RelType.DERIVED_FROM
     assert item.get_single_link(pystac.RelType.DERIVED_FROM) is None
 
 
-def test_set_derived_from(test_case_1_catalog: Catalog) -> None:
+def test_add_derived_from(test_case_1_catalog: Catalog) -> None:
     items = list(test_case_1_catalog.get_items(recursive=True))
     item_0 = items[0]
     item_1 = items[1]
-    item_0.set_derived_from(item_1)
+    item_2 = items[2]
+    item_0.add_derived_from(item_1, item_2)
     derived_from = item_0.get_derived_from()
-    assert derived_from is not None
-    assert derived_from.id == item_1.id
+    assert len(derived_from) == 2
+    assert derived_from[0].id == item_1.id
+    assert derived_from[1].id == item_2.id
     filtered = [
         link for link in item_0.links if link.rel == pystac.RelType.DERIVED_FROM
     ]
-    assert len(filtered) == 1
+    assert len(filtered) == 2
     assert filtered[0].to_dict()["href"] == item_1.self_href
+    assert filtered[1].to_dict()["href"] == item_2.self_href
 
 
-def test_set_derived_from_to_none(test_case_1_catalog: Catalog) -> None:
+def test_remove_derived_from(test_case_1_catalog: Catalog) -> None:
     items = list(test_case_1_catalog.get_items(recursive=True))
     item_0 = items[0]
     item_1 = items[1]
-    item_0.set_derived_from(item_1)
-    item_0.set_derived_from(None)
-    assert item_0.get_derived_from() is None
+    item_0.add_derived_from(item_1)
+    item_0.remove_derived_from(item_1.id)
+    assert item_0.get_derived_from() == []
     for link in item_0.links:
         assert link.rel != pystac.RelType.DERIVED_FROM
     assert item_0.get_single_link(pystac.RelType.DERIVED_FROM) is None

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -501,7 +501,7 @@ def test_add_derived_from(test_case_1_catalog: Catalog) -> None:
     item_0 = items[0]
     item_1 = items[1]
     item_2 = items[2]
-    item_0.add_derived_from(item_1, item_2)
+    item_0.add_derived_from(item_1, item_2.self_href)
     derived_from = item_0.get_derived_from()
     assert len(derived_from) == 2
     assert derived_from[0].id == item_1.id
@@ -512,6 +512,30 @@ def test_add_derived_from(test_case_1_catalog: Catalog) -> None:
     assert len(filtered) == 2
     assert filtered[0].to_dict()["href"] == item_1.self_href
     assert filtered[1].to_dict()["href"] == item_2.self_href
+
+
+def test_get_unresolvable_derived_from(test_case_1_catalog: Catalog) -> None:
+    item = next(test_case_1_catalog.get_items(recursive=True))
+    item.add_derived_from("foo")
+    with pytest.raises(
+        pystac.STACError, match="Link failed to resolve. Use get_links instead"
+    ):
+        item.get_derived_from()
+
+    links = item.get_links(pystac.RelType.DERIVED_FROM)
+    assert len(links) == 1
+
+
+def test_remove_unresolvable_derived_from(test_case_1_catalog: Catalog) -> None:
+    item = next(test_case_1_catalog.get_items(recursive=True))
+    item.add_derived_from("foo")
+    with pytest.raises(
+        pystac.STACError, match="Link failed to resolve. Use remove_links instead"
+    ):
+        item.remove_derived_from("foo")
+
+    item.remove_links(pystac.RelType.DERIVED_FROM)
+    assert item.get_derived_from() == []
 
 
 def test_remove_derived_from(test_case_1_catalog: Catalog) -> None:


### PR DESCRIPTION
**Related Issue(s):**

- #283

**Description:**

Add `get_derived_from` and `set_derived_from` to  pystac.Item

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
