### PR TITLE
Add roles to common metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add netCDF to pystac.media_type ([#1386](https://github.com/stac-utils/pystac/pull/1386))
 - Add convenience method for accessing pystac_client ([#1365](https://github.com/stac-utils/pystac/pull/1365))
 - Fix field ordering when saving `Item`s ([#1423](https://github.com/stac-utils/pystac/pull/1423))
+- Add roles to common metadata
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Add netCDF to pystac.media_type ([#1386](https://github.com/stac-utils/pystac/pull/1386))
 - Add convenience method for accessing pystac_client ([#1365](https://github.com/stac-utils/pystac/pull/1365))
 - Fix field ordering when saving `Item`s ([#1423](https://github.com/stac-utils/pystac/pull/1423))
-- Add roles to common metadata
+- Add roles to common metadata ([#1444](https://github.com/stac-utils/pystac/pull/1444/files))
 
 ### Changed
 

--- a/pystac/common_metadata.py
+++ b/pystac/common_metadata.py
@@ -216,7 +216,7 @@ class CommonMetadata:
 
     @property
     def roles(self) -> list[str] | None:
-        """Get or set the semantic roles of an object."""
+        """Get or set the semantic roles of the entity."""
         return self._get_field("roles", list[str])
 
     @roles.setter

--- a/pystac/common_metadata.py
+++ b/pystac/common_metadata.py
@@ -213,3 +213,12 @@ class CommonMetadata:
     @updated.setter
     def updated(self, v: datetime | None) -> None:
         self._set_field("updated", utils.map_opt(utils.datetime_to_str, v))
+
+    @property
+    def roles(self) -> list[str] | None:
+        """Get or set the semantic roles of an object."""
+        return self._get_field("roles", list[str])
+
+    @roles.setter
+    def roles(self, v: list[str] | None) -> None:
+        self._set_field("roles", v)

--- a/tests/data-files/item/sample-item-asset-properties.json
+++ b/tests/data-files/item/sample-item-asset-properties.json
@@ -74,6 +74,7 @@
       "start_datetime": "2017-05-01T13:22:30.040Z",
       "end_datetime": "2017-05-02T13:22:30.040Z",
       "license": "CC-BY-4.0",
+      "roles": ["a_role"],
       "providers": [
         {
           "name": "USGS",

--- a/tests/test_common_metadata.py
+++ b/tests/test_common_metadata.py
@@ -538,3 +538,25 @@ class AssetCommonMetadataTest(unittest.TestCase):
         self.assertEqual(
             analytic.to_dict()["updated"], utils.datetime_to_str(set_value)
         )
+
+    def test_roles(self) -> None:
+        item = self.item.clone()
+        cm = item.common_metadata
+        analytic = item.assets["analytic"]
+        analytic_cm = CommonMetadata(analytic)
+        thumbnail = item.assets["thumbnail"]
+        thumbnail_cm = CommonMetadata(thumbnail)
+
+        item_value = cm.roles
+        a2_known_value = ["a_role"]
+
+        # Get
+        self.assertNotEqual(thumbnail_cm.roles, item_value)
+        self.assertEqual(thumbnail_cm.roles, a2_known_value)
+
+        # Set
+        set_value = ["another_role"]
+        analytic_cm.roles = set_value
+
+        self.assertEqual(analytic_cm.roles, set_value)
+        self.assertEqual(analytic.to_dict()["roles"], set_value)


### PR DESCRIPTION
**Related Issue(s):**

- #1378

**Description:**

Move roles to common metadata for STAC spec 1.1.0

**PR Checklist:**

- [x] Pre-commit hooks and tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
