### PR TITLE
Make item pickle smaller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Made item pickles smaller by changing how nested links are stored([#1285](https://github.com/stac-utils/pystac/pull/1285))
+
 ### Fixed
 
- - No longer use the `datetime.utcnow` method that has been deprecated in Python 3.12 ([#1283](https://github.com/stac-utils/pystac/pull/1283))
+- No longer use the `datetime.utcnow` method that has been deprecated in Python 3.12 ([#1283](https://github.com/stac-utils/pystac/pull/1283))
 
 ## [v1.9.0] - 2023-10-23
 

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -172,6 +172,24 @@ class Item(STACObject, Assets):
     def __repr__(self) -> str:
         return f"<Item id={self.id}>"
 
+    def __getstate__(self) -> dict[str, Any]:
+        """Ensure that pystac does not encode too much information when pickling"""
+        d = self.__dict__.copy()
+
+        if all(link.get_href() for link in d["links"]):
+            d["links"] = [link.to_dict() for link in d["links"]]
+
+        return d
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        """Ensure that pystac knows how to decode the pickled object"""
+        d = state.copy()
+
+        if all(isinstance(link, dict) for link in d["links"]):
+            d["links"] = [Link.from_dict(link).set_owner(self) for link in d["links"]]
+
+        self.__dict__ = d
+
     def set_self_href(self, href: str | None) -> None:
         """Sets the absolute HREF that is represented by the ``rel == 'self'``
         :class:`~pystac.Link`.

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -176,8 +176,9 @@ class Item(STACObject, Assets):
         """Ensure that pystac does not encode too much information when pickling"""
         d = self.__dict__.copy()
 
-        if all(link.get_href() for link in d["links"]):
-            d["links"] = [link.to_dict() for link in d["links"]]
+        d["links"] = [
+            link.to_dict() if link.get_href() else link for link in d["links"]
+        ]
 
         return d
 
@@ -185,8 +186,10 @@ class Item(STACObject, Assets):
         """Ensure that pystac knows how to decode the pickled object"""
         d = state.copy()
 
-        if all(isinstance(link, dict) for link in d["links"]):
-            d["links"] = [Link.from_dict(link).set_owner(self) for link in d["links"]]
+        d["links"] = [
+            Link.from_dict(link).set_owner(self) if isinstance(link, dict) else link
+            for link in d["links"]
+        ]
 
         self.__dict__ = d
 


### PR DESCRIPTION
**Related Issue(s):**

- https://github.com/stac-utils/pystac-client/issues/315

**Description:**

Not totally sure if this is a good idea, but I figured a PR would be a good place to hash that out. The only limitation I can see is that if you have a resolved target object on your link, it will not be resolved with you roundtrip it to pickle and back.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
