### PR TITLE
Permissively deserialize temporal extents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Permissive deserialization of Collection temporal extents ([#1222](https://github.com/stac-utils/pystac/pull/1222))
+
 ### Fixed
 
 - Update usage of jsonschema ([#1215](https://github.com/stac-utils/pystac/pull/1215))
@@ -9,7 +13,6 @@
 ### Deprecated
 
 - `pystac.validation.local_validator.LocalValidator` ([#1215](https://github.com/stac-utils/pystac/pull/1215))
-
 
 ## [v1.8.3] - 2023-07-12
 

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -257,6 +257,20 @@ class TemporalExtent:
         """
         parsed_intervals: List[List[Optional[datetime]]] = []
         for i in d["interval"]:
+            if isinstance(i, str):
+                # d["interval"] is a list of strings, so we correct the list and
+                # try again
+                # https://github.com/stac-utils/pystac/issues/1221
+                warnings.warn(
+                    "A collection's temporal extent should be a list of lists, but "
+                    "is instead a "
+                    "list of strings. pystac is fixing this issue and continuing "
+                    "deserialization, but note that the source "
+                    "collection is invalid STAC.",
+                    UserWarning,
+                )
+                d["interval"] = [d["interval"]]
+                return TemporalExtent.from_dict(d)
             start = None
             end = None
 

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -660,3 +660,13 @@ def test_delete_asset_relative_no_self_link_fails(
     assert asset.href in str(e.value)
     assert name in collection.assets
     assert os.path.exists(href)
+
+
+def test_permissive_temporal_extent_deserialization(collection: Collection) -> None:
+    # https://github.com/stac-utils/pystac/issues/1221
+    collection_dict = collection.to_dict(include_self_link=False, transform_hrefs=False)
+    collection_dict["extent"]["temporal"]["interval"] = collection_dict["extent"][
+        "temporal"
+    ]["interval"][0]
+    with pytest.warns(UserWarning):
+        Collection.from_dict(collection_dict)


### PR DESCRIPTION
**Related Issue(s):**

- Closes #1221

**Description:**

Thanks to @giswqs for the report! Since this will enable use of one of the larger open catalogs out there, we'll try to get a PATCH release out after this is merged.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
