### PR TITLE
Add docs and hint about extension summaries

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -482,7 +482,7 @@ Extension <eo>`, you can access the properties associated with that extension us
    import pystac
    from pystac.extensions.eo import EOExtension
 
-   item = Item(...)  # See docs for creating an Item
+   item = pystac.Item.from_file("tests/data-files/eo/eo-landsat-example.json")
 
    # Check that the Item implements the EO Extension
    if EOExtension.has_extension(item):
@@ -490,6 +490,7 @@ Extension <eo>`, you can access the properties associated with that extension us
 
       bands = eo_ext.bands
       cloud_cover = eo_ext.cloud_cover
+      snow_cover = eo_ext.snow_cover
       ...
 
 .. note:: The ``ext`` method will raise an :exc:`~pystac.ExtensionNotImplemented`
@@ -511,7 +512,7 @@ can therefore mutate those properties.* For instance:
 
 .. code-block:: python
 
-   item = Item.from_file("tests/data-files/eo/eo-landsat-example.json")
+   item = pystac.Item.from_file("tests/data-files/eo/eo-landsat-example.json")
    print(item.properties["eo:cloud_cover"])
    # 78
 
@@ -563,7 +564,7 @@ extended.
 .. code-block:: python
 
    # Load a basic item without any extensions
-   item = Item.from_file("tests/data-files/item/sample-item.json")
+   item = pystac.Item.from_file("tests/data-files/item/sample-item.json")
    print(item.stac_extensions)
    # []
 
@@ -575,14 +576,38 @@ extended.
 Extended Summaries
 ------------------
 
-Extension classes like :class:`~pystac.extensions.eo.EOExtension` may also provide a
-``summaries`` static method that can be used to extend the Collection summaries. This
-method returns a class inheriting from
+Extension classes like :class:`~pystac.extensions.projection.ProjectionExtension` may
+also provide a ``summaries`` static method that can be used to extend the Collection
+summaries. This method returns a class inheriting from
 :class:`pystac.extensions.base.SummariesExtension` that provides tools for summarizing
 the properties defined by that extension. These classes also hold a reference to the
 Collection's :class:`pystac.Summaries` instance in the ``summaries`` attribute.
 
-See :class:`pystac.extensions.eo.SummariesEOExtension` for an example implementation.
+
+.. code-block:: python
+
+   import pystac
+   from pystac.extensions.projection import ProjectionExtension
+
+   # Load a collection that does not implement the Projection extension
+   collection = pystac.Collection.from_file(
+      "tests/data-files/examples/1.0.0/collection.json"
+   )
+
+   # Add Projection extension summaries to the collection
+   proj = ProjectionExtension.summaries(collection, add_if_missing=True)
+   print(collection.stac_extensions)
+   # [
+   #     ....,
+   #     'https://stac-extensions.github.io/projection/v1.1.0/schema.json'
+   # ]
+
+   # Set the values for various extension fields
+   proj.epsg = [4326]
+   collection_as_dict = collection.to_dict()
+   collection_as_dict["summaries"]["proj:epsg"]
+   # [4326]
+
 
 Item Asset properties
 =====================

--- a/pystac/extensions/base.py
+++ b/pystac/extensions/base.py
@@ -191,3 +191,10 @@ class ExtensionManagementMixin(Generic[S], ABC):
             raise pystac.ExtensionNotImplemented(
                 f"Could not find extension schema URI {cls.get_schema_uri()} in object."
             )
+
+    @classmethod
+    def _ext_error_message(cls, obj: Any) -> str:
+        hint = ""
+        if hasattr(cls, "summaries") and isinstance(obj, pystac.Collection):
+            hint = ". Hint: Did you mean to use `.summaries` instead?"
+        return f"{cls.__name__} does not apply to type '{type(obj).__name__}'{hint}"

--- a/pystac/extensions/classification.py
+++ b/pystac/extensions/classification.py
@@ -542,12 +542,8 @@ class ClassificationExtension(
             return cast(
                 ClassificationExtension[T], RasterBandClassificationExtension(obj)
             )
-
         else:
-            raise pystac.ExtensionTypeError(
-                "Classification extension does not apply to type "
-                f"'{type(obj).__name__}'"
-            )
+            raise pystac.ExtensionTypeError(cls._ext_error_message(obj))
 
     @classmethod
     def summaries(

--- a/pystac/extensions/datacube.py
+++ b/pystac/extensions/datacube.py
@@ -602,9 +602,7 @@ class DatacubeExtension(
             cls.validate_owner_has_extension(obj, add_if_missing)
             return cast(DatacubeExtension[T], AssetDatacubeExtension(obj))
         else:
-            raise pystac.ExtensionTypeError(
-                f"Datacube extension does not apply to type '{type(obj).__name__}'"
-            )
+            raise pystac.ExtensionTypeError(cls._ext_error_message(obj))
 
 
 class CollectionDatacubeExtension(DatacubeExtension[pystac.Collection]):

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -406,9 +406,7 @@ class EOExtension(
             cls.validate_owner_has_extension(obj, add_if_missing)
             return cast(EOExtension[T], AssetEOExtension(obj))
         else:
-            raise pystac.ExtensionTypeError(
-                f"EO extension does not apply to type '{type(obj).__name__}'"
-            )
+            raise pystac.ExtensionTypeError(cls._ext_error_message(obj))
 
     @classmethod
     def summaries(

--- a/pystac/extensions/file.py
+++ b/pystac/extensions/file.py
@@ -227,9 +227,7 @@ class FileExtension(
             cls.validate_owner_has_extension(obj, add_if_missing)
             return cls(obj)
         else:
-            raise pystac.ExtensionTypeError(
-                f"File Info extension does not apply to type '{type(obj).__name__}'"
-            )
+            raise pystac.ExtensionTypeError(cls._ext_error_message(obj))
 
 
 class FileExtensionHooks(ExtensionHooks):

--- a/pystac/extensions/grid.py
+++ b/pystac/extensions/grid.py
@@ -103,9 +103,7 @@ class GridExtension(
             cls.validate_has_extension(obj, add_if_missing)
             return GridExtension(obj)
         else:
-            raise pystac.ExtensionTypeError(
-                f"Grid Extension does not apply to type '{type(obj).__name__}'"
-            )
+            raise pystac.ExtensionTypeError(cls._ext_error_message(obj))
 
 
 class GridExtensionHooks(ExtensionHooks):

--- a/pystac/extensions/item_assets.py
+++ b/pystac/extensions/item_assets.py
@@ -248,9 +248,7 @@ class ItemAssetsExtension(ExtensionManagementMixin[pystac.Collection]):
             cls.validate_has_extension(obj, add_if_missing)
             return cls(obj)
         else:
-            raise pystac.ExtensionTypeError(
-                f"Item Assets extension does not apply to type '{type(obj).__name__}'"
-            )
+            raise pystac.ExtensionTypeError(cls._ext_error_message(obj))
 
 
 class ItemAssetsExtensionHooks(ExtensionHooks):

--- a/pystac/extensions/label.py
+++ b/pystac/extensions/label.py
@@ -709,9 +709,7 @@ class LabelExtension(ExtensionManagementMixin[Union[pystac.Item, pystac.Collecti
             cls.validate_has_extension(obj, add_if_missing)
             return cls(obj)
         else:
-            raise pystac.ExtensionTypeError(
-                f"Label extension does not apply to type '{type(obj).__name__}'"
-            )
+            raise pystac.ExtensionTypeError(cls._ext_error_message(obj))
 
     @classmethod
     def summaries(

--- a/pystac/extensions/mgrs.py
+++ b/pystac/extensions/mgrs.py
@@ -235,9 +235,7 @@ class MgrsExtension(
             cls.validate_has_extension(obj, add_if_missing)
             return MgrsExtension(obj)
         else:
-            raise pystac.ExtensionTypeError(
-                f"MGRS Extension does not apply to type '{type(obj).__name__}'"
-            )
+            raise pystac.ExtensionTypeError(cls._ext_error_message(obj))
 
 
 class MgrsExtensionHooks(ExtensionHooks):

--- a/pystac/extensions/pointcloud.py
+++ b/pystac/extensions/pointcloud.py
@@ -458,9 +458,7 @@ class PointcloudExtension(
             cls.validate_owner_has_extension(obj, add_if_missing)
             return cast(PointcloudExtension[T], AssetPointcloudExtension(obj))
         else:
-            raise pystac.ExtensionTypeError(
-                f"Pointcloud extension does not apply to type '{type(obj).__name__}'"
-            )
+            raise pystac.ExtensionTypeError(cls._ext_error_message(obj))
 
     @classmethod
     def summaries(

--- a/pystac/extensions/projection.py
+++ b/pystac/extensions/projection.py
@@ -286,9 +286,7 @@ class ProjectionExtension(
             cls.validate_owner_has_extension(obj, add_if_missing)
             return cast(ProjectionExtension[T], AssetProjectionExtension(obj))
         else:
-            raise pystac.ExtensionTypeError(
-                f"Projection extension does not apply to type '{type(obj).__name__}'"
-            )
+            raise pystac.ExtensionTypeError(cls._ext_error_message(obj))
 
     @classmethod
     def summaries(

--- a/pystac/extensions/raster.py
+++ b/pystac/extensions/raster.py
@@ -737,9 +737,7 @@ class RasterExtension(
             )
             return cast(RasterExtension[T], ItemAssetsRasterExtension(obj))
         else:
-            raise pystac.ExtensionTypeError(
-                f"Raster extension does not apply to type '{type(obj).__name__}'"
-            )
+            raise pystac.ExtensionTypeError(cls._ext_error_message(obj))
 
     @classmethod
     def summaries(

--- a/pystac/extensions/sar.py
+++ b/pystac/extensions/sar.py
@@ -322,9 +322,7 @@ class SarExtension(
             cls.validate_owner_has_extension(obj, add_if_missing)
             return cast(SarExtension[T], AssetSarExtension(obj))
         else:
-            raise pystac.ExtensionTypeError(
-                f"SAR extension does not apply to type '{type(obj).__name__}'"
-            )
+            raise pystac.ExtensionTypeError(cls._ext_error_message(obj))
 
     @classmethod
     def summaries(

--- a/pystac/extensions/sat.py
+++ b/pystac/extensions/sat.py
@@ -153,9 +153,7 @@ class SatExtension(
             cls.validate_owner_has_extension(obj, add_if_missing)
             return cast(SatExtension[T], AssetSatExtension(obj))
         else:
-            raise pystac.ExtensionTypeError(
-                f"Satellite extension does not apply to type '{type(obj).__name__}'"
-            )
+            raise pystac.ExtensionTypeError(cls._ext_error_message(obj))
 
     @classmethod
     def summaries(

--- a/pystac/extensions/scientific.py
+++ b/pystac/extensions/scientific.py
@@ -244,9 +244,7 @@ class ScientificExtension(
             cls.validate_has_extension(obj, add_if_missing)
             return cast(ScientificExtension[T], ItemScientificExtension(obj))
         else:
-            raise pystac.ExtensionTypeError(
-                f"Scientific extension does not apply to type '{type(obj).__name__}'"
-            )
+            raise pystac.ExtensionTypeError(cls._ext_error_message(obj))
 
     @classmethod
     def summaries(

--- a/pystac/extensions/storage.py
+++ b/pystac/extensions/storage.py
@@ -155,9 +155,7 @@ class StorageExtension(
             cls.validate_owner_has_extension(obj, add_if_missing)
             return cast(StorageExtension[T], AssetStorageExtension(obj))
         else:
-            raise pystac.ExtensionTypeError(
-                f"StorageExtension does not apply to type '{type(obj).__name__}'"
-            )
+            raise pystac.ExtensionTypeError(cls._ext_error_message(obj))
 
     @classmethod
     def summaries(

--- a/pystac/extensions/table.py
+++ b/pystac/extensions/table.py
@@ -161,9 +161,7 @@ class TableExtension(
             cls.validate_owner_has_extension(obj, add_if_missing)
             return cast(TableExtension[T], AssetTableExtension(obj))
         else:
-            raise pystac.ExtensionTypeError(
-                f"Table extension does not apply to type '{type(obj).__name__}'"
-            )
+            raise pystac.ExtensionTypeError(cls._ext_error_message(obj))
 
     @property
     def columns(self) -> Optional[List[Column]]:

--- a/pystac/extensions/timestamps.py
+++ b/pystac/extensions/timestamps.py
@@ -134,9 +134,7 @@ class TimestampsExtension(
             cls.validate_owner_has_extension(obj, add_if_missing)
             return cast(TimestampsExtension[T], AssetTimestampsExtension(obj))
         else:
-            raise pystac.ExtensionTypeError(
-                f"Timestamps extension does not apply to type '{type(obj).__name__}'"
-            )
+            raise pystac.ExtensionTypeError(cls._ext_error_message(obj))
 
     @classmethod
     def summaries(

--- a/pystac/extensions/version.py
+++ b/pystac/extensions/version.py
@@ -219,9 +219,7 @@ class VersionExtension(
             cls.validate_has_extension(obj, add_if_missing)
             return cast(VersionExtension[T], ItemVersionExtension(obj))
         else:
-            raise pystac.ExtensionTypeError(
-                f"Version extension does not apply to type '{type(obj).__name__}'"
-            )
+            raise pystac.ExtensionTypeError(cls._ext_error_message(obj))
 
 
 class CollectionVersionExtension(VersionExtension[pystac.Collection]):

--- a/pystac/extensions/view.py
+++ b/pystac/extensions/view.py
@@ -163,9 +163,7 @@ class ViewExtension(
             cls.validate_owner_has_extension(obj, add_if_missing)
             return cast(ViewExtension[T], AssetViewExtension(obj))
         else:
-            raise pystac.ExtensionTypeError(
-                f"View extension does not apply to type '{type(obj).__name__}'"
-            )
+            raise pystac.ExtensionTypeError(cls._ext_error_message(obj))
 
     @classmethod
     def summaries(

--- a/tests/data-files/examples/1.0.0/collection.json
+++ b/tests/data-files/examples/1.0.0/collection.json
@@ -60,10 +60,6 @@
       "minimum": 1.2,
       "maximum": 1.2
     },
-    "proj:epsg": {
-      "minimum": 32659,
-      "maximum": 32659
-    },
     "view:sun_elevation": {
       "minimum": 54.9,
       "maximum": 54.9

--- a/tests/extensions/test_custom.py
+++ b/tests/extensions/test_custom.py
@@ -66,9 +66,7 @@ class CustomExtension(
             cls.validate_has_extension(obj, add_if_missing)
             return cast(CustomExtension[T], CatalogCustomExtension(obj))
 
-        raise pystac.ExtensionTypeError(
-            f"Custom extension does not apply to {type(obj).__name__}"
-        )
+        raise pystac.ExtensionTypeError(cls._ext_error_message(obj))
 
 
 class CatalogCustomExtension(CustomExtension[pystac.Catalog]):

--- a/tests/extensions/test_datacube.py
+++ b/tests/extensions/test_datacube.py
@@ -57,7 +57,7 @@ class DatacubeTest(unittest.TestCase):
     ) -> None:
         self.assertRaisesRegex(
             ExtensionTypeError,
-            r"^Datacube extension does not apply to type 'object'$",
+            r"^DatacubeExtension does not apply to type 'object'$",
             DatacubeExtension.ext,
             object(),
         )

--- a/tests/extensions/test_eo.py
+++ b/tests/extensions/test_eo.py
@@ -342,7 +342,7 @@ class EOTest(unittest.TestCase):
     ) -> None:
         self.assertRaisesRegex(
             ExtensionTypeError,
-            r"^EO extension does not apply to type 'object'$",
+            r"^EOExtension does not apply to type 'object'$",
             EOExtension.ext,
             object(),
         )
@@ -472,3 +472,12 @@ def test_get_assets_works_even_if_band_info_is_incomplete(
 
     assets = eo_ext.get_assets(common_name=common_name)  # type:ignore
     assert len(assets) == 0
+
+
+def test_exception_should_include_hint_if_obj_is_collection(
+    collection: pystac.Collection,
+) -> None:
+    with pytest.raises(
+        ExtensionTypeError, match="Hint: Did you mean to use `.summaries` instead?"
+    ):
+        EOExtension.ext(collection)  # type:ignore

--- a/tests/extensions/test_file.py
+++ b/tests/extensions/test_file.py
@@ -232,7 +232,7 @@ class FileTest(unittest.TestCase):
     ) -> None:
         self.assertRaisesRegex(
             ExtensionTypeError,
-            r"^File Info extension does not apply to type 'object'$",
+            r"^FileExtension does not apply to type 'object'$",
             FileExtension.ext,
             object(),
         )

--- a/tests/extensions/test_grid.py
+++ b/tests/extensions/test_grid.py
@@ -136,7 +136,7 @@ class GridTest(unittest.TestCase):
     ) -> None:
         self.assertRaisesRegex(
             ExtensionTypeError,
-            r"^Grid Extension does not apply to type 'object'$",
+            r"^GridExtension does not apply to type 'object'$",
             GridExtension.ext,
             object(),
         )

--- a/tests/extensions/test_label.py
+++ b/tests/extensions/test_label.py
@@ -575,7 +575,7 @@ class LabelSummariesTest(unittest.TestCase):
     ) -> None:
         self.assertRaisesRegex(
             ExtensionTypeError,
-            r"^Label extension does not apply to type 'object'$",
+            r"^LabelExtension does not apply to type 'object'$",
             LabelExtension.ext,
             object(),
         )

--- a/tests/extensions/test_pointcloud.py
+++ b/tests/extensions/test_pointcloud.py
@@ -294,7 +294,7 @@ class PointcloudTest(unittest.TestCase):
 
         self.assertRaisesRegex(
             ExtensionTypeError,
-            r"^Pointcloud extension does not apply to type 'RandomObject'$",
+            r"^PointcloudExtension does not apply to type 'RandomObject'$",
             PointcloudExtension.ext,
             RandomObject(),
         )

--- a/tests/extensions/test_projection.py
+++ b/tests/extensions/test_projection.py
@@ -485,7 +485,7 @@ class ProjectionTest(unittest.TestCase):
     ) -> None:
         self.assertRaisesRegex(
             ExtensionTypeError,
-            r"^Projection extension does not apply to type 'object'$",
+            r"^ProjectionExtension does not apply to type 'object'$",
             ProjectionExtension.ext,
             object(),
         )

--- a/tests/extensions/test_raster.py
+++ b/tests/extensions/test_raster.py
@@ -254,7 +254,7 @@ class RasterTest(unittest.TestCase):
     ) -> None:
         self.assertRaisesRegex(
             ExtensionTypeError,
-            r"^Raster extension does not apply to type 'object'$",
+            r"^RasterExtension does not apply to type 'object'$",
             RasterExtension.ext,
             object(),
         )

--- a/tests/extensions/test_sar.py
+++ b/tests/extensions/test_sar.py
@@ -204,7 +204,7 @@ class SarItemExtTest(unittest.TestCase):
     ) -> None:
         self.assertRaisesRegex(
             ExtensionTypeError,
-            r"^SAR extension does not apply to type 'object'$",
+            r"^SarExtension does not apply to type 'object'$",
             SarExtension.ext,
             object(),
         )

--- a/tests/extensions/test_sat.py
+++ b/tests/extensions/test_sat.py
@@ -213,7 +213,7 @@ class SatTest(unittest.TestCase):
     ) -> None:
         self.assertRaisesRegex(
             ExtensionTypeError,
-            r"^Satellite extension does not apply to type 'object'$",
+            r"^SatExtension does not apply to type 'object'$",
             SatExtension.ext,
             object(),
         )

--- a/tests/extensions/test_scientific.py
+++ b/tests/extensions/test_scientific.py
@@ -412,7 +412,7 @@ class CollectionScientificExtensionTest(unittest.TestCase):
     ) -> None:
         self.assertRaisesRegex(
             ExtensionTypeError,
-            r"^Scientific extension does not apply to type 'object'$",
+            r"^ScientificExtension does not apply to type 'object'$",
             ScientificExtension.ext,
             object(),
         )

--- a/tests/extensions/test_table.py
+++ b/tests/extensions/test_table.py
@@ -56,7 +56,7 @@ class TableTest(unittest.TestCase):
     ) -> None:
         self.assertRaisesRegex(
             ExtensionTypeError,
-            r"^Table extension does not apply to type 'object'$",
+            r"^TableExtension does not apply to type 'object'$",
             TableExtension.ext,
             object(),
         )

--- a/tests/extensions/test_timestamps.py
+++ b/tests/extensions/test_timestamps.py
@@ -230,7 +230,7 @@ class TimestampsTest(unittest.TestCase):
     ) -> None:
         self.assertRaisesRegex(
             ExtensionTypeError,
-            r"^Timestamps extension does not apply to type 'object'$",
+            r"^TimestampsExtension does not apply to type 'object'$",
             TimestampsExtension.ext,
             object(),
         )

--- a/tests/extensions/test_version.py
+++ b/tests/extensions/test_version.py
@@ -42,7 +42,7 @@ class VersionExtensionTest(unittest.TestCase):
     ) -> None:
         self.assertRaisesRegex(
             ExtensionTypeError,
-            r"^Version extension does not apply to type 'object'$",
+            r"^VersionExtension does not apply to type 'object'$",
             VersionExtension.ext,
             object(),
         )

--- a/tests/extensions/test_view.py
+++ b/tests/extensions/test_view.py
@@ -263,7 +263,7 @@ class ViewTest(unittest.TestCase):
     ) -> None:
         self.assertRaisesRegex(
             ExtensionTypeError,
-            r"^View extension does not apply to type 'object'$",
+            r"^ViewExtension does not apply to type 'object'$",
             ViewExtension.ext,
             object(),
         )

--- a/tests/serialization/test_migrate.py
+++ b/tests/serialization/test_migrate.py
@@ -96,7 +96,7 @@ class TestMigrate:
     ) -> None:
         with pytest.raises(
             ExtensionTypeError,
-            match=r"^Item Assets extension does not apply to type 'object'$",
+            match=r"^ItemAssetsExtension does not apply to type 'object'$",
         ):
             ItemAssetsExtension.ext(object())  # type: ignore
 


### PR DESCRIPTION
**Related Issue(s):**

- closes #890 

**Description:**

I added some docs to the concepts page of the docs and I also added a hint in the exception that is raised when `ext` is called with an invalid object type.

```python
from pystac import Collection, Extent, SpatialExtent, TemporalExtent
from pystac.extensions.projection import ProjectionExtension

collection = Collection(
    "an-id",
    "a description",
    Extent(
        SpatialExtent([-106.0, 41.0, -105.0, 42.0]),
        TemporalExtent.from_now(),
    ),
)
ProjectionExtension.ext(collection, add_if_missing=True)
```

```python-traceback
---------------------------------------------------------------------------
ExtensionTypeError                        Traceback (most recent call last)
Cell In[1], line 12
      2 from pystac.extensions.projection import ProjectionExtension
      4 collection = Collection(
      5     "an-id",
      6     "a description",
   (...)
     10     ),
     11 )
---> 12 ProjectionExtension.ext(collection, add_if_missing=True)

File ~/pystac/pystac/extensions/projection.py:289, in ProjectionExtension.ext(cls, obj, add_if_missing)
    287     return cast(ProjectionExtension[T], AssetProjectionExtension(obj))
    288 else:
--> 289     raise pystac.ExtensionTypeError(cls._ext_error_message(obj))

ExtensionTypeError: ProjectionExtension does not apply to type 'Collection'. Hint: Did you mean to use `.summaries` instead?
```

**PR Checklist:**

- [ ] `pre-commit` hooks pass locally
- [ ] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [ ] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
