### PR TITLE
Use three digits for ~= v0.* deps

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -169,4 +169,4 @@ jobs:
       - name: Set asv machine
         run: asv machine --yes
       - name: Check benchmarks
-        run: asv run -a repeat=1 -a rounds=1 --strict HEAD
+        run: asv run -a repeat=1 -a rounds=1 HEAD

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,16 +28,16 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-bench = ["asv~=0.5", "virtualenv~=20.22"]
+bench = ["asv~=0.6.0", "packaging~=23.1", "virtualenv~=20.22"]
 docs = [
     "Sphinx~=6.2",
     "ipython~=8.12",
     "jinja2<4.0",
     "jupyter~=1.0",
-    "nbsphinx~=0.9",
+    "nbsphinx~=0.9.0",
     "pydata-sphinx-theme~=0.13",
     "sphinx-autobuild==2021.3.14",
-    "sphinx-design~=0.4",
+    "sphinx-design~=0.5.0",
     "sphinxcontrib-fulltoc~=1.2",
 ]
 jinja2 = ["jinja2<4.0"]
@@ -55,7 +55,7 @@ test = [
     "pre-commit~=3.2",
     "pytest-cov~=4.0",
     "pytest-mock~=3.10",
-    "pytest-recording~=0.13",
+    "pytest-recording~=0.13.0",
     "pytest~=7.3",
     "ruff==0.0.285",
     "types-html5lib~=1.1",


### PR DESCRIPTION
**Description:**

I realized recently that using `~=` and two digits for dependencies that start with `0.` is more-or-less meaningless, since it expands to `>=0.x,<1.0`. This updates to add a third digit for `0.*` dependencies.

This also fixes our bench check caused by `asv` breaking change in their CLI that popped up due to the dependency pinning problem. Doesn't need a changelog.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
