### PR TITLE
Make `get_all_collections` properly recursive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Allow object ID as input for getting APILayoutStrategy hrefs and add `items`, `collections`, `search`, `conformance`, `service_desc` and `service_doc` href methods. ([#1335](https://github.com/stac-utils/pystac/pull/1335))
 - Update docstring of `name` argument to `Classification.apply` and `Classification.create` to agree with extension specification. ([#1356](https://github.com/stac-utils/pystac/pull/1356))
 
+### Fixed
+
+- Make `get_all_collections` properly recursive ([#1361](https://github.com/stac-utils/pystac/pull/1361))
+
 ## [v1.10.1] - 2024-05-03
 
 ### Fixed

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -457,7 +457,7 @@ class Catalog(STACObject):
         any subcatalogs recursively."""
         yield from self.get_collections()
         for child in self.get_children():
-            yield from child.get_collections()
+            yield from child.get_all_collections()
 
     def get_child_links(self) -> list[Link]:
         """Return all child links of this catalog.

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -35,7 +35,13 @@ from pystac.utils import (
     make_posix_style,
     make_relative_href,
 )
-from tests.utils import ARBITRARY_BBOX, ARBITRARY_GEOM, MockStacIO, TestCases
+from tests.utils import (
+    ARBITRARY_BBOX,
+    ARBITRARY_EXTENT,
+    ARBITRARY_GEOM,
+    MockStacIO,
+    TestCases,
+)
 
 
 class CatalogTypeTest(unittest.TestCase):
@@ -1350,7 +1356,7 @@ class TestCatalog:
         catalog = TestCases.case_1()
         all_collections = list(catalog.get_all_collections())
 
-        assert len(all_collections) > 0
+        assert len(all_collections) == 4
         assert all(isinstance(c, pystac.Collection) for c in all_collections)
 
     def test_get_single_links_media_type(self) -> None:
@@ -1639,7 +1645,9 @@ def nested_catalog() -> pystac.Catalog:
     └── variables
         ├── catalog.json
         └── variable_a
-            ├── catalog.json
+            └── catalog.json
+                └── variable_a_1
+                    └── collection.json
     """
     root = pystac.Catalog("root", "root")
     variables = pystac.Catalog("variables", "variables")
@@ -1654,7 +1662,20 @@ def nested_catalog() -> pystac.Catalog:
     variables.add_child(variable_a)
     products.add_child(product_a)
 
+    variable_a_1 = pystac.Collection(
+        "variable_a_1", "variable_a_1", extent=ARBITRARY_EXTENT
+    )
+    variable_a.add_child(variable_a_1)
+
     return root
+
+
+def test_get_all_collections_deeply_nested(nested_catalog: pystac.Catalog) -> None:
+    catalog = nested_catalog
+    all_collections = list(catalog.get_all_collections())
+
+    assert len(all_collections) == 1
+    assert all(isinstance(c, pystac.Collection) for c in all_collections)
 
 
 def test_set_parent_false_stores_in_proper_place_on_normalize_and_save(


### PR DESCRIPTION
**Related Issue(s):**

- closes #1360 

**Description:**

The docstring states that this method is meant to traverse subcatalogs recursively.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
