### PR TITLE
Allow to pass a dict for the summarized fields, fix the doc rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Allow to pass a Dict with field names and summary strategies to the `fields` parameter in the `Summarizer` constructor
+- Allow to pass a Dict with field names and summary strategies to the `fields` parameter in the `Summarizer` constructor ([#1195](https://github.com/stac-utils/pystac/pull/1195))
 
 ### Changed
 
@@ -12,7 +12,7 @@
 
 ### Fixed
 
-- Fix the documentation rendering of the `fields` parameter in the `Summarizer` constructor
+- Fix the documentation rendering of the `fields` parameter in the `Summarizer` constructor ([#1195](https://github.com/stac-utils/pystac/pull/1195))
 
 ## [v1.8.2] - 2023-07-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,17 @@
 
 ## [Unreleased]
 
+### Added
+
+- Allow to pass a Dict with field names and summary strategies to the `fields` parameter in the `Summarizer` constructor
+
 ### Changed
 
 - Pin jsonschema version to <4.18 until regresssions are fixed
+
+### Fixed
+
+- Fix the documentation rendering of the `fields` parameter in the `Summarizer` constructor
 
 ## [v1.8.2] - 2023-07-12
 

--- a/tests/test_summaries.py
+++ b/tests/test_summaries.py
@@ -2,7 +2,7 @@ import socket
 import unittest
 from typing import Any
 
-from pystac.summaries import RangeSummary, Summaries, Summarizer
+from pystac.summaries import RangeSummary, Summaries, Summarizer, SummaryStrategy
 from tests.utils import TestCases
 
 
@@ -26,6 +26,20 @@ class SummariesTest(unittest.TestCase):
         coll = TestCases.case_5()
         path = TestCases.get_path("data-files/summaries/fields_no_bands.json")
         summaries = Summarizer(path).summarize(coll.get_items(recursive=True))
+        summaries_dict = summaries.to_dict()
+        self.assertIsNone(summaries_dict.get("eo:bands"))
+        self.assertEqual(len(summaries_dict["proj:epsg"]), 1)
+
+    def test_summary_custom_fields_dict(self) -> None:
+        coll = TestCases.case_5()
+        spec = {
+            "eo:bands": SummaryStrategy.DONT_SUMMARIZE,
+            "proj:epsg": SummaryStrategy.ARRAY,
+        }
+        obj = Summarizer(spec)
+        self.assertTrue("eo:bands" not in obj.summaryfields)
+        self.assertEqual(obj.summaryfields["proj:epsg"], SummaryStrategy.ARRAY)
+        summaries = obj.summarize(coll.get_items(recursive=True))
         summaries_dict = summaries.to_dict()
         self.assertIsNone(summaries_dict.get("eo:bands"))
         self.assertEqual(len(summaries_dict["proj:epsg"]), 1)


### PR DESCRIPTION
**Related Issue(s):**

- None

**Description:**

This implements two changes:
- Allow to pass a Dict with field names and summary strategies. Some people didn't realize they could set the `summaryfields` property so this makes it more obvious that you don't necessarily need to create a JSON file.
- Fix the foc rendering:
    ![grafik](https://github.com/stac-utils/pystac/assets/8262166/ce1fed59-c97a-4439-8f7b-bb6f02707d9b)
- Generally improve the summaries section a bit based on questions that I was asked during consulting.


**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
