### PR TITLE
Assets keep their own `stac_extensions`

### DIFF
--- a/pystac/asset.py
+++ b/pystac/asset.py
@@ -35,6 +35,8 @@ class Asset:
         extra_fields : Optional, additional fields for this asset. This is used
             by extensions as a way to serialize and deserialize properties on asset
             object JSON.
+        stac_extensions : Optional, a list of schema URIs for STAC Extensions
+            implemented by this STAC Asset.
     """
 
     href: str
@@ -64,6 +66,9 @@ class Asset:
     """Optional, additional fields for this asset. This is used by extensions as a
     way to serialize and deserialize properties on asset object JSON."""
 
+    stac_extensions: List[str]
+    """A list of schema URIs for STAC Extensions implemented by this STAC Asset."""
+
     def __init__(
         self,
         href: str,
@@ -79,6 +84,7 @@ class Asset:
         self.media_type = media_type
         self.roles = roles
         self.extra_fields = extra_fields or {}
+        self.stac_extensions = None
 
         # The Item which owns this Asset.
         self.owner = None

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -577,8 +577,22 @@ class Collection(Catalog):
         )
         d["extent"] = self.extent.to_dict()
         d["license"] = self.license
+
+        # we use the fact that in recent Python versions, dict keys are ordered
+        # by default
+        stac_extensions: Optional[Dict[str, None]] = None
         if self.stac_extensions:
-            d["stac_extensions"] = self.stac_extensions
+            stac_extensions = dict.fromkeys(self.stac_extensions)
+
+        for asset in self.assets.values():
+            if stac_extensions and asset.stac_extensions:
+                stac_extensions.update(dict.fromkeys(asset.stac_extensions))
+            elif asset.stac_extensions:
+                stac_extensions = dict.fromkeys(asset.stac_extensions)
+
+        if stac_extensions is not None:
+            d["stac_extensions"] = list(stac_extensions.keys())
+
         if self.keywords:
             d["keywords"] = self.keywords
         if self.providers:

--- a/pystac/extensions/classification.py
+++ b/pystac/extensions/classification.py
@@ -534,7 +534,7 @@ class ClassificationExtension(
             cls.ensure_has_extension(obj, add_if_missing)
             return cast(ClassificationExtension[T], ItemClassificationExtension(obj))
         elif isinstance(obj, pystac.Asset):
-            cls.validate_owner_has_extension(obj, add_if_missing)
+            cls.ensure_has_extension(obj, add_if_missing)
             return cast(ClassificationExtension[T], AssetClassificationExtension(obj))
         elif isinstance(obj, item_assets.AssetDefinition):
             cls.ensure_has_extension(

--- a/pystac/extensions/datacube.py
+++ b/pystac/extensions/datacube.py
@@ -543,7 +543,7 @@ class DatacubeExtension(
             cls.ensure_has_extension(obj, add_if_missing)
             return cast(DatacubeExtension[T], ItemDatacubeExtension(obj))
         elif isinstance(obj, pystac.Asset):
-            cls.validate_owner_has_extension(obj, add_if_missing)
+            cls.ensure_has_extension(obj, add_if_missing)
             return cast(DatacubeExtension[T], AssetDatacubeExtension(obj))
         else:
             raise pystac.ExtensionTypeError(cls._ext_error_message(obj))

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -408,7 +408,7 @@ class EOExtension(
             cls.ensure_has_extension(obj, add_if_missing)
             return cast(EOExtension[T], ItemEOExtension(obj))
         elif isinstance(obj, pystac.Asset):
-            cls.validate_owner_has_extension(obj, add_if_missing)
+            cls.ensure_has_extension(obj, add_if_missing)
             return cast(EOExtension[T], AssetEOExtension(obj))
         else:
             raise pystac.ExtensionTypeError(cls._ext_error_message(obj))

--- a/pystac/extensions/file.py
+++ b/pystac/extensions/file.py
@@ -224,7 +224,7 @@ class FileExtension(
         This extension can be applied to instances of :class:`~pystac.Asset`.
         """
         if isinstance(obj, pystac.Asset):
-            cls.validate_owner_has_extension(obj, add_if_missing)
+            cls.ensure_has_extension(obj, add_if_missing)
             return cls(obj)
         else:
             raise pystac.ExtensionTypeError(cls._ext_error_message(obj))

--- a/pystac/extensions/pointcloud.py
+++ b/pystac/extensions/pointcloud.py
@@ -455,7 +455,7 @@ class PointcloudExtension(
                 raise pystac.ExtensionTypeError(
                     "Pointcloud extension does not apply to Collection Assets."
                 )
-            cls.validate_owner_has_extension(obj, add_if_missing)
+            cls.ensure_has_extension(obj, add_if_missing)
             return cast(PointcloudExtension[T], AssetPointcloudExtension(obj))
         else:
             raise pystac.ExtensionTypeError(cls._ext_error_message(obj))

--- a/pystac/extensions/projection.py
+++ b/pystac/extensions/projection.py
@@ -288,7 +288,7 @@ class ProjectionExtension(
             cls.ensure_has_extension(obj, add_if_missing)
             return cast(ProjectionExtension[T], ItemProjectionExtension(obj))
         elif isinstance(obj, pystac.Asset):
-            cls.validate_owner_has_extension(obj, add_if_missing)
+            cls.ensure_has_extension(obj, add_if_missing)
             return cast(ProjectionExtension[T], AssetProjectionExtension(obj))
         else:
             raise pystac.ExtensionTypeError(cls._ext_error_message(obj))

--- a/pystac/extensions/raster.py
+++ b/pystac/extensions/raster.py
@@ -735,7 +735,7 @@ class RasterExtension(
             pystac.ExtensionTypeError : If an invalid object type is passed.
         """
         if isinstance(obj, pystac.Asset):
-            cls.validate_owner_has_extension(obj, add_if_missing)
+            cls.ensure_has_extension(obj, add_if_missing)
             return cast(RasterExtension[T], AssetRasterExtension(obj))
         elif isinstance(obj, item_assets.AssetDefinition):
             cls.ensure_has_extension(

--- a/pystac/extensions/sar.py
+++ b/pystac/extensions/sar.py
@@ -319,7 +319,7 @@ class SarExtension(
                 raise pystac.ExtensionTypeError(
                     "SAR extension does not apply to Collection Assets."
                 )
-            cls.validate_owner_has_extension(obj, add_if_missing)
+            cls.ensure_has_extension(obj, add_if_missing)
             return cast(SarExtension[T], AssetSarExtension(obj))
         else:
             raise pystac.ExtensionTypeError(cls._ext_error_message(obj))

--- a/pystac/extensions/sat.py
+++ b/pystac/extensions/sat.py
@@ -150,7 +150,7 @@ class SatExtension(
             cls.ensure_has_extension(obj, add_if_missing)
             return cast(SatExtension[T], ItemSatExtension(obj))
         elif isinstance(obj, pystac.Asset):
-            cls.validate_owner_has_extension(obj, add_if_missing)
+            cls.ensure_has_extension(obj, add_if_missing)
             return cast(SatExtension[T], AssetSatExtension(obj))
         else:
             raise pystac.ExtensionTypeError(cls._ext_error_message(obj))

--- a/pystac/extensions/storage.py
+++ b/pystac/extensions/storage.py
@@ -152,7 +152,7 @@ class StorageExtension(
             cls.ensure_has_extension(obj, add_if_missing)
             return cast(StorageExtension[T], ItemStorageExtension(obj))
         elif isinstance(obj, pystac.Asset):
-            cls.validate_owner_has_extension(obj, add_if_missing)
+            cls.ensure_has_extension(obj, add_if_missing)
             return cast(StorageExtension[T], AssetStorageExtension(obj))
         else:
             raise pystac.ExtensionTypeError(cls._ext_error_message(obj))

--- a/pystac/extensions/table.py
+++ b/pystac/extensions/table.py
@@ -158,7 +158,7 @@ class TableExtension(
             cls.ensure_has_extension(obj, add_if_missing)
             return cast(TableExtension[T], ItemTableExtension(obj))
         if isinstance(obj, pystac.Asset):
-            cls.validate_owner_has_extension(obj, add_if_missing)
+            cls.ensure_has_extension(obj, add_if_missing)
             return cast(TableExtension[T], AssetTableExtension(obj))
         else:
             raise pystac.ExtensionTypeError(cls._ext_error_message(obj))

--- a/pystac/extensions/timestamps.py
+++ b/pystac/extensions/timestamps.py
@@ -131,7 +131,7 @@ class TimestampsExtension(
             cls.ensure_has_extension(obj, add_if_missing)
             return cast(TimestampsExtension[T], ItemTimestampsExtension(obj))
         elif isinstance(obj, pystac.Asset):
-            cls.validate_owner_has_extension(obj, add_if_missing)
+            cls.ensure_has_extension(obj, add_if_missing)
             return cast(TimestampsExtension[T], AssetTimestampsExtension(obj))
         else:
             raise pystac.ExtensionTypeError(cls._ext_error_message(obj))

--- a/pystac/extensions/view.py
+++ b/pystac/extensions/view.py
@@ -160,7 +160,7 @@ class ViewExtension(
             cls.ensure_has_extension(obj, add_if_missing)
             return cast(ViewExtension[T], ItemViewExtension(obj))
         elif isinstance(obj, pystac.Asset):
-            cls.validate_owner_has_extension(obj, add_if_missing)
+            cls.ensure_has_extension(obj, add_if_missing)
             return cast(ViewExtension[T], AssetViewExtension(obj))
         else:
             raise pystac.ExtensionTypeError(cls._ext_error_message(obj))

--- a/pystac/extensions/xarray_assets.py
+++ b/pystac/extensions/xarray_assets.py
@@ -60,7 +60,7 @@ class XarrayAssetsExtension(
             cls.ensure_has_extension(obj, add_if_missing)
             return ItemXarrayAssetsExtension(obj)
         if isinstance(obj, pystac.Asset):
-            cls.validate_owner_has_extension(obj, add_if_missing)
+            cls.ensure_has_extension(obj, add_if_missing)
             return AssetXarrayAssetsExtension(obj)
         else:
             raise pystac.ExtensionTypeError(cls._ext_error_message(obj))

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -433,7 +433,22 @@ class Item(STACObject):
         if self.bbox is not None:
             d["bbox"] = self.bbox
 
-        if self.stac_extensions is not None:
+        # we use the fact that in recent Python versions, dict keys are ordered
+        # by default
+        stac_extensions: Optional[Dict[str, None]] = None
+        if self.stac_extensions:
+            stac_extensions = dict.fromkeys(self.stac_extensions)
+
+        for asset in self.assets.values():
+            if stac_extensions and asset.stac_extensions:
+                stac_extensions.update(dict.fromkeys(asset.stac_extensions))
+            elif asset.stac_extensions:
+                stac_extensions = dict.fromkeys(asset.stac_extensions)
+
+        if stac_extensions is not None:
+            d["stac_extensions"] = list(stac_extensions.keys())
+
+        if stac_extensions is not None:
             d["stac_extensions"] = self.stac_extensions
 
         if self.collection_id:

--- a/tests/extensions/test_custom.py
+++ b/tests/extensions/test_custom.py
@@ -54,7 +54,7 @@ class CustomExtension(
     @classmethod
     def ext(cls, obj: T, add_if_missing: bool = False) -> "CustomExtension[T]":
         if isinstance(obj, pystac.Asset):
-            cls.validate_owner_has_extension(obj, add_if_missing)
+            cls.ensure_has_extension(obj, add_if_missing)
             return cast(CustomExtension[T], AssetCustomExtension(obj))
         if isinstance(obj, pystac.Item):
             cls.ensure_has_extension(obj, add_if_missing)
@@ -151,6 +151,14 @@ class CustomExtensionTest(unittest.TestCase):
         custom.test_prop = "foo"
         catalog_as_dict = catalog.to_dict()
         assert catalog_as_dict["test:prop"] == "foo"
+
+    def test_add_to_asset_no_owner(self) -> None:
+        asset = Asset("http://pystac.test/asset.tif")
+        custom = CustomExtension.ext(asset, add_if_missing=True)
+        assert CustomExtension.has_extension(asset)
+        custom.apply("bar")
+        asset_as_dict = asset.to_dict()
+        assert asset_as_dict["test:prop"] == "bar"
 
     def test_add_to_collection(self) -> None:
         collection = Collection(


### PR DESCRIPTION
so that they can be extended without being added to an Item.
Deprecating validate_owner_has_extension
Switching from validate_owner_has_extension to ensure_has_extension
in extensions dealing with assets
Extracting a final list of assets in the `to_dict`
function for Items and Collections.

**Related Issue(s):**

- #793

**Description:**

**PR Checklist:**

- [ ] `pre-commit` hooks pass locally
- [ ] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [ ] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
