### PR TITLE
Use slots in common classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Write STAC v1.1.0 ([#1427](https://github.com/stac-utils/pystac/pull/1427))
+- Use `__slots__` for objects we expect to exist in large numbers ([#1434](https://github.com/stac-utils/pystac/pull/1434))
 
 ## [v1.11.0] - 2024-09-26
 

--- a/pystac/asset.py
+++ b/pystac/asset.py
@@ -37,6 +37,16 @@ class Asset:
             object JSON.
     """
 
+    __slots__: tuple[str, ...] = (
+        "href",
+        "title",
+        "description",
+        "media_type",
+        "roles",
+        "owner",
+        "extra_fields",
+    )
+
     href: str
     """Link to the asset object. Relative and absolute links are both allowed."""
 

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -133,6 +133,16 @@ class Catalog(STACObject):
             :class:`~pystac.layout.BestPracticesLayoutStrategy`.
     """
 
+    __slots__: tuple[str, ...] = STACObject.__slots__ + (
+        "catalog_type",
+        "description",
+        "extra_fields",
+        "title",
+        "_resolved_objects",
+        "_stac_io",
+        "strategy",
+    )
+
     catalog_type: CatalogType
     """The catalog type. Defaults to :attr:`CatalogType.ABSOLUTE_PUBLISHED`."""
 
@@ -159,7 +169,7 @@ class Catalog(STACObject):
 
     STAC_OBJECT_TYPE = pystac.STACObjectType.CATALOG
 
-    _stac_io: pystac.StacIO | None = None
+    _stac_io: pystac.StacIO | None
     """Optional instance of StacIO that will be used by default
     for any IO operations on objects contained by this catalog.
     Set while reading in a catalog. This is set when a catalog
@@ -206,6 +216,8 @@ class Catalog(STACObject):
         self.strategy: HrefLayoutStrategy | None = strategy
 
         self._resolved_objects.cache(self)
+
+        self._stac_io = None
 
     def __repr__(self) -> str:
         return f"<Catalog id={self.id}>"

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -479,6 +479,15 @@ class Collection(Catalog, Assets):
             :class:`~pystac.layout.BestPracticesLayoutStrategy`.
     """
 
+    __slots__: tuple[str, ...] = Catalog.__slots__ + (
+        "extent",
+        "license",
+        "keywords",
+        "providers",
+        "summaries",
+        "assets",
+    )
+
     description: str
     """Detailed multi-line description to fully explain the collection."""
 

--- a/pystac/link.py
+++ b/pystac/link.py
@@ -70,6 +70,16 @@ class Link(PathLike):
             object JSON.
     """
 
+    __slots__: tuple[str, ...] = (
+        "rel",
+        "media_type",
+        "extra_fields",
+        "owner",
+        "_target_href",
+        "_target_object",
+        "_title",
+    )
+
     rel: str | pystac.RelType
     """The relation of the link (e.g. 'child', 'item'). Registered rel Types are
     preferred. See :class:`~pystac.RelType` for common media types."""

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -41,6 +41,13 @@ class STACObject(ABC):
     functionality through the implementing classes.
     """
 
+    __slots__: tuple[str, ...] = (
+        "id",
+        "links",
+        "stac_extensions",
+        "_allow_parent_to_override_href",
+    )
+
     id: str
     """The ID of the STAC Object."""
 
@@ -53,12 +60,13 @@ class STACObject(ABC):
 
     STAC_OBJECT_TYPE: STACObjectType
 
-    _allow_parent_to_override_href: bool = True
+    _allow_parent_to_override_href: bool
     """Private attribute for whether parent objects should override on normalization"""
 
     def __init__(self, stac_extensions: list[str]) -> None:
         self.links = []
         self.stac_extensions = stac_extensions
+        self._allow_parent_to_override_href = True
 
     def validate(
         self,


### PR DESCRIPTION
**Related Issue(s):**

- #1229
- #1207

**Description:**
Because it isn't unexpected that even tens of thousands of `Item` and `Link` classes and a fortiori `StacObject` classes are regularly in memory, there should be some small but appreciable performance improvements from using `__slots__` rather than `__dict__` to hold class attributes. The downside of this change is that new attributes cannot be set at runtime that aren't expected in `__slots__` definitions. In general, the existence of `extra_fields` on `Item` classes makes that a non-issue for the cases we care about.

Beyond simply adding `__slots__` definitions, this PR also updates the serialization logic to properly use them and adds some `__init__` logic, where appropriate, to avoid non-initialization of expected `__slots__` values.

#1207 is a related issue but it should be noted that this PR *does not* fully address the performance issues indicated there, as many duplicated href lookups due to eager mutation of objects remain an issue. *IF* spilling memory to disk is the cause of the observed exponential increase in runtimes during `.save` is to blame, this PR *should* provide a bit more breathing room.

**PR Checklist:**

- [x] Pre-commit hooks and tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
