### PR TITLE
Update and clarify description, license, datetime properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Add example of custom `StacIO` for Azure Blob Storage to docs ([#1372](https://github.com/stac-utils/pystac/pull/1372))
 - Noted that collection links can be used in non-item objects in STAC v1.1.0 ([#1393](https://github.com/stac-utils/pystac/pull/1393))
 - Move test, docs, and bench requirements out of pyproject.toml ([#1407](https://github.com/stac-utils/pystac/pull/1407))
+- Clarify inclusive datetime ranges, update default license, and ensure description is not empty ([#1445](https://github.com/stac-utils/pystac/pull/1445))
 
 ### Fixed
 

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -461,9 +461,10 @@ class Collection(Catalog, Assets):
             be one of the values in :class`~pystac.CatalogType`.
         license :  Collection's license(s) as a
             `SPDX License identifier <https://spdx.org/licenses/>`_,
-            `various`, or `proprietary`. If collection includes
-            data with multiple different licenses, use `various` and add a link for
-            each. Defaults to 'proprietary'.
+            or `other`. If collection includes data with multiple
+            different licenses, use `other` and add a link for
+            each. The license `various` and `proprietary` are deprecated.
+            Defaults to 'other'.
         keywords : Optional list of keywords describing the collection.
         providers : Optional list of providers of this Collection.
         summaries : An optional map of property summaries,
@@ -528,7 +529,7 @@ class Collection(Catalog, Assets):
         href: str | None = None,
         extra_fields: dict[str, Any] | None = None,
         catalog_type: CatalogType | None = None,
-        license: str = "proprietary",
+        license: str = "other",
         keywords: list[str] | None = None,
         providers: list[Provider] | None = None,
         summaries: Summaries | None = None,

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -463,7 +463,7 @@ class Collection(Catalog, Assets):
             `SPDX License identifier <https://spdx.org/licenses/>`_,
             or `other`. If collection includes data with multiple
             different licenses, use `other` and add a link for
-            each. The license `various` and `proprietary` are deprecated.
+            each. The licenses `various` and `proprietary` are deprecated.
             Defaults to 'other'.
         keywords : Optional list of keywords describing the collection.
         providers : Optional list of providers of this Collection.

--- a/pystac/common_metadata.py
+++ b/pystac/common_metadata.py
@@ -85,7 +85,11 @@ class CommonMetadata:
     # Date and Time Range
     @property
     def start_datetime(self) -> datetime | None:
-        """Get or set the object's start_datetime."""
+        """Get or set the object's start_datetime.
+        
+        Note:
+            ``start_datetime`` is an inclusive datetime.
+        """
         return utils.map_opt(
             utils.str_to_datetime, self._get_field("start_datetime", str)
         )
@@ -96,7 +100,11 @@ class CommonMetadata:
 
     @property
     def end_datetime(self) -> datetime | None:
-        """Get or set the item's end_datetime."""
+        """Get or set the item's end_datetime.
+        
+        Note:
+            ``end_datetime`` is an inclusive datetime.
+        """
         return utils.map_opt(
             utils.str_to_datetime, self._get_field("end_datetime", str)
         )

--- a/pystac/common_metadata.py
+++ b/pystac/common_metadata.py
@@ -108,7 +108,15 @@ class CommonMetadata:
     # License
     @property
     def license(self) -> str | None:
-        """Get or set the current license."""
+        """Get or set the current license. License should be provided
+        as a `SPDX License identifier <https://spdx.org/licenses/>`_,
+        or `other`. If object includes data with multiple
+        different licenses, use `other` and add a link for
+        each.
+        
+        Note:
+            The license `various` and `proprietary` are deprecated.
+        """
         return self._get_field("license", str)
 
     @license.setter

--- a/pystac/common_metadata.py
+++ b/pystac/common_metadata.py
@@ -125,7 +125,7 @@ class CommonMetadata:
         each.
 
         Note:
-            The license `various` and `proprietary` are deprecated.
+            The licenses `various` and `proprietary` are deprecated.
         """
         return self._get_field("license", str)
 

--- a/pystac/common_metadata.py
+++ b/pystac/common_metadata.py
@@ -80,6 +80,8 @@ class CommonMetadata:
 
     @description.setter
     def description(self, v: str | None) -> None:
+        if v == "":
+            raise ValueError("description cannot be an empty string")
         self._set_field("description", v)
 
     # Date and Time Range

--- a/pystac/common_metadata.py
+++ b/pystac/common_metadata.py
@@ -88,7 +88,7 @@ class CommonMetadata:
     @property
     def start_datetime(self) -> datetime | None:
         """Get or set the object's start_datetime.
-        
+
         Note:
             ``start_datetime`` is an inclusive datetime.
         """
@@ -103,7 +103,7 @@ class CommonMetadata:
     @property
     def end_datetime(self) -> datetime | None:
         """Get or set the item's end_datetime.
-        
+
         Note:
             ``end_datetime`` is an inclusive datetime.
         """
@@ -123,7 +123,7 @@ class CommonMetadata:
         or `other`. If object includes data with multiple
         different licenses, use `other` and add a link for
         each.
-        
+
         Note:
             The license `various` and `proprietary` are deprecated.
         """

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -51,10 +51,10 @@ class Item(STACObject, Assets):
         datetime : datetime associated with this item. If None,
             a start_datetime and end_datetime must be supplied.
         properties : A dictionary of additional metadata for the item.
-        start_datetime : Optional inclusive start datetime, part of common metadata. This value
-            will override any `start_datetime` key in properties.
-        end_datetime : Optional inclusive end datetime, part of common metadata. This value
-            will override any `end_datetime` key in properties.
+        start_datetime : Optional inclusive start datetime, part of common metadata.
+            This value will override any `start_datetime` key in properties.
+        end_datetime : Optional inclusive end datetime, part of common metadata.
+            This value will override any `end_datetime` key in properties.
         stac_extensions : Optional list of extensions the Item implements.
         href : Optional HREF for this item, which be set as the item's
             self link's HREF.

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -51,9 +51,9 @@ class Item(STACObject, Assets):
         datetime : datetime associated with this item. If None,
             a start_datetime and end_datetime must be supplied.
         properties : A dictionary of additional metadata for the item.
-        start_datetime : Optional start datetime, part of common metadata. This value
+        start_datetime : Optional inclusive start datetime, part of common metadata. This value
             will override any `start_datetime` key in properties.
-        end_datetime : Optional end datetime, part of common metadata. This value
+        end_datetime : Optional inclusive end datetime, part of common metadata. This value
             will override any `end_datetime` key in properties.
         stac_extensions : Optional list of extensions the Item implements.
         href : Optional HREF for this item, which be set as the item's

--- a/tests/test_common_metadata.py
+++ b/tests/test_common_metadata.py
@@ -176,6 +176,8 @@ class CommonMetadataTest(unittest.TestCase):
         x.common_metadata.description = example_description
         self.assertEqual(x.common_metadata.description, example_description)
         self.assertEqual(x.properties["description"], example_description)
+        with self.assertRaises(ValueError):
+            x.common_metadata.description = ""
 
         # License
         license = "PDDL-1.0"


### PR DESCRIPTION
**Related Issue(s):**

- #1377
- #1381
- #1382

**Description:**

A collection of smaller updates for STAC 1.1.0 with regard to description, license, and datetime. I grouped these together as they were small changes, but can broken down if that's preferred. 

**PR Checklist:**

- [x] Pre-commit hooks and tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
