### PR TITLE
Do not use the deprecated utcnow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
- - No longer use the `datetime.utcnow` method that has been deprecated in Python 3.12.
+ - No longer use the `datetime.utcnow` method that has been deprecated in Python 3.12 ([1283](https://github.com/stac-utils/pystac/pull/1283))
 
 ## [v1.9.0] - 2023-10-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+ - No longer use the `datetime.utcnow` method that has been deprecated in Python 3.12.
+
 ## [v1.9.0] - 2023-10-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
- - No longer use the `datetime.utcnow` method that has been deprecated in Python 3.12 ([1283](https://github.com/stac-utils/pystac/pull/1283))
+ - No longer use the `datetime.utcnow` method that has been deprecated in Python 3.12 ([#1283](https://github.com/stac-utils/pystac/pull/1283))
 
 ## [v1.9.0] - 2023-10-23
 

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import warnings
 from collections.abc import Iterable
 from copy import deepcopy
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -294,7 +294,7 @@ class TemporalExtent:
             TemporalExtent: The resulting TemporalExtent.
         """
         return TemporalExtent(
-            intervals=[[datetime.utcnow().replace(microsecond=0), None]]
+            intervals=[[datetime.now(timezone.utc).replace(microsecond=0), None]]
         )
 
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -8,7 +8,7 @@ import unittest
 from collections import defaultdict
 from collections.abc import Iterator
 from copy import deepcopy
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, cast
 
@@ -140,7 +140,7 @@ class TestCatalog:
             id="test-item",
             geometry=ARBITRARY_GEOM,
             bbox=ARBITRARY_BBOX,
-            datetime=datetime.utcnow(),
+            datetime=datetime.now(timezone.utc),
             properties={"key": "one"},
         )
         subcat.add_item(item)
@@ -154,7 +154,7 @@ class TestCatalog:
             id="test-item",
             geometry=ARBITRARY_GEOM,
             bbox=ARBITRARY_BBOX,
-            datetime=datetime.utcnow(),
+            datetime=datetime.now(timezone.utc),
             properties={"key": "two"},
         )
         subcat.add_item(item)
@@ -168,7 +168,7 @@ class TestCatalog:
             id="test-item",
             geometry=ARBITRARY_GEOM,
             bbox=ARBITRARY_BBOX,
-            datetime=datetime.utcnow(),
+            datetime=datetime.now(timezone.utc),
             properties={"key": "three"},
         )
         subcat.add_item(item)
@@ -710,7 +710,7 @@ class TestCatalog:
                     id=f"item{ni}",
                     geometry=ARBITRARY_GEOM,
                     bbox=ARBITRARY_BBOX,
-                    datetime=datetime.utcnow(),
+                    datetime=datetime.now(timezone.utc),
                     properties=properties,
                 )
             )
@@ -748,7 +748,7 @@ class TestCatalog:
                 id="item1",
                 geometry=ARBITRARY_GEOM,
                 bbox=ARBITRARY_BBOX,
-                datetime=datetime.utcnow(),
+                datetime=datetime.now(timezone.utc),
                 properties=properties,
             )
         )
@@ -758,7 +758,7 @@ class TestCatalog:
                 id="item2",
                 geometry=ARBITRARY_GEOM,
                 bbox=ARBITRARY_BBOX,
-                datetime=datetime.utcnow(),
+                datetime=datetime.now(timezone.utc),
                 properties=properties,
             )
         )
@@ -787,7 +787,7 @@ class TestCatalog:
                     id=f"item{ni}",
                     geometry=ARBITRARY_GEOM,
                     bbox=ARBITRARY_BBOX,
-                    datetime=datetime.utcnow(),
+                    datetime=datetime.now(timezone.utc),
                     properties=properties,
                 )
             )
@@ -812,7 +812,7 @@ class TestCatalog:
                     id=f"item{ni}",
                     geometry=ARBITRARY_GEOM,
                     bbox=ARBITRARY_BBOX,
-                    datetime=datetime.utcnow(),
+                    datetime=datetime.now(timezone.utc),
                     properties=properties,
                 )
             )
@@ -896,7 +896,7 @@ class TestCatalog:
             id="item1",
             geometry=ARBITRARY_GEOM,
             bbox=ARBITRARY_BBOX,
-            datetime=datetime.utcnow(),
+            datetime=datetime.now(timezone.utc),
             properties={},
         )
         item1.add_asset("ortho", Asset(href="/some/ortho.tif"))
@@ -907,7 +907,7 @@ class TestCatalog:
             id="item2",
             geometry=ARBITRARY_GEOM,
             bbox=ARBITRARY_BBOX,
-            datetime=datetime.utcnow(),
+            datetime=datetime.now(timezone.utc),
             properties={},
         )
         item2.add_asset("ortho", Asset(href="/some/other/ortho.tif"))
@@ -1436,7 +1436,7 @@ class FullCopyTest(unittest.TestCase):
                 id="test_item",
                 geometry=ARBITRARY_GEOM,
                 bbox=ARBITRARY_BBOX,
-                datetime=datetime.utcnow(),
+                datetime=datetime.now(timezone.utc),
                 properties={},
             )
 
@@ -1456,7 +1456,7 @@ class FullCopyTest(unittest.TestCase):
                 id="Imagery",
                 geometry=ARBITRARY_GEOM,
                 bbox=ARBITRARY_BBOX,
-                datetime=datetime.utcnow(),
+                datetime=datetime.now(timezone.utc),
                 properties={},
             )
             for key in ["ortho", "dsm"]:
@@ -1469,7 +1469,7 @@ class FullCopyTest(unittest.TestCase):
                 id="Labels",
                 geometry=ARBITRARY_GEOM,
                 bbox=ARBITRARY_BBOX,
-                datetime=datetime.utcnow(),
+                datetime=datetime.now(timezone.utc),
                 properties={},
             )
             cat.add_items([image_item, label_item])

--- a/tests/utils/test_cases.py
+++ b/tests/utils/test_cases.py
@@ -1,6 +1,6 @@
 import csv
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 import pystac
@@ -156,7 +156,7 @@ class TestCases:
             id="imagery-item",
             geometry=ARBITRARY_GEOM,
             bbox=ARBITRARY_BBOX,
-            datetime=datetime.utcnow(),
+            datetime=datetime.now(timezone.utc),
             properties={},
         )
 
@@ -168,7 +168,7 @@ class TestCases:
             id="label-items",
             geometry=ARBITRARY_GEOM,
             bbox=ARBITRARY_BBOX,
-            datetime=datetime.utcnow(),
+            datetime=datetime.now(timezone.utc),
             properties={},
         )
 

--- a/tests/validation/test_validate.py
+++ b/tests/validation/test_validate.py
@@ -2,7 +2,7 @@ import json
 import os
 import shutil
 import tempfile
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 import jsonschema
@@ -176,7 +176,7 @@ class TestValidate:
             id="test-item",
             geometry=geom,
             bbox=[-115.308, 36.126, -115.305, 36.129],
-            datetime=datetime.utcnow(),
+            datetime=datetime.now(timezone.utc),
             properties={},
         )
 


### PR DESCRIPTION
**Related Issue(s):**

- #

**Description:**

The patch fixes the use of the `utcnow` method that has been deprecated in Python 3.12.

**PR Checklist:**

- [X] `pre-commit` hooks pass locally
- [ ] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [X] This PR maintains or improves overall codebase code coverage.
- [X] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
