### PR TITLE
Fixup url in Dimension.dim_type docs

### DIFF
--- a/pystac/extensions/datacube.py
+++ b/pystac/extensions/datacube.py
@@ -78,7 +78,7 @@ class Dimension(ABC):
     def dim_type(self) -> DimensionType | str:
         """The type of the dimension. Must be ``"spatial"`` for
         :stac-ext:`Horizontal Spatial Dimension Objects
-        <datacube#horizontal-raster-spatial-dimension-object>` or
+        <datacube#horizontal-spatial-raster-dimension-object>` or
         :stac-ext:`Vertical Spatial Dimension Objects
         <datacube#vertical-spatial-dimension-object>`, ``geometries`` for
         :stac-ext:`Spatial Vector Dimension Objects


### PR DESCRIPTION
Just a minor URL fix in a docstring

FYI: this was a quick edit in GitHub's online editor, so I did not really did anything of this PR checklist

- [ ] `pre-commit` hooks pass locally
- [ ] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
