### PR TITLE
Replace called methods in docstrings with simple code blocks

### DIFF
--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -503,7 +503,7 @@ class Catalog(STACObject):
         DEPRECATED.
 
         .. deprecated:: 1.8
-            Use :meth:`next(pystac.Catalog.get_items(id), None)` instead.
+            Use ``next(pystac.Catalog.get_items(id), None)`` instead.
 
         Returns an item with a given ID.
 
@@ -600,7 +600,7 @@ class Catalog(STACObject):
         DEPRECATED.
 
         .. deprecated:: 1.8
-            Use :meth:`pystac.Catalog.get_items(recursive=True)` instead.
+            Use ``pystac.Catalog.get_items(recursive=True)`` instead.
 
         Get all items from this catalog and all subcatalogs. Will traverse
         any subcatalogs recursively.


### PR DESCRIPTION
**Related Issue(s):**

- #1314

**Description:**

Fixing up docstrings

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
