### PR TITLE
Drop python 3.8

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,7 +26,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
@@ -59,10 +58,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.8
+      - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.9"
           cache: "pip"
 
       - name: Install with dependencies
@@ -102,7 +101,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
@@ -129,7 +127,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.9"
 
       - name: Install
         run: pip install .[validation,test]
@@ -147,7 +145,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.9"
           cache: "pip"
 
       - name: Install all dependencies
@@ -162,7 +160,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.9"
           cache: "pip"
       - name: Install pystac
         run: pip install .[bench]

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.9"
 
 formats:
   # Temporarily disabling PDF downloads due to problem with nbsphinx in LateX builds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - Typing of `href` arguments ([#1234](https://github.com/stac-utils/pystac/pull/1234))
 
+### Removed
+
+- Python 3.8 support ([#1236](https://github.com/stac-utils/pystac/pull/1236))
+
 ## [v1.8.4] - 2023-09-22
 
 ### Added

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -27,9 +27,9 @@ Install from source
 Dependencies
 ============
 
-PySTAC requires Python >= 3.8. This project follows the recommendations of
+PySTAC requires Python >= 3.9. This project follows the recommendations of
 `NEP-29 <https://numpy.org/neps/nep-0029-deprecation_policy.html>`__ in deprecating support
-for Python versions. This means that users can expect support for Python 3.8 to be
+for Python versions. This means that users can expect support for Python 3.9 to be
 removed from the ``main`` branch after Apr 14, 2023 and therefore from the next release
 after that date.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,16 +15,12 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
 ]
-requires-python = ">=3.8"
-dependencies = [
-    "importlib-resources>=5.12.0; python_version<'3.9'",
-    "python-dateutil>=2.7.0",
-]
+requires-python = ">=3.9"
+dependencies = ["python-dateutil>=2.7.0"]
 dynamic = ["version"]
 
 [project.optional-dependencies]

--- a/pystac/summaries.py
+++ b/pystac/summaries.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import importlib.resources
 import json
 import numbers
-import sys
 from abc import abstractmethod
 from copy import deepcopy
 from enum import Enum
@@ -19,11 +19,6 @@ from typing import (
     TypeVar,
     Union,
 )
-
-if sys.version_info[:2] < (3, 9):
-    from importlib_resources import files as importlib_resources_files
-else:
-    from importlib.resources import files as importlib_resources_files
 
 import pystac
 from pystac.utils import get_required
@@ -112,7 +107,7 @@ def _get_fields_json(url: Optional[str]) -> Dict[str, Any]:
         # Every time pystac is released this file gets pulled from
         # https://cdn.jsdelivr.net/npm/@radiantearth/stac-fields/fields-normalized.json
         jsonfields: Dict[str, Any] = json.loads(
-            importlib_resources_files("pystac.static")
+            importlib.resources.files("pystac.static")
             .joinpath("fields-normalized.json")
             .read_text()
         )

--- a/pystac/validation/local_validator.py
+++ b/pystac/validation/local_validator.py
@@ -1,5 +1,5 @@
+import importlib.resources
 import json
-import sys
 import warnings
 from typing import Any, Dict, List, cast
 
@@ -9,16 +9,11 @@ from referencing import Registry, Resource
 from pystac.errors import STACLocalValidationError
 from pystac.version import STACVersion
 
-if sys.version_info[:2] < (3, 9):
-    from importlib_resources import files as importlib_resources_files
-else:
-    from importlib.resources import files as importlib_resources_files
-
 VERSION = STACVersion.DEFAULT_STAC_VERSION
 
 
 def _read_schema(file_name: str) -> Dict[str, Any]:
-    with importlib_resources_files("pystac.validation.jsonschemas").joinpath(
+    with importlib.resources.files("pystac.validation.jsonschemas").joinpath(
         file_name
     ).open("r") as f:
         return cast(Dict[str, Any], json.load(f))


### PR DESCRIPTION
**Related Issue(s):**

- Closes #1148 

**Description:**

I did _not_ run **pyupgrade** as that'll be really noisy, so I'm going to wait until the sprint is over and the repo has fewer folks hacking on it. I've opened a ticket to track that: https://github.com/stac-utils/pystac/issues/1235.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
- [x] (when approved) Remove the required Python 3.8 Github Actions checks
