### PR TITLE
fix gridcode pydoc

### DIFF
--- a/pystac/extensions/grid.py
+++ b/pystac/extensions/grid.py
@@ -77,7 +77,7 @@ class GridExtension(
 
     @property
     def code(self) -> str | None:
-        """Get or sets the latitude band of the datasource."""
+        """Get or sets the grid code of the datasource."""
         return self._get_property(CODE_PROP, str)
 
     @code.setter


### PR DESCRIPTION
**Related Issue(s):**

- n/a

**Description:**

fix grid extension docs on `code` property, which were not modified after copying from the MGRS extension (oops, my fault!)

**PR Checklist:**

- [X] `pre-commit` hooks pass locally
- [X] Tests pass (run `scripts/test`)
- [X] Documentation has been updated to reflect changes, if applicable
- [X] This PR maintains or improves overall codebase code coverage.
- [X] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
