### PR TITLE
Fix item field ordering on `save_object`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
 
       - id: ruff-format
         name: ruff-format
-        entry: ruff format --force-exclude --check
+        entry: ruff format --force-exclude
         language: system
         stages: [commit]
         types_or: [python, pyi, jupyter]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add netCDF to pystac.media_type ([#1386](https://github.com/stac-utils/pystac/pull/1386))
 - Add convenience method for accessing pystac_client ([#1365](https://github.com/stac-utils/pystac/pull/1365))
+- Fix field ordering when saving `Item`s ([#1423](https://github.com/stac-utils/pystac/pull/1423))
 
 ### Changed
 

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -365,9 +365,11 @@ class Item(STACObject, Assets):
         d: dict[str, Any] = {
             "type": "Feature",
             "stac_version": pystac.get_stac_version(),
+            "stac_extensions": self.stac_extensions if self.stac_extensions else [],
             "id": self.id,
-            "properties": self.properties,
             "geometry": self.geometry,
+            "bbox": self.bbox if self.bbox is not None else [],
+            "properties": self.properties,
             "links": [link.to_dict(transform_href=transform_hrefs) for link in links],
             "assets": assets,
         }
@@ -383,6 +385,10 @@ class Item(STACObject, Assets):
 
         for key in self.extra_fields:
             d[key] = self.extra_fields[key]
+
+        # This field is prohibited if there's no geometry
+        if not self.geometry:
+            d.pop("bbox")
 
         return d
 

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -374,12 +374,6 @@ class Item(STACObject, Assets):
             "assets": assets,
         }
 
-        if self.bbox is not None:
-            d["bbox"] = self.bbox
-
-        if self.stac_extensions is not None:
-            d["stac_extensions"] = self.stac_extensions
-
         if self.collection_id:
             d["collection"] = self.collection_id
 

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -112,7 +112,7 @@ class ItemTest(unittest.TestCase):
         item = pystac.Item.from_file(
             TestCases.get_path("data-files/item/sample-item.json")
         )
-
+        item_dict = item.to_dict(include_self_link=False)
         expected_order = [
             "type",
             "stac_version",
@@ -125,21 +125,12 @@ class ItemTest(unittest.TestCase):
             "assets",
             "collection",
         ]
-
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            p = os.path.join(tmp_dir, "item.json")
-            item.save_object(include_self_link=False, dest_href=p)
-
-            with open(p) as f:
-                item_json = json.load(f)
-
-            # Assert the order matches the expected order
-            actual_order = list(item_json.keys())
-            self.assertEqual(
-                actual_order,
-                expected_order,
-                f"Order was {actual_order}, expected {expected_order}",
-            )
+        actual_order = list(item_dict.keys())
+        self.assertEqual(
+            actual_order,
+            expected_order,
+            f"Order was {actual_order}, expected {expected_order}",
+        )
 
     def test_extra_fields(self) -> None:
         item = pystac.Item.from_file(

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -108,6 +108,39 @@ class ItemTest(unittest.TestCase):
         actual_href = rel_asset.get_absolute_href()
         self.assertEqual(None, actual_href)
 
+    def test_item_field_order(self) -> None:
+        item = pystac.Item.from_file(
+            TestCases.get_path("data-files/item/sample-item.json")
+        )
+
+        expected_order = [
+            "type",
+            "stac_version",
+            "stac_extensions",
+            "id",
+            "geometry",
+            "bbox",
+            "properties",
+            "links",
+            "assets",
+            "collection",
+        ]
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            p = os.path.join(tmp_dir, "item.json")
+            item.save_object(include_self_link=False, dest_href=p)
+
+            with open(p) as f:
+                item_json = json.load(f)
+
+            # Assert the order matches the expected order
+            actual_order = list(item_json.keys())
+            self.assertEqual(
+                actual_order,
+                expected_order,
+                f"Order was {actual_order}, expected {expected_order}",
+            )
+
     def test_extra_fields(self) -> None:
         item = pystac.Item.from_file(
             TestCases.get_path("data-files/item/sample-item.json")


### PR DESCRIPTION
**Related Issue(s):**

- Closes #587

**Description:**
This PR fixes item field ordering in accordance with the order defined [here](https://github.com/radiantearth/stac-spec/blob/master/item-spec/item-spec.md#item-fields). Additionally, I've fixed what appears to be a small configuration error in pre-commit.config.yaml such that ruff-format wasn't actually fixing ill-formatted files.

**PR Checklist:**

- [x] Pre-commit hooks and tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
