### PR TITLE
set upper bound for jsonschema version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ test = [
     "vcrpy<5",
 ]
 urllib3 = ["urllib3>=1.26"]
-validation = ["jsonschema>=4.0.1"]
+validation = ["jsonschema>=4.0.1,<4.18"]
 
 [project.urls]
 homepage = "https://github.com/stac-utils/pystac"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ test = [
     "vcrpy<5",
 ]
 urllib3 = ["urllib3>=1.26"]
+# jsonschema v4.18.2 breaks validation, and it feels safer to set a ceiling rather than just skip this version. The ceiling should be removed when the v4.18 lineage has settled down and feels safer.
 validation = ["jsonschema>=4.0.1,<4.18"]
 
 [project.urls]


### PR DESCRIPTION
**Related Issue(s):**

#1186 


**Description:**

with 4.18.1 and 4.18.2, jsonschema will raise an error. While we wait for the removal of `RefResolver` it would be safer to pin jsonschema with an upper bound to `<4.18`

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [ ] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
