### PR TITLE
Update uv.lock for pystac 1.12.1

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1836,7 +1836,7 @@ wheels = [
 
 [[package]]
 name = "pystac"
-version = "1.11.0"
+version = "1.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "python-dateutil" },


### PR DESCRIPTION
**Related Issue(s):** None

**Description:** I rebuilt my environment and noticed uv updated `uv.lock`, seemed like a quick & easy PR.

**PR Checklist:**

- [x] Pre-commit hooks and tests pass (run `scripts/test`)
- [x] This PR maintains ~or improves~ overall codebase code coverage.

Didn't update documentation nor the changelog since it's a small, internal change.