### PR TITLE
Fix black-jupyter pre-commit hook config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
         language: python
         require_serial: true
         types_or: [python, pyi, jupyter]
-        additional_dependencies: [".[jupyter]"]
+        additional_dependencies: ["black[jupyter]"]
 
       - id: codespell
         name: codespell

--- a/docs/tutorials/pystac-spacenet-tutorial.ipynb
+++ b/docs/tutorials/pystac-spacenet-tutorial.ipynb
@@ -250,7 +250,9 @@
    "source": [
     "bounds = [\n",
     "    list(\n",
-    "        GeometryCollection([shape(s.geometry) for s in spacenet.get_items(recursive=True)]).bounds\n",
+    "        GeometryCollection(\n",
+    "            [shape(s.geometry) for s in spacenet.get_items(recursive=True)]\n",
+    "        ).bounds\n",
     "    )\n",
     "]\n",
     "vegas.extent.spatial = pystac.SpatialExtent(bounds)"


### PR DESCRIPTION
**Related Issue(s):** #1156

**Description:** Fix pre-commit configuration for black-jupyter, which was unintentionally skipping reformatting python within jupyter notebooks.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [ ] N/A ~~Documentation has been updated to reflect changes, if applicable~~
- [ ] N/A ~~This PR maintains or improves overall codebase code coverage.~~
- [ ] N/A ~~Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.~~
