### PR TITLE
Default layout strategy for catalogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Made item pickles smaller by changing how nested links are stored([#1285](https://github.com/stac-utils/pystac/pull/1285))
+- 
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Changed
 
 - Made item pickles smaller by changing how nested links are stored([#1285](https://github.com/stac-utils/pystac/pull/1285))
-- 
+- Allow setting a default layout strategy for Catalog ([#1295](https://github.com/stac-utils/pystac/pull/1295))
 
 ### Fixed
 

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -142,7 +142,7 @@ objects and items added to the catalog tree will be set correctly using that str
 
    catalog = Catalog(...,
                      href="/some/location/catalog.json",
-                     layout_strategy=custom_strategy)
+                     strategy=custom_strategy)
    collection = Collection(...)
    item = Item(...)
    catalog.add_child(collection)

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -82,7 +82,8 @@ Layouts
 ~~~~~~~
 
 PySTAC provides a few different strategies for laying out the HREFs of a STAC.
-To use them you can pass in a strategy to the normalize_hrefs call.
+To use them you can pass in a strategy when instantiating a catalog or when
+calling `normalize_hrefs`.
 
 Using templates
 '''''''''''''''
@@ -124,6 +125,30 @@ Catalogs, Collections or Items. Similar to the templating strategy, you can prov
 fallback strategy (which defaults to
 :class:`~pystac.layout.BestPracticesLayoutStrategy`) for any stac object type that you
 don't supply a function for.
+
+
+Set a default catalog layout strategy
+'''''''''''''''''''''''''''''''''''''
+
+Instead of fixing the HREFs of child objects retrospectively using `normalize_hrefs`,
+you can also define a default strategy for a catalog. When instantiating a catalog,
+pass in a custom strategy and base href. Consequently, the HREFs of all child
+objects and items added to the catalog tree will be set correctly using that strategy.
+
+
+.. code-block:: python
+
+   from pystac import Catalog, Collection, Item
+
+   catalog = Catalog(...,
+                     href="/some/location/catalog.json",
+                     layout_strategy=custom_strategy)
+   collection = Collection(...)
+   item = Item(...)
+   catalog.add_child(collection)
+   collection.add_item(item)
+   catalog.save()
+
 
 .. _catalog types:
 

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -128,6 +128,10 @@ class Catalog(STACObject):
             catalog's self link's HREF.
         catalog_type : Optional catalog type for this catalog. Must
             be one of the values in :class:`~pystac.CatalogType`.
+        strategy : The layout strategy to use for setting the
+            HREFs of the catalog child objections and items.
+            If not provided, it will default to the strategy of the root and fallback to
+            :class:`~pystac.layout.BestPracticesLayoutStrategy`.
     """
 
     catalog_type: CatalogType

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -473,6 +473,10 @@ class Collection(Catalog, Assets):
         assets : A dictionary mapping string keys to :class:`~pystac.Asset` objects. All
             :class:`~pystac.Asset` values in the dictionary will have their
             :attr:`~pystac.Asset.owner` attribute set to the created Collection.
+        strategy : The layout strategy to use for setting the
+            HREFs of the catalog child objections and items.
+            If not provided, it will default to strategy of the parent and fallback to
+            :class:`~pystac.layout.BestPracticesLayoutStrategy`.
     """
 
     description: str
@@ -529,6 +533,7 @@ class Collection(Catalog, Assets):
         providers: list[Provider] | None = None,
         summaries: Summaries | None = None,
         assets: dict[str, Asset] | None = None,
+        layout_strategy: HrefLayoutStrategy | None = None,
     ):
         super().__init__(
             id,
@@ -538,6 +543,7 @@ class Collection(Catalog, Assets):
             extra_fields,
             href,
             catalog_type or CatalogType.ABSOLUTE_PUBLISHED,
+            layout_strategy,
         )
         self.extent = extent
         self.license = license

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -533,7 +533,7 @@ class Collection(Catalog, Assets):
         providers: list[Provider] | None = None,
         summaries: Summaries | None = None,
         assets: dict[str, Asset] | None = None,
-        layout_strategy: HrefLayoutStrategy | None = None,
+        strategy: HrefLayoutStrategy | None = None,
     ):
         super().__init__(
             id,
@@ -543,7 +543,7 @@ class Collection(Catalog, Assets):
             extra_fields,
             href,
             catalog_type or CatalogType.ABSOLUTE_PUBLISHED,
-            layout_strategy,
+            strategy,
         )
         self.extent = extent
         self.license = license

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1762,11 +1762,9 @@ def test_add_child_layout_strategy(
         id="test",
         description="test desc",
         href=f"{base_url}/catalog.json",
-        layout_strategy=root_strategy,
+        strategy=root_strategy,
     )
-    subcat = Catalog(
-        id="subcat", description="subcat desc", layout_strategy=sub_strategy
-    )
+    subcat = Catalog(id="subcat", description="subcat desc", strategy=sub_strategy)
     subsubcat = Catalog(id="subsubcat", description="subsubcat desc")
 
     catalog.add_child(subcat, strategy=provided_root_strategy)
@@ -1848,11 +1846,9 @@ def test_add_child_layout_strategy_normalize(
         id="test",
         description="test desc",
         href=f"{base_url}/catalog.json",
-        layout_strategy=root_strategy,
+        strategy=root_strategy,
     )
-    subcat = Catalog(
-        id="subcat", description="subcat desc", layout_strategy=sub_strategy
-    )
+    subcat = Catalog(id="subcat", description="subcat desc", strategy=sub_strategy)
     subsubcat = Catalog(id="subsubcat", description="subsubcat desc")
     catalog.add_child(subcat)
     subcat.add_child(subsubcat)
@@ -1914,7 +1910,7 @@ def test_add_item_layout_strategy(
         id="test",
         description="test desc",
         href=f"{base_url}/catalog.json",
-        layout_strategy=root_strategy,
+        strategy=root_strategy,
     )
     item = Item(
         id=item_id,

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -24,6 +24,11 @@ from pystac import (
     Item,
     MediaType,
 )
+from pystac.layout import (
+    BestPracticesLayoutStrategy,
+    HrefLayoutStrategy,
+    TemplateLayoutStrategy,
+)
 from pystac.utils import (
     is_absolute_href,
     make_absolute_href,
@@ -1684,3 +1689,261 @@ def test_set_parent_false_stores_in_proper_place_on_save(
 
     assert (tmp_path / "products" / "product_a").exists()
     assert not (tmp_path / "variables" / "variable_a" / "product_a").exists()
+
+
+BEST_PRACTICE_CATALOG_TEMPLATE = "{id}"
+BEST_PRACTICE_ITEM_TEMPLATE = "{id}"
+TEST_CATALOG_TEMPLATE = "cat/${id}/${description}"
+TEST_ITEM_TEMPLATE = "cat/items/${id}"
+STRATEGY = TemplateLayoutStrategy(
+    catalog_template=TEST_CATALOG_TEMPLATE, item_template=TEST_ITEM_TEMPLATE
+)
+
+
+@pytest.mark.parametrize(
+    "root_strategy,sub_strategy,provided_root_strategy,provided_sub_strategy,root_template,sub_template",
+    [
+        (
+            None,
+            None,
+            None,
+            None,
+            BEST_PRACTICE_CATALOG_TEMPLATE,
+            BEST_PRACTICE_CATALOG_TEMPLATE,
+        ),
+        (STRATEGY, None, None, None, TEST_CATALOG_TEMPLATE, TEST_CATALOG_TEMPLATE),
+        (
+            STRATEGY,
+            BestPracticesLayoutStrategy(),
+            None,
+            None,
+            TEST_CATALOG_TEMPLATE,
+            BEST_PRACTICE_CATALOG_TEMPLATE,
+        ),
+        (
+            STRATEGY,
+            None,
+            BestPracticesLayoutStrategy(),
+            None,
+            BEST_PRACTICE_CATALOG_TEMPLATE,
+            TEST_CATALOG_TEMPLATE,
+        ),
+        (
+            STRATEGY,
+            None,
+            None,
+            BestPracticesLayoutStrategy(),
+            TEST_CATALOG_TEMPLATE,
+            BEST_PRACTICE_CATALOG_TEMPLATE,
+        ),
+    ],
+)
+def test_add_child_layout_strategy(
+    root_strategy: HrefLayoutStrategy,
+    sub_strategy: HrefLayoutStrategy,
+    provided_root_strategy: HrefLayoutStrategy,
+    provided_sub_strategy: HrefLayoutStrategy,
+    root_template: str,
+    sub_template: str,
+) -> None:
+    """Test for layout strategy when adding a child.
+
+    If no layout strategy is specified, children HREF should
+    always follow BestPracticesLayoutStrategy.
+    If only root strategy is set, all children HREFs should
+    follow than strategy.
+    If root and child strategy are set, root and child children
+    may follow different strategies.
+    Strategy provided to `add_child` always overrides other settings.
+    """
+
+    base_url = "http://example.com"
+    catalog = Catalog(
+        id="test",
+        description="test desc",
+        href=f"{base_url}/catalog.json",
+        layout_strategy=root_strategy,
+    )
+    subcat = Catalog(
+        id="subcat", description="subcat desc", layout_strategy=sub_strategy
+    )
+    subsubcat = Catalog(id="subsubcat", description="subsubcat desc")
+
+    catalog.add_child(subcat, strategy=provided_root_strategy)
+    subcat.add_child(subsubcat, strategy=provided_sub_strategy)
+
+    root_template = root_template.format(
+        id=subcat.id, description=subcat.description
+    ).replace("$", "")
+    sub_template = sub_template.format(
+        id=subsubcat.id, description=subsubcat.description
+    ).replace("$", "")
+
+    assert subcat.self_href == f"{base_url}/{root_template}/catalog.json"
+    assert (
+        subsubcat.self_href == f"{base_url}/{root_template}/{sub_template}/catalog.json"
+    )
+
+
+@pytest.mark.parametrize(
+    "root_strategy,sub_strategy,provided_root_strategy,"
+    "root_template,sub_template,norm_template",
+    [
+        (
+            None,
+            None,
+            None,
+            BEST_PRACTICE_CATALOG_TEMPLATE,
+            BEST_PRACTICE_CATALOG_TEMPLATE,
+            BEST_PRACTICE_CATALOG_TEMPLATE,
+        ),
+        (
+            STRATEGY,
+            None,
+            None,
+            TEST_CATALOG_TEMPLATE,
+            TEST_CATALOG_TEMPLATE,
+            TEST_CATALOG_TEMPLATE,
+        ),
+        (
+            STRATEGY,
+            BestPracticesLayoutStrategy(),
+            None,
+            TEST_CATALOG_TEMPLATE,
+            BEST_PRACTICE_CATALOG_TEMPLATE,
+            TEST_CATALOG_TEMPLATE,
+        ),
+        (
+            STRATEGY,
+            None,
+            BestPracticesLayoutStrategy(),
+            TEST_CATALOG_TEMPLATE,
+            TEST_CATALOG_TEMPLATE,
+            BEST_PRACTICE_CATALOG_TEMPLATE,
+        ),
+    ],
+)
+def test_add_child_layout_strategy_normalize(
+    root_strategy: HrefLayoutStrategy,
+    sub_strategy: HrefLayoutStrategy,
+    provided_root_strategy: HrefLayoutStrategy,
+    root_template: str,
+    sub_template: str,
+    norm_template: str,
+) -> None:
+    """Test for layout strategy when adding a child and normalizing HREFs.
+
+    If no layout strategy is specified, children HREF
+    should always follow BestPracticesLayoutStrategy.
+    If only root strategy is set, all children HREFs
+    should follow than strategy.
+    If root and child strategy are set, root strategy
+    overrides child strategy.
+    Strategy provided to `normalize_href` always
+    overrides other settings.
+    """
+
+    base_url = "http://example.com"
+    catalog = Catalog(
+        id="test",
+        description="test desc",
+        href=f"{base_url}/catalog.json",
+        layout_strategy=root_strategy,
+    )
+    subcat = Catalog(
+        id="subcat", description="subcat desc", layout_strategy=sub_strategy
+    )
+    subsubcat = Catalog(id="subsubcat", description="subsubcat desc")
+    catalog.add_child(subcat)
+    subcat.add_child(subsubcat)
+
+    _root_template = root_template.format(
+        id=subcat.id, description=subcat.description
+    ).replace("$", "")
+    _sub_template = sub_template.format(
+        id=subsubcat.id, description=subsubcat.description
+    ).replace("$", "")
+
+    assert subcat.self_href == f"{base_url}/{_root_template}/catalog.json"
+    assert (
+        subsubcat.self_href
+        == f"{base_url}/{_root_template}/{_sub_template}/catalog.json"
+    )
+
+    catalog.normalize_hrefs(base_url, strategy=provided_root_strategy)
+
+    _root_template = norm_template.format(
+        id=subcat.id, description=subcat.description
+    ).replace("$", "")
+    _sub_template = norm_template.format(
+        id=subsubcat.id, description=subsubcat.description
+    ).replace("$", "")
+
+    assert subcat.self_href == f"{base_url}/{_root_template}/catalog.json"
+    assert (
+        subsubcat.self_href
+        == f"{base_url}/{_root_template}/{_sub_template}/catalog.json"
+    )
+
+
+@pytest.mark.parametrize(
+    "root_strategy,provided_strategy,template",
+    [
+        (None, None, BEST_PRACTICE_ITEM_TEMPLATE),
+        (STRATEGY, None, TEST_ITEM_TEMPLATE),
+        (STRATEGY, BestPracticesLayoutStrategy(), BEST_PRACTICE_ITEM_TEMPLATE),
+    ],
+)
+def test_add_item_layout_strategy(
+    root_strategy: HrefLayoutStrategy,
+    provided_strategy: HrefLayoutStrategy,
+    template: str,
+) -> None:
+    """Test for layout strategy when adding an item.
+
+    If no layout strategy is specified, item HREF
+    should always follow BestPracticesLayoutStrategy.
+    If only root strategy is set, all item HREFs
+    should follow than strategy.
+    Strategy provided to `add_item` always overrides other settings.
+    """
+
+    base_url = "http://example.com"
+    item_id = "item_id"
+    catalog = Catalog(
+        id="test",
+        description="test desc",
+        href=f"{base_url}/catalog.json",
+        layout_strategy=root_strategy,
+    )
+    item = Item(
+        id=item_id,
+        geometry={
+            "type": "Polygon",
+            "coordinates": [
+                [
+                    [180.0, -90.0],
+                    [180.0, 90.0],
+                    [-180.0, 90.0],
+                    [-180.0, -90.0],
+                    [180.0, -90.0],
+                ]
+            ],
+        },
+        bbox=[-180, -90, 180, 90],
+        datetime=datetime(2023, 1, 1),
+        properties={},
+        assets={
+            "data": Asset(
+                href="http://example.com/assets/data.tif",
+                roles=["data"],
+                title="DATA",
+            )
+        },
+    )
+
+    catalog.add_item(item, strategy=provided_strategy)
+
+    template = template.format(id=item.id).replace("$", "")
+
+    assert item.self_href == f"{base_url}/{template}/{item_id}.json"


### PR DESCRIPTION
**Related Issue(s):**

- https://github.com/stac-utils/pystac-client/issues/241

**Description:**

This PR enables setting a default layout strategy for a catalog. Users can either set the default layout strategy
when instantiating the catalog or defining a fall back strategy when subclassing Catalog.

Together with #1294, this PR is part of setting the foundation for enabling API transactions using `pystac-client`.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
