### PR TITLE
Update migrate code to handle license updates for v1.1.0

### DIFF
--- a/tests/data-files/catalogs/cbers-partial/CBERS4AWFI/collection.json
+++ b/tests/data-files/catalogs/cbers-partial/CBERS4AWFI/collection.json
@@ -16,8 +16,7 @@
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
-    "https://schemas.stacspec.org/v1.0.0-beta.2/extensions/item-assets/json-schema/schema.json"
+    "https://stac-extensions.github.io/eo/v1.1.0/schema.json"
   ],
   "providers": [
     {

--- a/tests/data-files/catalogs/cbers-partial/CBERS4MUX/collection.json
+++ b/tests/data-files/catalogs/cbers-partial/CBERS4MUX/collection.json
@@ -16,8 +16,7 @@
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/eo/v1.1.0/schema.json"
   ],
   "providers": [
     {

--- a/tests/data-files/catalogs/cbers-partial/CBERS4PAN10M/collection.json
+++ b/tests/data-files/catalogs/cbers-partial/CBERS4PAN10M/collection.json
@@ -16,8 +16,7 @@
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/eo/v1.1.0/schema.json"
   ],
   "providers": [
     {

--- a/tests/data-files/catalogs/cbers-partial/CBERS4PAN5M/collection.json
+++ b/tests/data-files/catalogs/cbers-partial/CBERS4PAN5M/collection.json
@@ -16,8 +16,7 @@
     }
   ],
   "stac_extensions": [
-    "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+    "https://stac-extensions.github.io/eo/v1.1.0/schema.json"
   ],
   "providers": [
     {

--- a/tests/data-files/catalogs/test-case-1/country-1/area-1-1/collection.json
+++ b/tests/data-files/catalogs/test-case-1/country-1/area-1-1/collection.json
@@ -46,5 +46,5 @@
       ]
     }
   },
-  "license": "proprietary"
+  "license": "other"
 }

--- a/tests/data-files/catalogs/test-case-1/country-1/area-1-2/collection.json
+++ b/tests/data-files/catalogs/test-case-1/country-1/area-1-2/collection.json
@@ -46,5 +46,5 @@
       ]
     }
   },
-  "license": "proprietary"
+  "license": "other"
 }

--- a/tests/data-files/catalogs/test-case-1/country-2/area-2-1/collection.json
+++ b/tests/data-files/catalogs/test-case-1/country-2/area-2-1/collection.json
@@ -46,5 +46,5 @@
       ]
     }
   },
-  "license": "proprietary"
+  "license": "other"
 }

--- a/tests/data-files/catalogs/test-case-1/country-2/area-2-2/collection.json
+++ b/tests/data-files/catalogs/test-case-1/country-2/area-2-2/collection.json
@@ -46,5 +46,5 @@
       ]
     }
   },
-  "license": "proprietary"
+  "license": "other"
 }

--- a/tests/data-files/catalogs/test-case-2/1a8c1632-fa91-4a62-b33e-3a87c2ebdf16/5b922d42-9a77-4f79-a672-86096f7f849e/collection.json
+++ b/tests/data-files/catalogs/test-case-2/1a8c1632-fa91-4a62-b33e-3a87c2ebdf16/5b922d42-9a77-4f79-a672-86096f7f849e/collection.json
@@ -47,5 +47,5 @@
       ]
     }
   },
-  "license": "proprietary"
+  "license": "other"
 }

--- a/tests/data-files/catalogs/test-case-2/1a8c1632-fa91-4a62-b33e-3a87c2ebdf16/collection.json
+++ b/tests/data-files/catalogs/test-case-2/1a8c1632-fa91-4a62-b33e-3a87c2ebdf16/collection.json
@@ -53,5 +53,5 @@
       ]
     }
   },
-  "license": "proprietary"
+  "license": "other"
 }

--- a/tests/data-files/catalogs/test-case-2/1a8c1632-fa91-4a62-b33e-3a87c2ebdf16/f433578c-f879-414d-8101-83142a0a13c3/collection.json
+++ b/tests/data-files/catalogs/test-case-2/1a8c1632-fa91-4a62-b33e-3a87c2ebdf16/f433578c-f879-414d-8101-83142a0a13c3/collection.json
@@ -47,5 +47,5 @@
       ]
     }
   },
-  "license": "proprietary"
+  "license": "other"
 }

--- a/tests/data-files/catalogs/test-case-4/acc/collection.json
+++ b/tests/data-files/catalogs/test-case-4/acc/collection.json
@@ -76,5 +76,5 @@
       ]
     }
   },
-  "license": "various"
+  "license": "other"
 }

--- a/tests/data-files/catalogs/test-case-4/dar/collection.json
+++ b/tests/data-files/catalogs/test-case-4/dar/collection.json
@@ -96,5 +96,5 @@
       ]
     }
   },
-  "license": "various"
+  "license": "other"
 }

--- a/tests/data-files/catalogs/test-case-4/kam/collection.json
+++ b/tests/data-files/catalogs/test-case-4/kam/collection.json
@@ -46,5 +46,5 @@
       ]
     }
   },
-  "license": "various"
+  "license": "other"
 }

--- a/tests/data-files/catalogs/test-case-4/mon/collection.json
+++ b/tests/data-files/catalogs/test-case-4/mon/collection.json
@@ -76,5 +76,5 @@
       ]
     }
   },
-  "license": "various"
+  "license": "other"
 }

--- a/tests/data-files/catalogs/test-case-4/nia/collection.json
+++ b/tests/data-files/catalogs/test-case-4/nia/collection.json
@@ -46,5 +46,5 @@
       ]
     }
   },
-  "license": "various"
+  "license": "other"
 }

--- a/tests/data-files/catalogs/test-case-4/ptn/collection.json
+++ b/tests/data-files/catalogs/test-case-4/ptn/collection.json
@@ -56,5 +56,5 @@
       ]
     }
   },
-  "license": "various"
+  "license": "other"
 }

--- a/tests/data-files/classification/collection-item-assets-raster-bands.json
+++ b/tests/data-files/classification/collection-item-assets-raster-bands.json
@@ -110,7 +110,7 @@
       ]
     }
   },
-  "license": "proprietary",
+  "license": "other",
   "stac_extensions": [
     "https://stac-extensions.github.io/projection/v1.1.0/schema.json",
     "https://stac-extensions.github.io/eo/v1.1.0/schema.json",

--- a/tests/data-files/collections/multi-extent.json
+++ b/tests/data-files/collections/multi-extent.json
@@ -62,5 +62,5 @@
       ]
     }
   },
-  "license": "proprietary"
+  "license": "other"
 }

--- a/tests/data-files/collections/with-assets.json
+++ b/tests/data-files/collections/with-assets.json
@@ -56,5 +56,5 @@
       ]
     }
   },
-  "license": "proprietary"
+  "license": "other"
 }

--- a/tests/data-files/invalid/shared-id/test/collection.json
+++ b/tests/data-files/invalid/shared-id/test/collection.json
@@ -41,5 +41,5 @@
       ]
     }
   },
-  "license": "proprietary"
+  "license": "other"
 }

--- a/tests/data-files/item-assets/example-landsat8.json
+++ b/tests/data-files/item-assets/example-landsat8.json
@@ -1,7 +1,6 @@
 {
     "stac_version": "1.1.0",
     "stac_extensions": [
-        "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
         "eo"
     ],
     "type": "Collection",

--- a/tests/data-files/projection/collection-with-summaries.json
+++ b/tests/data-files/projection/collection-with-summaries.json
@@ -48,5 +48,5 @@
       ]
     }
   },
-  "license": "proprietary"
+  "license": "other"
 }

--- a/tests/data-files/storage/collection-naip.json
+++ b/tests/data-files/storage/collection-naip.json
@@ -61,5 +61,5 @@
       ]
     }
   },
-  "license": "proprietary"
+  "license": "other"
 }

--- a/tests/data-files/table/collection-2.json
+++ b/tests/data-files/table/collection-2.json
@@ -28,7 +28,7 @@
       ]
     }
   },
-  "license": "proprietary",
+  "license": "other",
   "item_assets": {},
   "table:columns": []
 }

--- a/tests/data-files/table/collection-2.json
+++ b/tests/data-files/table/collection-2.json
@@ -5,7 +5,6 @@
   "description": "desc",
   "links": [],
   "stac_extensions": [
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
     "https://stac-extensions.github.io/table/v1.2.0/schema.json"
   ],
   "extent": {

--- a/tests/data-files/table/collection.json
+++ b/tests/data-files/table/collection.json
@@ -1,7 +1,6 @@
 {
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
     "https://stac-extensions.github.io/table/v1.2.0/schema.json"
   ],
   "type": "Collection",

--- a/tests/data-files/table/table-collection.json
+++ b/tests/data-files/table/table-collection.json
@@ -1,7 +1,6 @@
 {
   "stac_version": "1.1.0",
   "stac_extensions": [
-    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
     "https://stac-extensions.github.io/table/v1.2.0/schema.json"
   ],
   "type": "Collection",

--- a/tests/data-files/view/collection-with-summaries.json
+++ b/tests/data-files/view/collection-with-summaries.json
@@ -65,5 +65,5 @@
       ]
     }
   },
-  "license": "proprietary"
+  "license": "other"
 }

--- a/tests/data-files/windows_hrefs/test-collection/collection.json
+++ b/tests/data-files/windows_hrefs/test-collection/collection.json
@@ -40,5 +40,5 @@
       ]
     }
   },
-  "license": "proprietary"
+  "license": "other"
 }

--- a/tests/serialization/test_migrate.py
+++ b/tests/serialization/test_migrate.py
@@ -112,3 +112,19 @@ def test_migrate_works_even_if_stac_extensions_is_null(
     collection_dict["stac_extensions"] = None
 
     pystac.Collection.from_dict(collection_dict, migrate=True)
+
+
+def test_migrate_updates_license_from_various() -> None:
+    path = TestCases.get_path("data-files/examples/1.0.0/collectionless-item.json")
+
+    item = pystac.Item.from_file(path)
+    assert item.properties["license"] == "other"
+
+
+def test_migrate_updates_license_from_proprietary() -> None:
+    path = TestCases.get_path(
+        "data-files/examples/1.0.0/collection-only/collection.json"
+    )
+
+    collection = pystac.Collection.from_file(path)
+    assert collection.license == "other"

--- a/tests/serialization/test_migrate.py
+++ b/tests/serialization/test_migrate.py
@@ -67,7 +67,7 @@ class TestMigrate:
         assert view_ext.sun_elevation, 58.8
         assert view_ext.off_nadir, 1
 
-    def test_migrates_renamed_extension(self) -> None:
+    def test_migrates_removes_extension(self) -> None:
         collection = pystac.Collection.from_file(
             TestCases.get_path(
                 "data-files/examples/0.9.0/extensions/asset/"
@@ -78,7 +78,8 @@ class TestMigrate:
         assert ItemAssetsExtension.get_schema_uri() not in collection.stac_extensions
         assert not ItemAssetsExtension.has_extension(collection)
         assert "item_assets" in collection.extra_fields
-        assert collection.item_assets
+
+        assert collection.stac_extensions == []
         assert collection.item_assets["thumbnail"].title == "Thumbnail"
 
     def test_migrates_pre_1_0_0_rc1_stats_summary(self) -> None:

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1120,7 +1120,7 @@ class TestCatalog:
                     spatial=pystac.SpatialExtent([[-180.0, -90.0, 180.0, 90.0]]),
                     temporal=pystac.TemporalExtent([[datetime(2021, 11, 1), None]]),
                 ),
-                license="proprietary",
+                license="other",
             )
 
             item = pystac.Item(


### PR DESCRIPTION
**Related Issue(s):**

- #1383 

**Description:**

Since we decided that bands (#1238) and `file://` (#1472)  are going to wait until pystac v2 there wasn't much left for the migration to do. Just `license`. 

**PR Checklist:**

- [ ] Pre-commit hooks and tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [ ] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
