### PR TITLE
Capitalize project.urls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,11 +67,11 @@ urllib3 = ["urllib3>=1.26"]
 validation = ["jsonschema~=4.18"]
 
 [project.urls]
-homepage = "https://github.com/stac-utils/pystac"
-documentation = "https://pystac.readthedocs.io"
-repository = "https://github.com/stac-utils/pystac.git"
-changelog = "https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md"
-discussions = "https://github.com/radiantearth/stac-spec/discussions/categories/stac-software"
+Homepage = "https://github.com/stac-utils/pystac"
+Documentation = "https://pystac.readthedocs.io"
+Repository = "https://github.com/stac-utils/pystac.git"
+Changelog = "https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md"
+Discussions = "https://github.com/radiantearth/stac-spec/discussions/categories/stac-software"
 
 [tool.setuptools.packages.find]
 include = ["pystac*"]
@@ -85,9 +85,7 @@ line-length = 88
 select = ["E", "F", "I"]
 
 [tool.pytest.ini_options]
-filterwarnings = [
-    "error",
-]
+filterwarnings = ["error"]
 
 [build-system]
 requires = ["setuptools>=61.0"]


### PR DESCRIPTION
**Description:**

They appear exactly as-is on https://pypi.org/project/pystac/. Currently they look a little awkward:

![image](https://github.com/stac-utils/pystac/assets/58314/0656002a-0bcb-4cd9-bac8-111ca4de12cd)

No CHANGELOG needed.


**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [ ] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
