### PR TITLE
Allow future extensions to be used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- More permissive schema_uri matching to allow future versions of extension schemas ([#1231](https://github.com/stac-utils/pystac/pull/1231))
+
 ## [v1.8.4] - 2023-09-22
 
 ### Added

--- a/pystac/extensions/base.py
+++ b/pystac/extensions/base.py
@@ -16,6 +16,8 @@ from typing import (
 
 import pystac
 
+VERSION_REGEX = re.compile("/v[0-9].[0-9].*/")
+
 
 class SummariesExtension:
     """Base class for extending the properties in :attr:`pystac.Collection.summaries`
@@ -146,7 +148,7 @@ class ExtensionManagementMixin(Generic[S], ABC):
     def has_extension(cls, obj: S) -> bool:
         """Check if the given object implements this extension by checking
         :attr:`pystac.STACObject.stac_extensions` for this extension's schema URI."""
-        schema_startswith = re.split("/v[0-9].[0-9].*/", cls.get_schema_uri())[0] + "/"
+        schema_startswith = re.split(VERSION_REGEX, cls.get_schema_uri())[0] + "/"
 
         return obj.stac_extensions is not None and any(
             uri.startswith(schema_startswith) for uri in obj.stac_extensions

--- a/pystac/extensions/base.py
+++ b/pystac/extensions/base.py
@@ -1,3 +1,5 @@
+import re
+import warnings
 from abc import ABC, abstractmethod
 from typing import (
     Any,
@@ -115,6 +117,10 @@ class ExtensionManagementMixin(Generic[S], ABC):
     @classmethod
     def get_schema_uris(cls) -> List[str]:
         """Gets a list of schema URIs associated with this extension."""
+        warnings.warn(
+            "get_schema_uris is deprecated and will be removed in v2",
+            DeprecationWarning,
+        )
         return [cls.get_schema_uri()]
 
     @classmethod
@@ -140,8 +146,10 @@ class ExtensionManagementMixin(Generic[S], ABC):
     def has_extension(cls, obj: S) -> bool:
         """Check if the given object implements this extension by checking
         :attr:`pystac.STACObject.stac_extensions` for this extension's schema URI."""
+        schema_startswith = re.split("/v[0-9].[0-9].*/", cls.get_schema_uri())[0] + "/"
+
         return obj.stac_extensions is not None and any(
-            uri in obj.stac_extensions for uri in cls.get_schema_uris()
+            uri.startswith(schema_startswith) for uri in obj.stac_extensions
         )
 
     @classmethod

--- a/pystac/extensions/classification.py
+++ b/pystac/extensions/classification.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import warnings
 from typing import (
     Any,
     Dict,
@@ -510,6 +511,10 @@ class ClassificationExtension(
 
     @classmethod
     def get_schema_uris(cls) -> List[str]:
+        warnings.warn(
+            "get_schema_uris is deprecated and will be removed in v2",
+            DeprecationWarning,
+        )
         return [SCHEMA_URI_PATTERN.format(version=v) for v in SUPPORTED_VERSIONS]
 
     @classmethod
@@ -637,9 +642,11 @@ class SummariesClassificationExtension(SummariesExtension):
 
 class ClassificationExtensionHooks(ExtensionHooks):
     schema_uri: str = SCHEMA_URI_PATTERN.format(version=DEFAULT_VERSION)
-    prev_extension_ids = set(ClassificationExtension.get_schema_uris()) - set(
-        [ClassificationExtension.get_schema_uri()]
-    )
+    prev_extension_ids = {
+        SCHEMA_URI_PATTERN.format(version=v)
+        for v in SUPPORTED_VERSIONS
+        if v != DEFAULT_VERSION
+    }
     stac_object_types = {pystac.STACObjectType.ITEM}
 
     def migrate(

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import (
     Any,
     Dict,
@@ -385,6 +386,10 @@ class EOExtension(
 
     @classmethod
     def get_schema_uris(cls) -> List[str]:
+        warnings.warn(
+            "get_schema_uris is deprecated and will be removed in v2",
+            DeprecationWarning,
+        )
         return SCHEMA_URIS
 
     @classmethod

--- a/pystac/extensions/grid.py
+++ b/pystac/extensions/grid.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import warnings
 from typing import Any, Dict, List, Optional, Pattern, Set, Union
 
 import pystac
@@ -86,6 +87,10 @@ class GridExtension(
 
     @classmethod
     def get_schema_uris(cls) -> List[str]:
+        warnings.warn(
+            "get_schema_uris is deprecated and will be removed in v2",
+            DeprecationWarning,
+        )
         return SCHEMA_URIS
 
     @classmethod

--- a/pystac/extensions/label.py
+++ b/pystac/extensions/label.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Union, cast
 
 import pystac
@@ -696,6 +697,10 @@ class LabelExtension(ExtensionManagementMixin[Union[pystac.Item, pystac.Collecti
 
     @classmethod
     def get_schema_uris(cls) -> List[str]:
+        warnings.warn(
+            "get_schema_uris is deprecated and will be removed in v2",
+            DeprecationWarning,
+        )
         return SCHEMA_URIS
 
     @classmethod

--- a/pystac/extensions/mgrs.py
+++ b/pystac/extensions/mgrs.py
@@ -8,6 +8,7 @@ from pystac.extensions.base import ExtensionManagementMixin, PropertiesExtension
 from pystac.extensions.hooks import ExtensionHooks
 
 SCHEMA_URI: str = "https://stac-extensions.github.io/mgrs/v1.0.0/schema.json"
+SCHEMA_STARTSWITH: str = "https://stac-extensions.github.io/mgrs/"
 PREFIX: str = "mgrs:"
 
 # Field names

--- a/pystac/extensions/projection.py
+++ b/pystac/extensions/projection.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import warnings
 from typing import Any, Dict, Generic, Iterable, List, Optional, TypeVar, Union, cast
 
 import pystac
@@ -265,6 +266,10 @@ class ProjectionExtension(
 
     @classmethod
     def get_schema_uris(cls) -> List[str]:
+        warnings.warn(
+            "get_schema_uris is deprecated and will be removed in v2",
+            DeprecationWarning,
+        )
         return SCHEMA_URIS
 
     @classmethod

--- a/pystac/extensions/raster.py
+++ b/pystac/extensions/raster.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from typing import (
     Any,
     Dict,
@@ -32,6 +33,7 @@ SCHEMA_URIS = [
     "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
     SCHEMA_URI,
 ]
+SCHEMA_STARTWITH = "https://stac-extensions.github.io/raster/"
 BANDS_PROP = "raster:bands"
 
 
@@ -715,6 +717,10 @@ class RasterExtension(
 
     @classmethod
     def get_schema_uris(cls) -> List[str]:
+        warnings.warn(
+            "get_schema_uris is deprecated and will be removed in v2",
+            DeprecationWarning,
+        )
         return SCHEMA_URIS
 
     @classmethod

--- a/tests/extensions/test_classification.py
+++ b/tests/extensions/test_classification.py
@@ -94,12 +94,13 @@ def test_bitfield_object() -> None:
 
 
 def test_get_schema_uri(landsat_item: Item) -> None:
-    assert any(
-        [
-            uri in landsat_item.stac_extensions
-            for uri in ClassificationExtension.get_schema_uris()
-        ]
-    )
+    with pytest.raises(DeprecationWarning):
+        assert any(
+            [
+                uri in landsat_item.stac_extensions
+                for uri in ClassificationExtension.get_schema_uris()
+            ]
+        )
 
 
 def test_ext_raises_if_item_does_not_conform(plain_item: Item) -> None:

--- a/tests/extensions/test_projection.py
+++ b/tests/extensions/test_projection.py
@@ -552,10 +552,10 @@ class ProjectionSummariesTest(unittest.TestCase):
 
 def test_older_extension_version(projection_landsat8_item: Item) -> None:
     old = "https://stac-extensions.github.io/projection/v1.0.0/schema.json"
-    new = "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+    current = "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
 
     stac_extensions = set(projection_landsat8_item.stac_extensions)
-    stac_extensions.remove(new)
+    stac_extensions.remove(current)
     stac_extensions.add(old)
     item_as_dict = projection_landsat8_item.to_dict(
         include_self_link=False, transform_hrefs=False
@@ -564,6 +564,26 @@ def test_older_extension_version(projection_landsat8_item: Item) -> None:
     item = Item.from_dict(item_as_dict)
     assert ProjectionExtension.has_extension(item)
     assert old in item.stac_extensions
+
+    migrated_item = pystac.Item.from_dict(item_as_dict, migrate=True)
+    assert ProjectionExtension.has_extension(migrated_item)
+    assert current in migrated_item.stac_extensions
+
+
+def test_newer_extension_version(projection_landsat8_item: Item) -> None:
+    new = "https://stac-extensions.github.io/projection/v2.0.0/schema.json"
+    current = "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+
+    stac_extensions = set(projection_landsat8_item.stac_extensions)
+    stac_extensions.remove(current)
+    stac_extensions.add(new)
+    item_as_dict = projection_landsat8_item.to_dict(
+        include_self_link=False, transform_hrefs=False
+    )
+    item_as_dict["stac_extensions"] = list(stac_extensions)
+    item = Item.from_dict(item_as_dict)
+    assert ProjectionExtension.has_extension(item)
+    assert new in item.stac_extensions
 
     migrated_item = pystac.Item.from_dict(item_as_dict, migrate=True)
     assert ProjectionExtension.has_extension(migrated_item)


### PR DESCRIPTION
**Related Issue(s):**

- Closes #1226

**Description:**

When loading extension data, extension implementations should use `startswith` (or whatever) to detect the presence of the extension, not an exact string match.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
