### PR TITLE
Un-special-case search box on index page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,12 +16,6 @@ of PySTAC are:
   as :stac-spec:`described in the best practices documentation
   <best-practices.md#use-of-links>`.
 
-.. raw:: html
-
-    <form class="bd-search align-items-center" action="search.html" method="get">
-      <input type="search" class="form-control" name="q" id="search-input" placeholder="&#128269; Search the docs ..." aria-label="Search the docs ..." autocomplete="off">
-    </form>
-
 .. grid:: 1 2 2 2
    :gutter: 2
 


### PR DESCRIPTION
**Related Issue(s):**

- Closes #1349 

**Description:**

The search box was embedded in the page, but that was not obvious and made the topbar search behave strangely. This PR makes the index page the same as the other pages.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
