### PR TITLE
Fix deprecation messages

### DIFF
--- a/pystac/extensions/base.py
+++ b/pystac/extensions/base.py
@@ -181,7 +181,7 @@ class ExtensionManagementMixin(Generic[S], ABC):
                 ``None``.
         """
         warnings.warn(
-            "ensure_owner_has_extension is deprecated and will be removed in v1.9. "
+            "ensure_owner_has_extension is deprecated. "
             "Use ensure_owner_has_extension instead",
             DeprecationWarning,
         )
@@ -234,8 +234,7 @@ class ExtensionManagementMixin(Generic[S], ABC):
                 not already present. Defaults to False.
         """
         warnings.warn(
-            "validate_has_extension is deprecated and will be removed in v1.9. "
-            "Use ensure_has_extension instead",
+            "validate_has_extension is deprecated. Use ensure_has_extension instead",
             DeprecationWarning,
         )
 


### PR DESCRIPTION
**Description:**

These things are deprecated in v1.9, not removed then. Doesn't need a CHANGELOG.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
