### PR TITLE
Make sure that get_items is backwards compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Return all validation errors from validation methods of `JsonSchemaSTACValidator` ([#1120](https://github.com/stac-utils/pystac/pull/1120))
 - EO extension updated to v1.1.0 ([#1131](https://github.com/stac-utils/pystac/pull/1131))
 - Use `id` in STACTypeError instead of entire dict ([#1126](https://github.com/stac-utils/pystac/pull/1126))
+- Make sure that `get_items` is backwards compatible ([#1139](https://github.com/stac-utils/pystac/pull/1139))
 
 ### Deprecated
 

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -506,15 +506,10 @@ class Catalog(STACObject):
                 self.get_stac_objects(pystac.RelType.ITEM),
             )
         else:
-            try:
-                items = chain(
-                    self.get_items(recursive=False),
-                    *(child.get_items(recursive=True) for child in self.get_children()),
-                )
-            except TypeError:
-                # For inherited classes that do not yet support recursive
-                # See https://github.com/stac-utils/pystac-client/issues/485
-                items = self.get_all_items()
+            items = chain(
+                self.get_items(recursive=False),
+                *(child.get_items(recursive=True) for child in self.get_children()),
+            )
         if ids:
             yield from (i for i in items if i.id in ids)
         else:

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -707,7 +707,12 @@ class Collection(Catalog):
         Return:
             Item or None: The item with the given ID, or None if not found.
         """
-        return next(self.get_items(id, recursive=recursive), None)
+        try:
+            return next(self.get_items(id, recursive=recursive), None)
+        except TypeError:
+            # For inherited classes that do not yet support recursive
+            # See https://github.com/stac-utils/pystac-client/issues/485
+            return super().get_item(id, recursive=recursive)
 
     def get_assets(
         self,

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -709,10 +709,12 @@ class Collection(Catalog):
         """
         try:
             return next(self.get_items(id, recursive=recursive), None)
-        except TypeError:
-            # For inherited classes that do not yet support recursive
-            # See https://github.com/stac-utils/pystac-client/issues/485
-            return super().get_item(id, recursive=recursive)
+        except TypeError as e:
+            if any("recursive" in arg for arg in e.args):
+                # For inherited classes that do not yet support recursive
+                # See https://github.com/stac-utils/pystac-client/issues/485
+                return super().get_item(id, recursive=recursive)
+            raise e
 
     def get_assets(
         self,

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -9,7 +9,7 @@ from collections import defaultdict
 from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union, cast
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union, cast
 
 import pytest
 
@@ -1501,7 +1501,8 @@ class CatalogSubClassTest(unittest.TestCase):
     case_1 = TestCases.get_path("data-files/catalogs/test-case-1/catalog.json")
 
     class BasicCustomCatalog(pystac.Catalog):
-        pass
+        def get_items(self) -> Iterator[Item]:  # type: ignore
+            return super().get_items()
 
     def setUp(self) -> None:
         self.stac_io = pystac.StacIO.default()
@@ -1522,6 +1523,18 @@ class CatalogSubClassTest(unittest.TestCase):
         cloned_catalog = custom_catalog.clone()
 
         self.assertIsInstance(cloned_catalog, self.BasicCustomCatalog)
+
+    def test_get_all_items_works(self) -> None:
+        custom_catalog = self.BasicCustomCatalog.from_file(self.case_1)
+        cloned_catalog = custom_catalog.clone()
+        with pytest.warns(DeprecationWarning):
+            cloned_catalog.get_all_items()
+
+    def test_get_item_works(self) -> None:
+        custom_catalog = self.BasicCustomCatalog.from_file(self.case_1)
+        cloned_catalog = custom_catalog.clone()
+        with pytest.warns(DeprecationWarning):
+            cloned_catalog.get_item("area-1-1-imagery")
 
 
 def test_custom_catalog_from_dict(catalog: Catalog) -> None:

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1502,6 +1502,9 @@ class CatalogSubClassTest(unittest.TestCase):
 
     class BasicCustomCatalog(pystac.Catalog):
         def get_items(self) -> Iterator[Item]:  # type: ignore
+            # This get_items does not have the `recursive` kwarg. This mimics
+            # the current state of pystac-client and is intended to test
+            # backwards compatibility of inherited classes
             return super().get_items()
 
     def setUp(self) -> None:

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -6,7 +6,7 @@ import tempfile
 import unittest
 from copy import deepcopy
 from datetime import datetime
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Iterator, Optional
 
 import pytest
 from dateutil import tz
@@ -496,7 +496,8 @@ class CollectionSubClassTest(unittest.TestCase):
     MULTI_EXTENT = TestCases.get_path("data-files/collections/multi-extent.json")
 
     class BasicCustomCollection(pystac.Collection):
-        pass
+        def get_items(self) -> Iterator[Item]:  # type: ignore
+            return super().get_items()
 
     def setUp(self) -> None:
         self.stac_io = pystac.StacIO.default()
@@ -517,6 +518,15 @@ class CollectionSubClassTest(unittest.TestCase):
         cloned_collection = custom_collection.clone()
 
         self.assertIsInstance(cloned_collection, self.BasicCustomCollection)
+
+    def test_collection_get_item_works(self) -> None:
+        path = TestCases.get_path(
+            "data-files/catalogs/test-case-1/country-1/area-1-1/collection.json"
+        )
+        custom_collection = self.BasicCustomCollection.from_file(path)
+        collection = custom_collection.clone()
+        with pytest.warns(DeprecationWarning):
+            collection.get_item("area-1-1-imagery")
 
 
 def test_custom_collection_from_dict(collection: Collection) -> None:

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -497,6 +497,9 @@ class CollectionSubClassTest(unittest.TestCase):
 
     class BasicCustomCollection(pystac.Collection):
         def get_items(self) -> Iterator[Item]:  # type: ignore
+            # This get_items does not have the `recursive` kwarg. This mimics
+            # the current state of pystac-client and is intended to test
+            # backwards compatibility of inherited classes
             return super().get_items()
 
     def setUp(self) -> None:

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -532,6 +532,24 @@ class CollectionSubClassTest(unittest.TestCase):
             collection.get_item("area-1-1-imagery")
 
 
+class CollectionPartialSubClassTest(unittest.TestCase):
+    class BasicCustomCollection(pystac.Collection):
+        def get_items(  # type: ignore
+            self, *, recursive: bool = False
+        ) -> Iterator[Item]:
+            # This get_items does not allow ids as args.
+            return super().get_items(recursive=recursive)
+
+    def test_collection_get_item_raises_type_error(self) -> None:
+        path = TestCases.get_path(
+            "data-files/catalogs/test-case-1/country-1/area-1-1/collection.json"
+        )
+        custom_collection = self.BasicCustomCollection.from_file(path)
+        collection = custom_collection.clone()
+        with pytest.raises(TypeError, match="takes 1 positional argument"):
+            collection.get_item("area-1-1-imagery")
+
+
 def test_custom_collection_from_dict(collection: Collection) -> None:
     # https://github.com/stac-utils/pystac/issues/862
     class CustomCollection(Collection):


### PR DESCRIPTION
**Related Issue(s):**

- Closes #1138 

**Description:**

I didn't quite go so far as reverting, but I did make the change backwards compatible by not relying on the new kwarg internally. I ran the pystac-client tests locally and the one that was failing in https://github.com/stac-utils/pystac-client/issues/485 passes now.

Note: I didn't add tests.There should be only 2 lines that aren't tested (the ones in the TypeError blocks), so it seemed like more trouble than it was worth, but just let me know if you think they are necessary. 

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
