### PR TITLE
Include collection assets in `make_all_asset_hrefs_relative/absolute` 

### DIFF
--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -657,20 +657,18 @@ class Catalog(STACObject):
         return clone
 
     def make_all_asset_hrefs_relative(self) -> None:
-        """Makes all the HREFs of assets belonging to items in this catalog
-        and all children to be relative, recursively.
-        """
-        for _, _, items in self.walk():
-            for item in items:
-                item.make_asset_hrefs_relative()
+        """Recursively makes all the HREFs of assets in this catalog relative"""
+        for item in self.get_all_items():
+            item.make_asset_hrefs_relative()
+        for collection in self.get_all_collections():
+            collection.make_asset_hrefs_relative()
 
     def make_all_asset_hrefs_absolute(self) -> None:
-        """Makes all the HREFs of assets belonging to items in this catalog
-        and all children to be absolute, recursively.
-        """
-        for _, _, items in self.walk():
-            for item in items:
-                item.make_asset_hrefs_absolute()
+        """Recursively makes all the HREFs of assets in this catalog absolute"""
+        for item in self.get_all_items():
+            item.make_asset_hrefs_absolute()
+        for collection in self.get_all_collections():
+            collection.make_asset_hrefs_absolute()
 
     def normalize_and_save(
         self,


### PR DESCRIPTION
**Related Issue(s):**

- https://github.com/stac-utils/stactools/issues/423

**Description:**

Broadly "all_assets" for a catalog should include collection assets. Specifically I needed this functionality to solve the stactools issue

**PR Checklist:**

- [ ] `pre-commit` hooks pass locally
- [ ] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [ ] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
