### PR TITLE
Minimize css a bit and make it better at overriding jupyter defaults

### DIFF
--- a/pystac/html/JSON.jinja2
+++ b/pystac/html/JSON.jinja2
@@ -3,15 +3,31 @@
 <style>
 .pystac-summary {
     cursor: pointer;
-    display:list-item;
+    display: list-item;
+    list-style: revert;
+    margin-bottom: 0 !important;
+
+    .pystac-l {
+        padding-left: 0.5em;
+        color: rgb(64, 128, 128);
+        font-style: italic;
+    }
 }
-.pystac-key {
+.pystac-row {
+    overflow-wrap: break-word;
+    padding-left: .825em;
+
+    .pystac-k {
+        display: inline-block;
+        margin: 0px 0.5em 0px 0px;
+    }
+    .pystac-v {
+        color: rgb(186, 33, 33);
+    }
+}
+.pystac-k {
     color: rgb(0, 128, 0);
     font-weight: 700;
-}
-.pystac-key-value {
-    display: inline-block;
-    margin: 0px 0.5em 0px 0px;
 }
 </style>
 <div class="jp-RenderedJSON jp-mod-trusted jp-OutputArea-output">

--- a/pystac/html/Macros.jinja2
+++ b/pystac/html/Macros.jinja2
@@ -1,23 +1,20 @@
 {% macro scalar(key, value) -%}
     {% if value is mapping %}
         <li><details>
-            <summary class="pystac-summary"><span class="pystac-key">{{ key }}</span></summary>
+            <summary class="pystac-summary"><span class="pystac-k">{{ key }}</span></summary>
             {{ dict(value) }}
         </details></li>
     {% else %}
-        <li style="overflow-wrap: break-word; padding-left: 2.125em; text-indent: -0.5em;">
-            <span class="pystac-key pystac-key-value">{{ key }}</span>
-            <span style="color: rgb(186, 33, 33);">{% if value is string %}"{{ value }}"{% else %}{{ value }}{% endif %}</span>
+        <li class="pystac-row">
+            <span class="pystac-k">{{ key }}</span>
+            <span class="pystac-v">{% if value is string %}"{{ value }}"{% else %}{{ value }}{% endif %}</span>
         </li>
     {% endif %}
 {%- endmacro %}
 
 {% macro list(key, value) -%}
     <li><details>
-        <summary class="pystac-summary">
-            <span class="pystac-key">{{ key }}</span>
-            <span style="padding-left: 0.5em; color: rgb(64, 128, 128); font-style: italic;">[] {{ value|length }} items</span>
-        </summary>
+        <summary class="pystac-summary"><span class="pystac-k">{{ key }}</span><span class="pystac-l">[] {{ value|length }} items</span></summary>
         {% for item in value %}
             {{ dict({loop.index - 1: item}) }}
         {% endfor %}


### PR DESCRIPTION
**Related Issue(s):**

- #1310 

**Description:**

Kind of hard to reproduce, but even if this is a noop in many cases the reduction in size will hopefully be compelling.

For a notebook containing an executed version of the following:
```python
search = client.search(
    max_items=10,
    collections=['sentinel-2-l2a'],
    bbox=[-72.5,40.5,-72,41]
)
search.item_collection()
```
![image](https://github.com/stac-utils/pystac/assets/4806877/bf6e9d55-11ad-4320-a7cc-316066ce120f)

The saved size on this branch is 4.4M as opposed to 5.4M on main

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
