### PR TITLE
Remove faulty mypy annotation

### DIFF
--- a/pystac/validation/__init__.py
+++ b/pystac/validation/__init__.py
@@ -94,7 +94,7 @@ def validate_dict(
         def _get_uri(ext: str) -> Optional[str]:
             return OldExtensionSchemaUriMap.get_extension_schema_uri(
                 ext,
-                stac_object_type,  # type:ignore
+                stac_object_type,
                 stac_version_id,
             )
 


### PR DESCRIPTION
**Description:**
There's a lint error generated with newer mypy versions.  This fix removes the erring annotation.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] ~~Documentation has been updated to reflect changes, if applicable~~
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
