### PR TITLE
Bump pytest-recording, remove vcrpy pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,12 @@ description = "Python library for working with the SpatioTemporal Asset Catalog 
 readme = "README.md"
 authors = [
     { name = "Rob Emanuele", email = "rdemanuele@gmail.com" },
-    { name = "Jon Duckworth", email = "duckontheweb@gmail.com" }
+    { name = "Jon Duckworth", email = "duckontheweb@gmail.com" },
 ]
-maintainers = [
-    { name = "Pete Gadomski", email = "pete.gadomski@gmail.com" }
-]
+maintainers = [{ name = "Pete Gadomski", email = "pete.gadomski@gmail.com" }]
 keywords = ["pystac", "imagery", "raster", "catalog", "STAC"]
 license = { text = "Apache-2.0" }
-classifiers=[
+classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
@@ -30,10 +28,7 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-bench = [
-    "asv~=0.5",
-    "virtualenv~=20.22",
-]
+bench = ["asv~=0.5", "virtualenv~=20.22"]
 docs = [
     "Sphinx~=6.2",
     "ipython~=8.12",
@@ -45,9 +40,7 @@ docs = [
     "sphinx-design~=0.4",
     "sphinxcontrib-fulltoc~=1.2",
 ]
-jinja2 = [
-    "jinja2<4.0",
-]
+jinja2 = ["jinja2<4.0"]
 orjson = ["orjson>=3.5"]
 test = [
     "black~=23.3",
@@ -62,16 +55,13 @@ test = [
     "pre-commit~=3.2",
     "pytest-cov~=4.0",
     "pytest-mock~=3.10",
-    "pytest-recording~=0.12",
+    "pytest-recording~=0.13",
     "pytest~=7.3",
     "ruff==0.0.283",
     "types-html5lib~=1.1",
     "types-orjson~=3.6",
     "types-python-dateutil~=2.8",
     "types-urllib3~=1.26",
-    # pytest-recording breakage with v5.0.0, need release of
-    # https://github.com/kiwicom/pytest-recording/pull/110 to remove this ceil
-    "vcrpy<5",
 ]
 urllib3 = ["urllib3>=1.26"]
 # jsonschema v4.18.2 breaks validation, and it feels safer to set a ceiling rather than just skip this version. The ceiling should be removed when the v4.18 lineage has settled down and feels safer.
@@ -100,7 +90,7 @@ filterwarnings = [
     "error",
     # Allows jsonschema's RefResolver deprecation warning through until we're
     # updated to support jsonschema v4.18
-    "default::DeprecationWarning:pystac.validation.*"
+    "default::DeprecationWarning:pystac.validation.*",
 ]
 
 [build-system]


### PR DESCRIPTION
**Description:**

We had to work around a breaking change to vcrpy for a bit, but that's fixed now. Includes some TOML-whitespace changes from my editor, hope that's ok.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
