### PR TITLE
Allow a DeprecationWarning from jsonschema

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,9 @@ select = ["E", "F", "I"]
 [tool.pytest.ini_options]
 filterwarnings = [
     "error",
+    # Allows jsonschema's RefResolver deprecation warning through until we're
+    # updated to support jsonschema v4.18
+    "default::DeprecationWarning:pystac.validation.*"
 ]
 
 [build-system]


### PR DESCRIPTION
**Related Issue(s):**

- Unblocks CI
- A quickfix until https://github.com/stac-utils/pystac/issues/1186 is fixed

**Description:**

**jsonschema** v4.18 deprecated `RefResolver`, so we'll need to update **pystac** to work around that deprecation. This PR is a quickfix to get CI working, and includes a note about the fix.

Doesn't need a changelog entry.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
