### PR TITLE
Include href when schema resolution fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Changed
 
 - `validate_all` now accepts a `STACObject` (in addition to accepting a dict, which is now deprecated), but prohibits supplying a value for `href`, which must be supplied _only_ when supplying an object as a dict.  Once `validate_all` removes support for an object as a dict, the `href` parameter will also be removed. ([#1246](https://github.com/stac-utils/pystac/pull/1246))
+- Report `href` when schema url resolution fails ([#1263](https://github.com/stac-utils/pystac/pull/1263))
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ test = [
     "pytest-mock~=3.10",
     "pytest-recording~=0.13.0",
     "pytest~=7.3",
+    "requests-mock~=1.11",
     "ruff==0.0.292",
     "types-html5lib~=1.1",
     "types-orjson~=3.6",

--- a/pystac/validation/__init__.py
+++ b/pystac/validation/__init__.py
@@ -9,6 +9,7 @@ from pystac.serialization.identify import STACVersionID, identify_stac_object
 from pystac.stac_object import STACObjectType
 from pystac.utils import make_absolute_href
 from pystac.validation.schema_uri_map import OldExtensionSchemaUriMap
+from pystac.validation.stac_validator import GetSchemaError
 
 if TYPE_CHECKING:
     from pystac.stac_object import STACObject
@@ -245,3 +246,6 @@ def set_validator(validator: STACValidator) -> None:
             validation.
     """
     RegisteredValidator.set_validator(validator)
+
+
+__all__ = ["GetSchemaError"]

--- a/tests/validation/test_validate.py
+++ b/tests/validation/test_validate.py
@@ -188,7 +188,7 @@ def test_catalog_latest_version_uses_local(catalog: pystac.Catalog) -> None:
 
 
 @pytest.mark.block_network
-def test_collection_latest_versio_uses_localn(collection: pystac.Collection) -> None:
+def test_collection_latest_version_uses_local(collection: pystac.Collection) -> None:
     assert collection.validate()
 
 


### PR DESCRIPTION
**Related Issue(s):**

- Closes #622

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
