### PR TITLE
Add `file://` to self links that don't have a protocol

### DIFF
--- a/pystac/asset.py
+++ b/pystac/asset.py
@@ -8,7 +8,12 @@ from typing import TYPE_CHECKING, Any, Protocol, TypeVar
 
 from pystac import MediaType, STACError, common_metadata, utils
 from pystac.html.jinja_env import get_jinja_env
-from pystac.utils import is_absolute_href, make_absolute_href, make_relative_href
+from pystac.utils import (
+    is_absolute_href,
+    make_absolute_href,
+    make_relative_href,
+    safe_urlparse,
+)
 
 if TYPE_CHECKING:
     from pystac.common_metadata import CommonMetadata
@@ -380,7 +385,7 @@ class Assets(Protocol):
 
 def _absolute_href(href: str, owner: Assets | None, action: str = "access") -> str:
     if utils.is_absolute_href(href):
-        return href
+        return safe_urlparse(href).path
     else:
         item_self = owner.get_self_href() if owner else None
         if item_self is None:
@@ -389,4 +394,4 @@ def _absolute_href(href: str, owner: Assets | None, action: str = "access") -> s
                 "and owner item is not set. Hint: try using "
                 ":func:`~pystac.Item.make_asset_hrefs_absolute`"
             )
-        return utils.make_absolute_href(href, item_self)
+        return safe_urlparse(utils.make_absolute_href(href, item_self)).path

--- a/pystac/link.py
+++ b/pystac/link.py
@@ -102,7 +102,7 @@ class Link(PathLike):
         self.rel = rel
         if isinstance(target, str):
             if rel == pystac.RelType.SELF:
-                self._target_href = make_absolute_href(target)
+                self._target_href = make_absolute_href(target, must_include_scheme=True)
             else:
                 self._target_href = make_posix_style(target)
             self._target_object = None

--- a/pystac/stac_io.py
+++ b/pystac/stac_io.py
@@ -303,6 +303,7 @@ class DefaultStacIO(StacIO):
             except HTTPError as e:
                 raise Exception(f"Could not read uri {href}") from e
         else:
+            href = safe_urlparse(href).path
             with open(href, encoding="utf-8") as f:
                 href_contents = f.read()
         return href_contents
@@ -328,7 +329,7 @@ class DefaultStacIO(StacIO):
         """
         if _is_url(href):
             raise NotImplementedError("DefaultStacIO cannot write to urls")
-        href = os.fspath(href)
+        href = safe_urlparse(href).path
         dirname = os.path.dirname(href)
         if dirname != "" and not os.path.isdir(dirname):
             os.makedirs(dirname)
@@ -391,7 +392,7 @@ class DuplicateKeyReportingMixin(StacIO):
 
 def _is_url(href: str) -> bool:
     parsed = safe_urlparse(href)
-    return parsed.scheme != ""
+    return parsed.scheme != "" and parsed.scheme != "file"
 
 
 if HAS_URLLIB3:

--- a/tests/test_asset.py
+++ b/tests/test_asset.py
@@ -21,9 +21,9 @@ def test_alter_asset_absolute_path(
     assert asset.get_absolute_href() == new_href
     assert os.path.exists(new_href)
     if action == "move":
-        assert not os.path.exists(old_href)
+        assert not os.path.exists(old_href.replace("file://", ""))
     elif action == "copy":
-        assert os.path.exists(old_href)
+        assert os.path.exists(old_href.replace("file://", ""))
 
 
 @pytest.mark.parametrize("action", ["copy", "move"])
@@ -38,11 +38,11 @@ def test_alter_asset_relative_path(action: str, tmp_asset: pystac.Asset) -> None
     assert asset.href == new_href
     href = asset.get_absolute_href()
     assert href is not None
-    assert os.path.exists(href)
+    assert os.path.exists(href.replace("file://", ""))
     if action == "move":
-        assert not os.path.exists(old_href)
+        assert not os.path.exists(old_href.replace("file://", ""))
     elif action == "copy":
-        assert os.path.exists(old_href)
+        assert os.path.exists(old_href.replace("file://", ""))
 
 
 @pytest.mark.parametrize("action", ["copy", "move"])
@@ -82,18 +82,18 @@ def test_delete_asset(tmp_asset: pystac.Asset) -> None:
     asset = tmp_asset
     href = asset.get_absolute_href()
     assert href is not None
-    assert os.path.exists(href)
+    assert os.path.exists(href.replace("file://", ""))
 
     asset.delete()
 
-    assert not os.path.exists(href)
+    assert not os.path.exists(href.replace("file://", ""))
 
 
 def test_delete_asset_relative_no_owner_fails(tmp_asset: pystac.Asset) -> None:
     asset = tmp_asset
     href = asset.get_absolute_href()
     assert href is not None
-    assert os.path.exists(href)
+    assert os.path.exists(href.replace("file://", ""))
 
     asset.owner = None
 
@@ -101,4 +101,4 @@ def test_delete_asset_relative_no_owner_fails(tmp_asset: pystac.Asset) -> None:
         asset.delete()
 
     assert asset.href in str(e.value)
-    assert os.path.exists(href)
+    assert os.path.exists(href.replace("file://", ""))

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -541,7 +541,7 @@ class TestCatalog:
 
         assert len(hrefs) == stac_io.mock.write_text.call_count
         for call_args_list in stac_io.mock.write_text.call_args_list:
-            assert call_args_list[0][0] in hrefs
+            assert f"file://{call_args_list[0][0]}" in hrefs
 
     def test_subcatalogs_saved_to_correct_path(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -691,7 +691,7 @@ def test_delete_asset_relative_no_self_link_fails(
 
     assert asset.href in str(e.value)
     assert name in collection.assets
-    assert os.path.exists(href)
+    assert os.path.exists(href.replace("file://", ""))
 
 
 def test_permissive_temporal_extent_deserialization(collection: Collection) -> None:

--- a/tests/test_item.py
+++ b/tests/test_item.py
@@ -92,11 +92,11 @@ class ItemTest(unittest.TestCase):
         item.set_self_href(item_path)
         rel_asset = Asset("./data.geojson")
         rel_asset.set_owner(item)
-        expected_href = make_posix_style(
+        expected_filepath = make_posix_style(
             os.path.abspath(os.path.join(os.path.dirname(item_path), "./data.geojson"))
         )
         actual_href = rel_asset.get_absolute_href()
-        self.assertEqual(expected_href, actual_href)
+        self.assertEqual(f"file://{expected_filepath}", actual_href)
 
     def test_asset_absolute_href_no_item_self(self) -> None:
         item_dict = self.get_example_item_dict()
@@ -612,7 +612,7 @@ def test_delete_asset_relative_no_self_link_fails(tmp_asset: pystac.Asset) -> No
 
     assert asset.href in str(e.value)
     assert name in item.assets
-    assert os.path.exists(href)
+    assert os.path.exists(href.replace("file://", ""))
 
 
 def test_resolve_collection_with_root(

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -421,7 +421,7 @@ class AsIsLayoutStrategyTest(unittest.TestCase):
         href = self.strategy.get_href(
             cat, parent_dir="https://example.com", is_root=True
         )
-        self.assertEqual(href, "/an/href")
+        self.assertEqual(href, "file:///an/href")
 
     def test_collection(self) -> None:
         collection = TestCases.case_8()
@@ -434,7 +434,7 @@ class AsIsLayoutStrategyTest(unittest.TestCase):
         href = self.strategy.get_href(
             collection, parent_dir="https://example.com", is_root=True
         )
-        self.assertEqual(href, "/an/href")
+        self.assertEqual(href, "file:///an/href")
 
     def test_item(self) -> None:
         collection = TestCases.case_8()
@@ -444,7 +444,7 @@ class AsIsLayoutStrategyTest(unittest.TestCase):
             self.strategy.get_href(item, parent_dir="http://example.com")
         item.set_self_href("/an/href")
         href = self.strategy.get_href(item, parent_dir="http://example.com")
-        self.assertEqual(href, "/an/href")
+        self.assertEqual(href, "file:///an/href")
 
 
 class APILayoutStrategyTest(unittest.TestCase):

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -107,7 +107,9 @@ class LinkTest(unittest.TestCase):
             link = catalog.get_single_link(pystac.RelType.SELF)
             assert link
             link.resolve_stac_object()
-            self.assertEqual(link.get_absolute_href(), make_posix_style(path))
+            self.assertEqual(
+                link.get_absolute_href(), f"file://{make_posix_style(path)}"
+            )
 
     def test_target_getter_setter(self) -> None:
         link = pystac.Link("my rel", target="./foo/bar.json")
@@ -140,7 +142,10 @@ class LinkTest(unittest.TestCase):
                 item = pystac.read_file("item.json")
                 href = item.get_self_href()
                 assert href
-                self.assertTrue(os.path.isabs(href), f"Not an absolute path: {href}")
+                self.assertTrue(
+                    os.path.isabs(href.replace("file://", "")),
+                    f"Not an absolute path: {href}",
+                )
             finally:
                 os.chdir(previous)
 
@@ -237,7 +242,10 @@ class StaticLinkTest(unittest.TestCase):
             d2 = pystac.Link.from_dict(d).to_dict()
             self.assertEqual(d, d2)
         d = {"rel": "self", "href": "t"}
-        d2 = {"rel": "self", "href": make_posix_style(os.path.join(os.getcwd(), "t"))}
+        d2 = {
+            "rel": "self",
+            "href": f"file://{make_posix_style(os.path.join(os.getcwd(), 't'))}",
+        }
         self.assertEqual(pystac.Link.from_dict(d).to_dict(), d2)
 
     def test_from_dict_failures(self) -> None:
@@ -333,7 +341,7 @@ def test_relative_self_link(tmp_path: Path) -> None:
     assert read_item
     asset_href = read_item.assets["data"].get_absolute_href()
     assert asset_href
-    assert Path(asset_href).exists()
+    assert Path(asset_href.replace("file://", "")).exists()
 
 
 @pytest.mark.parametrize("rel", HIERARCHICAL_LINKS)

--- a/tests/validation/test_validate.py
+++ b/tests/validation/test_validate.py
@@ -125,7 +125,9 @@ class TestValidate:
             dst_dir = os.path.join(tmp_dir, "catalog")
             # Copy test case 7 to the temporary directory
             catalog_href = get_opt(TestCases.case_7().get_self_href())
-            shutil.copytree(os.path.dirname(catalog_href), dst_dir)
+            shutil.copytree(
+                os.path.dirname(catalog_href.replace("file://", "")), dst_dir
+            )
 
             new_cat_href = os.path.join(dst_dir, "catalog.json")
 


### PR DESCRIPTION
**Related Issue(s):**

- closes #1347

**Description:**

Pystac already coerces self links to absolute, so now it adds `file://` as well. 

Notes:
- TODO:  There are still some tests that are failing. Mostly having to do with `normalize`.
- The json schema spec _does_ define how `"format": "iri"` should be handled, but the Python implementation does seem to validate it very well. For instance this passes:
```python
from jsonschema import validate

validate("any-string", {"type": "string", "format": "iri", "minLength": 1})
```
- Python in general seems rather bad at interpreting the `file://` protocol. Python 3.13 adds some support to `pathlib` in https://docs.python.org/3/library/pathlib.html#pathlib.Path.from_uri

**PR Checklist:**

- [ ] Pre-commit hooks and tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [ ] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
