### PR TITLE
Set collection to None in item constructor when there is no collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Fixed
 
 - Make `get_all_collections` properly recursive ([#1361](https://github.com/stac-utils/pystac/pull/1361))
+- Set `Item::collection` to `None` when there is no collection ([#1400](https://github.com/stac-utils/pystac/pull/1400))
 
 ### Removed
 

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -158,7 +158,9 @@ class Item(STACObject, Assets):
             self.set_self_href(href)
 
         self.collection_id: str | None = None
-        if collection is not None:
+        if collection is None:
+            self.collection = None
+        else:
             if isinstance(collection, Collection):
                 self.set_collection(collection)
             else:

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -692,3 +692,8 @@ def test_copy_with_unresolveable_root(item: Item) -> None:
         )
     )
     copy.deepcopy(item)
+
+
+def test_no_collection(item: Item) -> None:
+    # https://github.com/stac-utils/stac-api-validator/issues/527
+    assert item.collection is None


### PR DESCRIPTION
**Related Issue(s):**

- Reported in https://github.com/stac-utils/stac-api-validator/issues/527

**Description:**

`collection` is listed as a top-level attribute for `Item`, but it is not set when there is no collection, leading to an attribute error when trying to access `Item::collection`.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
