### PR TITLE
Improve handling of `bboxes` and `intervals` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Interactions between **pytest-recording** and the validator schema cache ([#1242](https://github.com/stac-utils/pystac/pull/1242))
 - Call `registry` when instantiating `Draft7Validator` ([#1240](https://github.com/stac-utils/pystac/pull/1240))
 - Migration for the classification, datacube, table, and timestamps extensions ([#1258](https://github.com/stac-utils/pystac/pull/1258))
+- Handling of `bboxes` and `intervals` arguments to `SpatialExtent` and `TemporalExtent`, respectively ([#1268](https://github.com/stac-utils/pystac/pull/1268))
 
 ### Removed
 

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
 
 C = TypeVar("C", bound="Collection")
 
+Bboxes = list[list[Union[float, int]]]
 TemporalIntervals = Union[list[list[datetime]], list[list[Optional[datetime]]]]
 TemporalIntervalsLike = Union[
     TemporalIntervals, list[datetime], list[Optional[datetime]]
@@ -59,7 +60,7 @@ class SpatialExtent:
             Spatial Extent object.
     """
 
-    bboxes: list[list[float]]
+    bboxes: Bboxes
     """A list of bboxes that represent the spatial
     extent of the collection. Each bbox can be 2D or 3D. The length of the bbox
     array must be 2*n where n is the number of dimensions. For example, a
@@ -71,15 +72,18 @@ class SpatialExtent:
 
     def __init__(
         self,
-        bboxes: list[list[float]] | list[float],
+        bboxes: Bboxes | list[float | int],
         extra_fields: dict[str, Any] | None = None,
     ) -> None:
+        if not isinstance(bboxes, list):
+            raise TypeError("bboxes must be a list")
+
         # A common mistake is to pass in a single bbox instead of a list of bboxes.
         # Account for this by transforming the input in that case.
-        if isinstance(bboxes, list) and isinstance(bboxes[0], float):
-            self.bboxes: list[list[float]] = [cast(list[float], bboxes)]
+        if isinstance(bboxes[0], (float, int)):
+            self.bboxes = [cast(list[float | int], bboxes)]
         else:
-            self.bboxes = cast(list[list[float]], bboxes)
+            self.bboxes = cast(Bboxes, bboxes)
 
         self.extra_fields = extra_fields or {}
 

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -207,7 +207,7 @@ class TemporalExtent:
         # list of intervals. Account for this by transforming the input
         # in that case.
         if isinstance(intervals, list) and isinstance(intervals[0], datetime):
-            self.intervals = intervals
+            self.intervals = [intervals]
         else:
             self.intervals = intervals
 

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -81,7 +81,7 @@ class SpatialExtent:
         # A common mistake is to pass in a single bbox instead of a list of bboxes.
         # Account for this by transforming the input in that case.
         if isinstance(bboxes[0], (float, int)):
-            self.bboxes = [cast(list[float | int], bboxes)]
+            self.bboxes = [cast(list[Union[float, int]], bboxes)]
         else:
             self.bboxes = cast(Bboxes, bboxes)
 

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -200,16 +200,18 @@ class TemporalExtent:
 
     def __init__(
         self,
-        intervals: TemporalIntervals,
+        intervals: TemporalIntervals | list[datetime | None],
         extra_fields: dict[str, Any] | None = None,
     ):
+        if not isinstance(intervals, list):
+            raise TypeError("intervals must be a list")
         # A common mistake is to pass in a single interval instead of a
         # list of intervals. Account for this by transforming the input
         # in that case.
-        if isinstance(intervals, list) and isinstance(intervals[0], datetime):
-            self.intervals = [intervals]
+        if isinstance(intervals[0], datetime) or intervals[0] is None:
+            self.intervals = [cast(list[Optional[datetime]], intervals)]
         else:
-            self.intervals = intervals
+            self.intervals = cast(TemporalIntervals, intervals)
 
         self.extra_fields = extra_fields or {}
 

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -382,6 +382,31 @@ class ExtentTest(unittest.TestCase):
         _ = TemporalExtent([[start_datetime, end_datetime]])
 
     @pytest.mark.block_network()
+    def test_temporal_extent_allows_single_interval(self) -> None:
+        start_datetime = str_to_datetime("2022-01-01T00:00:00Z")
+        end_datetime = str_to_datetime("2022-01-31T23:59:59Z")
+
+        interval = [start_datetime, end_datetime]
+        temporal_extent = TemporalExtent(intervals=interval)  # type: ignore
+
+        self.assertEqual(temporal_extent.intervals, [interval])
+
+    @pytest.mark.block_network()
+    def test_temporal_extent_allows_single_interval_open_start(self) -> None:
+        end_datetime = str_to_datetime("2022-01-31T23:59:59Z")
+
+        interval = [None, end_datetime]
+        temporal_extent = TemporalExtent(intervals=interval)
+
+        self.assertEqual(temporal_extent.intervals, [interval])
+
+    @pytest.mark.block_network()
+    def test_temporal_extent_non_list_intervals_fails(self) -> None:
+        with pytest.raises(TypeError):
+            # Pass in non-list intervals
+            _ = TemporalExtent(intervals=1)  # type: ignore
+
+    @pytest.mark.block_network()
     def test_spatial_allows_single_bbox(self) -> None:
         temporal_extent = TemporalExtent(intervals=[[TEST_DATETIME, None]])
 

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -424,6 +424,12 @@ class ExtentTest(unittest.TestCase):
 
         collection.validate()
 
+    @pytest.mark.block_network()
+    def test_spatial_extent_non_list_bboxes_fails(self) -> None:
+        with pytest.raises(TypeError):
+            # Pass in non-list bboxes
+            _ = SpatialExtent(bboxes=1)  # type: ignore
+
     def test_from_items(self) -> None:
         item1 = Item(
             id="test-item-1",


### PR DESCRIPTION
**Related Issue(s):**

- #1267

**Description:**

* Allow `SpatialExtent.bboxes` to be a nested list of floats _and/or_ integers to reflect the STAC spec typing of `[[number]]`.
* In `SpatialExtent`, wrap `bboxes` in a list if passed as list of floats OR integers.
* In `TemporalExtent`, wrap `intervals` in a list if passed as a single interval.

While the linked issue discusses adding more robust validation/coercion of inputs, I opted to start simple because stricter checks on `bboxes` start to get a little gnarly:

```python
        if all(isinstance(coord, (float, int)) for coord in bboxes):
            self.bboxes = [cast(list[float | int], bboxes)]
        elif all(
            all(
                isinstance(coord, (float, int)) for coord in bbox
            ) for bbox in bboxes
        ):
            self.bboxes = cast(Bboxes, bboxes)
        else:
            raise TypeError(f"unexpected type encountered in bboxes: {bboxes}")
```

If stricter checks are preferred, I can make that change. I can also add a version of `test_spatial_allows_single_bbox` to cover single bbox of `int`s if it's warranted.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
