### PR TITLE
Add example of custom StacIO for Azure Blob storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Allow object ID as input for getting APILayoutStrategy hrefs and add `items`, `collections`, `search`, `conformance`, `service_desc` and `service_doc` href methods ([#1335](https://github.com/stac-utils/pystac/pull/1335))
 - Updated classification extension to v2.0.0 ([#1359](https://github.com/stac-utils/pystac/pull/1359))
 - Update docstring of `name` argument to `Classification.apply` and `Classification.create` to agree with extension specification ([#1356](https://github.com/stac-utils/pystac/pull/1356))
+- Add example of custom `StacIO` for Azure Blob Storage to docs ([#1372](https://github.com/stac-utils/pystac/pull/1372))
 
 ### Fixed
 


### PR DESCRIPTION
**Description:**
Adds an example of a custom `StacIO` for reading/writing STAC objects from/to Azure Blob storage. I organized the existing S3 example and new Blob storage example into tabs to avoid cluttering up the docs:

![Screenshot 2024-07-25 at 15 24 55](https://github.com/user-attachments/assets/cb3eb519-4212-4b20-9236-df1f41052d8c)

I implemented this custom `StacIO` and thought it might be a nice to include an example for another cloud provider in the docs, but feel free to reject if this is unwanted.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
