### PR TITLE
Update docs to reflect that collection rel type can be for anything

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Updated classification extension to v2.0.0 ([#1359](https://github.com/stac-utils/pystac/pull/1359))
 - Update docstring of `name` argument to `Classification.apply` and `Classification.create` to agree with extension specification ([#1356](https://github.com/stac-utils/pystac/pull/1356))
 - Add example of custom `StacIO` for Azure Blob Storage to docs ([#1372](https://github.com/stac-utils/pystac/pull/1372))
+- Noted that collection links can be used in non-item objects in STAC v1.1.0 ([#1393](https://github.com/stac-utils/pystac/pull/1393))
 
 ### Fixed
 

--- a/pystac/link.py
+++ b/pystac/link.py
@@ -455,7 +455,7 @@ class Link(PathLike):
 
     @classmethod
     def collection(cls: type[L], c: Collection) -> L:
-        """Creates a link to an item's Collection."""
+        """Creates a link to a Collection."""
         return cls(pystac.RelType.COLLECTION, c, media_type=pystac.MediaType.JSON)
 
     @classmethod


### PR DESCRIPTION
**Related Issue(s):**

- Closes #1379 

**Description:**

We already have a [collection rel type](https://github.com/stac-utils/pystac/blob/28352e7c8932ee25f72c1eb74fd8516cd2a7ed73/pystac/rel_type.py#L18-L19), so this PR is just a small docs tweak to reflect that collection links don't have to be only for items.

It's not required, but it would be nice to move `{get|set}_collection` to `STACObject` from `Item`: https://github.com/stac-utils/pystac/blob/28352e7c8932ee25f72c1eb74fd8516cd2a7ed73/pystac/item.py#L260-L295

However, as documented in #1392, `set_collection` returns `self`, which makes it a bit more awkward to return from the `STACObject` base class. My instinct is to hold off for moving `{get|set}_collection`, and just create a tracking issue in the v2.0 milestone so that we can solve #1392 and the method move at the same time.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
- [x] Create tracking issue for moving `{get|set}_collection` to `STACObject`: https://github.com/stac-utils/pystac/issues/1399
