### PR TITLE
Install package data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,12 @@ repository = "https://github.com/stac-utils/pystac.git"
 changelog = "https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md"
 discussions = "https://github.com/radiantearth/stac-spec/discussions/categories/stac-software"
 
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.package-data]
+"pystac.static" = ["*.json"]
+
 [tool.setuptools.packages.find]
 include = ["pystac*"]
 exclude = ["tests*", "benchmarks*"]


### PR DESCRIPTION
**Related Issue(s):**

- N/A

**Description:**

The `pystac/static/fields-normalized.json` file appears to be part of package date but it seems that it is not installed.
The PR modifies slightly the `pyproject.toml` file to properly declare `pystac/static/fields-normalized.json` properly and install it.

**PR Checklist:**

- [X] `pre-commit` hooks pass locally
- [X] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [X] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
