### PR TITLE
custom StacIO init needs to call parent init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Made item pickles smaller by changing how nested links are stored([#1285](https://github.com/stac-utils/pystac/pull/1285))
 - Add APILayoutStrategy ([#1294](https://github.com/stac-utils/pystac/pull/1294))
 - Allow setting a default layout strategy for Catalog ([#1295](https://github.com/stac-utils/pystac/pull/1295))
+- Updated documentation code examples that use AWS S3 for file storage.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Made item pickles smaller by changing how nested links are stored([#1285](https://github.com/stac-utils/pystac/pull/1285))
 - Add APILayoutStrategy ([#1294](https://github.com/stac-utils/pystac/pull/1294))
 - Allow setting a default layout strategy for Catalog ([#1295](https://github.com/stac-utils/pystac/pull/1295))
-- Updated documentation code examples that use AWS S3 for file storage.
+- Updated documentation code examples that use AWS S3 for file storage ([#1308](https://github.com/stac-utils/pystac/pull/1308)
 
 ### Fixed
 

--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -333,6 +333,7 @@ for reading from AWS's S3 cloud object storage using `boto3
    class CustomStacIO(DefaultStacIO):
       def __init__(self):
          self.s3 = boto3.resource("s3")
+         super().__init__()
 
       def read_text(
          self, source: Union[str, Link], *args: Any, **kwargs: Any

--- a/docs/tutorials/how-to-create-stac-catalogs.ipynb
+++ b/docs/tutorials/how-to-create-stac-catalogs.ipynb
@@ -3142,6 +3142,7 @@
     "class CustomStacIO(DefaultStacIO):\n",
     "    def __init__(self):\n",
     "        self.s3 = boto3.resource(\"s3\")\n",
+    "        super().__init__()\n",
     "\n",
     "    def read_text(self, source: Union[str, Link], *args: Any, **kwargs: Any) -> str:\n",
     "        parsed = urlparse(source)\n",
@@ -3599,7 +3600,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.12.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
**Related Issue(s):**

none

**Description:**
This fixes tutorial code that accesses S3, which probably broke with commit https://github.com/stac-utils/pystac/commit/01f71b15e91762557aa1d2c9374458c5dcef.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
