### PR TITLE
Fix recursion error when eo band name is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 - Make `get_all_collections` properly recursive ([#1361](https://github.com/stac-utils/pystac/pull/1361))
 - Set `Item::collection` to `None` when there is no collection ([#1400](https://github.com/stac-utils/pystac/pull/1400))
+- Recursion error when `name` not set on `eo:bands` ([#1406](https://github.com/stac-utils/pystac/pull/1406))
 
 ### Removed
 

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -225,7 +225,7 @@ class Band:
             self.properties.pop("solar_illumination", None)
 
     def __repr__(self) -> str:
-        return f"<Band name={self.name}>"
+        return f"<Band name={self.properties.get('name')}>"
 
     def to_dict(self) -> dict[str, Any]:
         """Returns this band as a dictionary.


### PR DESCRIPTION
**Related Issue(s):**

- Closes #1402 

**Description:**

Fixed simply by using `get` on the properties dict instead of the accessor.

**PR Checklist:**

- [x] `pre-commit` hooks pass locally
- [x] Tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
