### PR TITLE
Allow more configuration with `Catalog.validate_all`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Classification extension ([#1093](https://github.com/stac-utils/pystac/pull/1093)), with support for adding classification information to item_assets' `AssetDefinition`s and raster's `RasterBand` objects.
 - `get_derived_from`, `add_derived_from` and `remove_derived_from` to Items ([#1136](https://github.com/stac-utils/pystac/pull/1136))
 - `ItemEOExtension.get_assets` for getting assets filtered on band `name` or `common_name` ([#1140](https://github.com/stac-utils/pystac/pull/1140))
+- `max_items` and `recursive` to `Catalog.validate_all` ([#1141](https://github.com/stac-utils/pystac/pull/1141))
 
 ### Changed
 

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -986,21 +986,42 @@ class Catalog(STACObject):
             for item in items:
                 pass
 
-    def validate_all(self) -> None:
-        """Validates each catalog, collection contained within this catalog.
+    def validate_all(self, recursive: bool = True, max_n: Optional[int] = None) -> int:
+        """Validates each catalog, collection, item contained within this catalog.
 
         Walks through the children and items of the catalog and validates each
         stac object.
+
+        Args:
+            recursive : Whether to validate catalog, collections, and items contained
+                within child objects.
+            max_n : The maximum number of STAC objects to validate. Default
+                is None which does not enforce a max.
+
+        Returns:
+            int : Number of STAC objects validated.
 
         Raises:
             STACValidationError: Raises this error on any item that is invalid.
                 Will raise on the first invalid stac object encountered.
         """
         self.validate()
+        n = 1
         for child in self.get_children():
-            child.validate_all()
+            if max_n is not None and n >= max_n:
+                break
+            if recursive:
+                inner_max_n = None if max_n is None else max_n - n
+                n += child.validate_all(recursive=True, max_n=inner_max_n)
+            else:
+                child.validate()
+                n += 1
         for item in self.get_items():
+            if max_n is not None and n >= max_n:
+                break
             item.validate()
+            n += 1
+        return n
 
     def _object_links(self) -> List[Union[str, pystac.RelType]]:
         return [

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -986,38 +986,37 @@ class Catalog(STACObject):
             for item in items:
                 pass
 
-    def validate_all(self, recursive: bool = True, max_n: Optional[int] = None) -> int:
+    def validate_all(
+        self, max_items: Optional[int] = None, recursive: bool = True
+    ) -> int:
         """Validates each catalog, collection, item contained within this catalog.
 
         Walks through the children and items of the catalog and validates each
         stac object.
 
         Args:
+            max_items : The maximum number of STAC items to validate. Default
+                is None which means, validate them all.
             recursive : Whether to validate catalog, collections, and items contained
                 within child objects.
-            max_n : The maximum number of STAC objects to validate. Default
-                is None which does not enforce a max.
 
         Returns:
-            int : Number of STAC objects validated.
+            int : Number of STAC items validated.
 
         Raises:
             STACValidationError: Raises this error on any item that is invalid.
                 Will raise on the first invalid stac object encountered.
         """
+        n = 0
         self.validate()
-        n = 1
         for child in self.get_children():
-            if max_n is not None and n >= max_n:
-                break
             if recursive:
-                inner_max_n = None if max_n is None else max_n - n
-                n += child.validate_all(recursive=True, max_n=inner_max_n)
+                inner_max_items = None if max_items is None else max_items - n
+                n += child.validate_all(max_items=inner_max_items, recursive=True)
             else:
                 child.validate()
-                n += 1
         for item in self.get_items():
-            if max_n is not None and n >= max_n:
+            if max_items is not None and n >= max_items:
                 break
             item.validate()
             n += 1

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1141,6 +1141,7 @@ class TestCatalog:
             cat.normalize_hrefs("/tmp")
         cat.validate_all()
 
+    def test_validate_all_invalid(self) -> None:
         # Make one invalid, write it off, read it in, ensure it throws
         cat = TestCases.case_1()
         item = next(cat.get_items("area-1-1-labels", recursive=True))
@@ -1579,3 +1580,22 @@ def test_get_items_with_multiple_ids(test_case_1_catalog: Catalog) -> None:
     cat = test_case_1_catalog
     items = cat.get_items("area-2-1-imagery", "area-1-1-labels", recursive=True)
     assert len(list(items)) == 2
+
+
+def test_validate_all_with_max_n(test_case_1_catalog: Catalog) -> None:
+    cat = test_case_1_catalog
+    # If hrefs are not set, it will fail validation.
+    if cat.get_self_href() is None:
+        cat.normalize_hrefs("/tmp")
+    assert cat.validate_all() == 15
+    assert cat.validate_all(max_n=10) == 10
+    assert cat.validate_all(max_n=1) == 1
+
+
+def test_validate_all_with_recusive_off(test_case_1_catalog: Catalog) -> None:
+    cat = test_case_1_catalog
+    # If hrefs are not set, it will fail validation.
+    if cat.get_self_href() is None:
+        cat.normalize_hrefs("/tmp")
+    assert cat.validate_all() == 15
+    assert cat.validate_all(recursive=False) == 3

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1584,9 +1584,6 @@ def test_get_items_with_multiple_ids(test_case_1_catalog: Catalog) -> None:
 
 def test_validate_all_with_max_n(test_case_1_catalog: Catalog) -> None:
     cat = test_case_1_catalog
-    # If hrefs are not set, it will fail validation.
-    if cat.get_self_href() is None:
-        cat.normalize_hrefs("/tmp")
     assert cat.validate_all() == 15
     assert cat.validate_all(max_n=10) == 10
     assert cat.validate_all(max_n=1) == 1
@@ -1594,8 +1591,5 @@ def test_validate_all_with_max_n(test_case_1_catalog: Catalog) -> None:
 
 def test_validate_all_with_recusive_off(test_case_1_catalog: Catalog) -> None:
     cat = test_case_1_catalog
-    # If hrefs are not set, it will fail validation.
-    if cat.get_self_href() is None:
-        cat.normalize_hrefs("/tmp")
     assert cat.validate_all() == 15
     assert cat.validate_all(recursive=False) == 3

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1584,12 +1584,12 @@ def test_get_items_with_multiple_ids(test_case_1_catalog: Catalog) -> None:
 
 def test_validate_all_with_max_n(test_case_1_catalog: Catalog) -> None:
     cat = test_case_1_catalog
-    assert cat.validate_all() == 15
-    assert cat.validate_all(max_n=10) == 10
-    assert cat.validate_all(max_n=1) == 1
+    assert cat.validate_all() == 8
+    assert cat.validate_all(max_items=6) == 6
+    assert cat.validate_all(max_items=1) == 1
 
 
 def test_validate_all_with_recusive_off(test_case_1_catalog: Catalog) -> None:
     cat = test_case_1_catalog
-    assert cat.validate_all() == 15
-    assert cat.validate_all(recursive=False) == 3
+    assert cat.validate_all() == 8
+    assert cat.validate_all(recursive=False) == 0


### PR DESCRIPTION
Replaces #1141 

**Related Issue(s):**

- Closes #345 

**Description:**

I think this covers the scenario described in the original issue of limiting the amount of objects that are iterated over. It made more sense to be to track that as a single number (items + catalogs + collections) and then to separately give a knob for changing whether or no we recurse into the children. 

That being said there are _lots_ of ways to tackle this. Anther approach could use a timeout rather than tracking number of objects at all.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
