### PR TITLE
pin jsonschema to <4.18 in validation and test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Pin jsonschema version to <4.18 until regresssions are fixed
+
 ## [v1.8.2] - 2023-07-12
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ test = [
     "doc8~=1.1",
     "html5lib~=1.1",
     "jinja2<4.0",
-    "jsonschema~=4.17",
+    "jsonschema<4.18",
     "mypy~=1.2",
     "orjson~=3.8",
     "pre-commit~=3.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ test = [
     "doc8~=1.1",
     "html5lib~=1.1",
     "jinja2<4.0",
-    "jsonschema<4.18",
+    "jsonschema>=4.0.1,<4.18",
     "mypy~=1.2",
     "orjson~=3.8",
     "pre-commit~=3.2",


### PR DESCRIPTION
**Related Issue(s):**

- https://github.com/stac-utils/pystac/issues/1186

**Description:**

**PR Checklist:**

- [X] `pre-commit` hooks pass locally
- [X] Tests pass (run `scripts/test`)
- [X] Documentation has been updated to reflect changes, if applicable
- [X] This PR maintains or improves overall codebase code coverage.
- [X] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
