### PR TITLE
Fix typo in dev install instructions

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -13,8 +13,8 @@ pip as follows:
 .. code-block:: bash
 
     git clone git@github.com:your_user_name/pystac.git
-    cd  pystac
-    pip install -e '.[dev]'
+    cd pystac
+    pip install -e '.[test]'
 
 Testing
 ^^^^^^^


### PR DESCRIPTION
**Related Issue(s):** None

**Description:** Fix typo in development installation instructions in contributing guide

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [ ] ~~This PR maintains or improves overall codebase code coverage.~~ N/A
- [ ] ~~Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.~~ N/A
