### PR TITLE
Implement classification v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 ### Changed
 
-- Allow object ID as input for getting APILayoutStrategy hrefs and add `items`, `collections`, `search`, `conformance`, `service_desc` and `service_doc` href methods. ([#1335](https://github.com/stac-utils/pystac/pull/1335))
-- Update docstring of `name` argument to `Classification.apply` and `Classification.create` to agree with extension specification. ([#1356](https://github.com/stac-utils/pystac/pull/1356))
+- Allow object ID as input for getting APILayoutStrategy hrefs and add `items`, `collections`, `search`, `conformance`, `service_desc` and `service_doc` href methods ([#1335](https://github.com/stac-utils/pystac/pull/1335))
+- Updated classification extension to v2.0.0 ([#1359](https://github.com/stac-utils/pystac/pull/1359))
+- Update docstring of `name` argument to `Classification.apply` and `Classification.create` to agree with extension specification ([#1356](https://github.com/stac-utils/pystac/pull/1356))
 
 ## [v1.10.1] - 2024-05-03
 

--- a/pystac/extensions/classification.py
+++ b/pystac/extensions/classification.py
@@ -206,7 +206,7 @@ class Classification:
         """Get or set the nodata value for this class.
 
         Returns:
-            Optional[bool]
+            bool | None
         """
         return self.properties.get("nodata")
 

--- a/pystac/extensions/classification.py
+++ b/pystac/extensions/classification.py
@@ -58,8 +58,8 @@ class Classification:
     def apply(
         self,
         value: int,
-        name: str,
         description: str | None = None,
+        name: str | None = None,
         color_hint: str | None = None,
         nodata: bool | None = None,
         percentage: float | None = None,
@@ -70,9 +70,10 @@ class Classification:
 
         Args:
             value: The integer value corresponding to this class
-            name: Short name of the class for machine readability. Must consist only
-                of letters, numbers, -, and _ characters.
             description: The description of this class
+            name: Short name of the class for machine readability. Must consist only
+                of letters, numbers, -, and _ characters. Required as of v2.0 of
+                this extension.
             color_hint: An optional hexadecimal string-encoded representation of the
                 RGB color that is suggested to represent this class (six hexadecimal
                 characters, all capitalized)
@@ -83,6 +84,12 @@ class Classification:
             count: The number of data values that belong to this class.
         """
         self.value = value
+        # TODO pystac v2.0: make `name` non-optional, move it before
+        # `description` in the arg list, and remove this check
+        if name is None:
+            raise Exception(
+                "As of v2.0.0 of the classification extension, 'name' is required"
+            )
         self.name = name
         self.description = description
         self.color_hint = color_hint
@@ -100,8 +107,8 @@ class Classification:
     def create(
         cls,
         value: int,
-        name: str,
         description: str | None = None,
+        name: str | None = None,
         color_hint: str | None = None,
         nodata: bool | None = None,
         percentage: float | None = None,
@@ -112,9 +119,10 @@ class Classification:
 
         Args:
             value: The integer value corresponding to this class
-            name: Short name of the class for machine readability. Must consist only
-                of letters, numbers, -, and _ characters.
             description: The optional long-form description of this class
+            name: Short name of the class for machine readability. Must consist only
+                of letters, numbers, -, and _ characters. Required as of v2.0 of
+                this extension.
             color_hint: An optional hexadecimal string-encoded representation of the
                 RGB color that is suggested to represent this class (six hexadecimal
                 characters, all capitalized)
@@ -166,7 +174,7 @@ class Classification:
             self.properties.pop("description", None)
 
     @property
-    def name(self) -> str | None:
+    def name(self) -> str:
         """Get or set the name of the class
 
         Returns:
@@ -175,7 +183,7 @@ class Classification:
         return get_required(self.properties.get("name"), self, "name")
 
     @name.setter
-    def name(self, v: str | None) -> None:
+    def name(self, v: str) -> None:
         self.properties["name"] = v
 
     @property

--- a/pystac/extensions/classification.py
+++ b/pystac/extensions/classification.py
@@ -158,7 +158,7 @@ class Classification:
         self.properties["value"] = v
 
     @property
-    def description(self) -> str:
+    def description(self) -> str | None:
         """Get or set the description of the class
 
         Returns:

--- a/pystac/extensions/classification.py
+++ b/pystac/extensions/classification.py
@@ -182,6 +182,11 @@ class Classification:
 
     @name.setter
     def name(self, v: str) -> None:
+        if v is None:
+            raise Exception(
+                "`name` was converted to a required attribute in classification"
+                " version v2.0, so cannot be set to None"
+            )
         self.properties["name"] = v
 
     @property

--- a/pystac/extensions/classification.py
+++ b/pystac/extensions/classification.py
@@ -32,8 +32,8 @@ T = TypeVar("T", pystac.Item, pystac.Asset, item_assets.AssetDefinition, RasterB
 SCHEMA_URI_PATTERN: str = (
     "https://stac-extensions.github.io/classification/v{version}/schema.json"
 )
-DEFAULT_VERSION: str = "1.1.0"
-SUPPORTED_VERSIONS: list[str] = ["1.1.0", "1.0.0"]
+DEFAULT_VERSION: str = "2.0.0"
+SUPPORTED_VERSIONS: list[str] = ["2.0.0", "1.1.0", "1.0.0"]
 
 # Field names
 PREFIX: str = "classification:"
@@ -58,32 +58,37 @@ class Classification:
     def apply(
         self,
         value: int,
-        description: str,
-        name: str | None = None,
+        name: str,
+        description: str | None = None,
         color_hint: str | None = None,
+        nodata: bool | None = None,
+        percentage: float | None = None,
+        count: int | None = None,
     ) -> None:
         """
         Set the properties for a new Classification.
 
         Args:
             value: The integer value corresponding to this class
-            description: The description of this class
             name: Short name of the class for machine readability. Must consist only
                 of letters, numbers, -, and _ characters.
+            description: The description of this class
             color_hint: An optional hexadecimal string-encoded representation of the
                 RGB color that is suggested to represent this class (six hexadecimal
                 characters, all capitalized)
+            nodata: If set to true classifies a value as a no-data value,
+                defaults to false
+            percentage: The percentage of data values that belong to this class
+                in comparison to all data values, in percent (0-100).
+            count: The number of data values that belong to this class.
         """
         self.value = value
         self.name = name
         self.description = description
         self.color_hint = color_hint
-
-        if color_hint is not None:
-            match = COLOR_HINT_PATTERN.match(color_hint)
-            assert (
-                color_hint is None or match is not None and match.group() == color_hint
-            ), "Must format color hints as '^([0-9A-F]{6})$'"
+        self.nodata = nodata
+        self.percentage = percentage
+        self.count = count
 
         if color_hint is not None:
             match = COLOR_HINT_PATTERN.match(color_hint)
@@ -95,9 +100,12 @@ class Classification:
     def create(
         cls,
         value: int,
-        description: str,
-        name: str | None = None,
+        name: str,
+        description: str | None = None,
         color_hint: str | None = None,
+        nodata: bool | None = None,
+        percentage: float | None = None,
+        count: int | None = None,
     ) -> Classification:
         """
         Create a new Classification.
@@ -110,6 +118,11 @@ class Classification:
             color_hint: An optional hexadecimal string-encoded representation of the
                 RGB color that is suggested to represent this class (six hexadecimal
                 characters, all capitalized)
+            nodata: If set to true classifies a value as a no-data value,
+                defaults to false
+            percentage: The percentage of data values that belong to this class
+                in comparison to all data values, in percent (0-100).
+            count: The number of data values that belong to this class.
         """
         c = cls({})
         c.apply(
@@ -117,6 +130,9 @@ class Classification:
             name=name,
             description=description,
             color_hint=color_hint,
+            nodata=nodata,
+            percentage=percentage,
+            count=count,
         )
         return c
 
@@ -140,11 +156,14 @@ class Classification:
         Returns:
             str
         """
-        return get_required(self.properties.get("description"), self, "description")
+        return self.properties.get("description")
 
     @description.setter
-    def description(self, v: str) -> None:
-        self.properties["description"] = v
+    def description(self, v: str | None) -> None:
+        if v is not None:
+            self.properties["description"] = v
+        else:
+            self.properties.pop("description", None)
 
     @property
     def name(self) -> str | None:
@@ -153,14 +172,11 @@ class Classification:
         Returns:
             Optional[str]
         """
-        return self.properties.get("name")
+        return get_required(self.properties.get("name"), self, "name")
 
     @name.setter
     def name(self, v: str | None) -> None:
-        if v is not None:
-            self.properties["name"] = v
-        else:
-            self.properties.pop("name", None)
+        self.properties["name"] = v
 
     @property
     def color_hint(self) -> str | None:
@@ -184,6 +200,54 @@ class Classification:
             self.properties["color_hint"] = v
         else:
             self.properties.pop("color_hint", None)
+
+    @property
+    def nodata(self) -> bool | None:
+        """Get or set the nodata value for this class.
+
+        Returns:
+            Optional[bool]
+        """
+        return self.properties.get("nodata")
+
+    @nodata.setter
+    def nodata(self, v: bool | None) -> None:
+        if v is not None:
+            self.properties["nodata"] = v
+        else:
+            self.properties.pop("nodata", None)
+
+    @property
+    def percentage(self) -> float | None:
+        """Get or set the percentage value for this class.
+
+        Returns:
+            Optional[float]
+        """
+        return self.properties.get("percentage")
+
+    @percentage.setter
+    def percentage(self, v: float | None) -> None:
+        if v is not None:
+            self.properties["percentage"] = v
+        else:
+            self.properties.pop("percentage", None)
+
+    @property
+    def count(self) -> int | None:
+        """Get or set the count value for this class.
+
+        Returns:
+            Optional[int]
+        """
+        return self.properties.get("count")
+
+    @count.setter
+    def count(self, v: int | None) -> None:
+        if v is not None:
+            self.properties["count"] = v
+        else:
+            self.properties.pop("count", None)
 
     def to_dict(self) -> dict[str, Any]:
         """Returns the dictionary encoding of this class

--- a/pystac/extensions/classification.py
+++ b/pystac/extensions/classification.py
@@ -77,8 +77,7 @@ class Classification:
             color_hint: An optional hexadecimal string-encoded representation of the
                 RGB color that is suggested to represent this class (six hexadecimal
                 characters, all capitalized)
-            nodata: If set to true classifies a value as a no-data value,
-                defaults to false
+            nodata: If set to true classifies a value as a no-data value.
             percentage: The percentage of data values that belong to this class
                 in comparison to all data values, in percent (0-100).
             count: The number of data values that belong to this class.
@@ -126,8 +125,7 @@ class Classification:
             color_hint: An optional hexadecimal string-encoded representation of the
                 RGB color that is suggested to represent this class (six hexadecimal
                 characters, all capitalized)
-            nodata: If set to true classifies a value as a no-data value,
-                defaults to false
+            nodata: If set to true classifies a value as a no-data value.
             percentage: The percentage of data values that belong to this class
                 in comparison to all data values, in percent (0-100).
             count: The number of data values that belong to this class.

--- a/tests/data-files/classification/collection-item-assets-raster-bands.json
+++ b/tests/data-files/classification/collection-item-assets-raster-bands.json
@@ -115,6 +115,6 @@
     "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
     "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
-    "https://stac-extensions.github.io/classification/v1.1.0/schema.json"
+    "https://stac-extensions.github.io/classification/v2.0.0/schema.json"
   ]
 }

--- a/tests/extensions/cassettes/test_classification/test_apply_bitfields.yaml
+++ b/tests/extensions/cassettes/test_classification/test_apply_bitfields.yaml
@@ -7,115 +7,99 @@ interactions:
       Host:
       - stac-extensions.github.io
       User-Agent:
-      - Python-urllib/3.11
+      - Python-urllib/3.12
     method: GET
-    uri: https://stac-extensions.github.io/classification/v1.1.0/schema.json
+    uri: https://stac-extensions.github.io/classification/v2.0.0/schema.json
   response:
     body:
-      string: "{\n    \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n
-        \   \"$id\": \"https://stac-extensions.github.io/classification/v1.1.0/schema.json#\",\n
-        \   \"title\": \"Classification Extension\",\n    \"description\": \"STAC
-        Classification Extension for STAC Items and STAC Collections.\",\n    \"oneOf\":
-        [\n        {\n            \"$comment\": \"This is the schema for STAC Items.\",\n
-        \           \"allOf\": [\n                {\n                    \"$ref\":
-        \"#/definitions/stac_extensions\"\n                },\n                {\n
-        \                   \"type\": \"object\",\n                    \"required\":
-        [\n                        \"type\",\n                        \"properties\",\n
-        \                       \"assets\"\n                    ],\n                    \"properties\":
-        {\n                        \"type\": {\n                            \"const\":
-        \"Feature\"\n                        },\n                        \"properties\":
-        {\n                            \"$comment\": \"This validates the fields in
-        Item Properties, but does not require them.\",\n                            \"$ref\":
-        \"#/definitions/fields\"\n                        },\n                        \"assets\":
-        {\n                            \"$comment\": \"This validates the fields in
-        Item Assets (including in Raster Band Objects), but does not require them.\",\n
-        \                           \"type\": \"object\",\n                            \"additionalProperties\":
-        {\n                                \"allOf\": [\n                                    {\n
-        \                                       \"$ref\": \"#/definitions/fields\"\n
-        \                                   },\n                                    {\n
-        \                                       \"$ref\": \"#/definitions/raster_bands\"\n
-        \                                   }\n                                ]\n
-        \                           }\n                        }\n                    }\n
-        \               }\n            ]\n        },\n        {\n            \"$comment\":
-        \"This is the schema for STAC Collections.\",\n            \"allOf\": [\n
-        \               {\n                    \"$ref\": \"#/definitions/stac_extensions\"\n
-        \               },\n                {\n                    \"type\": \"object\",\n
-        \                   \"required\": [\n                        \"type\"\n                    ],\n
-        \                   \"properties\": {\n                        \"type\": {\n
-        \                           \"const\": \"Collection\"\n                        },\n
-        \                       \"assets\": {\n                            \"$comment\":
-        \"This validates the fields in Collection Assets, but does not require them.\",\n
-        \                           \"type\": \"object\",\n                            \"additionalProperties\":
-        {\n                                \"allOf\": [\n                                    {\n
-        \                                       \"$ref\": \"#/definitions/fields\"\n
-        \                                   },\n                                    {\n
-        \                                       \"$ref\": \"#/definitions/raster_bands\"\n
-        \                                   }\n                                ]\n
-        \                           }\n                        },\n                        \"item_assets\":
-        {\n                            \"$comment\": \"This validates the fields in
-        Item Asset Definitions, but does not require them.\",\n                            \"type\":
-        \"object\",\n                            \"additionalProperties\": {\n                                \"allOf\":
-        [\n                                    {\n                                        \"$ref\":
-        \"#/definitions/fields\"\n                                    },\n                                    {\n
-        \                                       \"$ref\": \"#/definitions/raster_bands\"\n
-        \                                   }\n                                ]\n
-        \                           }\n                        },\n                        \"summaries\":
-        {\n                            \"$comment\": \"This validates the fields in
-        Summaries, but does not require them.\",\n                            \"$ref\":
-        \"#/definitions/fields\"\n                        }\n                    }\n
-        \               }\n            ]\n        }\n    ],\n    \"definitions\":
-        {\n        \"stac_extensions\": {\n            \"type\": \"object\",\n            \"required\":
-        [\n                \"stac_extensions\"\n            ],\n            \"properties\":
-        {\n                \"stac_extensions\": {\n                    \"type\": \"array\",\n
-        \                   \"contains\": {\n                        \"const\": \"https://stac-extensions.github.io/classification/v1.1.0/schema.json\"\n
-        \                   }\n                }\n            }\n        },\n        \"require_any_field\":
-        {\n            \"$comment\": \"Please list all fields here so that we can
-        force the existance of one of them in other parts of the schemas.\",\n            \"anyOf\":
-        [\n                {\n                    \"required\": [\n                        \"classification:bitfields\"\n
-        \                   ]\n                },\n                {\n                    \"required\":
-        [\n                        \"classification:classes\"\n                    ]\n
-        \               }\n            ]\n        },\n        \"fields\": {\n            \"$comment\":
-        \"Add your new fields here. Don't require them here, do that above in the
-        corresponding schema.\",\n            \"type\": \"object\",\n            \"properties\":
-        {\n                \"classification:bitfields\": {\n                    \"type\":
-        \"array\",\n                    \"uniqueItems\": true,\n                    \"minItems\":
-        1,\n                    \"items\": {\n                        \"$ref\": \"#/definitions/bit_field_object\"\n
-        \                   }\n                },\n                \"classification:classes\":
-        {\n                    \"type\": \"array\",\n                    \"uniqueItems\":
-        true,\n                    \"minItems\": 1,\n                    \"items\":
-        {\n                        \"$ref\": \"#/definitions/class_object\"\n                    }\n
-        \               }\n            },\n            \"patternProperties\": {\n
-        \               \"^(?!classification:)\": {}\n            },\n            \"additionalProperties\":
-        false\n        },\n        \"class_object\": {\n            \"$comment\":
-        \"Object for storing classes\",\n            \"type\": \"object\",\n            \"required\":
-        [\n                \"value\",\n                \"description\"\n            ],\n
-        \           \"properties\": {\n                \"value\": {\n                    \"type\":
-        \"integer\"\n                },\n                \"description\": {\n                    \"type\":
-        \"string\"\n                },\n                \"name\": {\n                    \"type\":
-        \"string\"\n                },\n                \"color_hint\": {\n                    \"type\":
-        \"string\",\n                    \"pattern\": \"^([0-9A-Fa-f]{6})$\"\n                }\n
-        \           }\n        },\n        \"bit_field_object\": {\n            \"$comment\":
-        \"Object for storing bit fields\",\n            \"type\": \"object\",\n            \"required\":
-        [\n                \"offset\",\n                \"length\",\n                \"classes\"\n
-        \           ],\n            \"properties\": {\n                \"offset\":
-        {\n                    \"type\": \"integer\",\n                    \"minimum\":
-        0\n                },\n                \"length\": {\n                    \"type\":
-        \"integer\",\n                    \"minimum\": 1\n                },\n                \"classes\":
-        {\n                    \"type\": \"array\",\n                    \"uniqueItems\":
-        true,\n                    \"minItems\": 1,\n                    \"items\":
-        {\n                        \"$ref\": \"#/definitions/class_object\"\n                    }\n
-        \               },\n                \"roles\": {\n                    \"type\":
-        \"array\",\n                    \"uniqueItems\": true,\n                    \"minItems\":
-        1,\n                    \"items\": {\n                        \"type\": \"string\"\n
-        \                   }\n                },\n                \"description\":
-        {\n                    \"type\": \"string\"\n                },\n                \"name\":
-        {\n                    \"type\": \"string\"\n                }\n            }\n
-        \       },\n        \"raster_bands\": {\n            \"$comment\": \"Classification
-        fields on the Raster Extension raster:bands object\",\n            \"type\":
-        \"object\",\n            \"properties\": {\n                \"raster:bands\":
-        {\n                    \"type\": \"array\",\n                    \"items\":
-        {\n                        \"$ref\": \"#/definitions/fields\"\n                    }\n
-        \               }\n            }\n        }\n    }\n}"
+      string: "{\n  \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n  \"$id\":
+        \"https://stac-extensions.github.io/classification/v2.0.0/schema.json#\",\n
+        \ \"title\": \"Classification Extension\",\n  \"description\": \"STAC Classification
+        Extension for STAC Items and STAC Collections.\",\n  \"type\": \"object\",\n
+        \ \"required\": [\"stac_extensions\"],\n  \"properties\": {\n    \"stac_extensions\":
+        {\n      \"type\": \"array\",\n      \"contains\": {\n        \"const\": \"https://stac-extensions.github.io/classification/v2.0.0/schema.json\"\n
+        \     }\n    }\n  },\n  \"oneOf\": [\n    {\n      \"$comment\": \"This is
+        the schema for STAC Items.\",\n      \"type\": \"object\",\n      \"required\":
+        [\"type\", \"properties\", \"assets\"],\n      \"properties\": {\n        \"type\":
+        {\n          \"const\": \"Feature\"\n        },\n        \"properties\": {\n
+        \         \"$comment\": \"This validates the fields in Item Properties, but
+        does not require them.\",\n          \"allOf\": [\n            {\n              \"$ref\":
+        \"#/definitions/fields\"\n            },\n            {\n              \"$ref\":
+        \"#/definitions/ml_model_output\"\n            }\n          ]\n        },\n
+        \       \"assets\": {\n          \"$comment\": \"This validates the fields
+        in Item Assets (including in Raster Band Objects), but does not require them.\",\n
+        \         \"type\": \"object\",\n          \"additionalProperties\": {\n            \"allOf\":
+        [\n              {\n                \"$ref\": \"#/definitions/fields\"\n              },\n
+        \             {\n                \"$ref\": \"#/definitions/raster_bands\"\n
+        \             },\n              {\n                \"$ref\": \"#/definitions/ml_model_output\"\n
+        \             }\n            ]\n          }\n        }\n      }\n    },\n
+        \   {\n      \"$comment\": \"This is the schema for STAC Collections.\",\n
+        \     \"type\": \"object\",\n      \"required\": [\"type\"],\n      \"properties\":
+        {\n        \"type\": {\n          \"const\": \"Collection\"\n        },\n
+        \       \"assets\": {\n          \"$comment\": \"This validates the fields
+        in Collection Assets, but does not require them.\",\n          \"type\": \"object\",\n
+        \         \"additionalProperties\": {\n            \"allOf\": [\n              {\n
+        \               \"$ref\": \"#/definitions/fields\"\n              },\n              {\n
+        \               \"$ref\": \"#/definitions/raster_bands\"\n              },\n
+        \             {\n                \"$ref\": \"#/definitions/ml_model_output\"\n
+        \             }\n            ]\n          }\n        },\n        \"item_assets\":
+        {\n          \"$comment\": \"This validates the fields in Item Asset Definitions,
+        but does not require them.\",\n          \"type\": \"object\",\n          \"additionalProperties\":
+        {\n            \"allOf\": [\n              {\n                \"$ref\": \"#/definitions/fields\"\n
+        \             },\n              {\n                \"$ref\": \"#/definitions/raster_bands\"\n
+        \             },\n              {\n                \"$ref\": \"#/definitions/ml_model_output\"\n
+        \             }\n            ]\n          }\n        },\n        \"summaries\":
+        {\n          \"$comment\": \"This validates the fields in Summaries, but does
+        not require them.\",\n          \"$ref\": \"#/definitions/fields\"\n        }\n
+        \     }\n    }\n  ],\n  \"definitions\": {\n    \"require_any_field\": {\n
+        \     \"$comment\": \"Please list all fields here so that we can force the
+        existance of one of them in other parts of the schemas.\",\n      \"anyOf\":
+        [\n        {\n          \"required\": [\"classification:bitfields\"]\n        },\n
+        \       {\n          \"required\": [\"classification:classes\"]\n        }\n
+        \     ]\n    },\n    \"fields\": {\n      \"$comment\": \"Add your new fields
+        here. Don't require them here, do that above in the corresponding schema.\",\n
+        \     \"type\": \"object\",\n      \"properties\": {\n        \"classification:bitfields\":
+        {\n          \"type\": \"array\",\n          \"uniqueItems\": true,\n          \"minItems\":
+        1,\n          \"items\": {\n            \"$ref\": \"#/definitions/bit_field_object\"\n
+        \         }\n        },\n        \"classification:classes\": {\n          \"type\":
+        \"array\",\n          \"uniqueItems\": true,\n          \"minItems\": 1,\n
+        \         \"items\": {\n            \"$ref\": \"#/definitions/class_object\"\n
+        \         }\n        }\n      },\n      \"patternProperties\": {\n        \"^(?!classification:)\":
+        {}\n      },\n      \"additionalProperties\": false\n    },\n    \"class_object\":
+        {\n      \"$comment\": \"Object for storing classes\",\n      \"type\": \"object\",\n
+        \     \"required\": [\"value\", \"name\"],\n      \"properties\": {\n        \"value\":
+        {\n          \"type\": \"integer\"\n        },\n        \"description\": {\n
+        \         \"type\": \"string\"\n        },\n        \"name\": {\n          \"type\":
+        \"string\",\n          \"pattern\": \"^[0-9A-Za-z-_]+$\"\n        },\n        \"title\":
+        {\n          \"type\": \"string\"\n        },\n        \"color_hint\": {\n
+        \         \"type\": \"string\",\n          \"pattern\": \"^([0-9A-Fa-f]{6})$\"\n
+        \       },\n        \"nodata\": {\n          \"type\": \"boolean\"\n        },\n
+        \       \"percentage\": {\n          \"type\": \"number\",\n          \"minimum\":
+        0,\n          \"maximum\": 100\n        },\n        \"count\": {\n          \"type\":
+        \"integer\",\n          \"minimum\": 0\n        }\n      }\n    },\n    \"bit_field_object\":
+        {\n      \"$comment\": \"Object for storing bit fields\",\n      \"type\":
+        \"object\",\n      \"required\": [\"offset\", \"length\", \"classes\"],\n
+        \     \"properties\": {\n        \"offset\": {\n          \"type\": \"integer\",\n
+        \         \"minimum\": 0\n        },\n        \"length\": {\n          \"type\":
+        \"integer\",\n          \"minimum\": 1\n        },\n        \"classes\": {\n
+        \         \"type\": \"array\",\n          \"uniqueItems\": true,\n          \"minItems\":
+        1,\n          \"items\": {\n            \"$ref\": \"#/definitions/class_object\"\n
+        \         }\n        },\n        \"roles\": {\n          \"type\": \"array\",\n
+        \         \"uniqueItems\": true,\n          \"minItems\": 1,\n          \"items\":
+        {\n            \"type\": \"string\"\n          }\n        },\n        \"description\":
+        {\n          \"type\": \"string\"\n        },\n        \"name\": {\n          \"type\":
+        \"string\",\n          \"pattern\": \"^[0-9A-Za-z-_]+$\"\n        }\n      }\n
+        \   },\n    \"raster_bands\": {\n      \"$comment\": \"Classification fields
+        on the Raster Extension raster:bands object\",\n      \"type\": \"object\",\n
+        \     \"properties\": {\n        \"raster:bands\": {\n          \"type\":
+        \"array\",\n          \"items\": {\n            \"$ref\": \"#/definitions/fields\"\n
+        \         }\n        }\n      }\n    },\n    \"ml_model_output\": {\n      \"$comment\":
+        \"Classification fields on the MLM Extension mlm:output objects (https://crim-ca.github.io/mlm-extension/v1.0.0/schema.json).\",\n
+        \     \"description\": \"Describes the classes embedded in the output of the
+        ML model following inference.\",\n      \"type\": \"object\",\n      \"properties\":
+        {\n        \"mlm:output\": {\n          \"type\": \"array\",\n          \"items\":
+        {\n            \"$ref\": \"#/definitions/fields\"\n          }\n        }\n
+        \     }\n    }\n  }\n}\n"
     headers:
       Accept-Ranges:
       - bytes
@@ -128,15 +112,15 @@ interactions:
       Connection:
       - close
       Content-Length:
-      - '8234'
+      - '6554'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 28 Mar 2024 20:13:58 GMT
+      - Mon, 01 Jul 2024 22:19:05 GMT
       ETag:
-      - '"62719998-202a"'
+      - '"66487a48-199a"'
       Last-Modified:
-      - Tue, 03 May 2022 21:07:36 GMT
+      - Sat, 18 May 2024 09:52:08 GMT
       Server:
       - GitHub.com
       Strict-Transport-Security:
@@ -146,19 +130,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - MISS
+      - HIT
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - d9b90ce0d3271f588d38ab817e120cc794af59d6
+      - 1ece189559fae48ccd92693626d4a5fd01e01597
       X-GitHub-Request-Id:
-      - 4A02:5B96:E2D6FD:123D048:6605CF86
+      - 10BE:2C4D72:327703C:3BB1110:6683282D
       X-Served-By:
-      - cache-ewr18175-EWR
+      - cache-den8244-DEN
       X-Timer:
-      - S1711656838.135787,VS0,VE22
+      - S1719872346.927209,VS0,VE64
       expires:
-      - Thu, 28 Mar 2024 20:23:58 GMT
+      - Mon, 01 Jul 2024 22:15:34 GMT
       permissions-policy:
       - interest-cohort=()
       x-proxy-cache:

--- a/tests/extensions/cassettes/test_classification/test_validate_classification.yaml
+++ b/tests/extensions/cassettes/test_classification/test_validate_classification.yaml
@@ -7,7 +7,7 @@ interactions:
       Host:
       - stac-extensions.github.io
       User-Agent:
-      - Python-urllib/3.11
+      - Python-urllib/3.12
     method: GET
     uri: https://stac-extensions.github.io/raster/v1.1.0/schema.json
   response:
@@ -114,7 +114,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 28 Mar 2024 20:13:58 GMT
+      - Mon, 01 Jul 2024 22:19:06 GMT
       ETag:
       - '"60e44dd0-18ae"'
       Last-Modified:
@@ -128,19 +128,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - MISS
+      - HIT
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 2eb25a2b1e72f21f90097868ba97f876406969ae
+      - 2ea418a39c3b4e7568fcbebdf6cfee253588a8b7
       X-GitHub-Request-Id:
-      - B43C:3D15:F31CD7:13449A2:6605CF86
+      - C9F9:192CCB:34F0451:3E2A920:6683282D
       X-Served-By:
-      - cache-ewr18151-EWR
+      - cache-den8244-DEN
       X-Timer:
-      - S1711656838.256513,VS0,VE20
+      - S1719872346.070418,VS0,VE71
       expires:
-      - Thu, 28 Mar 2024 20:23:58 GMT
+      - Mon, 01 Jul 2024 22:15:34 GMT
       permissions-policy:
       - interest-cohort=()
       x-proxy-cache:
@@ -156,7 +156,7 @@ interactions:
       Host:
       - stac-extensions.github.io
       User-Agent:
-      - Python-urllib/3.11
+      - Python-urllib/3.12
     method: GET
     uri: https://stac-extensions.github.io/eo/v1.1.0/schema.json
   response:
@@ -234,7 +234,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '15'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -244,7 +244,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 28 Mar 2024 20:13:58 GMT
+      - Mon, 01 Jul 2024 22:19:06 GMT
       ETag:
       - '"63e664c8-13bc"'
       Last-Modified:
@@ -260,17 +260,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '0'
       X-Fastly-Request-ID:
-      - 7191713dbd3c0105b8a6ef43e197af2a5d3889c2
+      - 0b0c2ec0235f8b6229ddcd82d66a0b878b89f6e3
       X-GitHub-Request-Id:
-      - 5B26:3FB5:EBCC97:12D0123:6605CF76
+      - 2E63:167D:2B00C0B:32E0C8E:6683282D
       X-Served-By:
-      - cache-ewr18146-EWR
+      - cache-den8256-DEN
       X-Timer:
-      - S1711656838.360519,VS0,VE1
+      - S1719872346.180489,VS0,VE60
       expires:
-      - Thu, 28 Mar 2024 20:23:42 GMT
+      - Mon, 01 Jul 2024 22:15:34 GMT
       permissions-policy:
       - interest-cohort=()
       x-proxy-cache:
@@ -286,7 +286,7 @@ interactions:
       Host:
       - stac-extensions.github.io
       User-Agent:
-      - Python-urllib/3.11
+      - Python-urllib/3.12
     method: GET
     uri: https://stac-extensions.github.io/view/v1.0.0/schema.json
   response:
@@ -344,7 +344,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '15'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -354,7 +354,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 28 Mar 2024 20:13:58 GMT
+      - Mon, 01 Jul 2024 22:19:06 GMT
       ETag:
       - '"60635220-dff"'
       Last-Modified:
@@ -370,17 +370,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '0'
       X-Fastly-Request-ID:
-      - 27b0b69f1f1832b710382c2e505fdd7df132cda6
+      - 24d137e785eef4c1d9637b342c6cc052e9e3d0bd
       X-GitHub-Request-Id:
-      - 2772:14C61:6E9024:8F3B81:6605BE0D
+      - E770:16E8:CA8738:EBC6BE:6683282D
       X-Served-By:
-      - cache-ewr18153-EWR
+      - cache-den8234-DEN
       X-Timer:
-      - S1711656838.448291,VS0,VE2
+      - S1719872346.267408,VS0,VE62
       expires:
-      - Thu, 28 Mar 2024 19:09:25 GMT
+      - Mon, 01 Jul 2024 22:15:34 GMT
       permissions-policy:
       - interest-cohort=()
       x-proxy-cache:
@@ -396,7 +396,7 @@ interactions:
       Host:
       - stac-extensions.github.io
       User-Agent:
-      - Python-urllib/3.11
+      - Python-urllib/3.12
     method: GET
     uri: https://stac-extensions.github.io/projection/v1.1.0/schema.json
   response:
@@ -464,7 +464,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '16'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -474,7 +474,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 28 Mar 2024 20:13:58 GMT
+      - Mon, 01 Jul 2024 22:19:06 GMT
       ETag:
       - '"63e6651b-1111"'
       Last-Modified:
@@ -490,17 +490,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '0'
       X-Fastly-Request-ID:
-      - da0d56ed58aefe85f3434840fb0e150fa85d5c6e
+      - c4a296b1ff8172dbd8751495d13fb19515966897
       X-GitHub-Request-Id:
-      - 3C38:3106DE:EFEE58:131462C:6605CF76
+      - 101E:2C4D72:32770B6:3BB119A:6683282E
       X-Served-By:
-      - cache-ewr18120-EWR
+      - cache-den8253-DEN
       X-Timer:
-      - S1711656839.531613,VS0,VE1
+      - S1719872346.366036,VS0,VE65
       expires:
-      - Thu, 28 Mar 2024 20:23:43 GMT
+      - Mon, 01 Jul 2024 22:15:34 GMT
       permissions-policy:
       - interest-cohort=()
       x-proxy-cache:
@@ -516,7 +516,7 @@ interactions:
       Host:
       - landsat.usgs.gov
       User-Agent:
-      - Python-urllib/3.11
+      - Python-urllib/3.12
     method: GET
     uri: https://landsat.usgs.gov/stac/landsat-extension/v1.1.1/schema.json
   response:
@@ -582,7 +582,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 28 Mar 2024 20:13:59 GMT
+      - Mon, 01 Jul 2024 22:19:06 GMT
       ETag:
       - '"f5d-5c78e5c04950e"'
       Last-Modified:
@@ -590,8 +590,8 @@ interactions:
       Server:
       - Apache
       Set-Cookie:
-      - fwb=429bb9b17ca48ed3eeddde0787cf0566;max-age=300;Path=/;Secure;HttpOnly
-      - cookiesession1=678A3E640CFDEA19B4F429A1B0B24FCE;Expires=Fri, 28 Mar 2025 20:13:59
+      - fwb=429bb9b17ca48ed3eeddde075a2b8366;max-age=300;Path=/;Secure;HttpOnly
+      - cookiesession1=678A3E63ECA46BDACA4A1E617FA72C2A;Expires=Tue, 01 Jul 2025 22:19:06
         GMT;Path=/;HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
@@ -610,7 +610,7 @@ interactions:
       Host:
       - stac-extensions.github.io
       User-Agent:
-      - Python-urllib/3.11
+      - Python-urllib/3.12
     method: GET
     uri: https://stac-extensions.github.io/scientific/v1.0.0/schema.json
   response:
@@ -706,7 +706,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 28 Mar 2024 20:13:59 GMT
+      - Mon, 01 Jul 2024 22:19:06 GMT
       ETag:
       - '"60febab7-15fa"'
       Last-Modified:
@@ -720,19 +720,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - MISS
+      - HIT
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 01ecb2afdd063683818baff60c496302389bb100
+      - 209548a91e4dfb2e8066fd34c48367545137ab86
       X-GitHub-Request-Id:
-      - 5588:2AA28D:E284B4:123CF3A:6605CF87
+      - 2F82:161906:348FC3F:3DC9F1E:6683282D
       X-Served-By:
-      - cache-ewr18150-EWR
+      - cache-den8221-DEN
       X-Timer:
-      - S1711656839.199697,VS0,VE25
+      - S1719872347.618275,VS0,VE57
       expires:
-      - Thu, 28 Mar 2024 20:23:59 GMT
+      - Mon, 01 Jul 2024 22:15:35 GMT
       permissions-policy:
       - interest-cohort=()
       x-proxy-cache:
@@ -748,115 +748,99 @@ interactions:
       Host:
       - stac-extensions.github.io
       User-Agent:
-      - Python-urllib/3.11
+      - Python-urllib/3.12
     method: GET
-    uri: https://stac-extensions.github.io/classification/v1.1.0/schema.json
+    uri: https://stac-extensions.github.io/classification/v2.0.0/schema.json
   response:
     body:
-      string: "{\n    \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n
-        \   \"$id\": \"https://stac-extensions.github.io/classification/v1.1.0/schema.json#\",\n
-        \   \"title\": \"Classification Extension\",\n    \"description\": \"STAC
-        Classification Extension for STAC Items and STAC Collections.\",\n    \"oneOf\":
-        [\n        {\n            \"$comment\": \"This is the schema for STAC Items.\",\n
-        \           \"allOf\": [\n                {\n                    \"$ref\":
-        \"#/definitions/stac_extensions\"\n                },\n                {\n
-        \                   \"type\": \"object\",\n                    \"required\":
-        [\n                        \"type\",\n                        \"properties\",\n
-        \                       \"assets\"\n                    ],\n                    \"properties\":
-        {\n                        \"type\": {\n                            \"const\":
-        \"Feature\"\n                        },\n                        \"properties\":
-        {\n                            \"$comment\": \"This validates the fields in
-        Item Properties, but does not require them.\",\n                            \"$ref\":
-        \"#/definitions/fields\"\n                        },\n                        \"assets\":
-        {\n                            \"$comment\": \"This validates the fields in
-        Item Assets (including in Raster Band Objects), but does not require them.\",\n
-        \                           \"type\": \"object\",\n                            \"additionalProperties\":
-        {\n                                \"allOf\": [\n                                    {\n
-        \                                       \"$ref\": \"#/definitions/fields\"\n
-        \                                   },\n                                    {\n
-        \                                       \"$ref\": \"#/definitions/raster_bands\"\n
-        \                                   }\n                                ]\n
-        \                           }\n                        }\n                    }\n
-        \               }\n            ]\n        },\n        {\n            \"$comment\":
-        \"This is the schema for STAC Collections.\",\n            \"allOf\": [\n
-        \               {\n                    \"$ref\": \"#/definitions/stac_extensions\"\n
-        \               },\n                {\n                    \"type\": \"object\",\n
-        \                   \"required\": [\n                        \"type\"\n                    ],\n
-        \                   \"properties\": {\n                        \"type\": {\n
-        \                           \"const\": \"Collection\"\n                        },\n
-        \                       \"assets\": {\n                            \"$comment\":
-        \"This validates the fields in Collection Assets, but does not require them.\",\n
-        \                           \"type\": \"object\",\n                            \"additionalProperties\":
-        {\n                                \"allOf\": [\n                                    {\n
-        \                                       \"$ref\": \"#/definitions/fields\"\n
-        \                                   },\n                                    {\n
-        \                                       \"$ref\": \"#/definitions/raster_bands\"\n
-        \                                   }\n                                ]\n
-        \                           }\n                        },\n                        \"item_assets\":
-        {\n                            \"$comment\": \"This validates the fields in
-        Item Asset Definitions, but does not require them.\",\n                            \"type\":
-        \"object\",\n                            \"additionalProperties\": {\n                                \"allOf\":
-        [\n                                    {\n                                        \"$ref\":
-        \"#/definitions/fields\"\n                                    },\n                                    {\n
-        \                                       \"$ref\": \"#/definitions/raster_bands\"\n
-        \                                   }\n                                ]\n
-        \                           }\n                        },\n                        \"summaries\":
-        {\n                            \"$comment\": \"This validates the fields in
-        Summaries, but does not require them.\",\n                            \"$ref\":
-        \"#/definitions/fields\"\n                        }\n                    }\n
-        \               }\n            ]\n        }\n    ],\n    \"definitions\":
-        {\n        \"stac_extensions\": {\n            \"type\": \"object\",\n            \"required\":
-        [\n                \"stac_extensions\"\n            ],\n            \"properties\":
-        {\n                \"stac_extensions\": {\n                    \"type\": \"array\",\n
-        \                   \"contains\": {\n                        \"const\": \"https://stac-extensions.github.io/classification/v1.1.0/schema.json\"\n
-        \                   }\n                }\n            }\n        },\n        \"require_any_field\":
-        {\n            \"$comment\": \"Please list all fields here so that we can
-        force the existance of one of them in other parts of the schemas.\",\n            \"anyOf\":
-        [\n                {\n                    \"required\": [\n                        \"classification:bitfields\"\n
-        \                   ]\n                },\n                {\n                    \"required\":
-        [\n                        \"classification:classes\"\n                    ]\n
-        \               }\n            ]\n        },\n        \"fields\": {\n            \"$comment\":
-        \"Add your new fields here. Don't require them here, do that above in the
-        corresponding schema.\",\n            \"type\": \"object\",\n            \"properties\":
-        {\n                \"classification:bitfields\": {\n                    \"type\":
-        \"array\",\n                    \"uniqueItems\": true,\n                    \"minItems\":
-        1,\n                    \"items\": {\n                        \"$ref\": \"#/definitions/bit_field_object\"\n
-        \                   }\n                },\n                \"classification:classes\":
-        {\n                    \"type\": \"array\",\n                    \"uniqueItems\":
-        true,\n                    \"minItems\": 1,\n                    \"items\":
-        {\n                        \"$ref\": \"#/definitions/class_object\"\n                    }\n
-        \               }\n            },\n            \"patternProperties\": {\n
-        \               \"^(?!classification:)\": {}\n            },\n            \"additionalProperties\":
-        false\n        },\n        \"class_object\": {\n            \"$comment\":
-        \"Object for storing classes\",\n            \"type\": \"object\",\n            \"required\":
-        [\n                \"value\",\n                \"description\"\n            ],\n
-        \           \"properties\": {\n                \"value\": {\n                    \"type\":
-        \"integer\"\n                },\n                \"description\": {\n                    \"type\":
-        \"string\"\n                },\n                \"name\": {\n                    \"type\":
-        \"string\"\n                },\n                \"color_hint\": {\n                    \"type\":
-        \"string\",\n                    \"pattern\": \"^([0-9A-Fa-f]{6})$\"\n                }\n
-        \           }\n        },\n        \"bit_field_object\": {\n            \"$comment\":
-        \"Object for storing bit fields\",\n            \"type\": \"object\",\n            \"required\":
-        [\n                \"offset\",\n                \"length\",\n                \"classes\"\n
-        \           ],\n            \"properties\": {\n                \"offset\":
-        {\n                    \"type\": \"integer\",\n                    \"minimum\":
-        0\n                },\n                \"length\": {\n                    \"type\":
-        \"integer\",\n                    \"minimum\": 1\n                },\n                \"classes\":
-        {\n                    \"type\": \"array\",\n                    \"uniqueItems\":
-        true,\n                    \"minItems\": 1,\n                    \"items\":
-        {\n                        \"$ref\": \"#/definitions/class_object\"\n                    }\n
-        \               },\n                \"roles\": {\n                    \"type\":
-        \"array\",\n                    \"uniqueItems\": true,\n                    \"minItems\":
-        1,\n                    \"items\": {\n                        \"type\": \"string\"\n
-        \                   }\n                },\n                \"description\":
-        {\n                    \"type\": \"string\"\n                },\n                \"name\":
-        {\n                    \"type\": \"string\"\n                }\n            }\n
-        \       },\n        \"raster_bands\": {\n            \"$comment\": \"Classification
-        fields on the Raster Extension raster:bands object\",\n            \"type\":
-        \"object\",\n            \"properties\": {\n                \"raster:bands\":
-        {\n                    \"type\": \"array\",\n                    \"items\":
-        {\n                        \"$ref\": \"#/definitions/fields\"\n                    }\n
-        \               }\n            }\n        }\n    }\n}"
+      string: "{\n  \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n  \"$id\":
+        \"https://stac-extensions.github.io/classification/v2.0.0/schema.json#\",\n
+        \ \"title\": \"Classification Extension\",\n  \"description\": \"STAC Classification
+        Extension for STAC Items and STAC Collections.\",\n  \"type\": \"object\",\n
+        \ \"required\": [\"stac_extensions\"],\n  \"properties\": {\n    \"stac_extensions\":
+        {\n      \"type\": \"array\",\n      \"contains\": {\n        \"const\": \"https://stac-extensions.github.io/classification/v2.0.0/schema.json\"\n
+        \     }\n    }\n  },\n  \"oneOf\": [\n    {\n      \"$comment\": \"This is
+        the schema for STAC Items.\",\n      \"type\": \"object\",\n      \"required\":
+        [\"type\", \"properties\", \"assets\"],\n      \"properties\": {\n        \"type\":
+        {\n          \"const\": \"Feature\"\n        },\n        \"properties\": {\n
+        \         \"$comment\": \"This validates the fields in Item Properties, but
+        does not require them.\",\n          \"allOf\": [\n            {\n              \"$ref\":
+        \"#/definitions/fields\"\n            },\n            {\n              \"$ref\":
+        \"#/definitions/ml_model_output\"\n            }\n          ]\n        },\n
+        \       \"assets\": {\n          \"$comment\": \"This validates the fields
+        in Item Assets (including in Raster Band Objects), but does not require them.\",\n
+        \         \"type\": \"object\",\n          \"additionalProperties\": {\n            \"allOf\":
+        [\n              {\n                \"$ref\": \"#/definitions/fields\"\n              },\n
+        \             {\n                \"$ref\": \"#/definitions/raster_bands\"\n
+        \             },\n              {\n                \"$ref\": \"#/definitions/ml_model_output\"\n
+        \             }\n            ]\n          }\n        }\n      }\n    },\n
+        \   {\n      \"$comment\": \"This is the schema for STAC Collections.\",\n
+        \     \"type\": \"object\",\n      \"required\": [\"type\"],\n      \"properties\":
+        {\n        \"type\": {\n          \"const\": \"Collection\"\n        },\n
+        \       \"assets\": {\n          \"$comment\": \"This validates the fields
+        in Collection Assets, but does not require them.\",\n          \"type\": \"object\",\n
+        \         \"additionalProperties\": {\n            \"allOf\": [\n              {\n
+        \               \"$ref\": \"#/definitions/fields\"\n              },\n              {\n
+        \               \"$ref\": \"#/definitions/raster_bands\"\n              },\n
+        \             {\n                \"$ref\": \"#/definitions/ml_model_output\"\n
+        \             }\n            ]\n          }\n        },\n        \"item_assets\":
+        {\n          \"$comment\": \"This validates the fields in Item Asset Definitions,
+        but does not require them.\",\n          \"type\": \"object\",\n          \"additionalProperties\":
+        {\n            \"allOf\": [\n              {\n                \"$ref\": \"#/definitions/fields\"\n
+        \             },\n              {\n                \"$ref\": \"#/definitions/raster_bands\"\n
+        \             },\n              {\n                \"$ref\": \"#/definitions/ml_model_output\"\n
+        \             }\n            ]\n          }\n        },\n        \"summaries\":
+        {\n          \"$comment\": \"This validates the fields in Summaries, but does
+        not require them.\",\n          \"$ref\": \"#/definitions/fields\"\n        }\n
+        \     }\n    }\n  ],\n  \"definitions\": {\n    \"require_any_field\": {\n
+        \     \"$comment\": \"Please list all fields here so that we can force the
+        existance of one of them in other parts of the schemas.\",\n      \"anyOf\":
+        [\n        {\n          \"required\": [\"classification:bitfields\"]\n        },\n
+        \       {\n          \"required\": [\"classification:classes\"]\n        }\n
+        \     ]\n    },\n    \"fields\": {\n      \"$comment\": \"Add your new fields
+        here. Don't require them here, do that above in the corresponding schema.\",\n
+        \     \"type\": \"object\",\n      \"properties\": {\n        \"classification:bitfields\":
+        {\n          \"type\": \"array\",\n          \"uniqueItems\": true,\n          \"minItems\":
+        1,\n          \"items\": {\n            \"$ref\": \"#/definitions/bit_field_object\"\n
+        \         }\n        },\n        \"classification:classes\": {\n          \"type\":
+        \"array\",\n          \"uniqueItems\": true,\n          \"minItems\": 1,\n
+        \         \"items\": {\n            \"$ref\": \"#/definitions/class_object\"\n
+        \         }\n        }\n      },\n      \"patternProperties\": {\n        \"^(?!classification:)\":
+        {}\n      },\n      \"additionalProperties\": false\n    },\n    \"class_object\":
+        {\n      \"$comment\": \"Object for storing classes\",\n      \"type\": \"object\",\n
+        \     \"required\": [\"value\", \"name\"],\n      \"properties\": {\n        \"value\":
+        {\n          \"type\": \"integer\"\n        },\n        \"description\": {\n
+        \         \"type\": \"string\"\n        },\n        \"name\": {\n          \"type\":
+        \"string\",\n          \"pattern\": \"^[0-9A-Za-z-_]+$\"\n        },\n        \"title\":
+        {\n          \"type\": \"string\"\n        },\n        \"color_hint\": {\n
+        \         \"type\": \"string\",\n          \"pattern\": \"^([0-9A-Fa-f]{6})$\"\n
+        \       },\n        \"nodata\": {\n          \"type\": \"boolean\"\n        },\n
+        \       \"percentage\": {\n          \"type\": \"number\",\n          \"minimum\":
+        0,\n          \"maximum\": 100\n        },\n        \"count\": {\n          \"type\":
+        \"integer\",\n          \"minimum\": 0\n        }\n      }\n    },\n    \"bit_field_object\":
+        {\n      \"$comment\": \"Object for storing bit fields\",\n      \"type\":
+        \"object\",\n      \"required\": [\"offset\", \"length\", \"classes\"],\n
+        \     \"properties\": {\n        \"offset\": {\n          \"type\": \"integer\",\n
+        \         \"minimum\": 0\n        },\n        \"length\": {\n          \"type\":
+        \"integer\",\n          \"minimum\": 1\n        },\n        \"classes\": {\n
+        \         \"type\": \"array\",\n          \"uniqueItems\": true,\n          \"minItems\":
+        1,\n          \"items\": {\n            \"$ref\": \"#/definitions/class_object\"\n
+        \         }\n        },\n        \"roles\": {\n          \"type\": \"array\",\n
+        \         \"uniqueItems\": true,\n          \"minItems\": 1,\n          \"items\":
+        {\n            \"type\": \"string\"\n          }\n        },\n        \"description\":
+        {\n          \"type\": \"string\"\n        },\n        \"name\": {\n          \"type\":
+        \"string\",\n          \"pattern\": \"^[0-9A-Za-z-_]+$\"\n        }\n      }\n
+        \   },\n    \"raster_bands\": {\n      \"$comment\": \"Classification fields
+        on the Raster Extension raster:bands object\",\n      \"type\": \"object\",\n
+        \     \"properties\": {\n        \"raster:bands\": {\n          \"type\":
+        \"array\",\n          \"items\": {\n            \"$ref\": \"#/definitions/fields\"\n
+        \         }\n        }\n      }\n    },\n    \"ml_model_output\": {\n      \"$comment\":
+        \"Classification fields on the MLM Extension mlm:output objects (https://crim-ca.github.io/mlm-extension/v1.0.0/schema.json).\",\n
+        \     \"description\": \"Describes the classes embedded in the output of the
+        ML model following inference.\",\n      \"type\": \"object\",\n      \"properties\":
+        {\n        \"mlm:output\": {\n          \"type\": \"array\",\n          \"items\":
+        {\n            \"$ref\": \"#/definitions/fields\"\n          }\n        }\n
+        \     }\n    }\n  }\n}\n"
     headers:
       Accept-Ranges:
       - bytes
@@ -869,15 +853,15 @@ interactions:
       Connection:
       - close
       Content-Length:
-      - '8234'
+      - '6554'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 28 Mar 2024 20:13:59 GMT
+      - Mon, 01 Jul 2024 22:19:06 GMT
       ETag:
-      - '"62719998-202a"'
+      - '"66487a48-199a"'
       Last-Modified:
-      - Tue, 03 May 2022 21:07:36 GMT
+      - Sat, 18 May 2024 09:52:08 GMT
       Server:
       - GitHub.com
       Strict-Transport-Security:
@@ -891,15 +875,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 157aeee6315ad2cb7edef3822543866f8153be13
+      - 67b8727546644f385c7db6b26afaf5f8badae4a5
       X-GitHub-Request-Id:
-      - 4A02:5B96:E2D6FD:123D048:6605CF86
+      - 10BE:2C4D72:327703C:3BB1110:6683282D
       X-Served-By:
-      - cache-ewr18133-EWR
+      - cache-den8224-DEN
       X-Timer:
-      - S1711656839.311722,VS0,VE2
+      - S1719872347.701193,VS0,VE1
       expires:
-      - Thu, 28 Mar 2024 20:23:58 GMT
+      - Mon, 01 Jul 2024 22:15:34 GMT
       permissions-policy:
       - interest-cohort=()
       x-proxy-cache:

--- a/tests/extensions/test_classification.py
+++ b/tests/extensions/test_classification.py
@@ -78,8 +78,8 @@ def test_bitfield_object() -> None:
         offset=0,
         length=1,
         classes=[
-            Classification.create(description="no", value=0),
-            Classification.create(description="yes", value=1),
+            Classification.create(name="no", value=0),
+            Classification.create(name="yes", value=1),
         ],
         roles=["data"],
         description="dummy description",
@@ -126,8 +126,8 @@ def test_apply_bitfields(plain_item: Item) -> None:
                 offset=0,
                 length=1,
                 classes=[
-                    Classification.create(description="no", value=0),
-                    Classification.create(description="yes", value=1),
+                    Classification.create(name="no", value=0),
+                    Classification.create(name="yes", value=1),
                 ],
             )
         ]
@@ -171,15 +171,15 @@ def test_create_classes(plain_item: Item) -> None:
                 offset=0,
                 length=1,
                 classes=[
-                    Classification.create(description="no", value=0),
-                    Classification.create(description="yes", value=1),
+                    Classification.create(name="no", value=0),
+                    Classification.create(name="yes", value=1),
                 ],
             )
         ]
     )
     ext.classes = [
-        Classification.create(description="no", value=0),
-        Classification.create(description="yes", value=1),
+        Classification.create(name="no", value=0),
+        Classification.create(name="yes", value=1),
     ]
     assert ext.bitfields is None
     ext.bitfields = [
@@ -187,8 +187,8 @@ def test_create_classes(plain_item: Item) -> None:
             offset=0,
             length=1,
             classes=[
-                Classification.create(description="no", value=0),
-                Classification.create(description="yes", value=1),
+                Classification.create(name="no", value=0),
+                Classification.create(name="yes", value=1),
             ],
         )
     ]
@@ -222,8 +222,8 @@ def test_create() -> None:
 
 def test_color_hint_formatting() -> None:
     with pytest.raises(Exception):
-        Classification.create(value=0, description="water", color_hint="#0000ff")
-    Classification.create(value=0, description="water", color_hint="0000FF")
+        Classification.create(value=0, name="water", color_hint="#0000ff")
+    Classification.create(value=0, name="water", color_hint="0000FF")
 
 
 def test_to_from_dict(item_dict: dict[str, Any]) -> None:
@@ -277,8 +277,8 @@ def test_add_item_classes(plain_item: Item) -> None:
     item_ext = ClassificationExtension.ext(plain_item, add_if_missing=True)
     item_ext.__repr__()
     assert item_ext.classes is None
-    item_ext.classes = [Classification.create(description="dummy", value=0)]
-    assert item_ext.properties[CLASSES_PROP] == [{"value": 0, "description": "dummy"}]
+    item_ext.classes = [Classification.create(name="dummy", value=0)]
+    assert item_ext.properties[CLASSES_PROP] == [{"value": 0, "name": "dummy"}]
 
 
 def test_add_asset_classes(plain_item: Item) -> None:
@@ -287,9 +287,9 @@ def test_add_asset_classes(plain_item: Item) -> None:
     assert CLASSES_PROP not in asset.extra_fields.keys()
     asset_ext = ClassificationExtension.ext(asset)
     asset_ext.__repr__()
-    asset_ext.classes = [Classification.create(value=0, description="dummy")]
+    asset_ext.classes = [Classification.create(value=0, name="dummy")]
     assert CLASSES_PROP in asset.extra_fields.keys()
-    assert asset.extra_fields[CLASSES_PROP] == [{"value": 0, "description": "dummy"}]
+    assert asset.extra_fields[CLASSES_PROP] == [{"value": 0, "name": "dummy"}]
 
 
 def test_item_asset_raster_classes(collection: Collection) -> None:


### PR DESCRIPTION
**Related Issue(s):**

- Closes #1354 

**Description:**

- Adds the new `nodata`, `percentage`, and `count` fields
- Makes `description` optional
- Make `name` required
- Removes a copy-pasta double-check of the color hint

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
