### PR TITLE
Adds user-agent to the request, if it doesn't exist in the headers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Changed
-
+- Adds user-agent header to the request headers if it doen't exist ([#1292](https://github.com/stac-utils/pystac/pull/1292))
 - Made item pickles smaller by changing how nested links are stored([#1285](https://github.com/stac-utils/pystac/pull/1285))
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 ### Changed
-- Adds user-agent header to the request headers if it doen't exist ([#1292](https://github.com/stac-utils/pystac/pull/1292))
+- Adds user-agent header to the request headers if it doesn't exist ([#1292](https://github.com/stac-utils/pystac/pull/1292))
 - Made item pickles smaller by changing how nested links are stored([#1285](https://github.com/stac-utils/pystac/pull/1285))
 
 ### Fixed

--- a/pystac/stac_io.py
+++ b/pystac/stac_io.py
@@ -43,21 +43,20 @@ logger = logging.getLogger(__name__)
 
 def _add_user_agent_if_not_available(request: Request) -> Request:
     """
-    Some servers block the requests without User-agent headers. Therefore, in 
-    this method we add a 'User-agent' header to the request if it's not already 
-    present. 
+    Some servers block the requests without User-agent headers. Therefore, in
+    this method we add a 'User-agent' header to the request if it's not already
+    present.
     Args:
         request (Request): The original request.
 
     Returns:
-        Request: The new request with 'User-agent' header added if it was not 
+        Request: The new request with 'User-agent' header added if it was not
             present in the original request.
     """
     new_request = deepcopy(request)
     if not new_request.has_header("User-agent"):
         new_request.add_header("User-agent", f"Python-pystac/{__version__}")
     return new_request
-
 
 
 class StacIO(ABC):

--- a/tests/test_stac_io.py
+++ b/tests/test_stac_io.py
@@ -105,18 +105,27 @@ class StacIOTest(unittest.TestCase):
 
     @unittest.mock.patch("pystac.stac_io.urlopen")
     def test_headers_stac_io(self, urlopen_mock: unittest.mock.MagicMock) -> None:
-        stac_io = DefaultStacIO(headers={"Authorization": "api-key fake-api-key-value"})
+        for headers in [
+            {"Authorization": "api-key fake-api-key-value"},
+            {"User-agent": "test_agent"},
+        ]:
+            stac_io = DefaultStacIO(headers=headers)
 
-        catalog = pystac.Catalog("an-id", "a description").to_dict()
-        # required until https://github.com/stac-utils/pystac/pull/896 is merged
-        catalog["links"] = []
-        urlopen_mock.return_value.__enter__.return_value.read.return_value = json.dumps(
-            catalog
-        ).encode("utf-8")
-        pystac.Catalog.from_file("https://example.com/catalog.json", stac_io=stac_io)
+            catalog = pystac.Catalog("an-id", "a description").to_dict()
+            # required until https://github.com/stac-utils/pystac/pull/896 is merged
+            catalog["links"] = []
+            urlopen_mock.return_value.__enter__.return_value.read.return_value = (
+                json.dumps(catalog).encode("utf-8")
+            )
+            pystac.Catalog.from_file(
+                "https://example.com/catalog.json", stac_io=stac_io
+            )
 
-        request_obj = urlopen_mock.call_args[0][0]
-        self.assertEqual(request_obj.headers, stac_io.headers)
+            request_obj = urlopen_mock.call_args[0][0]
+            assert request_obj.has_header(
+                "User-agent"
+            ), "Request object misses user-agent"
+            assert request_obj.headers.items() >= stac_io.headers.items()
 
 
 @pytest.mark.vcr()


### PR DESCRIPTION
**Related Issue(s):**

- #

**Description:**
Some servers block the request without user-agent. This PR adds user-agent to headers if it doesn't already exist (through headers override).

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
