### PR TITLE
replace str() with repr() in StringEnum & test it (#1369)

### DIFF
--- a/pystac/utils.py
+++ b/pystac/utils.py
@@ -80,7 +80,7 @@ class StringEnum(str, Enum):
     value."""
 
     def __repr__(self) -> str:
-        return str(self.value)
+        return repr(self.value)
 
     def __str__(self) -> str:
         return cast(str, self.value)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,6 +10,7 @@ from dateutil import tz
 from pystac import utils
 from pystac.utils import (
     JoinType,
+    StringEnum,
     is_absolute_href,
     is_file_path,
     join_path_or_url,
@@ -474,3 +475,10 @@ def test_join_path_or_url() -> None:
 )
 def test_is_file_path(href: str, expected: bool) -> None:
     assert is_file_path(href) == expected
+
+
+def test_stringenum_repr() -> None:
+    class SomeEnum(StringEnum):
+        THIS = "this"
+
+    assert repr(SomeEnum.THIS) == "'this'"


### PR DESCRIPTION
**Related Issue(s):**

- #1369 

**Description:** Simple replacement of `str()` with `repr()`. This technically changes the output from a string to a quoted string, eg `foo` to `'foo'`. But I couldn't find any places where it'd matter.

This is such a minor change I wasn't sure whether to add to the changelog; should I?

**PR Checklist:**

- [x] Pre-commit hooks and tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [x] This PR ~~maintains or~~ improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.