### PR TITLE
Unclutter autodoc slightly

### DIFF
--- a/docs/api/extensions.rst
+++ b/docs/api/extensions.rst
@@ -7,3 +7,28 @@ pystac.extensions
     :glob:
 
     extensions/*
+
+
+.. currentmodule:: pystac.extensions
+
+.. autosummary::
+
+    datacube.DatacubeExtension
+    classification.ClassificationExtension
+    eo.EOExtension
+    file.FileExtension
+    grid.GridExtension
+    item_assets.ItemAssetsExtension
+    label.LabelExtension
+    mgrs.MgrsExtension
+    pointcloud.PointcloudExtension
+    projection.ProjectionExtension
+    raster.RasterExtension
+    sar.SarExtension
+    sat.SatExtension
+    scientific.ScientificExtension
+    storage.StorageExtension
+    table.TableExtension
+    timestamps.TimestampsExtension
+    version.VersionExtension
+    view.ViewExtension

--- a/docs/api/extensions/base.rst
+++ b/docs/api/extensions/base.rst
@@ -4,4 +4,3 @@ pytac.extensions.base
 .. automodule:: pystac.extensions.base
    :members:
    :undoc-members:
-   :show-inheritance:

--- a/docs/api/extensions/classification.rst
+++ b/docs/api/extensions/classification.rst
@@ -1,0 +1,6 @@
+pytac.extensions.classification
+===============================
+
+.. automodule:: pystac.extensions.classification
+   :members:
+   :undoc-members:

--- a/docs/api/extensions/datacube.rst
+++ b/docs/api/extensions/datacube.rst
@@ -4,4 +4,6 @@ pystac.extensions.datacube
 .. automodule:: pystac.extensions.datacube
    :members:
    :undoc-members:
-   :show-inheritance:
+
+   .. autoautosummary::
+      :methods:

--- a/docs/api/extensions/eo.rst
+++ b/docs/api/extensions/eo.rst
@@ -4,4 +4,3 @@ pystac.extensions.eo
 .. automodule:: pystac.extensions.eo
    :members:
    :undoc-members:
-   :show-inheritance:

--- a/docs/api/extensions/file.rst
+++ b/docs/api/extensions/file.rst
@@ -4,4 +4,3 @@ pystac.extensions.file
 .. automodule:: pystac.extensions.file
    :members:
    :undoc-members:
-   :show-inheritance:

--- a/docs/api/extensions/grid.rst
+++ b/docs/api/extensions/grid.rst
@@ -1,0 +1,6 @@
+pytac.extensions.grid
+=====================
+
+.. automodule:: pystac.extensions.grid
+   :members:
+   :undoc-members:

--- a/docs/api/extensions/hooks.rst
+++ b/docs/api/extensions/hooks.rst
@@ -4,4 +4,3 @@ pystac.extensions.hooks
 .. automodule:: pystac.extensions.hooks
    :members:
    :undoc-members:
-   :show-inheritance:

--- a/docs/api/extensions/item_assets.rst
+++ b/docs/api/extensions/item_assets.rst
@@ -4,4 +4,3 @@ pystac.extensions.item\_assets
 .. automodule:: pystac.extensions.item_assets
    :members:
    :undoc-members:
-   :show-inheritance:

--- a/docs/api/extensions/label.rst
+++ b/docs/api/extensions/label.rst
@@ -4,4 +4,3 @@ pystac.extensions.label
 .. automodule:: pystac.extensions.label
    :members:
    :undoc-members:
-   :show-inheritance:

--- a/docs/api/extensions/mgrs.rst
+++ b/docs/api/extensions/mgrs.rst
@@ -4,4 +4,3 @@ pystac.extensions.mgrs
 .. automodule:: pystac.extensions.mgrs
    :members:
    :undoc-members:
-   :show-inheritance:

--- a/docs/api/extensions/pointcloud.rst
+++ b/docs/api/extensions/pointcloud.rst
@@ -4,4 +4,3 @@ pystac.extensions.pointcloud
 .. automodule:: pystac.extensions.pointcloud
    :members:
    :undoc-members:
-   :show-inheritance:

--- a/docs/api/extensions/projection.rst
+++ b/docs/api/extensions/projection.rst
@@ -4,4 +4,3 @@ pystac.extensions.projection
 .. automodule:: pystac.extensions.projection
    :members:
    :undoc-members:
-   :show-inheritance:

--- a/docs/api/extensions/raster.rst
+++ b/docs/api/extensions/raster.rst
@@ -4,4 +4,3 @@ pystac.extensions.raster
 .. automodule:: pystac.extensions.raster
    :members:
    :undoc-members:
-   :show-inheritance:

--- a/docs/api/extensions/sar.rst
+++ b/docs/api/extensions/sar.rst
@@ -4,4 +4,3 @@ pystac.extensions.sar
 .. automodule:: pystac.extensions.sar
    :members:
    :undoc-members:
-   :show-inheritance:

--- a/docs/api/extensions/sat.rst
+++ b/docs/api/extensions/sat.rst
@@ -4,4 +4,3 @@ pystac.extensions.sat
 .. automodule:: pystac.extensions.sat
    :members:
    :undoc-members:
-   :show-inheritance:

--- a/docs/api/extensions/scientific.rst
+++ b/docs/api/extensions/scientific.rst
@@ -4,4 +4,3 @@ pystac.extensions.scientific
 .. automodule:: pystac.extensions.scientific
    :members:
    :undoc-members:
-   :show-inheritance:

--- a/docs/api/extensions/storage.rst
+++ b/docs/api/extensions/storage.rst
@@ -4,4 +4,3 @@ pystac.extensions.storage
 .. automodule:: pystac.extensions.storage
    :members:
    :undoc-members:
-   :show-inheritance:

--- a/docs/api/extensions/table.rst
+++ b/docs/api/extensions/table.rst
@@ -4,4 +4,3 @@ pystac.extensions.table
 .. automodule:: pystac.extensions.table
    :members:
    :undoc-members:
-   :show-inheritance:

--- a/docs/api/extensions/timestamps.rst
+++ b/docs/api/extensions/timestamps.rst
@@ -4,4 +4,3 @@ pystac.extensions.timestamps
 .. automodule:: pystac.extensions.timestamps
    :members:
    :undoc-members:
-   :show-inheritance:

--- a/docs/api/extensions/version.rst
+++ b/docs/api/extensions/version.rst
@@ -4,4 +4,3 @@ pystac.extensions.version
 .. automodule:: pystac.extensions.version
    :members:
    :undoc-members:
-   :show-inheritance:

--- a/docs/api/extensions/view.rst
+++ b/docs/api/extensions/view.rst
@@ -4,4 +4,3 @@ pystac.extensions.view
 .. automodule:: pystac.extensions.view
    :members:
    :undoc-members:
-   :show-inheritance:

--- a/docs/api/pystac.rst
+++ b/docs/api/pystac.rst
@@ -4,6 +4,28 @@ pystac
 .. automodule:: pystac
    :members: read_file, write_file, read_dict, set_stac_version, get_stac_version
 
+   .. autosummary::
+      STACObject
+      Catalog
+      Collection
+      Extent
+      SpatialExtent
+      TemporalExtent
+      Provider
+      Summaries
+      Item
+      Asset
+      CommonMetadata
+      ItemCollection
+      Link
+      StacIO
+      read_file
+      write_file
+      read_dict
+      set_stac_version
+      get_stac_version
+
+
 STACObject
 ----------
 
@@ -22,7 +44,6 @@ Catalog
 .. autoclass:: pystac.Catalog
    :members:
    :undoc-members:
-   :show-inheritance:
 
 CatalogType
 -----------
@@ -38,7 +59,6 @@ Collection
 .. autoclass:: pystac.Collection
    :members:
    :undoc-members:
-   :show-inheritance:
 
 Extent
 ------
@@ -67,7 +87,6 @@ ProviderRole
 .. autoclass:: pystac.ProviderRole
    :members:
    :undoc-members:
-   :show-inheritance:
 
 Provider
 --------
@@ -89,7 +108,6 @@ Item
 .. autoclass:: pystac.Item
    :members:
    :undoc-members:
-   :show-inheritance:
 
 Asset
 -----
@@ -110,7 +128,6 @@ ItemCollection
 
 .. autoclass:: pystac.ItemCollection
    :members:
-   :show-inheritance:
 
 Link
 ----

--- a/docs/api/serialization/common_properties.rst
+++ b/docs/api/serialization/common_properties.rst
@@ -4,4 +4,3 @@ pystac.serialization.common\_properties
 .. automodule:: pystac.serialization.common_properties
    :members:
    :undoc-members:
-   :show-inheritance:

--- a/docs/api/serialization/identify.rst
+++ b/docs/api/serialization/identify.rst
@@ -4,5 +4,5 @@ pystac.serialization.identify
 .. automodule:: pystac.serialization.identify
    :members:
    :undoc-members:
-   :show-inheritance:
+
    :noindex:

--- a/docs/api/serialization/migrate.rst
+++ b/docs/api/serialization/migrate.rst
@@ -4,4 +4,3 @@ pystac.serialization.migrate
 .. automodule:: pystac.serialization.migrate
    :members:
    :undoc-members:
-   :show-inheritance:

--- a/docs/api/validation/schema_uri_map.rst
+++ b/docs/api/validation/schema_uri_map.rst
@@ -4,4 +4,3 @@ pystac.validation.schema\_uri\_map
 .. automodule:: pystac.validation.schema_uri_map
    :members:
    :undoc-members:
-   :show-inheritance:

--- a/docs/api/validation/stac_validator.rst
+++ b/docs/api/validation/stac_validator.rst
@@ -4,4 +4,3 @@ pystac.validation.stac\_validator
 .. automodule:: pystac.validation.stac_validator
    :members:
    :undoc-members:
-   :show-inheritance:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,6 +51,7 @@ release = __version__
 extensions = [
     "sphinx_design",
     "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
     "sphinx.ext.viewcode",
     "sphinx.ext.intersphinx",
     "sphinx.ext.napoleon",


### PR DESCRIPTION
**Related Issue(s):**

- Closes #446

**Description:**

autodoc can always stand to be decluttered more, but in this PR I tried to make things a little better by:

- removing inheritance from class docstrings
- adding autosummary to some key pages

I also added a few stubs for extension classes where the docs were missing.

![image](https://github.com/stac-utils/pystac/assets/4806877/f4558f87-d774-437b-8ef8-b34f294fc1de)
![image](https://github.com/stac-utils/pystac/assets/4806877/ff45b6d9-2cea-4c4f-8a53-4eda31b38913)


**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
