### PR TITLE
Remove python 3.9

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -26,7 +26,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
@@ -59,10 +58,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.10"
           cache: "pip"
 
       - name: Install with dependencies
@@ -102,7 +101,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
@@ -129,7 +127,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Install
         run: pip install .[validation,test]
@@ -147,7 +145,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.10"
           cache: "pip"
 
       - name: Install all dependencies
@@ -162,7 +160,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.10"
           cache: "pip"
       - name: Install pystac
         run: pip install .[bench]
@@ -177,7 +175,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.10"
           cache: "pip"
       - name: Install pandoc
         run: sudo apt-get install pandoc

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.10"
 
 formats:
   # Temporarily disabling PDF downloads due to problem with nbsphinx in LateX builds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 - Make `get_all_collections` properly recursive ([#1361](https://github.com/stac-utils/pystac/pull/1361))
 
+### Removed
+
+- Python 3.9 ([#1384](https://github.com/stac-utils/pystac/pull/1384))
+
 ## [v1.10.1] - 2024-05-03
 
 ### Fixed

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -27,10 +27,10 @@ Install from source
 Dependencies
 ============
 
-PySTAC requires Python >= 3.9. This project follows the recommendations of
+PySTAC requires Python >= 3.10. This project follows the recommendations of
 `NEP-29 <https://numpy.org/neps/nep-0029-deprecation_policy.html>`__ in deprecating support
-for Python versions. This means that users can expect support for Python 3.9 to be
-removed from the ``main`` branch after Apr 14, 2023 and therefore from the next release
+for Python versions. This means that users can expect support for Python 3.10 to be
+removed from the ``main`` branch after Apr 04, 2025 and therefore from the next release
 after that date.
 
 As a foundational component of the Python STAC ecosystem used in a number of downstream

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,12 +15,11 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = ["python-dateutil>=2.7.0"]
 dynamic = ["version"]
 


### PR DESCRIPTION
**Description:**

Numpy ended support Apr 05, 2024. We've done these in MINOR releases in the past, so if https://github.com/stac-utils/pystac/milestone/37 requires a MAJOR we'll want to get a MINOR out w/ this change first, I reckon.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
