### PR TITLE
Use the pre-compiled version regex

### DIFF
--- a/pystac/extensions/base.py
+++ b/pystac/extensions/base.py
@@ -148,7 +148,7 @@ class ExtensionManagementMixin(Generic[S], ABC):
     def has_extension(cls, obj: S) -> bool:
         """Check if the given object implements this extension by checking
         :attr:`pystac.STACObject.stac_extensions` for this extension's schema URI."""
-        schema_startswith = re.split(VERSION_REGEX, cls.get_schema_uri())[0] + "/"
+        schema_startswith = VERSION_REGEX.split(cls.get_schema_uri())[0] + "/"
 
         return obj.stac_extensions is not None and any(
             uri.startswith(schema_startswith) for uri in obj.stac_extensions


### PR DESCRIPTION
**Related Issue(s):**

- Introduced during https://github.com/stac-utils/pystac/pull/1231
- Needs https://github.com/stac-utils/pystac/pull/1240 to get CI happy

**Description:**

Sorry should have caught this during review 🙇🏼, doesn't need a changelog

**PR Checklist:**

- [ ] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
