### PR TITLE
Allow HREF when opening files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - More permissive schema_uri matching to allow future versions of extension schemas ([#1231](https://github.com/stac-utils/pystac/pull/1231))
 
+### Fixed
+
+- Typing of `href` arguments ([#1234](https://github.com/stac-utils/pystac/pull/1234))
+
 ## [v1.8.4] - 2023-09-22
 
 ### Added

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -36,6 +36,7 @@ from pystac.serialization import (
 )
 from pystac.stac_object import STACObject, STACObjectType
 from pystac.utils import (
+    HREF,
     StringEnum,
     is_absolute_href,
     make_absolute_href,
@@ -1245,7 +1246,7 @@ class Catalog(STACObject):
 
     @classmethod
     def from_file(
-        cls: Type[C], href: str, stac_io: Optional[pystac.StacIO] = None
+        cls: Type[C], href: HREF, stac_io: Optional[pystac.StacIO] = None
     ) -> C:
         if stac_io is None:
             stac_io = pystac.StacIO.default()

--- a/pystac/item_collection.py
+++ b/pystac/item_collection.py
@@ -19,7 +19,7 @@ import pystac
 from pystac.errors import STACTypeError
 from pystac.html.jinja_env import get_jinja_env
 from pystac.serialization.identify import identify_stac_object_type
-from pystac.utils import is_absolute_href, make_absolute_href
+from pystac.utils import HREF, is_absolute_href, make_absolute_href, make_posix_style
 
 ItemLike = Union[pystac.Item, Dict[str, Any]]
 
@@ -195,7 +195,7 @@ class ItemCollection(Collection[pystac.Item]):
 
     @classmethod
     def from_file(
-        cls: Type[C], href: str, stac_io: Optional[pystac.StacIO] = None
+        cls: Type[C], href: HREF, stac_io: Optional[pystac.StacIO] = None
     ) -> C:
         """Reads a :class:`ItemCollection` from a JSON file.
 
@@ -206,6 +206,7 @@ class ItemCollection(Collection[pystac.Item]):
         if stac_io is None:
             stac_io = pystac.StacIO.default()
 
+        href = make_posix_style(href)
         if not is_absolute_href(href):
             href = make_absolute_href(href)
 

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -22,6 +22,7 @@ from pystac import STACError
 from pystac.html.jinja_env import get_jinja_env
 from pystac.link import Link
 from pystac.utils import (
+    HREF,
     StringEnum,
     is_absolute_href,
     make_absolute_href,
@@ -603,7 +604,7 @@ class STACObject(ABC):
 
     @classmethod
     def from_file(
-        cls: Type[S], href: str, stac_io: Optional[pystac.StacIO] = None
+        cls: Type[S], href: HREF, stac_io: Optional[pystac.StacIO] = None
     ) -> S:
         """Reads a STACObject implementation from a file.
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1720,7 +1720,7 @@ def test_set_parent_false_stores_in_proper_place_on_save(
     nested_catalog.normalize_and_save(
         root_href=str(tmp_path), catalog_type=pystac.CatalogType.ABSOLUTE_PUBLISHED
     )
-    root = pystac.Catalog.from_file(str(tmp_path / "catalog.json"))
+    root = pystac.Catalog.from_file(tmp_path / "catalog.json")
     product_a = next(root.get_child("products").get_children())  # type: ignore
     variable_a = next(root.get_child("variables").get_children())  # type: ignore
 

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -488,7 +488,7 @@ def test_duplicate_self_links(tmp_path: Path, sample_item: pystac.Item) -> None:
     assert len(sample_item.get_links(rel="self")) == 1
     path = tmp_path / "item.json"
     sample_item.save_object(include_self_link=True, dest_href=str(path))
-    sample_item = Item.from_file(str(path))
+    sample_item = Item.from_file(path)
     assert len(sample_item.get_links(rel="self")) == 1
 
 

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -630,3 +630,9 @@ def test_non_hierarchical_relative_link() -> None:
     assert a.target_in_hierarchy(b)
     assert root.target_in_hierarchy(next(b.get_items()))
     assert root.target_in_hierarchy(root)
+
+
+def test_pathlib() -> None:
+    # This works, but breaks mypy until we fix
+    # https://github.com/stac-utils/pystac/issues/1216
+    Item.from_file(Path(TestCases.get_path("data-files/item/sample-item.json")))

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -328,7 +328,7 @@ def test_relative_self_link(tmp_path: Path) -> None:
     collection.save_object(
         include_self_link=False, dest_href=str(tmp_path / "collection.json")
     )
-    collection = Collection.from_file(str(tmp_path / "collection.json"))
+    collection = Collection.from_file(tmp_path / "collection.json")
     read_item = collection.get_item("an-id")
     assert read_item
     asset_href = read_item.assets["data"].get_absolute_href()


### PR DESCRIPTION
**Related Issue(s):**

- Closes #1216

**Description:**

Functionally this worked, but the typing needed a fix.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
