### PR TITLE
DRY asset methods

### DIFF
--- a/tests/extensions/test_xarray_assets.py
+++ b/tests/extensions/test_xarray_assets.py
@@ -146,6 +146,7 @@ def test_set_field(ext_asset: pystac.Asset, field: str, value) -> None:  # type:
 
     item = ext_asset.owner
     assert item is not None
+    assert isinstance(item, pystac.Item)
     assert item.validate()
 
 

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -576,6 +576,7 @@ def test_delete_asset_relative_no_self_link_fails(tmp_asset: pystac.Asset) -> No
 
     assert href is not None
     assert item is not None
+    assert isinstance(item, pystac.Item)
 
     item.set_self_href(None)
 


### PR DESCRIPTION
**Related Issue(s):**

- Closes #1199
- Refactor of #1168

**Description:**

I started working on #1199 only to discover it had already be fixed by #1168. However, I went an extra step and refactored the asset-modifying methods to an `Assets` protocol, so we only need to implement the logic once. The only hackey bit is the `get_self_href` stub, which is in place instead of trying to refactor all link-related logic to a `Links` protocol (which I tried but felt too disruptive).

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
