### PR TITLE
Collection link should be resolved with root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,14 +44,15 @@
 - Include collection assets in `make_all_asset_hrefs_relative/absolute` ([#1168](https://github.com/stac-utils/pystac/pull/1168))
 - Use cassettes for all tests that pull files from remote ([#1162](https://github.com/stac-utils/pystac/pull/1162))
 
+### Fixed
+
+- Include the item's root when resolving its collection link ([#1171](https://github.com/stac-utils/pystac/pull/1171))
+
 ### Deprecated
 
 - `pystac.summaries.FIELDS_JSON_URL` ([#1045](https://github.com/stac-utils/pystac/pull/1045))
 - Catalog `get_item()`. Use `get_items(id)` instead ([#1075](https://github.com/stac-utils/pystac/pull/1075))
 - Catalog and Collection `get_all_items`. Use `get_items(recursive=True)` instead ([#1075](https://github.com/stac-utils/pystac/pull/1075))
-
-### Fixed
-
 
 ## [v1.7.3]
 

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -349,7 +349,9 @@ class Item(STACObject):
         if collection_link is None:
             return None
         else:
-            return cast(Collection, collection_link.resolve_stac_object().target)
+            return cast(
+                Collection, collection_link.resolve_stac_object(self.get_root()).target
+            )
 
     def add_derived_from(self, *items: Union[Item, str]) -> Item:
         """Add one or more items that this is derived from.


### PR DESCRIPTION
**Related Issue(s):**

- Motivated by https://github.com/stac-utils/pystac-client/issues/548

**Description:**

When resolving an item's collection link, we should pass the item's root into `resolve_stac_object`. This situation can come up when bouncing around a STAC API, where you don't always have a full tree built up in your cache.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
