### PR TITLE
Explicitly re-export href

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,17 @@
 
 ## [Unreleased]
 
+## [v1.8.2] - 2023-06-30
+
+### Fixed
+
+- Explicitly re-export HREF from `link` ([#1182](https://github.com/stac-utils/pystac/pull/1182))
+
 ## [v1.8.1] - 2023-06-30
 
 ### Fixed
 
-- Include jsonschemas in package
+- Include jsonschemas in package ([#1181](https://github.com/stac-utils/pystac/pull/1181))
 
 ## [v1.8.0] - 2023-06-27
 
@@ -743,7 +749,8 @@ use `Band.create`
 
 Initial release.
 
-[Unreleased]: <https://github.com/stac-utils/pystac/compare/v1.8.1..main>
+[Unreleased]: <https://github.com/stac-utils/pystac/compare/v1.8.2..main>
+[v1.8.2]: <https://github.com/stac-utils/pystac/compare/v1.8.1..v1.8.2>
 [v1.8.1]: <https://github.com/stac-utils/pystac/compare/v1.8.0..v1.8.1>
 [v1.8.0]: <https://github.com/stac-utils/pystac/compare/v1.7.3..v1.8.0>
 [v1.7.3]: <https://github.com/stac-utils/pystac/compare/v1.7.2..v1.7.3>

--- a/pystac/link.py
+++ b/pystac/link.py
@@ -8,7 +8,9 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Type, TypeVar, Union
 import pystac
 from pystac.html.jinja_env import get_jinja_env
 from pystac.utils import (
-    HREF,
+    HREF as HREF,
+)
+from pystac.utils import (
     is_absolute_href,
     make_absolute_href,
     make_posix_style,

--- a/pystac/version.py
+++ b/pystac/version.py
@@ -1,7 +1,7 @@
 import os
 from typing import Optional
 
-__version__ = "1.8.1"
+__version__ = "1.8.2"
 """Library version"""
 
 


### PR DESCRIPTION
**Related Issue(s):**

- Accidentally removed in #1125

**Description:**

Discovered in **stactools** CI: https://github.com/stac-utils/stactools/actions/runs/5424579095/jobs/9864137816?pr=452#step:5:38. Includes a version bump to v1.8.2 to pick up the fix 🤦🏼

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
