### PR TITLE
Fix internal usage of deprecated function

### DIFF
--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -658,14 +658,14 @@ class Catalog(STACObject):
 
     def make_all_asset_hrefs_relative(self) -> None:
         """Recursively makes all the HREFs of assets in this catalog relative"""
-        for item in self.get_all_items():
+        for item in self.get_items(recursive=True):
             item.make_asset_hrefs_relative()
         for collection in self.get_all_collections():
             collection.make_asset_hrefs_relative()
 
     def make_all_asset_hrefs_absolute(self) -> None:
         """Recursively makes all the HREFs of assets in this catalog absolute"""
-        for item in self.get_all_items():
+        for item in self.get_items(recursive=True):
             item.make_asset_hrefs_absolute()
         for collection in self.get_all_collections():
             collection.make_asset_hrefs_absolute()


### PR DESCRIPTION
**Related Issue(s):**

- Deprecation introduced in #1075

**Description:**

Quick fix to use the non-deprecated versions (thanks warnings!). doesn't need a changelog

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
