### PR TITLE
fix: don't transform_href in __getstate__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Don't transform hrefs in `Item.__getstate__` ([#1337](https://github.com/stac-utils/pystac/pull/1337))
+
 ## [v1.10.0] - 2024-03-28
 
 ### Added

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -177,7 +177,12 @@ class Item(STACObject, Assets):
         d = self.__dict__.copy()
 
         d["links"] = [
-            link.to_dict() if link.get_href() else link for link in d["links"]
+            (
+                link.to_dict(transform_href=False)
+                if link.get_href(transform_href=False)
+                else link
+            )
+            for link in d["links"]
         ]
 
         return d

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import json
 import os
 import pickle
@@ -682,3 +683,12 @@ def test_pickle_with_only_href_links(item: Item) -> None:
         assert original.media_type == new.media_type
         assert str(original.owner) == str(new.owner)
         assert str(original.target) == str(new.target)
+
+
+def test_copy_with_unresolveable_root(item: Item) -> None:
+    item.add_link(
+        pystac.Link(
+            "root", "s3://naip-visualization/this-is-a-non-existent-catalog.json"
+        )
+    )
+    copy.deepcopy(item)


### PR DESCRIPTION
**Related Issue(s):**

- Closes #1336 
- Relates to #960

**Description:**

`__getstate__` was doing too much work by trying to resolve the root. @jsignell we'll want to release a PATCH once this merges, as this will be a good fix to get out in the wild.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
