### PR TITLE
993 progress: Convert `test_catalog.py`, `test_layout.py` and `test_link.py` to pytest

### DIFF
--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -4,7 +4,6 @@ import json
 import os
 import posixpath
 import tempfile
-import unittest
 from collections import defaultdict
 from collections.abc import Iterator
 from copy import deepcopy
@@ -1540,7 +1539,7 @@ class TestFullCopy:
             assert os.path.exists(href)
 
 
-class CatalogSubClassTest(unittest.TestCase):
+class TestCatalogSubClass:
     """This tests cases related to creating classes inheriting from pystac.Catalog to
     ensure that inheritance, class methods, etc. function as expected."""
 
@@ -1553,25 +1552,20 @@ class CatalogSubClassTest(unittest.TestCase):
             # backwards compatibility of inherited classes
             return super().get_items()
 
-    def setUp(self) -> None:
-        self.stac_io = pystac.StacIO.default()
-
     def test_from_dict_returns_subclass(self) -> None:
+        self.stac_io = pystac.StacIO.default()
         catalog_dict = self.stac_io.read_json(self.case_1)
         custom_catalog = self.BasicCustomCatalog.from_dict(catalog_dict)
-
-        self.assertIsInstance(custom_catalog, self.BasicCustomCatalog)
+        assert isinstance(custom_catalog, self.BasicCustomCatalog)
 
     def test_from_file_returns_subclass(self) -> None:
         custom_catalog = self.BasicCustomCatalog.from_file(self.case_1)
-
-        self.assertIsInstance(custom_catalog, self.BasicCustomCatalog)
+        assert isinstance(custom_catalog, self.BasicCustomCatalog)
 
     def test_clone(self) -> None:
         custom_catalog = self.BasicCustomCatalog.from_file(self.case_1)
         cloned_catalog = custom_catalog.clone()
-
-        self.assertIsInstance(cloned_catalog, self.BasicCustomCatalog)
+        assert isinstance(cloned_catalog, self.BasicCustomCatalog)
 
     def test_get_all_items_works(self) -> None:
         custom_catalog = self.BasicCustomCatalog.from_file(self.case_1)

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -46,7 +46,7 @@ from tests.utils import (
 )
 
 
-class CatalogTypeTest(unittest.TestCase):
+class TestCatalogType:
     def test_determine_type_for_absolute_published(self) -> None:
         cat = TestCases.case_1()
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -56,7 +56,7 @@ class CatalogTypeTest(unittest.TestCase):
             )
 
         catalog_type = CatalogType.determine_type(cat_json)
-        self.assertEqual(catalog_type, CatalogType.ABSOLUTE_PUBLISHED)
+        assert catalog_type == CatalogType.ABSOLUTE_PUBLISHED
 
     def test_determine_type_for_relative_published(self) -> None:
         cat = TestCases.case_2()
@@ -67,14 +67,14 @@ class CatalogTypeTest(unittest.TestCase):
             )
 
         catalog_type = CatalogType.determine_type(cat_json)
-        self.assertEqual(catalog_type, CatalogType.RELATIVE_PUBLISHED)
+        assert catalog_type == CatalogType.RELATIVE_PUBLISHED
 
     def test_determine_type_for_self_contained(self) -> None:
         cat_json = pystac.StacIO.default().read_json(
             TestCases.get_path("data-files/catalogs/test-case-1/catalog.json")
         )
         catalog_type = CatalogType.determine_type(cat_json)
-        self.assertEqual(catalog_type, CatalogType.SELF_CONTAINED)
+        assert catalog_type == CatalogType.SELF_CONTAINED
 
     def test_determine_type_for_unknown(self) -> None:
         catalog = Catalog(id="test", description="test desc")
@@ -83,7 +83,7 @@ class CatalogTypeTest(unittest.TestCase):
         catalog.normalize_hrefs("http://example.com")
         d = catalog.to_dict(include_self_link=False)
 
-        self.assertIsNone(CatalogType.determine_type(d))
+        assert CatalogType.determine_type(d) is None
 
 
 class TestCatalog:

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1423,7 +1423,7 @@ class TestCatalog:
         Catalog.from_dict(d)
 
 
-class FullCopyTest(unittest.TestCase):
+class TestFullCopy:
     def check_link(self, link: pystac.Link, tag: str) -> None:
         if link.is_resolved():
             target_href: str = cast(pystac.STACObject, link.target).self_href
@@ -1438,7 +1438,7 @@ class FullCopyTest(unittest.TestCase):
             self.check_link(link, tag)
 
     def check_catalog(self, c: Catalog, tag: str) -> None:
-        self.assertEqual(len(c.get_links("root")), 1, msg=f"{c}")
+        assert len(c.get_links("root")) == 1, f"Failure for catalog: {c}"
 
         for link in c.links:
             self.check_link(link, tag)

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1,5 +1,4 @@
 import posixpath
-import unittest
 from collections.abc import Callable
 from datetime import datetime, timedelta
 
@@ -23,7 +22,7 @@ from tests.utils import (
 )
 
 
-class LayoutTemplateTest(unittest.TestCase):
+class TestLayoutTemplate:
     def test_templates_item_datetime(self) -> None:
         year = 2020
         month = 11
@@ -191,7 +190,7 @@ class LayoutTemplateTest(unittest.TestCase):
         assert path3 == "landsat-8-l1/CC-BY-3.0"
 
 
-class CustomLayoutStrategyTest(unittest.TestCase):
+class TestCustomLayoutStrategy:
     def get_custom_catalog_func(self) -> Callable[[pystac.Catalog, str, bool], str]:
         def fn(cat: pystac.Catalog, parent_dir: str, is_root: bool) -> str:
             return posixpath.join(parent_dir, f"cat/{is_root}/{cat.id}.json")
@@ -271,7 +270,7 @@ class CustomLayoutStrategyTest(unittest.TestCase):
         assert href == expected
 
 
-class TemplateLayoutStrategyTest(unittest.TestCase):
+class TestTemplateLayoutStrategy:
     TEST_CATALOG_TEMPLATE = "cat/${id}/${description}"
     TEST_COLLECTION_TEMPLATE = "col/${id}/${license}"
     TEST_ITEM_TEMPLATE = "item/${collection}/${id}.json"
@@ -375,149 +374,164 @@ class TemplateLayoutStrategyTest(unittest.TestCase):
         assert href == expected
 
 
-class BestPracticesLayoutStrategyTest(unittest.TestCase):
-    def setUp(self) -> None:
-        self.strategy = BestPracticesLayoutStrategy()
-
+class TestBestPracticesLayoutStrategy:
     def test_produces_layout_for_root_catalog(self) -> None:
+        strategy = BestPracticesLayoutStrategy()
         cat = pystac.Catalog(id="test", description="test desc")
-        href = self.strategy.get_href(
+        href = strategy.get_href(
             cat, parent_dir="http://example.com", is_root=True
         )
         assert href == "http://example.com/catalog.json"
 
     def test_produces_layout_for_child_catalog(self) -> None:
+        strategy = BestPracticesLayoutStrategy()
         cat = pystac.Catalog(id="test", description="test desc")
-        href = self.strategy.get_href(cat, parent_dir="http://example.com")
+        href = strategy.get_href(cat, parent_dir="http://example.com")
         assert href == "http://example.com/test/catalog.json"
 
     def test_produces_layout_for_root_collection(self) -> None:
+        strategy = BestPracticesLayoutStrategy()
         collection = TestCases.case_8()
-        href = self.strategy.get_href(
+        href = strategy.get_href(
             collection, parent_dir="http://example.com", is_root=True
         )
         assert href == "http://example.com/collection.json"
 
     def test_produces_layout_for_child_collection(self) -> None:
+        strategy = BestPracticesLayoutStrategy()
         collection = TestCases.case_8()
-        href = self.strategy.get_href(collection, parent_dir="http://example.com")
+        href = strategy.get_href(collection, parent_dir="http://example.com")
         assert href == f"http://example.com/{collection.id}/collection.json"
 
     def test_produces_layout_for_item(self) -> None:
+        strategy = BestPracticesLayoutStrategy()
         collection = TestCases.case_8()
         item = next(collection.get_items(recursive=True))
-        href = self.strategy.get_href(item, parent_dir="http://example.com")
+        href = strategy.get_href(item, parent_dir="http://example.com")
         expected = f"http://example.com/{item.id}/{item.id}.json"
         assert href == expected
 
 
-class AsIsLayoutStrategyTest(unittest.TestCase):
-    def setUp(self) -> None:
-        self.strategy = AsIsLayoutStrategy()
-        self.expected_local_href = (
+class TestAsIsLayoutStrategy:
+    def test_catalog(self) -> None:
+        strategy = AsIsLayoutStrategy()
+        expected_local_href = (
             "/an/href" if not path_includes_drive_letter() else "D:/an/href"
         )
-
-    def test_catalog(self) -> None:
         cat = pystac.Catalog(id="test", description="test desc")
         with pytest.raises(ValueError):
-            self.strategy.get_href(cat, parent_dir="http://example.com", is_root=True)
+            strategy.get_href(cat, parent_dir="http://example.com", is_root=True)
         cat.set_self_href("/an/href")
-        href = self.strategy.get_href(
+        href = strategy.get_href(
             cat, parent_dir="https://example.com", is_root=True
         )
-        assert href == self.expected_local_href
+        assert href == expected_local_href
 
     def test_collection(self) -> None:
+        strategy = AsIsLayoutStrategy()
+        expected_local_href = (
+            "/an/href" if not path_includes_drive_letter() else "D:/an/href"
+        )
         collection = TestCases.case_8()
         collection.set_self_href(None)
         with pytest.raises(ValueError):
-            self.strategy.get_href(
+            strategy.get_href(
                 collection, parent_dir="http://example.com", is_root=True
             )
         collection.set_self_href("/an/href")
-        href = self.strategy.get_href(
+        href = strategy.get_href(
             collection, parent_dir="https://example.com", is_root=True
         )
-        assert href == self.expected_local_href
+        assert href == expected_local_href
 
     def test_item(self) -> None:
+        strategy = AsIsLayoutStrategy()
+        expected_local_href = (
+            "/an/href" if not path_includes_drive_letter() else "D:/an/href"
+        )
         collection = TestCases.case_8()
         item = next(collection.get_items(recursive=True))
         item.set_self_href(None)
         with pytest.raises(ValueError):
-            self.strategy.get_href(item, parent_dir="http://example.com")
+            strategy.get_href(item, parent_dir="http://example.com")
         item.set_self_href("/an/href")
-        href = self.strategy.get_href(item, parent_dir="http://example.com")
-        assert href == self.expected_local_href
+        href = strategy.get_href(item, parent_dir="http://example.com")
+        assert href == expected_local_href
 
 
-class APILayoutStrategyTest(unittest.TestCase):
-    def setUp(self) -> None:
-        self.strategy = APILayoutStrategy()
-
+class TestAPILayoutStrategy:
     def test_produces_layout_for_root_catalog(self) -> None:
+        strategy = APILayoutStrategy()
         cat = pystac.Catalog(id="test", description="test desc")
-        href = self.strategy.get_href(
+        href = strategy.get_href(
             cat, parent_dir="http://example.com", is_root=True
         )
         assert href == "http://example.com"
 
     def test_produces_layout_for_root_catalog_str(self) -> None:
+        strategy = APILayoutStrategy()
         cat = pystac.Catalog(id="test", description="test desc")
-        href = self.strategy.get_catalog_href(
+        href = strategy.get_catalog_href(
             cat.id, parent_dir="http://example.com", is_root=True
         )
         assert href == "http://example.com"
 
     def test_produces_layout_for_child_catalog(self) -> None:
+        strategy = APILayoutStrategy()
         cat = pystac.Catalog(id="test", description="test desc")
-        href = self.strategy.get_href(cat, parent_dir="http://example.com")
+        href = strategy.get_href(cat, parent_dir="http://example.com")
         assert href == "http://example.com/test"
 
     def test_produces_layout_for_child_catalog_str(self) -> None:
+        strategy = APILayoutStrategy()
         cat = pystac.Catalog(id="test", description="test desc")
-        href = self.strategy.get_catalog_href(
+        href = strategy.get_catalog_href(
             cat.id, parent_dir="http://example.com", is_root=False
         )
         assert href == "http://example.com/test"
 
     def test_cannot_produce_layout_for_root_collection(self) -> None:
+        strategy = APILayoutStrategy()
         collection = TestCases.case_8()
         with pytest.raises(ValueError):
-            self.strategy.get_href(
+            strategy.get_href(
                 collection, parent_dir="http://example.com", is_root=True
             )
 
     def test_produces_layout_for_child_collection(self) -> None:
+        strategy = APILayoutStrategy()
         collection = TestCases.case_8()
-        href = self.strategy.get_href(collection, parent_dir="http://example.com")
+        href = strategy.get_href(collection, parent_dir="http://example.com")
         assert href == f"http://example.com/collections/{collection.id}"
 
     def test_produces_layout_for_child_collection_str(self) -> None:
+        strategy = APILayoutStrategy()
         collection = TestCases.case_8()
-        href = self.strategy.get_collection_href(
+        href = strategy.get_collection_href(
             collection.id, parent_dir="http://example.com", is_root=False
         )
         assert href == f"http://example.com/collections/{collection.id}"
 
     def test_produces_layout_for_item(self) -> None:
+        strategy = APILayoutStrategy()
         collection = TestCases.case_8()
-        col_href = self.strategy.get_href(collection, parent_dir="http://example.com")
+        col_href = strategy.get_href(collection, parent_dir="http://example.com")
         item = next(collection.get_items(recursive=True))
-        href = self.strategy.get_href(item, parent_dir=col_href)
+        href = strategy.get_href(item, parent_dir=col_href)
         expected = f"http://example.com/collections/{collection.id}/items/{item.id}"
         assert href == expected
 
     def test_produces_layout_for_item_str(self) -> None:
+        strategy = APILayoutStrategy()
         collection = TestCases.case_8()
-        col_href = self.strategy.get_href(collection, parent_dir="http://example.com")
+        col_href = strategy.get_href(collection, parent_dir="http://example.com")
         item = next(collection.get_items(recursive=True))
-        href = self.strategy.get_item_href(item.id, parent_dir=col_href)
+        href = strategy.get_item_href(item.id, parent_dir=col_href)
         expected = f"http://example.com/collections/{collection.id}/items/{item.id}"
         assert href == expected
 
     def test_produces_normalized_layout(self) -> None:
+        strategy = APILayoutStrategy()
         cat = pystac.Catalog(id="test_catalog", description="Test Catalog")
         col = pystac.Collection(
             id="test_collection",
@@ -556,7 +570,7 @@ class APILayoutStrategyTest(unittest.TestCase):
         )
         cat.add_child(col)
         col.add_item(item)
-        cat.normalize_hrefs("http://example.com", strategy=self.strategy)
+        cat.normalize_hrefs("http://example.com", strategy=strategy)
 
         assert cat.self_href == "http://example.com"
         assert col.self_href == "http://example.com/collections/test_collection"
@@ -566,17 +580,21 @@ class APILayoutStrategyTest(unittest.TestCase):
         )
 
     def test_produces_layout_for_search(self) -> None:
-        href = self.strategy.get_search_href(parent_dir="http://example.com")
+        strategy = APILayoutStrategy()
+        href = strategy.get_search_href(parent_dir="http://example.com")
         assert href == "http://example.com/search"
 
     def test_produces_layout_for_conformance(self) -> None:
-        href = self.strategy.get_conformance_href(parent_dir="http://example.com")
+        strategy = APILayoutStrategy()
+        href = strategy.get_conformance_href(parent_dir="http://example.com")
         assert href == "http://example.com/conformance"
 
     def test_produces_layout_for_service_description(self) -> None:
-        href = self.strategy.get_service_desc_href(parent_dir="http://example.com")
+        strategy = APILayoutStrategy()
+        href = strategy.get_service_desc_href(parent_dir="http://example.com")
         assert href == "http://example.com/api"
 
     def test_produces_layout_for_service_doc(self) -> None:
-        href = self.strategy.get_service_doc_href(parent_dir="http://example.com")
+        strategy = APILayoutStrategy()
+        href = strategy.get_service_doc_href(parent_dir="http://example.com")
         assert href == "http://example.com/api.html"

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -43,15 +43,15 @@ class LayoutTemplateTest(unittest.TestCase):
 
         parts = template.get_template_values(item)
 
-        self.assertEqual(set(parts), {"year", "month", "day", "date"})
+        assert set(parts), {"year", "month", "day" == "date"}
 
-        self.assertEqual(parts["year"], year)
-        self.assertEqual(parts["month"], month)
-        self.assertEqual(parts["day"], day)
-        self.assertEqual(parts["date"], date)
+        assert parts["year"] == year
+        assert parts["month"] == month
+        assert parts["day"] == day
+        assert parts["date"] == date
 
         path = template.substitute(item)
-        self.assertEqual(path, "2020/11/3/2020-11-03/item.json")
+        assert path == "2020/11/3/2020-11-03/item.json"
 
     def test_templates_item_start_datetime(self) -> None:
         year = 2020
@@ -75,15 +75,15 @@ class LayoutTemplateTest(unittest.TestCase):
 
         parts = template.get_template_values(item)
 
-        self.assertEqual(set(parts), {"year", "month", "day", "date"})
+        assert set(parts), {"year", "month", "day" == "date"}
 
-        self.assertEqual(parts["year"], year)
-        self.assertEqual(parts["month"], month)
-        self.assertEqual(parts["day"], day)
-        self.assertEqual(parts["date"], date)
+        assert parts["year"] == year
+        assert parts["month"] == month
+        assert parts["day"] == day
+        assert parts["date"] == date
 
         path = template.substitute(item)
-        self.assertEqual(path, "2020/11/3/2020-11-03/item.json")
+        assert path == "2020/11/3/2020-11-03/item.json"
 
     def test_templates_item_collection(self) -> None:
         template = LayoutTemplate("${collection}/item.json")
@@ -94,12 +94,12 @@ class LayoutTemplateTest(unittest.TestCase):
         assert item.collection_id is not None
 
         parts = template.get_template_values(item)
-        self.assertEqual(len(parts), 1)
-        self.assertIn("collection", parts)
-        self.assertEqual(parts["collection"], item.collection_id)
+        assert len(parts) == 1
+        assert "collection" in parts
+        assert parts["collection"] == item.collection_id
 
         path = template.substitute(item)
-        self.assertEqual(path, f"{item.collection_id}/item.json")
+        assert path == f"{item.collection_id}/item.json"
 
     def test_throws_for_no_collection(self) -> None:
         template = LayoutTemplate("${collection}/item.json")
@@ -110,7 +110,7 @@ class LayoutTemplateTest(unittest.TestCase):
         item.set_collection(None)
         assert item.collection_id is None
 
-        with self.assertRaises(pystac.TemplateError):
+        with pytest.raises(pystac.TemplateError):
             template.get_template_values(item)
 
     def test_nested_properties(self) -> None:
@@ -129,14 +129,14 @@ class LayoutTemplateTest(unittest.TestCase):
 
         parts = template.get_template_values(item)
 
-        self.assertEqual(set(parts), {"test.prop", "ext:extra.test.prop"})
+        assert set(parts), {"test.prop" == "ext:extra.test.prop"}
 
-        self.assertEqual(parts["test.prop"], 4326)
-        self.assertEqual(parts["ext:extra.test.prop"], 3857)
+        assert parts["test.prop"] == 4326
+        assert parts["ext:extra.test.prop"] == 3857
 
         path = template.substitute(item)
 
-        self.assertEqual(path, "4326/3857/item.json")
+        assert path == "4326/3857/item.json"
 
     def test_substitute_with_colon_properties(self) -> None:
         dt = datetime(2020, 11, 3, 18, 30)
@@ -153,7 +153,7 @@ class LayoutTemplateTest(unittest.TestCase):
 
         path = template.substitute(item)
 
-        self.assertEqual(path, "1/item.json")
+        assert path == "1/item.json"
 
     def test_defaults(self) -> None:
         template = LayoutTemplate(
@@ -165,7 +165,7 @@ class LayoutTemplateTest(unittest.TestCase):
         catalog.extra_fields = {"one": "two"}
         path = template.substitute(catalog)
 
-        self.assertEqual(path, "yes/collection.json")
+        assert path == "yes/collection.json"
 
     def test_docstring_examples(self) -> None:
         item = pystac.Item.from_file(
@@ -178,17 +178,17 @@ class LayoutTemplateTest(unittest.TestCase):
         # Uses the year, month and day of the item
         template1 = LayoutTemplate("${year}/${month}/${day}")
         path1 = template1.substitute(item)
-        self.assertEqual(path1, "2014/6/2")
+        assert path1 == "2014/6/2"
 
         # Uses a custom extension properties found on in the item properties.
         template2 = LayoutTemplate("${landsat:path}/${landsat:row}")
         path2 = template2.substitute(item)
-        self.assertEqual(path2, "107/18")
+        assert path2 == "107/18"
 
         # Uses the collection ID and a common metadata property for an item.
         template3 = LayoutTemplate("${collection}/${common_metadata.license}")
         path3 = template3.substitute(item)
-        self.assertEqual(path3, "landsat-8-l1/CC-BY-3.0")
+        assert path3 == "landsat-8-l1/CC-BY-3.0"
 
 
 class CustomLayoutStrategyTest(unittest.TestCase):
@@ -216,7 +216,7 @@ class CustomLayoutStrategyTest(unittest.TestCase):
         strategy = CustomLayoutStrategy(catalog_func=self.get_custom_catalog_func())
         cat = pystac.Catalog(id="test", description="test desc")
         href = strategy.get_href(cat, parent_dir="http://example.com", is_root=True)
-        self.assertEqual(href, "http://example.com/cat/True/test.json")
+        assert href == "http://example.com/cat/True/test.json"
 
     def test_produces_fallback_layout_for_catalog(self) -> None:
         fallback = BestPracticesLayoutStrategy()
@@ -228,7 +228,7 @@ class CustomLayoutStrategyTest(unittest.TestCase):
         cat = pystac.Catalog(id="test", description="test desc")
         href = strategy.get_href(cat, parent_dir="http://example.com")
         expected = fallback.get_href(cat, parent_dir="http://example.com")
-        self.assertEqual(href, expected)
+        assert href == expected
 
     def test_produces_layout_for_collection(self) -> None:
         strategy = CustomLayoutStrategy(
@@ -236,7 +236,7 @@ class CustomLayoutStrategyTest(unittest.TestCase):
         )
         collection = TestCases.case_8()
         href = strategy.get_href(collection, parent_dir="http://example.com")
-        self.assertEqual(href, f"http://example.com/col/False/{collection.id}.json")
+        assert href == f"http://example.com/col/False/{collection.id}.json"
 
     def test_produces_fallback_layout_for_collection(self) -> None:
         fallback = BestPracticesLayoutStrategy()
@@ -248,14 +248,14 @@ class CustomLayoutStrategyTest(unittest.TestCase):
         collection = TestCases.case_8()
         href = strategy.get_href(collection, parent_dir="http://example.com")
         expected = fallback.get_href(collection, parent_dir="http://example.com")
-        self.assertEqual(href, expected)
+        assert href == expected
 
     def test_produces_layout_for_item(self) -> None:
         strategy = CustomLayoutStrategy(item_func=self.get_custom_item_func())
         collection = TestCases.case_8()
         item = next(collection.get_items(recursive=True))
         href = strategy.get_href(item, parent_dir="http://example.com")
-        self.assertEqual(href, f"http://example.com/item/{item.id}.json")
+        assert href == f"http://example.com/item/{item.id}.json"
 
     def test_produces_fallback_layout_for_item(self) -> None:
         fallback = BestPracticesLayoutStrategy()
@@ -268,7 +268,7 @@ class CustomLayoutStrategyTest(unittest.TestCase):
         item = next(collection.get_items(recursive=True))
         href = strategy.get_href(item, parent_dir="http://example.com")
         expected = fallback.get_href(item, parent_dir="http://example.com")
-        self.assertEqual(href, expected)
+        assert href == expected
 
 
 class TemplateLayoutStrategyTest(unittest.TestCase):
@@ -285,14 +285,14 @@ class TemplateLayoutStrategyTest(unittest.TestCase):
         strategy = TemplateLayoutStrategy(catalog_template=self.TEST_CATALOG_TEMPLATE)
         cat = pystac.Catalog(id="test", description="test-desc")
         href = strategy.get_href(cat, parent_dir="http://example.com")
-        self.assertEqual(href, "http://example.com/cat/test/test-desc/catalog.json")
+        assert href == "http://example.com/cat/test/test-desc/catalog.json"
 
     def test_produces_layout_for_catalog_with_filename(self) -> None:
         template = "cat/${id}/${description}/${id}.json"
         strategy = TemplateLayoutStrategy(catalog_template=template)
         cat = pystac.Catalog(id="test", description="test-desc")
         href = strategy.get_href(cat, parent_dir="http://example.com")
-        self.assertEqual(href, "http://example.com/cat/test/test-desc/test.json")
+        assert href == "http://example.com/cat/test/test-desc/test.json"
 
     def test_produces_fallback_layout_for_catalog(self) -> None:
         fallback = BestPracticesLayoutStrategy()
@@ -304,7 +304,7 @@ class TemplateLayoutStrategyTest(unittest.TestCase):
         cat = pystac.Catalog(id="test", description="test desc")
         href = strategy.get_href(cat, parent_dir="http://example.com")
         expected = fallback.get_href(cat, parent_dir="http://example.com")
-        self.assertEqual(href, expected)
+        assert href == expected
 
     def test_produces_layout_for_collection(self) -> None:
         strategy = TemplateLayoutStrategy(
@@ -312,23 +312,20 @@ class TemplateLayoutStrategyTest(unittest.TestCase):
         )
         collection = self._get_collection()
         href = strategy.get_href(collection, parent_dir="http://example.com")
-        self.assertEqual(
-            href,
+        assert (href ==
             "http://example.com/col/{}/{}/collection.json".format(
-                collection.id, collection.license
-            ),
-        )
+                collection.id, collection.license))
 
     def test_produces_layout_for_collection_with_filename(self) -> None:
         template = "col/${id}/${license}/col.json"
         strategy = TemplateLayoutStrategy(collection_template=template)
         collection = self._get_collection()
         href = strategy.get_href(collection, parent_dir="http://example.com")
-        self.assertEqual(
-            href,
+        assert (
+            href ==
             "http://example.com/col/{}/{}/col.json".format(
                 collection.id, collection.license
-            ),
+            )
         )
 
     def test_produces_fallback_layout_for_collection(self) -> None:
@@ -341,16 +338,16 @@ class TemplateLayoutStrategyTest(unittest.TestCase):
         collection = self._get_collection()
         href = strategy.get_href(collection, parent_dir="http://example.com")
         expected = fallback.get_href(collection, parent_dir="http://example.com")
-        self.assertEqual(href, expected)
+        assert href == expected
 
     def test_produces_layout_for_item(self) -> None:
         strategy = TemplateLayoutStrategy(item_template=self.TEST_ITEM_TEMPLATE)
         collection = self._get_collection()
         item = next(collection.get_items())
         href = strategy.get_href(item, parent_dir="http://example.com")
-        self.assertEqual(
-            href,
-            f"http://example.com/item/{item.collection_id}/{item.id}.json",
+        assert (
+            href ==
+            f"http://example.com/item/{item.collection_id}/{item.id}.json"
         )
 
     def test_produces_layout_for_item_without_filename(self) -> None:
@@ -359,9 +356,9 @@ class TemplateLayoutStrategyTest(unittest.TestCase):
         collection = self._get_collection()
         item = next(collection.get_items())
         href = strategy.get_href(item, parent_dir="http://example.com")
-        self.assertEqual(
-            href,
-            f"http://example.com/item/{item.collection_id}/{item.id}.json",
+        assert (
+            href ==
+            f"http://example.com/item/{item.collection_id}/{item.id}.json"
         )
 
     def test_produces_fallback_layout_for_item(self) -> None:
@@ -375,7 +372,7 @@ class TemplateLayoutStrategyTest(unittest.TestCase):
         item = next(collection.get_items())
         href = strategy.get_href(item, parent_dir="http://example.com")
         expected = fallback.get_href(item, parent_dir="http://example.com")
-        self.assertEqual(href, expected)
+        assert href == expected
 
 
 class BestPracticesLayoutStrategyTest(unittest.TestCase):
@@ -387,31 +384,31 @@ class BestPracticesLayoutStrategyTest(unittest.TestCase):
         href = self.strategy.get_href(
             cat, parent_dir="http://example.com", is_root=True
         )
-        self.assertEqual(href, "http://example.com/catalog.json")
+        assert href == "http://example.com/catalog.json"
 
     def test_produces_layout_for_child_catalog(self) -> None:
         cat = pystac.Catalog(id="test", description="test desc")
         href = self.strategy.get_href(cat, parent_dir="http://example.com")
-        self.assertEqual(href, "http://example.com/test/catalog.json")
+        assert href == "http://example.com/test/catalog.json"
 
     def test_produces_layout_for_root_collection(self) -> None:
         collection = TestCases.case_8()
         href = self.strategy.get_href(
             collection, parent_dir="http://example.com", is_root=True
         )
-        self.assertEqual(href, "http://example.com/collection.json")
+        assert href == "http://example.com/collection.json"
 
     def test_produces_layout_for_child_collection(self) -> None:
         collection = TestCases.case_8()
         href = self.strategy.get_href(collection, parent_dir="http://example.com")
-        self.assertEqual(href, f"http://example.com/{collection.id}/collection.json")
+        assert href == f"http://example.com/{collection.id}/collection.json"
 
     def test_produces_layout_for_item(self) -> None:
         collection = TestCases.case_8()
         item = next(collection.get_items(recursive=True))
         href = self.strategy.get_href(item, parent_dir="http://example.com")
         expected = f"http://example.com/{item.id}/{item.id}.json"
-        self.assertEqual(href, expected)
+        assert href == expected
 
 
 class AsIsLayoutStrategyTest(unittest.TestCase):
@@ -423,18 +420,18 @@ class AsIsLayoutStrategyTest(unittest.TestCase):
 
     def test_catalog(self) -> None:
         cat = pystac.Catalog(id="test", description="test desc")
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             self.strategy.get_href(cat, parent_dir="http://example.com", is_root=True)
         cat.set_self_href("/an/href")
         href = self.strategy.get_href(
             cat, parent_dir="https://example.com", is_root=True
         )
-        self.assertEqual(href, self.expected_local_href)
+        assert href == self.expected_local_href
 
     def test_collection(self) -> None:
         collection = TestCases.case_8()
         collection.set_self_href(None)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             self.strategy.get_href(
                 collection, parent_dir="http://example.com", is_root=True
             )
@@ -442,17 +439,17 @@ class AsIsLayoutStrategyTest(unittest.TestCase):
         href = self.strategy.get_href(
             collection, parent_dir="https://example.com", is_root=True
         )
-        self.assertEqual(href, self.expected_local_href)
+        assert href == self.expected_local_href
 
     def test_item(self) -> None:
         collection = TestCases.case_8()
         item = next(collection.get_items(recursive=True))
         item.set_self_href(None)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             self.strategy.get_href(item, parent_dir="http://example.com")
         item.set_self_href("/an/href")
         href = self.strategy.get_href(item, parent_dir="http://example.com")
-        self.assertEqual(href, self.expected_local_href)
+        assert href == self.expected_local_href
 
 
 class APILayoutStrategyTest(unittest.TestCase):
@@ -464,26 +461,26 @@ class APILayoutStrategyTest(unittest.TestCase):
         href = self.strategy.get_href(
             cat, parent_dir="http://example.com", is_root=True
         )
-        self.assertEqual(href, "http://example.com")
+        assert href == "http://example.com"
 
     def test_produces_layout_for_root_catalog_str(self) -> None:
         cat = pystac.Catalog(id="test", description="test desc")
         href = self.strategy.get_catalog_href(
             cat.id, parent_dir="http://example.com", is_root=True
         )
-        self.assertEqual(href, "http://example.com")
+        assert href == "http://example.com"
 
     def test_produces_layout_for_child_catalog(self) -> None:
         cat = pystac.Catalog(id="test", description="test desc")
         href = self.strategy.get_href(cat, parent_dir="http://example.com")
-        self.assertEqual(href, "http://example.com/test")
+        assert href == "http://example.com/test"
 
     def test_produces_layout_for_child_catalog_str(self) -> None:
         cat = pystac.Catalog(id="test", description="test desc")
         href = self.strategy.get_catalog_href(
             cat.id, parent_dir="http://example.com", is_root=False
         )
-        self.assertEqual(href, "http://example.com/test")
+        assert href == "http://example.com/test"
 
     def test_cannot_produce_layout_for_root_collection(self) -> None:
         collection = TestCases.case_8()
@@ -495,14 +492,14 @@ class APILayoutStrategyTest(unittest.TestCase):
     def test_produces_layout_for_child_collection(self) -> None:
         collection = TestCases.case_8()
         href = self.strategy.get_href(collection, parent_dir="http://example.com")
-        self.assertEqual(href, f"http://example.com/collections/{collection.id}")
+        assert href == f"http://example.com/collections/{collection.id}"
 
     def test_produces_layout_for_child_collection_str(self) -> None:
         collection = TestCases.case_8()
         href = self.strategy.get_collection_href(
             collection.id, parent_dir="http://example.com", is_root=False
         )
-        self.assertEqual(href, f"http://example.com/collections/{collection.id}")
+        assert href == f"http://example.com/collections/{collection.id}"
 
     def test_produces_layout_for_item(self) -> None:
         collection = TestCases.case_8()
@@ -510,7 +507,7 @@ class APILayoutStrategyTest(unittest.TestCase):
         item = next(collection.get_items(recursive=True))
         href = self.strategy.get_href(item, parent_dir=col_href)
         expected = f"http://example.com/collections/{collection.id}/items/{item.id}"
-        self.assertEqual(href, expected)
+        assert href == expected
 
     def test_produces_layout_for_item_str(self) -> None:
         collection = TestCases.case_8()
@@ -518,7 +515,7 @@ class APILayoutStrategyTest(unittest.TestCase):
         item = next(collection.get_items(recursive=True))
         href = self.strategy.get_item_href(item.id, parent_dir=col_href)
         expected = f"http://example.com/collections/{collection.id}/items/{item.id}"
-        self.assertEqual(href, expected)
+        assert href == expected
 
     def test_produces_normalized_layout(self) -> None:
         cat = pystac.Catalog(id="test_catalog", description="Test Catalog")
@@ -570,16 +567,16 @@ class APILayoutStrategyTest(unittest.TestCase):
 
     def test_produces_layout_for_search(self) -> None:
         href = self.strategy.get_search_href(parent_dir="http://example.com")
-        self.assertEqual(href, "http://example.com/search")
+        assert href == "http://example.com/search"
 
     def test_produces_layout_for_conformance(self) -> None:
         href = self.strategy.get_conformance_href(parent_dir="http://example.com")
-        self.assertEqual(href, "http://example.com/conformance")
+        assert href == "http://example.com/conformance"
 
     def test_produces_layout_for_service_description(self) -> None:
         href = self.strategy.get_service_desc_href(parent_dir="http://example.com")
-        self.assertEqual(href, "http://example.com/api")
+        assert href == "http://example.com/api"
 
     def test_produces_layout_for_service_doc(self) -> None:
         href = self.strategy.get_service_doc_href(parent_dir="http://example.com")
-        self.assertEqual(href, "http://example.com/api.html")
+        assert href == "http://example.com/api.html"

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -42,7 +42,7 @@ class TestLayoutTemplate:
 
         parts = template.get_template_values(item)
 
-        assert set(parts), {"year", "month", "day" == "date"}
+        assert set(parts) == {"year", "month", "day", "date"}
 
         assert parts["year"] == year
         assert parts["month"] == month
@@ -74,7 +74,7 @@ class TestLayoutTemplate:
 
         parts = template.get_template_values(item)
 
-        assert set(parts), {"year", "month", "day" == "date"}
+        assert set(parts) == {"year", "month", "day", "date"}
 
         assert parts["year"] == year
         assert parts["month"] == month
@@ -128,7 +128,7 @@ class TestLayoutTemplate:
 
         parts = template.get_template_values(item)
 
-        assert set(parts), {"test.prop" == "ext:extra.test.prop"}
+        assert set(parts) == {"test.prop", "ext:extra.test.prop"}
 
         assert parts["test.prop"] == 4326
         assert parts["ext:extra.test.prop"] == 3857

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -311,20 +311,17 @@ class TestTemplateLayoutStrategy:
         )
         collection = self._get_collection()
         href = strategy.get_href(collection, parent_dir="http://example.com")
-        assert (href ==
-            "http://example.com/col/{}/{}/collection.json".format(
-                collection.id, collection.license))
+        assert href == "http://example.com/col/{}/{}/collection.json".format(
+            collection.id, collection.license
+        )
 
     def test_produces_layout_for_collection_with_filename(self) -> None:
         template = "col/${id}/${license}/col.json"
         strategy = TemplateLayoutStrategy(collection_template=template)
         collection = self._get_collection()
         href = strategy.get_href(collection, parent_dir="http://example.com")
-        assert (
-            href ==
-            "http://example.com/col/{}/{}/col.json".format(
-                collection.id, collection.license
-            )
+        assert href == "http://example.com/col/{}/{}/col.json".format(
+            collection.id, collection.license
         )
 
     def test_produces_fallback_layout_for_collection(self) -> None:
@@ -344,10 +341,7 @@ class TestTemplateLayoutStrategy:
         collection = self._get_collection()
         item = next(collection.get_items())
         href = strategy.get_href(item, parent_dir="http://example.com")
-        assert (
-            href ==
-            f"http://example.com/item/{item.collection_id}/{item.id}.json"
-        )
+        assert href == f"http://example.com/item/{item.collection_id}/{item.id}.json"
 
     def test_produces_layout_for_item_without_filename(self) -> None:
         template = "item/${collection}"
@@ -355,10 +349,7 @@ class TestTemplateLayoutStrategy:
         collection = self._get_collection()
         item = next(collection.get_items())
         href = strategy.get_href(item, parent_dir="http://example.com")
-        assert (
-            href ==
-            f"http://example.com/item/{item.collection_id}/{item.id}.json"
-        )
+        assert href == f"http://example.com/item/{item.collection_id}/{item.id}.json"
 
     def test_produces_fallback_layout_for_item(self) -> None:
         fallback = BestPracticesLayoutStrategy()
@@ -378,9 +369,7 @@ class TestBestPracticesLayoutStrategy:
     def test_produces_layout_for_root_catalog(self) -> None:
         strategy = BestPracticesLayoutStrategy()
         cat = pystac.Catalog(id="test", description="test desc")
-        href = strategy.get_href(
-            cat, parent_dir="http://example.com", is_root=True
-        )
+        href = strategy.get_href(cat, parent_dir="http://example.com", is_root=True)
         assert href == "http://example.com/catalog.json"
 
     def test_produces_layout_for_child_catalog(self) -> None:
@@ -422,9 +411,7 @@ class TestAsIsLayoutStrategy:
         with pytest.raises(ValueError):
             strategy.get_href(cat, parent_dir="http://example.com", is_root=True)
         cat.set_self_href("/an/href")
-        href = strategy.get_href(
-            cat, parent_dir="https://example.com", is_root=True
-        )
+        href = strategy.get_href(cat, parent_dir="https://example.com", is_root=True)
         assert href == expected_local_href
 
     def test_collection(self) -> None:
@@ -435,9 +422,7 @@ class TestAsIsLayoutStrategy:
         collection = TestCases.case_8()
         collection.set_self_href(None)
         with pytest.raises(ValueError):
-            strategy.get_href(
-                collection, parent_dir="http://example.com", is_root=True
-            )
+            strategy.get_href(collection, parent_dir="http://example.com", is_root=True)
         collection.set_self_href("/an/href")
         href = strategy.get_href(
             collection, parent_dir="https://example.com", is_root=True
@@ -463,9 +448,7 @@ class TestAPILayoutStrategy:
     def test_produces_layout_for_root_catalog(self) -> None:
         strategy = APILayoutStrategy()
         cat = pystac.Catalog(id="test", description="test desc")
-        href = strategy.get_href(
-            cat, parent_dir="http://example.com", is_root=True
-        )
+        href = strategy.get_href(cat, parent_dir="http://example.com", is_root=True)
         assert href == "http://example.com"
 
     def test_produces_layout_for_root_catalog_str(self) -> None:
@@ -494,9 +477,7 @@ class TestAPILayoutStrategy:
         strategy = APILayoutStrategy()
         collection = TestCases.case_8()
         with pytest.raises(ValueError):
-            strategy.get_href(
-                collection, parent_dir="http://example.com", is_root=True
-            )
+            strategy.get_href(collection, parent_dir="http://example.com", is_root=True)
 
     def test_produces_layout_for_child_collection(self) -> None:
         strategy = APILayoutStrategy()

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -17,310 +17,268 @@ from tests.utils.test_cases import ARBITRARY_EXTENT
 
 TEST_DATETIME: datetime = datetime(2020, 3, 14, 16, 32)
 
+def test_path_like() -> None:
+    rel = "some-rel"
+    target = os.path.abspath("../elsewhere")
+    link = pystac.Link(rel, target)
+    assert os.fspath(link) == make_posix_style(target)
 
-class LinkTest(unittest.TestCase):
-    item: pystac.Item
+def test_minimal(item: pystac.Item) -> None:
+    rel = "my rel"
+    target = "https://example.com/a/b"
+    link = pystac.Link(rel, target)
+    assert target == link.get_href()
+    assert target == link.get_absolute_href()
 
-    def setUp(self) -> None:
-        self.item = pystac.Item(
-            id="test-item",
-            geometry=None,
-            bbox=None,
-            datetime=TEST_DATETIME,
-            properties={},
-        )
+    expected_repr = f"<Link rel={rel} target={target}>"
+    assert expected_repr == link.__repr__()
 
-    def test_path_like(self) -> None:
-        rel = "some-rel"
-        target = os.path.abspath("../elsewhere")
-        link = pystac.Link(rel, target)
+    assert not link.is_resolved()
 
-        self.assertEqual(os.fspath(link), make_posix_style(target))
+    expected_dict = {"rel": rel, "href": target}
+    assert expected_dict == link.to_dict()
 
-    def test_minimal(self) -> None:
-        rel = "my rel"
-        target = "https://example.com/a/b"
-        link = pystac.Link(rel, target)
-        self.assertEqual(target, link.get_href())
-        self.assertEqual(target, link.get_absolute_href())
+    # Run the same tests on the clone.
+    clone = link.clone()
+    assert link != clone
 
-        expected_repr = f"<Link rel={rel} target={target}>"
-        self.assertEqual(expected_repr, link.__repr__())
+    assert target == clone.get_href()
+    assert target == clone.get_absolute_href()
 
-        self.assertFalse(link.is_resolved())
+    assert expected_repr == clone.__repr__()
 
-        expected_dict = {"rel": rel, "href": target}
-        self.assertEqual(expected_dict, link.to_dict())
+    assert expected_dict == clone.to_dict()
 
-        # Run the same tests on the clone.
-        clone = link.clone()
-        self.assertNotEqual(link, clone)
+    # Try the modification methods.
+    assert link.owner is None
+    link.set_owner(None)
+    assert link.owner is None
 
-        self.assertEqual(target, clone.get_href())
-        self.assertEqual(target, clone.get_absolute_href())
+    link.set_owner(item)
+    assert item == link.owner
 
-        self.assertEqual(expected_repr, clone.__repr__())
 
-        self.assertEqual(expected_dict, clone.to_dict())
+def test_relative() -> None:
+    rel = "my rel"
+    target = "../elsewhere"
+    mime_type = "example/stac_thing"
+    link = pystac.Link(rel, target, mime_type, "a title", extra_fields={"a": "b"})
+    expected_dict = {
+        "rel": rel,
+        "href": target,
+        "type": "example/stac_thing",
+        "title": "a title",
+        "a": "b",
+    }
+    assert expected_dict == link.to_dict()
 
-        # Try the modification methods.
-        self.assertIsNone(link.owner)
-        link.set_owner(None)
-        self.assertIsNone(link.owner)
+def test_link_does_not_fail_if_href_is_none(item: pystac.Item) -> None:
+    """Test to ensure get_href does not fail when the href is None."""
+    catalog = pystac.Catalog(id="test", description="test desc")
+    catalog.add_item(item)
+    catalog.set_self_href("/some/href")
 
-        link.set_owner(self.item)
-        self.assertEqual(self.item, link.owner)
+    link = catalog.get_single_link("item")
+    assert link is not None
+    assert link.get_href() is None
 
-    def test_relative(self) -> None:
-        rel = "my rel"
-        target = "../elsewhere"
-        mime_type = "example/stac_thing"
-        link = pystac.Link(rel, target, mime_type, "a title", extra_fields={"a": "b"})
-        expected_dict = {
-            "rel": rel,
-            "href": target,
-            "type": "example/stac_thing",
-            "title": "a title",
-            "a": "b",
-        }
-        self.assertEqual(expected_dict, link.to_dict())
+def test_resolve_stac_object_no_root_and_target_is_item(item: pystac.Item) -> None:
+    link = pystac.Link("my rel", target=item)
+    link.resolve_stac_object()
 
-    def test_link_does_not_fail_if_href_is_none(self) -> None:
-        """Test to ensure get_href does not fail when the href is None."""
-        catalog = pystac.Catalog(id="test", description="test desc")
-        catalog.add_item(self.item)
-        catalog.set_self_href("/some/href")
-
-        link = catalog.get_single_link("item")
-        assert link is not None
-        self.assertIsNone(link.get_href())
-
-    def test_resolve_stac_object_no_root_and_target_is_item(self) -> None:
-        link = pystac.Link("my rel", target=self.item)
+@pytest.mark.skipif(os.name == "nt", reason="Non-windows test")
+def test_resolve_stac_object_throws_informative_error() -> None:
+    link = pystac.Link("root", target="/a/b/foo.json")
+    with pytest.raises(
+        STACError, match="HREF: '/a/b/foo.json' does not resolve to a STAC object"
+    ):
         link.resolve_stac_object()
 
-    @pytest.mark.skipif(os.name == "nt", reason="Non-windows test")
-    def test_resolve_stac_object_throws_informative_error(self) -> None:
-        link = pystac.Link("root", target="/a/b/foo.json")
-        with pytest.raises(
-            STACError, match="HREF: '/a/b/foo.json' does not resolve to a STAC object"
-        ):
-            link.resolve_stac_object()
+def test_resolved_self_href() -> None:
+    catalog = pystac.Catalog(id="test", description="test desc")
+    with TemporaryDirectory() as temporary_directory:
+        catalog.normalize_and_save(temporary_directory)
+        path = os.path.join(temporary_directory, "catalog.json")
+        catalog = pystac.Catalog.from_file(path)
+        link = catalog.get_single_link(pystac.RelType.SELF)
+        assert link
+        link.resolve_stac_object()
+        assert link.get_absolute_href() == make_posix_style(path)
 
-    def test_resolved_self_href(self) -> None:
-        catalog = pystac.Catalog(id="test", description="test desc")
-        with TemporaryDirectory() as temporary_directory:
-            catalog.normalize_and_save(temporary_directory)
-            path = os.path.join(temporary_directory, "catalog.json")
-            catalog = pystac.Catalog.from_file(path)
-            link = catalog.get_single_link(pystac.RelType.SELF)
-            assert link
-            link.resolve_stac_object()
-            self.assertEqual(link.get_absolute_href(), make_posix_style(path))
+def test_target_getter_setter(item: pystac.Item) -> None:
+    link = pystac.Link("my rel", target="./foo/bar.json")
+    assert link.target == "./foo/bar.json"
+    assert link.get_target_str() == "./foo/bar.json"
 
-    def test_target_getter_setter(self) -> None:
-        link = pystac.Link("my rel", target="./foo/bar.json")
-        self.assertEqual(link.target, "./foo/bar.json")
-        self.assertEqual(link.get_target_str(), "./foo/bar.json")
+    link.target = item
+    assert link.target == item
+    assert link.get_target_str() == item.get_self_href()
 
-        link.target = self.item
-        self.assertEqual(link.target, self.item)
-        self.assertEqual(link.get_target_str(), self.item.get_self_href())
+    link.target = "./bar/foo.json"
+    assert link.target == "./bar/foo.json"
 
-        link.target = "./bar/foo.json"
-        self.assertEqual(link.target, "./bar/foo.json")
+def test_get_target_str_no_href(item: pystac.Item) -> None:
+    item.remove_links("self")
+    link = pystac.Link("self", target=item)
+    item.add_link(link)
+    assert link.get_target_str() is None
 
-    def test_get_target_str_no_href(self) -> None:
-        self.item.remove_links("self")
-        link = pystac.Link("self", target=self.item)
-        self.item.add_link(link)
-        self.assertIsNone(link.get_target_str())
-
-    def test_relative_self_href(self) -> None:
-        with TemporaryDirectory() as temporary_directory:
-            pystac.write_file(
-                self.item,
-                include_self_link=False,
-                dest_href=os.path.join(temporary_directory, "item.json"),
-            )
-            previous = os.getcwd()
-            try:
-                os.chdir(temporary_directory)
-                item = pystac.read_file("item.json")
-                href = item.get_self_href()
-                assert href
-                self.assertTrue(os.path.isabs(href), f"Not an absolute path: {href}")
-            finally:
-                os.chdir(previous)
-
-    def test_auto_title_when_resolved(self) -> None:
-        extent = pystac.Extent.from_items([self.item])
-        collection = pystac.Collection(
-            id="my_collection",
-            description="Test Collection",
-            extent=extent,
-            title="Collection Title",
+def test_relative_self_href(item: pystac.Item) -> None:
+    with TemporaryDirectory() as temporary_directory:
+        pystac.write_file(
+            item,
+            include_self_link=False,
+            dest_href=os.path.join(temporary_directory, "item.json"),
         )
-        link = pystac.Link("my rel", target=collection)
+        previous = os.getcwd()
+        try:
+            os.chdir(temporary_directory)
+            item = pystac.read_file("item.json")
+            href = item.get_self_href()
+            assert href
+            assert os.path.isabs(href), f"Not an absolute path: {href}"
+        finally:
+            os.chdir(previous)
 
-        self.assertEqual(collection.title, link.title)
+def test_auto_title_when_resolved(item: pystac.Item) -> None:
+    extent = pystac.Extent.from_items([item])
+    collection = pystac.Collection(
+        id="my_collection",
+        description="Test Collection",
+        extent=extent,
+        title="Collection Title",
+    )
+    link = pystac.Link("my rel", target=collection)
 
-    def test_auto_title_not_found(self) -> None:
-        extent = pystac.Extent.from_items([self.item])
-        collection = pystac.Collection(
-            id="my_collection",
-            description="Test Collection",
-            extent=extent,
-        )
-        link = pystac.Link("my rel", target=collection)
+    assert collection.title == link.title
 
-        self.assertEqual(None, link.title)
+def test_auto_title_not_found(item: pystac.Item) -> None:
+    extent = pystac.Extent.from_items([item])
+    collection = pystac.Collection(
+        id="my_collection",
+        description="Test Collection",
+        extent=extent,
+    )
+    link = pystac.Link("my rel", target=collection)
 
-    def test_auto_title_is_serialized(self) -> None:
-        extent = pystac.Extent.from_items([self.item])
-        collection = pystac.Collection(
-            id="my_collection",
-            description="Test Collection",
-            extent=extent,
-            title="Collection Title",
-        )
-        link = pystac.Link("my rel", target=collection)
+    assert link.title is None
 
-        assert link.to_dict().get("title") == collection.title
+def test_auto_title_is_serialized(item: pystac.Item) -> None:
+    extent = pystac.Extent.from_items([item])
+    collection = pystac.Collection(
+        id="my_collection",
+        description="Test Collection",
+        extent=extent,
+        title="Collection Title",
+    )
+    link = pystac.Link("my rel", target=collection)
 
-    def test_no_auto_title_if_not_resolved(self) -> None:
-        link = pystac.Link(
-            "my rel", target="https://www.some-domain.com/path/to/thing.txt"
-        )
+    assert link.to_dict().get("title") == collection.title
 
-        assert link.title is None
+def test_no_auto_title_if_not_resolved() -> None:
+    link = pystac.Link(
+        "my rel", target="https://www.some-domain.com/path/to/thing.txt"
+    )
 
-    def test_title_as_init_argument(self) -> None:
-        link_title = "Link title"
-        extent = pystac.Extent.from_items([self.item])
-        collection = pystac.Collection(
-            id="my_collection",
-            description="Test Collection",
-            extent=extent,
-            title="Collection Title",
-        )
-        link = pystac.Link("my rel", title=link_title, target=collection)
+    assert link.title is None
 
-        assert link.title == link_title
-        assert link.to_dict().get("title") == link_title
+def test_title_as_init_argument(item: pystac.Item) -> None:
+    link_title = "Link title"
+    extent = pystac.Extent.from_items([item])
+    collection = pystac.Collection(
+        id="my_collection",
+        description="Test Collection",
+        extent=extent,
+        title="Collection Title",
+    )
+    link = pystac.Link("my rel", title=link_title, target=collection)
 
-    def test_serialize_link(self) -> None:
-        href = "https://some-domain/path/to/item.json"
-        title = "A Test Link"
-        link = pystac.Link(pystac.RelType.SELF, href, pystac.MediaType.JSON, title)
-        link_dict = link.to_dict()
+    assert link.title == link_title
+    assert link.to_dict().get("title") == link_title
 
-        self.assertEqual(link_dict["rel"], "self")
-        self.assertEqual(link_dict["type"], "application/json")
-        self.assertEqual(link_dict["title"], title)
-        self.assertEqual(link_dict["href"], href)
+def test_serialize_link() -> None:
+    href = "https://some-domain/path/to/item.json"
+    title = "A Test Link"
+    link = pystac.Link(pystac.RelType.SELF, href, pystac.MediaType.JSON, title)
+    link_dict = link.to_dict()
 
+    assert link_dict["rel"] == "self"
+    assert link_dict["type"] == "application/json"
+    assert link_dict["title"] == title
+    assert link_dict["href"] == href
 
-class StaticLinkTest(unittest.TestCase):
-    def setUp(self) -> None:
-        self.item = pystac.Item(
-            id="test-item",
-            geometry=None,
-            bbox=None,
-            datetime=TEST_DATETIME,
-            properties={},
-        )
+def test_static_from_dict_round_trip() -> None:
+    test_cases: list[dict[str, Any]] = [
+        {"rel": "", "href": ""},  # Not valid, but works.
+        {"rel": "r", "href": "t"},
+        {"rel": "r", "href": "/t"},
+        {"rel": "r", "href": "t", "type": "a/b", "title": "t", "c": "d", "1": 2},
+    ]
+    for d in test_cases:
+        d2 = pystac.Link.from_dict(d).to_dict()
+        assert d == d2
+    d = {"rel": "self", "href": "t"}
+    d2 = {"rel": "self", "href": make_posix_style(os.path.join(os.getcwd(), "t"))}
+    assert pystac.Link.from_dict(d).to_dict() == d2
 
-        self.collection = pystac.Collection(
-            "collection id", "desc", extent=ARBITRARY_EXTENT
-        )
+def test_static_from_dict_failures() -> None:
+    dicts: list[dict[str, Any]] = [{}, {"href": "t"}, {"rel": "r"}]
+    for d in dicts:
+        with pytest.raises(KeyError):
+            pystac.Link.from_dict(d)
 
-    def test_from_dict_round_trip(self) -> None:
-        test_cases: list[dict[str, Any]] = [
-            {"rel": "", "href": ""},  # Not valid, but works.
-            {"rel": "r", "href": "t"},
-            {"rel": "r", "href": "/t"},
-            {"rel": "r", "href": "t", "type": "a/b", "title": "t", "c": "d", "1": 2},
-        ]
-        for d in test_cases:
-            d2 = pystac.Link.from_dict(d).to_dict()
-            self.assertEqual(d, d2)
-        d = {"rel": "self", "href": "t"}
-        d2 = {"rel": "self", "href": make_posix_style(os.path.join(os.getcwd(), "t"))}
-        self.assertEqual(pystac.Link.from_dict(d).to_dict(), d2)
+def test_static_collection(collection: pystac.Collection) -> None:
+    link = pystac.Link.collection(collection)
+    expected = {"rel": "collection", "href": None, "type": "application/json"}
+    assert expected == link.to_dict()
 
-    def test_from_dict_failures(self) -> None:
-        dicts: list[dict[str, Any]] = [{}, {"href": "t"}, {"rel": "r"}]
-        for d in dicts:
-            with self.assertRaises(KeyError):
-                pystac.Link.from_dict(d)
+def test_static_child(collection: pystac.Collection) -> None:
+    link = pystac.Link.child(collection)
+    expected = {"rel": "child", "href": None, "type": "application/json"}
+    assert expected == link.to_dict()
 
-    def test_collection(self) -> None:
-        link = pystac.Link.collection(self.collection)
-        expected = {"rel": "collection", "href": None, "type": "application/json"}
-        self.assertEqual(expected, link.to_dict())
+def test_static_canonical_item(item: pystac.Item) -> None:
+    link = pystac.Link.canonical(item)
+    expected = {"rel": "canonical", "href": None, "type": "application/json"}
+    assert expected == link.to_dict()
 
-    def test_child(self) -> None:
-        link = pystac.Link.child(self.collection)
-        expected = {"rel": "child", "href": None, "type": "application/json"}
-        self.assertEqual(expected, link.to_dict())
-
-    def test_canonical_item(self) -> None:
-        link = pystac.Link.canonical(self.item)
-        expected = {"rel": "canonical", "href": None, "type": "application/json"}
-        self.assertEqual(expected, link.to_dict())
-
-    def test_canonical_collection(self) -> None:
-        link = pystac.Link.canonical(self.collection)
-        expected = {"rel": "canonical", "href": None, "type": "application/json"}
-        self.assertEqual(expected, link.to_dict())
+def test_static_canonical_collection(collection: pystac.Collection) -> None:
+    link = pystac.Link.canonical(collection)
+    expected = {"rel": "canonical", "href": None, "type": "application/json"}
+    assert expected == link.to_dict()
 
 
-class LinkInheritanceTest(unittest.TestCase):
-    def setUp(self) -> None:
-        self.maxDiff = None
-        self.collection = pystac.Collection(
-            "collection id", "desc", extent=ARBITRARY_EXTENT
-        )
-        self.item = pystac.Item(
-            id="test-item",
-            geometry=None,
-            bbox=None,
-            datetime=TEST_DATETIME,
-            properties={},
-        )
+class CustomLink(pystac.Link):
+    pass
 
-    class CustomLink(pystac.Link):
-        pass
+def test_inheritance_from_dict() -> None:
+    link = CustomLink.from_dict(
+        {"rel": "r", "href": "t", "type": "a/b", "title": "t", "c": "d", "1": 2}
+    )
+    assert isinstance(link, CustomLink)
 
-    def test_from_dict(self) -> None:
-        link = self.CustomLink.from_dict(
-            {"rel": "r", "href": "t", "type": "a/b", "title": "t", "c": "d", "1": 2}
-        )
-        self.assertIsInstance(link, self.CustomLink)
+def test_inheritance_collection(collection: Collection) -> None:
+    link = CustomLink.collection(collection)
+    assert isinstance(link, CustomLink)
 
-    def test_collection(self) -> None:
-        link = self.CustomLink.collection(self.collection)
-        self.assertIsInstance(link, self.CustomLink)
+def test_inheritance_child(collection: Collection) -> None:
+    link = CustomLink.child(collection)
+    assert isinstance(link, CustomLink)
 
-    def test_child(self) -> None:
-        link = self.CustomLink.child(self.collection)
-        self.assertIsInstance(link, self.CustomLink)
+def test_inheritance_canonical_item(item: Item) -> None:
+    link = CustomLink.canonical(item)
+    assert isinstance(link, CustomLink)
 
-    def test_canonical_item(self) -> None:
-        link = self.CustomLink.canonical(self.item)
-        self.assertIsInstance(link, self.CustomLink)
+def test_inheritance_canonical_collection(collection: Collection) -> None:
+    link = CustomLink.canonical(collection)
+    assert isinstance(link, CustomLink)
 
-    def test_canonical_collection(self) -> None:
-        link = self.CustomLink.canonical(self.collection)
-        self.assertIsInstance(link, self.CustomLink)
-
-    def test_clone(self) -> None:
-        link = self.CustomLink.from_dict(
-            {"rel": "r", "href": "t", "type": "a/b", "title": "t", "c": "d", "1": 2}
-        )
-        cloned_link = link.clone()
-        self.assertIsInstance(cloned_link, self.CustomLink)
+def test_inheritance_clone() -> None:
+    link = CustomLink.from_dict(
+        {"rel": "r", "href": "t", "type": "a/b", "title": "t", "c": "d", "1": 2}
+    )
+    cloned_link = link.clone()
+    assert isinstance(cloned_link, CustomLink)
 
 
 def test_relative_self_link(tmp_path: Path) -> None:


### PR DESCRIPTION
**Related Issue(s):** #993 

**Description:** Convert `test_catalog.py`, `test_layout.py` and `test_link.py` to pytest. 

**PR Checklist:**

- [x] Pre-commit hooks pass (run `pre-commit run --all-files`)
- [x] Tests pass (run `pytest`)
- [ ] ~Documentation has been updated to reflect changes, if applicable~
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] ~Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.~
