### PR TITLE
Return Link Object after adding a child or item #1159

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Make sure that `get_items` is backwards compatible ([#1139](https://github.com/stac-utils/pystac/pull/1139))
 - Make `_repr_html_` look like `_repr_json_` output ([#1142](https://github.com/stac-utils/pystac/pull/1142))
 - Improved error message when `.ext` is called on a Collection ([#1157](https://github.com/stac-utils/pystac/pull/1157))
+- `add_child` and `add_item` return a Link object instead of None [#1159](https://github.com/stac-utils/pystac/issues/1159)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,8 @@
 - Make sure that `get_items` is backwards compatible ([#1139](https://github.com/stac-utils/pystac/pull/1139))
 - Make `_repr_html_` look like `_repr_json_` output ([#1142](https://github.com/stac-utils/pystac/pull/1142))
 - Improved error message when `.ext` is called on a Collection ([#1157](https://github.com/stac-utils/pystac/pull/1157))
-- `add_child` and `add_item` return a Link object instead of None [#1159](https://github.com/stac-utils/pystac/issues/1159)
+- `add_child` and `add_item` return a Link object instead of None ([#1160](https://github.com/stac-utils/pystac/pull/1160))
+- `add_children` and `add_items` return a list of Link objects instead of None ([#1160](https://github.com/stac-utils/pystac/pull/1160))
 
 ### Deprecated
 

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -231,7 +231,7 @@ class Catalog(STACObject):
         title: Optional[str] = None,
         strategy: Optional[HrefLayoutStrategy] = None,
         set_parent: bool = True,
-    ) -> None:
+    ) -> Link:
         """Adds a link to a child :class:`~pystac.Catalog` or
         :class:`~pystac.Collection`.
 
@@ -248,6 +248,9 @@ class Catalog(STACObject):
                 :class:`~pystac.layout.BestPracticesLayoutStrategy`.
             set_parent : Whether to set the parent on the child as well.
                 Defaults to True.
+
+        Returns:
+            Link: The link created for the child
         """
 
         # Prevent typo confusion
@@ -269,7 +272,9 @@ class Catalog(STACObject):
             child_href = strategy.get_href(child, os.path.dirname(self_href))
             child.set_self_href(child_href)
 
-        self.add_link(Link.child(child, title=title))
+        child_link = Link.child(child, title=title)
+        self.add_link(child_link)
+        return child_link
 
     def add_children(self, children: Iterable[Union["Catalog", Collection]]) -> None:
         """Adds links to multiple :class:`~pystac.Catalog` or `~pystac.Collection`
@@ -288,7 +293,7 @@ class Catalog(STACObject):
         title: Optional[str] = None,
         strategy: Optional[HrefLayoutStrategy] = None,
         set_parent: bool = True,
-    ) -> None:
+    ) -> Link:
         """Adds a link to an :class:`~pystac.Item`.
 
         This method will set the item's parent to this object and potentially
@@ -304,6 +309,9 @@ class Catalog(STACObject):
                 :class:`~pystac.layout.BestPracticesLayoutStrategy`.
             set_parent : Whether to set the parent on the item as well.
                 Defaults to True.
+
+        Returns:
+            Link: The link created for the item
         """
 
         # Prevent typo confusion
@@ -325,7 +333,9 @@ class Catalog(STACObject):
             item_href = strategy.get_href(item, os.path.dirname(self_href))
             item.set_self_href(item_href)
 
-        self.add_link(Link.item(item, title=title))
+        item_link = Link.item(item, title=title)
+        self.add_link(item_link)
+        return item_link
 
     def add_items(
         self,

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -276,16 +276,20 @@ class Catalog(STACObject):
         self.add_link(child_link)
         return child_link
 
-    def add_children(self, children: Iterable[Union["Catalog", Collection]]) -> None:
+    def add_children(
+        self, children: Iterable[Union["Catalog", Collection]]
+    ) -> List[Link]:
         """Adds links to multiple :class:`~pystac.Catalog` or `~pystac.Collection`
         objects. This method will set each child's parent to this object, and their
         root to this Catalog's root.
 
         Args:
             children : The children to add.
+
+        Returns:
+            List[Link]: An array of links created for the children
         """
-        for child in children:
-            self.add_child(child)
+        return [self.add_child(child) for child in children]
 
     def add_item(
         self,
@@ -341,7 +345,7 @@ class Catalog(STACObject):
         self,
         items: Iterable[Item],
         strategy: Optional[HrefLayoutStrategy] = None,
-    ) -> None:
+    ) -> List[Link]:
         """Adds links to multiple :class:`Items <pystac.Item>`.
 
         This method will set each item's parent to this object, and their root to
@@ -352,9 +356,11 @@ class Catalog(STACObject):
             strategy : The layout strategy to use for setting the
                 self href of the items. If not provided, defaults to
                 :class:`~pystac.layout.BestPracticesLayoutStrategy`.
+
+        Returns:
+            List[Link]: A list of links created for the item
         """
-        for item in items:
-            self.add_item(item, strategy=strategy)
+        return [self.add_item(item, strategy=strategy) for item in items]
 
     def get_child(
         self, id: str, recursive: bool = False, sort_links_by_id: bool = True

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -544,9 +544,10 @@ class Collection(Catalog):
         title: Optional[str] = None,
         strategy: Optional[HrefLayoutStrategy] = None,
         set_parent: bool = True,
-    ) -> None:
-        super().add_item(item, title, strategy, set_parent)
+    ) -> Link:
+        link = super().add_item(item, title, strategy, set_parent)
         item.set_collection(self)
+        return link
 
     def to_dict(
         self, include_self_link: bool = True, transform_hrefs: bool = True

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -228,6 +228,12 @@ class TestCatalog:
         with pytest.raises(pystac.STACError):
             cat.add_child(item)  # type:ignore
 
+    def test_add_child_returns_link(self) -> None:
+        parent = Catalog(id="parent", description="test")
+        child = Catalog(id="child", description="test")
+        link = parent.add_child(child)
+        assert isinstance(link, pystac.Link)
+
     def test_add_child_override_parent(self) -> None:
         parent1 = Catalog(id="parent1", description="test1")
         parent2 = Catalog(id="parent2", description="test2")
@@ -295,6 +301,18 @@ class TestCatalog:
         child = next(iter(cat.get_children()))
         with pytest.raises(pystac.STACError):
             cat.add_item(child)  # type:ignore
+
+    def test_add_item_returns_link(self) -> None:
+        parent = Catalog(id="parent", description="test")
+        child = Item(
+            id="child",
+            geometry=None,
+            bbox=None,
+            datetime=datetime.now(),
+            properties={},
+        )
+        link = parent.add_item(child)
+        assert isinstance(link, pystac.Link)
 
     def test_get_child_returns_none_if_not_found(self) -> None:
         cat = TestCases.case_1()

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -233,6 +233,23 @@ class TestCatalog:
         child = Catalog(id="child", description="test")
         link = parent.add_child(child)
         assert isinstance(link, pystac.Link)
+        link.extra_fields["foo"] = "bar"
+        link2 = parent.get_single_link("child")
+        assert link2 is not None
+        assert link2.extra_fields["foo"] == "bar"
+
+    def test_add_children_returns_links(self) -> None:
+        parent = Catalog(id="parent", description="test")
+        child1 = Catalog(id="child", description="test")
+        child2 = Catalog(id="child2", description="test")
+        links = parent.add_children([child1, child2])
+        assert isinstance(links, list)
+        assert len(links) == 2
+        assert isinstance(links[0], pystac.Link)
+        assert isinstance(links[1], pystac.Link)
+        links2 = parent.get_links("child")
+        assert links[0] in links2
+        assert links[1] in links2
 
     def test_add_child_override_parent(self) -> None:
         parent1 = Catalog(id="parent1", description="test1")
@@ -313,6 +330,35 @@ class TestCatalog:
         )
         link = parent.add_item(child)
         assert isinstance(link, pystac.Link)
+        link.extra_fields["foo"] = "bar"
+        link2 = parent.get_single_link("item")
+        assert link2 is not None
+        assert link2.extra_fields["foo"] == "bar"
+
+    def test_add_items_returns_links(self) -> None:
+        parent = Catalog(id="parent", description="test")
+        child1 = Item(
+            id="child1",
+            geometry=None,
+            bbox=None,
+            datetime=datetime.now(),
+            properties={},
+        )
+        child2 = Item(
+            id="child2",
+            geometry=None,
+            bbox=None,
+            datetime=datetime.now(),
+            properties={},
+        )
+        links = parent.add_items([child1, child2])
+        assert isinstance(links, list)
+        assert len(links) == 2
+        assert isinstance(links[0], pystac.Link)
+        assert isinstance(links[1], pystac.Link)
+        links2 = parent.get_links("item")
+        assert links[0] in links2
+        assert links[1] in links2
 
     def test_get_child_returns_none_if_not_found(self) -> None:
         cat = TestCases.case_1()


### PR DESCRIPTION
**Related Issue(s):**

- #1159

**Description:**

Catalog: `add_child` and `add_item` return a Link object instead of None [#1159](https://github.com/stac-utils/pystac/issues/1159)

**Example:**
```py
import pystac

root = pystac.Catalog("root", "root")
left = pystac.Catalog("left", "left")

link = root.add_child(left)
link.extra_fields["datetime"] = "2020-01-01T00:00:00Z"

root.normalize_and_save("out_test", pystac.CatalogType.ABSOLUTE_PUBLISHED)
```

Creates:
```json
{
  "type": "Catalog",
  "id": "root",
  "stac_version": "1.0.0",
  "description": "root",
  "links": [
    {
      "rel": "root",
      "href": "/mnt/c/Dev/pystac/out_test/catalog.json",
      "type": "application/json"
    },
    {
      "rel": "child",
      "href": "/mnt/c/Dev/pystac/out_test/left/catalog.json",
      "type": "application/json",
      "datetime": "2020-01-01T00:00:00Z"
    },
    {
      "rel": "self",
      "href": "/mnt/c/Dev/pystac/out_test/catalog.json",
      "type": "application/json"
    }
  ]
}
```

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [ ] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
