### PR TITLE
Make sure that VersionRange has VersionIDs rather than strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Make sure that `VersionRange` has `VersionID`s rather than strings ([#1512](https://github.com/stac-utils/pystac/pull/1512))
+
 ## [v1.12.1]
 
 ### Changed

--- a/pystac/serialization/identify.py
+++ b/pystac/serialization/identify.py
@@ -82,8 +82,8 @@ class STACVersionID:
 class STACVersionRange:
     """Defines a range of STAC versions."""
 
-    min_version: STACVersionID
-    max_version: STACVersionID
+    _min_version: STACVersionID
+    _max_version: STACVersionID
 
     def __init__(
         self,
@@ -103,21 +103,45 @@ class STACVersionRange:
             else:
                 self.max_version = max_version
 
-    def set_min(self, v: STACVersionID) -> None:
+    @property
+    def min_version(self) -> STACVersionID:
+        return self._min_version
+
+    @min_version.setter
+    def min_version(self, v: str | STACVersionID) -> None:
+        if isinstance(v, str):
+            v = STACVersionID(v)
+        self._min_version = v
+
+    @property
+    def max_version(self) -> STACVersionID:
+        return self._max_version
+
+    @max_version.setter
+    def max_version(self, v: str | STACVersionID) -> None:
+        if isinstance(v, str):
+            v = STACVersionID(v)
+        self._max_version = v
+
+    def set_min(self, v: str | STACVersionID) -> None:
+        if isinstance(v, str):
+            v = STACVersionID(v)
         if self.min_version < v:
             if v < self.max_version:
                 self.min_version = v
             else:
                 self.min_version = self.max_version
 
-    def set_max(self, v: STACVersionID) -> None:
+    def set_max(self, v: str | STACVersionID) -> None:
+        if isinstance(v, str):
+            v = STACVersionID(v)
         if v < self.max_version:
             if self.min_version < v:
                 self.max_version = v
             else:
                 self.max_version = self.min_version
 
-    def set_to_single(self, v: STACVersionID) -> None:
+    def set_to_single(self, v: str | STACVersionID) -> None:
         self.set_min(v)
         self.set_max(v)
 
@@ -263,12 +287,12 @@ def identify_stac_object(json_dict: dict[str, Any]) -> STACJSONDescription:
     stac_extensions = json_dict.get("stac_extensions", None)
 
     if stac_version is None:
-        version_range.set_min(STACVersionID("0.8.0"))
+        version_range.set_min("0.8.0")
     else:
         version_range.set_to_single(stac_version)
 
     if stac_extensions is not None:
-        version_range.set_min(STACVersionID("0.8.0"))
+        version_range.set_min("0.8.0")
 
     if stac_extensions is None:
         stac_extensions = []

--- a/tests/extensions/test_eo.py
+++ b/tests/extensions/test_eo.py
@@ -516,3 +516,18 @@ def test_required_property_missing(ext_item: pystac.Item) -> None:
     assert bands is not None
     with pytest.raises(RequiredPropertyMissing):
         bands[0].name
+
+
+def test_unnecessary_migrations_not_performed(ext_item: Item) -> None:
+    item_as_dict = ext_item.to_dict(include_self_link=False, transform_hrefs=False)
+    item_as_dict["stac_version"] = "1.0.0"
+    item_as_dict["properties"]["eo:bands"] = [{"name": "B1", "common_name": "coastal"}]
+
+    item = Item.from_dict(item_as_dict)
+
+    migrated_item = pystac.Item.from_dict(item_as_dict, migrate=True)
+
+    assert item.properties == migrated_item.properties
+    assert len(item.assets) == len(migrated_item.assets)
+    for key, value in item.assets.items():
+        assert value.to_dict() == migrated_item.assets[key].to_dict()

--- a/tests/serialization/test_identify.py
+++ b/tests/serialization/test_identify.py
@@ -118,3 +118,17 @@ class VersionTest(unittest.TestCase):
 
         version_range = STACVersionRange(min_version="0.6.0-rc1", max_version="0.9.0")
         self.assertTrue(version_range.contains("0.9.0"))
+
+    def test_version_range_set_to_single(self) -> None:
+        version_range = STACVersionRange()
+        version_range.set_min("1.0.0-beta.1")
+        version_range.set_to_single("1.0.0")
+
+        self.assertTrue(version_range.contains("1.0.0"))
+
+    def test_version_range_set_min_and_max_directly(self) -> None:
+        version_range = STACVersionRange()
+        version_range.min_version = "1.0.0-beta.1"  # type:ignore
+        version_range.max_version = "1.1.0"  # type:ignore
+
+        self.assertTrue(version_range.contains("1.0.0"))


### PR DESCRIPTION
**Related Issue(s):**

- Closes #1506 

**Description:**

The `min_version` and `max_version` should always be coerced to `STACVersionID` objects.

**PR Checklist:**

- [ ] Pre-commit hooks and tests pass (run `scripts/test`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [ ] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
