### PR TITLE
add custom validator as input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- Add `validator` input to `STACObject.validate` for inline reference of the validator to use
+  ([#1320](https://github.com/stac-utils/pystac/pull/1320))
 - Made item pickles smaller by changing how nested links are stored([#1285](https://github.com/stac-utils/pystac/pull/1285))
 - Add APILayoutStrategy ([#1294](https://github.com/stac-utils/pystac/pull/1294))
 - Allow setting a default layout strategy for Catalog ([#1295](https://github.com/stac-utils/pystac/pull/1295))

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -71,6 +71,11 @@ class STACObject(ABC):
         implementation. For JSON Schema validation (default validator), this
         will be a list of schema URIs that were used during validation.
 
+        Args:
+            validator : A custom validator to use for validation of the object.
+                If omitted, the default validator from
+                :class:`~pystac.validation.RegisteredValidator`
+                will be used instead.
         Raises:
             STACValidationError
         """

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -61,19 +61,22 @@ class STACObject(ABC):
         self.links = []
         self.stac_extensions = stac_extensions
 
-    def validate(self) -> list[Any]:
+    def validate(
+        self,
+        validator: "pystac.validation.stac_validator.STACValidator" = None,
+    ) -> list[Any]:
         """Validate this STACObject.
 
         Returns a list of validation results, which depends on the validation
-        implementation. For JSON Schema validation, this will be a list
-        of schema URIs that were used during validation.
+        implementation. For JSON Schema validation (default validator), this
+        will be a list of schema URIs that were used during validation.
 
         Raises:
             STACValidationError
         """
         import pystac.validation
 
-        return pystac.validation.validate(self)
+        return pystac.validation.validate(self, validator=validator)
 
     def add_link(self, link: Link) -> None:
         """Add a link to this object's set of links.

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -63,7 +63,7 @@ class STACObject(ABC):
 
     def validate(
         self,
-        validator: "pystac.validation.stac_validator.STACValidator" = None,
+        validator: pystac.validation.stac_validator.STACValidator | None = None,
     ) -> list[Any]:
         """Validate this STACObject.
 

--- a/pystac/validation/__init__.py
+++ b/pystac/validation/__init__.py
@@ -27,7 +27,10 @@ def validate(
 
     Args:
         stac_object : The stac object to validate.
-        validator: The validator to employ.
+        validator : A custom validator to use for validation of the STAC object.
+            If omitted, the default validator from
+            :class:`~pystac.validation.RegisteredValidator`
+            will be used instead.
 
     Returns:
         List[Object]: List of return values from the validation calls for the
@@ -259,4 +262,8 @@ def set_validator(validator: STACValidator) -> None:
     RegisteredValidator.set_validator(validator)
 
 
-__all__ = ["GetSchemaError"]
+__all__ = [
+    "GetSchemaError",
+    "JsonSchemaSTACValidator",
+    "RegisteredValidator",
+]

--- a/pystac/validation/__init__.py
+++ b/pystac/validation/__init__.py
@@ -73,7 +73,10 @@ def validate_dict(
         extensions : Extension IDs for this stac object. If not supplied,
             PySTAC's identification logic to identify the extensions.
         href : Optional HREF of the STAC object being validated.
-        validator: The validator to employ.
+        validator : A custom validator to use for validation of the STAC dictionary.
+            If omitted, the default validator from
+            :class:`~pystac.validation.RegisteredValidator`
+            will be used instead.
 
     Returns:
         List[Object]: List of return values from the validation calls for the

--- a/pystac/validation/__init__.py
+++ b/pystac/validation/__init__.py
@@ -19,11 +19,15 @@ if TYPE_CHECKING:
 from pystac.validation.stac_validator import JsonSchemaSTACValidator, STACValidator
 
 
-def validate(stac_object: STACObject) -> list[Any]:
+def validate(
+    stac_object: STACObject,
+    validator: STACValidator | None = None,
+) -> list[Any]:
     """Validates a :class:`~pystac.STACObject`.
 
     Args:
         stac_object : The stac object to validate.
+        validator: The validator to employ.
 
     Returns:
         List[Object]: List of return values from the validation calls for the
@@ -39,6 +43,7 @@ def validate(stac_object: STACObject) -> list[Any]:
         stac_version=pystac.get_stac_version(),
         extensions=stac_object.stac_extensions,
         href=stac_object.get_self_href(),
+        validator=validator,
     )
 
 
@@ -48,6 +53,7 @@ def validate_dict(
     stac_version: str | None = None,
     extensions: list[str] | None = None,
     href: str | None = None,
+    validator: STACValidator | None = None,
 ) -> list[Any]:
     """Validate a stac object serialized as JSON into a dict.
 
@@ -67,6 +73,7 @@ def validate_dict(
         extensions : Extension IDs for this stac object. If not supplied,
             PySTAC's identification logic to identify the extensions.
         href : Optional HREF of the STAC object being validated.
+        validator: The validator to employ.
 
     Returns:
         List[Object]: List of return values from the validation calls for the
@@ -104,7 +111,8 @@ def validate_dict(
 
         extensions = [uri for uri in map(_get_uri, extensions) if uri is not None]
 
-    return RegisteredValidator.get_validator().validate(
+    validator = validator or RegisteredValidator.get_validator()
+    return validator.validate(
         stac_dict, stac_object_type, stac_version, extensions, href
     )
 


### PR DESCRIPTION
**Related Issue(s):**

- n/a

**Description:**

Currently, performing validation on STAC objects with extensions that are not directly part of `pystac`, or that the schema is not yet published at the expected URI defined by the extension, is not convenient or obvious. 

In order to call `<STACObject>.validate()`, one has to either duplicate the operations done in `pystac.validation.validate_dict` to use their own validator or set it globally with `RegisteredValidator.set_validator` before calling `<STACObject>.validate()`. This PR adds a `validator` input to all the relevant functions to directly provide the validator to use for validation, with a local reference. This makes it easier to manage the "active" validator at the moment the `validate` method gets called.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
