### PR TITLE
Docs fix: added import for typing objects

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -303,6 +303,7 @@ for reading from AWS's S3 cloud object storage using `boto3
    import boto3
    from pystac import Link
    from pystac.stac_io import DefaultStacIO, StacIO
+   from typing import Union, Any
 
    class CustomStacIO(DefaultStacIO):
       def __init__(self):
@@ -345,6 +346,7 @@ to take advantage of connection pooling using a `requests.Session
    from urllib.parse import urlparse
    import requests
    from pystac.stac_io import DefaultStacIO, StacIO
+   from typing import Union, Any
 
    class ConnectionPoolingIO(DefaultStacIO):
       def __init__(self):


### PR DESCRIPTION
**Related Issue(s):**

- None

**Description:**
Currently the code examples use `Union` and `Any` without first importing the typing package. This change adds the missing import for 2 code examples.

**PR Checklist:**

- [ ] `pre-commit` hooks pass locally
- [ ] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [ ] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
