### PR TITLE
Get assets by eo:bands common_name or name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Updated raster extension to work with the item_assets extension's AssetDefinition objects ([#1110](https://github.com/stac-utils/pystac/pull/1110))
 - Classification extension ([#1093](https://github.com/stac-utils/pystac/pull/1093)), with support for adding classification information to item_assets' `AssetDefinition`s and raster's `RasterBand` objects.
 - `get_derived_from`, `add_derived_from` and `remove_derived_from` to Items ([#1136](https://github.com/stac-utils/pystac/pull/1136))
+- `ItemEOExtension.get_assets` for getting assets filtered on band `name` or `common_name` ([#1140](https://github.com/stac-utils/pystac/pull/1140))
 
 ### Changed
 

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -483,7 +483,7 @@ class ItemEOExtension(EOExtension[pystac.Item]):
             for key, asset in self.item.get_assets().items()
             if BANDS_PROP in asset.extra_fields
             and all(
-                v is None or v in [b.get(k) for b in asset.extra_fields[BANDS_PROP]]
+                v is None or any(v == b.get(k) for b in asset.extra_fields[BANDS_PROP])
                 for k, v in kwargs.items()
             )
         }

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -470,7 +470,7 @@ class ItemEOExtension(EOExtension[pystac.Item]):
             name: If set, filter the assets such that only those with a
                 matching ``eo:band.name`` are returned.
             common_name: If set, filter the assets such that only those with a matching
-                ``eo:band.name`` are returned.
+                ``eo:band.common_name`` are returned.
 
         Returns:
             Dict[str, Asset]: A dictionary of assets that match ``name``

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -459,6 +459,35 @@ class ItemEOExtension(EOExtension[pystac.Item]):
             return [Band(b) for b in bands]
         return None
 
+    def get_assets(
+        self,
+        name: Optional[str] = None,
+        common_name: Optional[str] = None,
+    ) -> Dict[str, pystac.Asset]:
+        """Get the item's assets where eo:bands are defined.
+
+        Args:
+            name: If set, filter the assets such that only those with a
+                matching ``eo:band.name`` are returned.
+            common_name: If set, filter the assets such that only those with a matching
+                ``eo:band.name`` are returned.
+
+        Returns:
+            Dict[str, Asset]: A dictionary of assets that match ``name``
+                and/or ``common_name`` if set or else all of this item's assets were
+                eo:bands are defined.
+        """
+        kwargs = {"name": name, "common_name": common_name}
+        return {
+            key: asset
+            for key, asset in self.item.get_assets().items()
+            if BANDS_PROP in asset.extra_fields
+            and all(
+                v is None or v in [b[k] for b in asset.extra_fields[BANDS_PROP]]
+                for k, v in kwargs.items()
+            )
+        }
+
     def __repr__(self) -> str:
         return "<ItemEOExtension Item id={}>".format(self.item.id)
 

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -483,7 +483,7 @@ class ItemEOExtension(EOExtension[pystac.Item]):
             for key, asset in self.item.get_assets().items()
             if BANDS_PROP in asset.extra_fields
             and all(
-                v is None or v in [b[k] for b in asset.extra_fields[BANDS_PROP]]
+                v is None or v in [b.get(k) for b in asset.extra_fields[BANDS_PROP]]
                 for k, v in kwargs.items()
             )
         }

--- a/tests/extensions/test_eo.py
+++ b/tests/extensions/test_eo.py
@@ -457,3 +457,18 @@ def test_older_extension_version(ext_item: Item) -> None:
 def test_get_assets(ext_item: pystac.Item, filter: Dict[str, str], count: int) -> None:
     assets = EOExtension.ext(ext_item).get_assets(**filter)  # type:ignore
     assert len(assets) == count
+
+
+def test_get_assets_works_even_if_band_info_is_incomplete(
+    ext_item: pystac.Item,
+) -> None:
+    name = ext_item.assets["B4"].extra_fields["eo:bands"][0].pop("name")
+    common_name = ext_item.assets["B2"].extra_fields["eo:bands"][0].pop("common_name")
+
+    eo_ext = EOExtension.ext(ext_item)
+
+    assets = eo_ext.get_assets(name=name)  # type:ignore
+    assert len(assets) == 0
+
+    assets = eo_ext.get_assets(common_name=common_name)  # type:ignore
+    assert len(assets) == 0

--- a/tests/extensions/test_eo.py
+++ b/tests/extensions/test_eo.py
@@ -1,5 +1,6 @@
 import json
 import unittest
+from typing import Dict
 
 import pytest
 
@@ -441,3 +442,18 @@ def test_older_extension_version(ext_item: Item) -> None:
     migrated_item = pystac.Item.from_dict(item_as_dict, migrate=True)
     assert EOExtension.has_extension(migrated_item)
     assert new in migrated_item.stac_extensions
+
+
+@pytest.mark.parametrize(
+    "filter,count",
+    [
+        (dict(), 11),
+        ({"name": "B4"}, 1),
+        ({"common_name": "blue"}, 1),
+        ({"name": "B4", "common_name": "red"}, 1),
+        ({"name": "B4", "common_name": "green"}, 0),
+    ],
+)
+def test_get_assets(ext_item: pystac.Item, filter: Dict[str, str], count: int) -> None:
+    assets = EOExtension.ext(ext_item).get_assets(**filter)  # type:ignore
+    assert len(assets) == count


### PR DESCRIPTION
**Related Issue(s):**

- Closes #275

**Description:**

This PR adds a new `get_assets` method on the `ItemEOExtension` class:

```python
import pystac_client
import planetary_computer
from pystac.extensions.eo import EOExtension

catalog = pystac_client.Client.open(
    "https://planetarycomputer.microsoft.com/api/stac/v1",
    modifier=planetary_computer.sign_inplace,
)

landsat = catalog.get_collection("landsat-c2-l2")
item = next(landsat.get_items())

eo_ext = EOExtension.ext(item)
eo_ext.get_assets()
```

![image](https://github.com/stac-utils/pystac/assets/4806877/9298ecbf-3031-4bad-85d9-85c4b8c77cb3)


**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
