### PR TITLE
Add optional jinja2 dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ network requests when reading with PySTAC, you'll need
 pip install 'pystac[urllib3]'
 ```
 
+If you are using jupyter notebooks and want to enable pretty display of pystac objects you'll need [`jinja2`](https://pypi.org/project/Jinja2/)
+
+```shell
+pip install 'pystac[jinja2]'
+```
+
 ### Install from source
 
 ```shell

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -78,6 +78,18 @@ additional functionality:
 
       pip install pystac[urllib3]
 
+* ``jinja2``
+
+  Installs the additional `jinja2 <https://github.com/pallets/jinja>`__ dependency.
+  When this dependency is installed, jupyter notebooks display pretty representations
+  of PySTAC objects
+
+  To install:
+
+  .. code-block:: bash
+
+      pip install pystac[jinja2]
+
 Versions
 ========
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ docs = [
     "sphinx-design~=0.4",
     "sphinxcontrib-fulltoc~=1.2",
 ]
+jinja2 = [
+    "jinja2<4.0",
+]
 orjson = ["orjson>=3.5"]
 test = [
     "black~=23.3",


### PR DESCRIPTION
**Related Issue(s):**

- Closes #1082

**Description:**

#1142 still relies on jinja2 being installed, so it is totally independent of this PR

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
