### PR TITLE
Raise an error on APILayoutStrategy when root_href is non-url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Update migrate code to handle license changes in STAC spec 1.1.0 ([#1491](https://github.com/stac-utils/pystac/pull/1491))
 - Allow links to have `file://` prefix - but don't write them that way by default ([#1489](https://github.com/stac-utils/pystac/pull/1489))
 - Raise `STACError` with message when a link is expected to resolve to a STAC object but doesn't ([#1500](https://github.com/stac-utils/pystac/pull/1500))
+- Raise an error on APILayoutStrategy when root_href is non-url ([#1498](https://github.com/stac-utils/pystac/pull/1498))
 
 ### Fixed
 

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -31,8 +31,8 @@ from pystac.stac_object import STACObject, STACObjectType
 from pystac.utils import (
     HREF,
     StringEnum,
+    _is_url,
     is_absolute_href,
-    is_url,
     make_absolute_href,
     make_relative_href,
 )
@@ -771,7 +771,7 @@ class Catalog(STACObject):
         if not is_absolute_href(root_href):
             root_href = make_absolute_href(root_href, os.getcwd(), start_is_dir=True)
 
-        if isinstance(_strategy, APILayoutStrategy) and not is_url(root_href):
+        if isinstance(_strategy, APILayoutStrategy) and not _is_url(root_href):
             raise STACError("When using APILayoutStrategy the root_href must be a URL")
 
         def process_item(

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -15,8 +15,9 @@ from typing import (
 
 import pystac
 from pystac.cache import ResolvedObjectCache
-from pystac.errors import STACTypeError
+from pystac.errors import STACError, STACTypeError
 from pystac.layout import (
+    APILayoutStrategy,
     BestPracticesLayoutStrategy,
     HrefLayoutStrategy,
     LayoutTemplate,
@@ -32,6 +33,7 @@ from pystac.utils import (
     HREF,
     StringEnum,
     is_absolute_href,
+    is_url,
     make_absolute_href,
     make_relative_href,
 )
@@ -768,6 +770,9 @@ class Catalog(STACObject):
         # Normalizing requires an absolute path
         if not is_absolute_href(root_href):
             root_href = make_absolute_href(root_href, os.getcwd(), start_is_dir=True)
+
+        if isinstance(_strategy, APILayoutStrategy) and not is_url(root_href):
+            raise STACError("When using APILayoutStrategy the root_href must be a URL")
 
         def process_item(
             item: Item, _root_href: str, is_root: bool, parent: Catalog | None

--- a/pystac/stac_io.py
+++ b/pystac/stac_io.py
@@ -16,7 +16,7 @@ from pystac.serialization import (
     merge_common_properties,
     migrate_to_latest,
 )
-from pystac.utils import HREF, safe_urlparse
+from pystac.utils import HREF, is_url, safe_urlparse
 
 # Use orjson if available
 try:
@@ -294,7 +294,7 @@ class DefaultStacIO(StacIO):
             href : The URI of the file to open.
         """
         href_contents: str
-        if _is_url(href):
+        if is_url(href):
             try:
                 logger.debug(f"GET {href} Headers: {self.headers}")
                 req = Request(href, headers=self.headers)
@@ -327,7 +327,7 @@ class DefaultStacIO(StacIO):
             href : The path to which the file will be written.
             txt : The string content to write to the file.
         """
-        if _is_url(href):
+        if is_url(href):
             raise NotImplementedError("DefaultStacIO cannot write to urls")
         href = safe_urlparse(href).path
         dirname = os.path.dirname(href)
@@ -390,11 +390,6 @@ class DuplicateKeyReportingMixin(StacIO):
         return result
 
 
-def _is_url(href: str) -> bool:
-    parsed = safe_urlparse(href)
-    return parsed.scheme not in ["", "file"]
-
-
 if HAS_URLLIB3:
     from typing import cast
 
@@ -433,7 +428,7 @@ if HAS_URLLIB3:
             Args:
                 href : The URI of the file to open.
             """
-            if _is_url(href):
+            if is_url(href):
                 # TODO provide a pooled StacIO to enable more efficient network
                 # access (probably named `PooledStacIO`).
                 http = PoolManager()

--- a/pystac/stac_io.py
+++ b/pystac/stac_io.py
@@ -16,7 +16,7 @@ from pystac.serialization import (
     merge_common_properties,
     migrate_to_latest,
 )
-from pystac.utils import HREF, is_url, safe_urlparse
+from pystac.utils import HREF, _is_url, safe_urlparse
 
 # Use orjson if available
 try:
@@ -294,7 +294,7 @@ class DefaultStacIO(StacIO):
             href : The URI of the file to open.
         """
         href_contents: str
-        if is_url(href):
+        if _is_url(href):
             try:
                 logger.debug(f"GET {href} Headers: {self.headers}")
                 req = Request(href, headers=self.headers)
@@ -328,7 +328,7 @@ class DefaultStacIO(StacIO):
             href : The path to which the file will be written.
             txt : The string content to write to the file.
         """
-        if is_url(href):
+        if _is_url(href):
             raise NotImplementedError("DefaultStacIO cannot write to urls")
         href = safe_urlparse(href).path
         dirname = os.path.dirname(href)
@@ -429,7 +429,7 @@ if HAS_URLLIB3:
             Args:
                 href : The URI of the file to open.
             """
-            if is_url(href):
+            if _is_url(href):
                 # TODO provide a pooled StacIO to enable more efficient network
                 # access (probably named `PooledStacIO`).
                 http = PoolManager()

--- a/pystac/utils.py
+++ b/pystac/utils.py
@@ -605,3 +605,8 @@ def is_file_path(href: str) -> bool:
     """
     parsed = urlparse(href)
     return bool(os.path.splitext(parsed.path)[1])
+
+
+def is_url(href: str) -> bool:
+    parsed = safe_urlparse(href)
+    return parsed.scheme not in ["", "file"]

--- a/pystac/utils.py
+++ b/pystac/utils.py
@@ -608,6 +608,7 @@ def is_file_path(href: str) -> bool:
     return bool(os.path.splitext(parsed.path)[1])
 
 
-def is_url(href: str) -> bool:
+def _is_url(href: str) -> bool:
+    """Checks if an HREF is a url rather than a local path"""
     parsed = safe_urlparse(href)
     return parsed.scheme not in ["", "file"]

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -25,6 +25,7 @@ from pystac import (
     MediaType,
 )
 from pystac.layout import (
+    APILayoutStrategy,
     BestPracticesLayoutStrategy,
     HrefLayoutStrategy,
     TemplateLayoutStrategy,
@@ -1968,3 +1969,15 @@ def test_add_item_layout_strategy(
     template = template.format(id=item.id).replace("$", "")
 
     assert item.self_href == f"{base_url}/{template}/{item_id}.json"
+
+
+def test_APILayoutStrategy_requires_root_to_be_url(
+    catalog: Catalog, collection: Collection, item: Item
+) -> None:
+    collection.add_item(item)
+    catalog.add_child(collection)
+    with pytest.raises(
+        pystac.errors.STACError,
+        match="When using APILayoutStrategy the root_href must be a URL",
+    ):
+        catalog.normalize_hrefs(root_href="issues-1486", strategy=APILayoutStrategy())


### PR DESCRIPTION
**Related Issue(s):**

- closes #1486 

**Description:**

Doesn't strictly disallow saving. Saving to a URL already throws an error if you are using the default stac_io so I think it is more appropriate to raise an error if you try to set the root to a non-url

**PR Checklist:**

- [ ] Pre-commit hooks and tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [ ] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
