### PR TITLE
get_root_link/get_child_links/get_item_links: Ensure correct media types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Top-level `item_assets` dict on `Collection`s ([#1476](https://github.com/stac-utils/pystac/pull/1476))
 - Render Extension ([#1465](https://github.com/stac-utils/pystac/pull/1465))
+- Filter by links by list of media_types
 
 ### Changed
 
@@ -16,6 +17,7 @@
 - Update Projection Extension to version 2 - proj:epsg -> proj:code ([#1287](https://github.com/stac-utils/pystac/pull/1287))
 - Update migrate code to handle license changes in STAC spec 1.1.0 ([#1491](https://github.com/stac-utils/pystac/pull/1491))
 - Allow links to have `file://` prefix - but don't write them that way by default ([#1489](https://github.com/stac-utils/pystac/pull/1489))
+- For `get_root_link`, `get_child_links`, `get_item_links`: Ensure json media types ([#1497](https://github.com/stac-utils/pystac/pull/1497))
 - Raise `STACError` with message when a link is expected to resolve to a STAC object but doesn't ([#1500](https://github.com/stac-utils/pystac/pull/1500))
 
 ### Fixed

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -13,6 +13,7 @@ from typing import (
 )
 
 import pystac
+import pystac.media_type
 from pystac.cache import ResolvedObjectCache
 from pystac.errors import STACTypeError
 from pystac.layout import (
@@ -466,7 +467,7 @@ class Catalog(STACObject):
         """
         return self.get_links(
             rel=pystac.RelType.CHILD,
-            media_type=[None, pystac.MediaType.GEOJSON, pystac.MediaType.JSON],
+            media_type=pystac.media_type.STAC_JSON,
         )
 
     def clear_children(self) -> None:
@@ -628,8 +629,7 @@ class Catalog(STACObject):
             List[Link]: List of links of this catalog with ``rel == 'item'``
         """
         return self.get_links(
-            rel=pystac.RelType.ITEM,
-            media_type=[None, pystac.MediaType.GEOJSON, pystac.MediaType.JSON],
+            rel=pystac.RelType.ITEM, media_type=pystac.media_type.STAC_JSON
         )
 
     def to_dict(

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -464,7 +464,10 @@ class Catalog(STACObject):
         Return:
             List[Link]: List of links of this catalog with ``rel == 'child'``
         """
-        return self.get_links(pystac.RelType.CHILD)
+        return self.get_links(
+            rel=pystac.RelType.CHILD,
+            media_type=[None, pystac.MediaType.GEOJSON, pystac.MediaType.JSON],
+        )
 
     def clear_children(self) -> None:
         """Removes all children from this catalog.
@@ -624,7 +627,10 @@ class Catalog(STACObject):
         Return:
             List[Link]: List of links of this catalog with ``rel == 'item'``
         """
-        return self.get_links(pystac.RelType.ITEM)
+        return self.get_links(
+            rel=pystac.RelType.ITEM,
+            media_type=[None, pystac.MediaType.GEOJSON, pystac.MediaType.JSON],
+        )
 
     def to_dict(
         self, include_self_link: bool = True, transform_hrefs: bool = True

--- a/pystac/media_type.py
+++ b/pystac/media_type.py
@@ -24,3 +24,7 @@ class MediaType(StringEnum):
     PDF = "application/pdf"
     ZARR = "application/vnd+zarr"  # https://github.com/openMetadataInitiative/openMINDS_core/blob/v4/instances/data/contentTypes/zarr.jsonld
     NETCDF = "application/netcdf"  # https://github.com/Unidata/netcdf/issues/42#issuecomment-1007618822
+
+
+#: Media types that can be resolved as STAC Objects
+STAC_JSON = [None, MediaType.GEOJSON, MediaType.JSON]

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 S = TypeVar("S", bound="STACObject")
 
-STACObject_MediaType: TypeAlias = str | pystac.MediaType | None
+OptionalMediaType: TypeAlias = str | pystac.MediaType | None
 
 
 class STACObjectType(StringEnum):
@@ -174,7 +174,7 @@ class STACObject(ABC):
     def get_single_link(
         self,
         rel: str | pystac.RelType | None = None,
-        media_type: STACObject_MediaType | Iterable[STACObject_MediaType] = None,
+        media_type: OptionalMediaType | Iterable[OptionalMediaType] = None,
     ) -> Link | None:
         """Get a single :class:`~pystac.Link` instance associated with this
         object.
@@ -208,7 +208,7 @@ class STACObject(ABC):
     def get_links(
         self,
         rel: str | pystac.RelType | None = None,
-        media_type: STACObject_MediaType | Iterable[STACObject_MediaType] = None,
+        media_type: OptionalMediaType | Iterable[OptionalMediaType] = None,
     ) -> list[Link]:
         """Gets the :class:`~pystac.Link` instances associated with this object.
 
@@ -256,7 +256,7 @@ class STACObject(ABC):
         """
         return self.get_single_link(
             rel=pystac.RelType.ROOT,
-            media_type=[None, pystac.MediaType.GEOJSON, pystac.MediaType.JSON],
+            media_type=pystac.media_type.STAC_JSON,
         )
 
     @property

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -3,12 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable
 from html import escape
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    TypeVar,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar, cast
 
 import pystac
 from pystac import STACError
@@ -26,6 +21,8 @@ if TYPE_CHECKING:
     from pystac.catalog import Catalog
 
 S = TypeVar("S", bound="STACObject")
+
+STACObject_MediaType: TypeAlias = str | pystac.MediaType | None
 
 
 class STACObjectType(StringEnum):
@@ -177,7 +174,7 @@ class STACObject(ABC):
     def get_single_link(
         self,
         rel: str | pystac.RelType | None = None,
-        media_type: str | pystac.MediaType | None = None,
+        media_type: STACObject_MediaType | Iterable[STACObject_MediaType] = None,
     ) -> Link | None:
         """Get a single :class:`~pystac.Link` instance associated with this
         object.
@@ -186,21 +183,24 @@ class STACObject(ABC):
             rel : If set, filter links such that only those
                 matching this relationship are returned.
             media_type: If set, filter the links such that only
-                those matching media_type are returned
+                those matching media_type are returned. media_type can
+                be a single value or a list of values.
 
         Returns:
-            Optional[:class:`~pystac.Link`]: First link that matches ``rel``
+            :class:`~pystac.Link` | None: First link that matches ``rel``
             and/or ``media_type``, or else the first link associated with
             this object.
         """
         if rel is None and media_type is None:
             return next(iter(self.links), None)
+        if media_type and isinstance(media_type, (str, pystac.MediaType)):
+            media_type = [media_type]
         return next(
             (
                 link
                 for link in self.links
                 if (rel is None or link.rel == rel)
-                and (media_type is None or link.media_type == media_type)
+                and (media_type is None or link.media_type in media_type)
             ),
             None,
         )
@@ -208,7 +208,7 @@ class STACObject(ABC):
     def get_links(
         self,
         rel: str | pystac.RelType | None = None,
-        media_type: str | pystac.MediaType | None = None,
+        media_type: STACObject_MediaType | Iterable[STACObject_MediaType] = None,
     ) -> list[Link]:
         """Gets the :class:`~pystac.Link` instances associated with this object.
 
@@ -216,7 +216,8 @@ class STACObject(ABC):
             rel : If set, filter links such that only those
                 matching this relationship are returned.
             media_type: If set, filter the links such that only
-                those matching media_type are returned
+                those matching media_type are returned. media_type can
+                be a single value or a list of values.
 
         Returns:
             List[:class:`~pystac.Link`]: A list of links that match ``rel`` and/
@@ -225,13 +226,14 @@ class STACObject(ABC):
         """
         if rel is None and media_type is None:
             return self.links
-        else:
-            return [
-                link
-                for link in self.links
-                if (rel is None or link.rel == rel)
-                and (media_type is None or link.media_type == media_type)
-            ]
+        if media_type and isinstance(media_type, (str, pystac.MediaType)):
+            media_type = [media_type]
+        return [
+            link
+            for link in self.links
+            if (rel is None or link.rel == rel)
+            and (media_type is None or link.media_type in media_type)
+        ]
 
     def clear_links(self, rel: str | pystac.RelType | None = None) -> None:
         """Clears all :class:`~pystac.Link` instances associated with this object.
@@ -252,7 +254,10 @@ class STACObject(ABC):
             :class:`~pystac.Link` or None: The root link for this object,
             or ``None`` if no root link is set.
         """
-        return self.get_single_link(pystac.RelType.ROOT)
+        return self.get_single_link(
+            rel=pystac.RelType.ROOT,
+            media_type=[None, pystac.MediaType.GEOJSON, pystac.MediaType.JSON],
+        )
 
     @property
     def self_href(self) -> str:


### PR DESCRIPTION
**Related Issue(s):**

- closes #1255 
- closes #1325 

**Description:**

* Allow media_type on get_links and get_single_link to an iterable
* Use `application/json", "application/geo+json" or None as the media_type for `get_root_link`, `get_child_links` and `get_item_links`


**PR Checklist:**

- [x] Pre-commit hooks and tests pass (run `scripts/test`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
