### PR TITLE
Migrate pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
         name: ruff-format
         entry: ruff format --force-exclude
         language: system
-        stages: [commit]
+        stages: [pre-commit]
         types_or: [python, pyi, jupyter]
         require_serial: true
 
@@ -30,7 +30,7 @@ repos:
         name: codespell
         entry: codespell
         language: system
-        stages: [commit]
+        stages: [pre-commit]
         types_or: [jupyter, markdown, python, shell]
 
       - id: doc8
@@ -45,6 +45,6 @@ repos:
         entry: mypy
         args: [--no-incremental]
         language: system
-        stages: [commit]
+        stages: [pre-commit]
         types: [python]
         require_serial: true


### PR DESCRIPTION
Prompted by the following warnings:

```
[WARNING] hook id `ruff-format` uses deprecated stage names (commit) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
[WARNING] hook id `codespell` uses deprecated stage names (commit) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
[WARNING] hook id `mypy` uses deprecated stage names (commit) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
```