### PR TITLE
Access scientific extension on item using .ext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,14 @@
 - Use [uv](https://github.com/astral-sh/uv) for development dependencies and docs ([#1439](https://github.com/stac-utils/pystac/pull/1439))
 - Correctly detect absolute file path ref on windows, reflecting change in python 3.13 ([#1475](https://github.com/stac-utils/pystac/pull/14750)) (only effects python 3.13)
 - Deprecated `ItemAssetExtension` ([#1476](https://github.com/stac-utils/pystac/pull/1476))
+- Update Projection Extension to version 2 - proj:epsg -> proj:code ([#1287](https://github.com/stac-utils/pystac/pull/1287))
+- Update migrate code to handle license changes in STAC spec 1.1.0 ([#1491](https://github.com/stac-utils/pystac/pull/1491))
+- Allow links to have `file://` prefix - but don't write them that way by default ([#1489](https://github.com/stac-utils/pystac/pull/1489))
 
 ### Fixed
 
 - Use `application/geo+json` for `item` links ([#1495](https://github.com/stac-utils/pystac/pull/1495))
+- Includes the scientific extension in Item's ext interface ([#1496](https://github.com/stac-utils/pystac/pull/1496))
 
 ## [v1.11.0] - 2024-09-26
 

--- a/pystac/extensions/ext.py
+++ b/pystac/extensions/ext.py
@@ -181,6 +181,10 @@ class ItemExt:
         return SatExtension.ext(self.stac_object)
 
     @property
+    def sci(self) -> ScientificExtension[Item]:
+        return ScientificExtension.ext(self.stac_object)
+
+    @property
     def storage(self) -> StorageExtension[Item]:
         return StorageExtension.ext(self.stac_object)
 

--- a/tests/extensions/test_scientific.py
+++ b/tests/extensions/test_scientific.py
@@ -7,6 +7,7 @@ import pytest
 
 import pystac
 from pystac import ExtensionTypeError
+from pystac.errors import ExtensionNotImplemented
 from pystac.extensions import scientific
 from pystac.extensions.scientific import (
     Publication,
@@ -494,3 +495,26 @@ class SummariesScientificTest(unittest.TestCase):
         self.assertNotIn(
             ScientificExtension.get_schema_uri(), collection.stac_extensions
         )
+
+
+@pytest.fixture
+def ext_item() -> pystac.Item:
+    path = TestCases.get_path("data-files/scientific/item.json")
+    return pystac.Item.from_file(path)
+
+
+def test_ext_syntax(ext_item: pystac.Item) -> None:
+    assert ext_item.ext.sci.doi == "10.5061/dryad.s2v81.2/27.2"
+
+
+def test_ext_syntax_remove(ext_item: pystac.Item) -> None:
+    ext_item.ext.remove("sci")
+    assert ext_item.ext.has("sci") is False
+    with pytest.raises(ExtensionNotImplemented):
+        ext_item.ext.sci
+
+
+def test_ext_syntax_add(item: pystac.Item) -> None:
+    item.ext.add("sci")
+    assert item.ext.has("sci") is True
+    assert isinstance(item.ext.sci, ScientificExtension)


### PR DESCRIPTION
**Related Issue(s):**

closes #1485 

**Description:**

It was indeed very straightforward

**PR Checklist:**

- [ ] Pre-commit hooks and tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [ ] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
