### PR TITLE
Fix warning  message from get_all_items deprecation

### DIFF
--- a/docs/tutorials/pystac-introduction.ipynb
+++ b/docs/tutorials/pystac-introduction.ipynb
@@ -1671,7 +1671,7 @@
    ],
    "source": [
     "# get all items anywhere below this catalog on the STAC tree\n",
-    "list(cat.get_all_items())"
+    "list(cat.get_items(recursive=True))"
    ]
   },
   {
@@ -1812,7 +1812,7 @@
    ],
    "source": [
     "print(\"\\n**Items**\")\n",
-    "for i in cat.get_all_items():\n",
+    "for i in cat.get_items(recursive=True):\n",
     "    print(i.id)"
    ]
   },
@@ -6096,7 +6096,7 @@
     }
    ],
    "source": [
-    "item = next(mycat.get_all_items())\n",
+    "item = next(mycat.get_items(recursive=True))\n",
     "item.get_single_link(\"parent\").get_href()"
    ]
   },
@@ -6135,7 +6135,7 @@
     }
    ],
    "source": [
-    "item = next(mycat.get_all_items())\n",
+    "item = next(mycat.get_items(recursive=True))\n",
     "item.get_single_link(\"parent\").get_href()"
    ]
   }

--- a/docs/tutorials/pystac-spacenet-tutorial.ipynb
+++ b/docs/tutorials/pystac-spacenet-tutorial.ipynb
@@ -250,7 +250,7 @@
    "source": [
     "bounds = [\n",
     "    list(\n",
-    "        GeometryCollection([shape(s.geometry) for s in spacenet.get_all_items()]).bounds\n",
+    "        GeometryCollection([shape(s.geometry) for s in spacenet.get_items(recursive=True)]).bounds\n",
     "    )\n",
     "]\n",
     "vegas.extent.spatial = pystac.SpatialExtent(bounds)"

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -585,12 +585,12 @@ class Catalog(STACObject):
                 child links.
         """
         warnings.warn(
-            "get_item is deprecated and will be removed in v2",
+            "get_all_items is deprecated and will be removed in v2",
             DeprecationWarning,
         )
         return chain(
             self.get_items(),
-            *(child.get_all_items() for child in self.get_children()),
+            *(child.get_items(recursive=True) for child in self.get_children()),
         )
 
     def get_item_links(self) -> List[Link]:


### PR DESCRIPTION
**Related Issue(s):**

- Introduced in #1075

**Description:**

Also, remove usages of deprecated functions.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
