### PR TITLE
fix: fall back to epsg in crs_string, too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fall back to `epsg` when `code` is not present in the Projection extension ([#1505](https://github.com/stac-utils/pystac/pull/1505))
+- Fall back to `epsg` when `code` is not present in the Projection extension ([#1505](https://github.com/stac-utils/pystac/pull/1505), [#1510](https://github.com/stac-utils/pystac/pull/1510))
 
 ## [v1.12.0]
 

--- a/pystac/extensions/projection.py
+++ b/pystac/extensions/projection.py
@@ -218,6 +218,8 @@ class ProjectionExtension(
         """
         if self.code:
             return self.code
+        elif self.epsg:
+            return f"EPSG:{self.epsg}"
         elif self.wkt2:
             return self.wkt2
         elif self.projjson:

--- a/tests/data-files/projection/another-1.1.json
+++ b/tests/data-files/projection/another-1.1.json
@@ -1,0 +1,94 @@
+{
+  "stac_version": "0.9.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/file/v2.1.0/schema.json",
+    "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+  ],
+  "type": "Feature",
+  "id": "JQT-123456789",
+  "bbox": [-81.3085227080129, 32.10817938759764, -78.81735409341113, 34.22870275071835],
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+        [
+            [
+                -81.3085227080129,
+                32.10817938759764
+            ],
+            [
+                -78.81735409341113,
+                32.10817938759764
+            ],
+            [
+                -78.81735409341113,
+                34.22870275071835
+            ],
+            [
+                -81.3085227080129,
+                34.22870275071835
+            ],
+            [
+                -81.3085227080129,
+                32.10817938759764
+            ]
+        ]
+    ]
+  },
+  "properties": {
+    "proj:epsg": 32617,
+    "proj:shape": [
+      259,
+      255
+    ],
+    "proj:transform": [
+      900.0,
+      0.0,
+      471585.0,
+      0.0,
+      -900.0,
+      3787515.0,
+      0.0,
+      0.0,
+      1.0
+    ],
+    "datetime": "2016-05-03T13:21:30.040Z",
+    "collection": "JQT"
+  },
+  "links": [
+    {
+      "rel": "self",
+      "href": "http://cool-sat.com/catalog/JQT/a-fake-item.json"
+    },
+    {
+      "rel": "collection",
+      "href": "http://cool-sat.com/catalog.json"
+    }
+  ],
+  "assets": {
+    "red": {
+      "href": "http://somewhere-over-the-rainbow.io/red.tif",
+      "title": "red",
+      "file:header_size": 16384
+    },
+    "green": {
+        "href": "http://somewhere-over-the-rainbow.io/green.tif",
+        "title": "green",
+        "file:header_size": 30000
+    },
+    "blue": {
+        "href": "http://somewhere-over-the-rainbow.io/blue.tif",
+        "title": "blue",
+        "file:header_size": 20000
+    },
+    "lowres": {
+        "href": "http://somewhere-over-the-rainbow.io/lowres.tif",
+        "title": "lowres"
+    },
+    "thumbnail": {
+      "href": "http://cool-sat.com/catalog/a-fake-item/thumbnail.png",
+      "title": "Thumbnail",
+      "type": "image/png",
+      "roles": [ "thumbnail" ]
+    }
+  }
+}

--- a/tests/extensions/test_projection.py
+++ b/tests/extensions/test_projection.py
@@ -656,3 +656,12 @@ def test_v1_from_dict() -> None:
         data = json.load(f)
     item = pystac.Item.from_dict(data, migrate=False)
     assert item.ext.proj.epsg is not None
+    assert item.ext.proj.crs_string is not None
+
+
+def test_v1_crs_string() -> None:
+    with open(TestCases.get_path("data-files/projection/another-1.1.json")) as f:
+        data = json.load(f)
+    item = pystac.Item.from_dict(data, migrate=False)
+    assert item.ext.proj.epsg is not None
+    assert item.ext.proj.crs_string == "EPSG:32617"


### PR DESCRIPTION
**Description:**

Hopefully this, with https://github.com/stac-utils/pystac/pull/1509, will fix our backwards-compatability 🤞🏼 . We didn't catch this previously because our other proj v1.1 item had a `proj:wkt` set.

**PR Checklist:**

- [x] Pre-commit hooks and tests pass (run `scripts/test`)
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
