### PR TITLE
Add keywords to common metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add netCDF to pystac.media_type ([#1386](https://github.com/stac-utils/pystac/pull/1386))
 - Add convenience method for accessing pystac_client ([#1365](https://github.com/stac-utils/pystac/pull/1365))
 - Fix field ordering when saving `Item`s ([#1423](https://github.com/stac-utils/pystac/pull/1423))
+- Add keywords to common metadata ([#1443](https://github.com/stac-utils/pystac/pull/1443))
 
 ### Changed
 

--- a/pystac/common_metadata.py
+++ b/pystac/common_metadata.py
@@ -216,7 +216,7 @@ class CommonMetadata:
 
     @property
     def keywords(self) -> list[str] | None:
-        """Get or set the keywords describing an object."""
+        """Get or set the keywords describing the STAC entity."""
         return self._get_field("keywords", list[str])
 
     @keywords.setter

--- a/pystac/common_metadata.py
+++ b/pystac/common_metadata.py
@@ -213,3 +213,12 @@ class CommonMetadata:
     @updated.setter
     def updated(self, v: datetime | None) -> None:
         self._set_field("updated", utils.map_opt(utils.datetime_to_str, v))
+
+    @property
+    def keywords(self) -> list[str] | None:
+        """Get or set the keywords describing an object."""
+        return self._get_field("keywords", list[str])
+
+    @keywords.setter
+    def keywords(self, v: list[str] | None) -> None:
+        self._set_field("keywords", v)

--- a/pystac/common_metadata.py
+++ b/pystac/common_metadata.py
@@ -240,7 +240,7 @@ class CommonMetadata:
     @keywords.setter
     def keywords(self, v: list[str] | None) -> None:
         self._set_field("keywords", v)
-    
+
     @property
     def roles(self) -> list[str] | None:
         """Get or set the semantic roles of the entity."""

--- a/tests/data-files/item/sample-item-asset-properties.json
+++ b/tests/data-files/item/sample-item-asset-properties.json
@@ -74,6 +74,7 @@
       "start_datetime": "2017-05-01T13:22:30.040Z",
       "end_datetime": "2017-05-02T13:22:30.040Z",
       "license": "CC-BY-4.0",
+      "keywords": ["keyword_a"],
       "providers": [
         {
           "name": "USGS",

--- a/tests/test_common_metadata.py
+++ b/tests/test_common_metadata.py
@@ -548,7 +548,7 @@ class AssetCommonMetadataTest(unittest.TestCase):
         analytic_cm = CommonMetadata(analytic)
         thumbnail = item.assets["thumbnail"]
         thumbnail_cm = CommonMetadata(thumbnail)
-        
+
         item_value = cm.keywords
         a2_known_value = ["keyword_a"]
 
@@ -562,7 +562,7 @@ class AssetCommonMetadataTest(unittest.TestCase):
 
         self.assertEqual(analytic_cm.keywords, set_value)
         self.assertEqual(analytic.to_dict()["keywords"], set_value)
-    
+
     def test_roles(self) -> None:
         item = self.item.clone()
         cm = item.common_metadata

--- a/tests/test_common_metadata.py
+++ b/tests/test_common_metadata.py
@@ -538,3 +538,25 @@ class AssetCommonMetadataTest(unittest.TestCase):
         self.assertEqual(
             analytic.to_dict()["updated"], utils.datetime_to_str(set_value)
         )
+
+    def test_keywords(self) -> None:
+        item = self.item.clone()
+        cm = item.common_metadata
+        analytic = item.assets["analytic"]
+        analytic_cm = CommonMetadata(analytic)
+        thumbnail = item.assets["thumbnail"]
+        thumbnail_cm = CommonMetadata(thumbnail)
+
+        item_value = cm.keywords
+        a2_known_value = ["keyword_a"]
+
+        # Get
+        self.assertNotEqual(thumbnail_cm.keywords, item_value)
+        self.assertEqual(thumbnail_cm.keywords, a2_known_value)
+
+        # Set
+        set_value = ["keyword_b"]
+        analytic_cm.keywords = set_value
+
+        self.assertEqual(analytic_cm.keywords, set_value)
+        self.assertEqual(analytic.to_dict()["keywords"], set_value)


### PR DESCRIPTION
**Related Issue(s):**

- #1376

**Description:**

Moves keywords into common metadata for STAC spec 1.1.0

**PR Checklist:**

- [x] Pre-commit hooks and tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
