### PR TITLE
Add convenience method for accessing pystac_client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Add netCDF to pystac.media_type ([#1386](https://github.com/stac-utils/pystac/pull/1386)) 
+- Add convenience method for accessing pystac_client ([#1365](https://github.com/stac-utils/pystac/pull/1365))
 
 ### Changed
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -86,6 +86,18 @@ as to serialize and deserialize STAC object to and from JSON.
 * :class:`pystac.stac_io.DefaultStacIO`: The default :class:`pystac.StacIO`
   implementation used throughout the library.
 
+Client
+------
+
+A convenience method for accessing `pystac-client <https://github.com/stac-utils/pystac-client>`__
+
+**Example:**
+
+.. code-block:: python
+
+  from pystac.client import Client
+
+
 Extensions
 ----------
 

--- a/pystac/client.py
+++ b/pystac/client.py
@@ -1,6 +1,4 @@
-from __future__ import annotations
-
-from typing import Any
+# mypy: ignore-errors
 
 _import_error_message = (
     "pystac-client is not installed.\n\n"
@@ -17,7 +15,7 @@ except ImportError as e:
         raise
 
 
-def __getattr__(value: str) -> Any:
+def __getattr__(value: str):
     try:
         import pystac_client
     except ImportError as e:

--- a/pystac/client.py
+++ b/pystac/client.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Any
+
+_import_error_message = (
+    "pystac-client is not installed.\n\n"
+    "Please install pystac-client:\n\n"
+    "  pip install pystac-client"
+)
+
+try:
+    from pystac_client import *  # noqa: F403
+except ImportError as e:
+    if e.msg == "No module named 'pystac_client'":
+        raise ImportError(_import_error_message) from e
+    else:
+        raise
+
+
+def __getattr__(value: str) -> Any:
+    try:
+        import pystac_client
+    except ImportError as e:
+        raise ImportError(_import_error_message) from e
+    return getattr(pystac_client, value)

--- a/tests/test_pystac_client.py
+++ b/tests/test_pystac_client.py
@@ -1,0 +1,9 @@
+import pytest
+
+pytest.importorskip("pystac_client")
+
+
+def test_import_pystac_client() -> None:
+    from pystac.client import Client
+
+    assert Client.__doc__

--- a/tests/test_pystac_client.py
+++ b/tests/test_pystac_client.py
@@ -1,9 +1,42 @@
+import builtins
+import sys
+from types import ModuleType
+from typing import Any
+
 import pytest
 
-pytest.importorskip("pystac_client")
+real_import = builtins.__import__
+
+try:
+    import pystac_client  # noqa:F401
+
+    HAS_PYSTAC_CLIENT = True
+except ImportError:
+    HAS_PYSTAC_CLIENT = False
 
 
-def test_import_pystac_client() -> None:
+@pytest.mark.skipif(not HAS_PYSTAC_CLIENT, reason="requires pystac_client")
+def test_import_pystac_client_when_available() -> None:
     from pystac.client import Client
 
     assert Client.__doc__
+
+
+# copied from
+# http://materials-scientist.com/blog/2021/02/11/mocking-failing-module-import-python/
+def monkey_import_importerror(name: str, *args: Any, **kwargs: Any) -> ModuleType:
+    if name == "pystac_client":
+        raise ImportError(f"No module named '{name}'")
+    return real_import(name, *args, **kwargs)
+
+
+def test_import_pystac_client_when_not_available(monkeypatch: Any) -> None:
+    if HAS_PYSTAC_CLIENT:
+        monkeypatch.delitem(sys.modules, "pystac_client", raising=False)
+        monkeypatch.setattr(builtins, "__import__", monkey_import_importerror)
+
+    with pytest.raises(ImportError):
+        from pystac_client import Client  # noqa:F401
+
+    with pytest.raises(ImportError, match="Please install pystac-client:"):
+        from pystac.client import Client  # noqa:F401,F811

--- a/tests/test_pystac_client.py
+++ b/tests/test_pystac_client.py
@@ -1,3 +1,4 @@
+# mypy: ignore-errors
 import builtins
 import sys
 from types import ModuleType


### PR DESCRIPTION
**Related Issue(s):**

- Closes #1334 

**Description:**

```python
from pystac.client import Client
```

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
