### PR TITLE
993 progress: convert 3 more files to pytest

### DIFF
--- a/tests/test_stac_io.py
+++ b/tests/test_stac_io.py
@@ -20,6 +20,7 @@ def test_read_write_collection() -> None:
         pystac.write_file(collection, dest_href=dest_href)
         assert os.path.exists(dest_href), "File was not written."
 
+
 def test_read_write_collection_with_file_protocol() -> None:
     collection = pystac.read_file(
         "file://" + TestCases.get_path("data-files/collections/multi-extent.json")
@@ -29,12 +30,14 @@ def test_read_write_collection_with_file_protocol() -> None:
         pystac.write_file(collection, dest_href="file://" + dest_href)
         assert os.path.exists(dest_href), "File was not written."
 
+
 def test_read_item() -> None:
     item = pystac.read_file(TestCases.get_path("data-files/item/sample-item.json"))
     with tempfile.TemporaryDirectory() as tmp_dir:
         dest_href = os.path.join(tmp_dir, "item.json")
         pystac.write_file(item, dest_href=dest_href)
         assert os.path.exists(dest_href), "File was not written."
+
 
 def test_read_write_catalog() -> None:
     catalog = pystac.read_file(
@@ -45,13 +48,13 @@ def test_read_write_catalog() -> None:
         pystac.write_file(catalog, dest_href=dest_href)
         assert os.path.exists(dest_href), "File was not written."
 
+
 def test_read_item_collection_raises_exception() -> None:
     with pytest.raises(pystac.STACTypeError):
         _ = pystac.read_file(
-            TestCases.get_path(
-                "data-files/item-collection/sample-item-collection.json"
-            )
+            TestCases.get_path("data-files/item-collection/sample-item-collection.json")
         )
+
 
 def test_read_item_dict() -> None:
     stac_io = StacIO.default()
@@ -61,6 +64,7 @@ def test_read_item_dict() -> None:
     item = pystac.read_dict(item_dict)
     assert isinstance(item, pystac.Item)
 
+
 def test_read_collection_dict() -> None:
     stac_io = StacIO.default()
     collection_dict = stac_io.read_json(
@@ -68,6 +72,7 @@ def test_read_collection_dict() -> None:
     )
     collection = pystac.read_dict(collection_dict)
     assert isinstance(collection, pystac.Collection)
+
 
 def test_read_catalog_dict() -> None:
     stac_io = StacIO.default()
@@ -77,11 +82,13 @@ def test_read_catalog_dict() -> None:
     catalog = pystac.read_dict(catalog_dict)
     assert isinstance(catalog, pystac.Catalog)
 
+
 def test_read_from_stac_object() -> None:
     catalog = pystac.STACObject.from_file(
         TestCases.get_path("data-files/catalogs/test-case-1/catalog.json")
     )
     assert isinstance(catalog, pystac.Catalog)
+
 
 def test_report_duplicate_keys() -> None:
     # Directly from dict
@@ -107,6 +114,7 @@ def test_report_duplicate_keys() -> None:
         with pytest.raises(pystac.DuplicateObjectKeyError) as excinfo:
             stac_io.read_json(src_href)
         assert str(excinfo.value), f'Found duplicate object name "key" in {src_href}'
+
 
 @unittest.mock.patch("pystac.stac_io.urlopen")
 def test_headers_stac_io(urlopen_mock: unittest.mock.MagicMock) -> None:

--- a/tests/test_stac_io.py
+++ b/tests/test_stac_io.py
@@ -20,7 +20,7 @@ class StacIOTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             dest_href = os.path.join(tmp_dir, "collection.json")
             pystac.write_file(collection, dest_href=dest_href)
-            self.assertTrue(os.path.exists(dest_href), msg="File was not written.")
+            assert os.path.exists(dest_href), "File was not written."
 
     def test_read_write_collection_with_file_protocol(self) -> None:
         collection = pystac.read_file(
@@ -29,14 +29,14 @@ class StacIOTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             dest_href = os.path.join(tmp_dir, "collection.json")
             pystac.write_file(collection, dest_href="file://" + dest_href)
-            self.assertTrue(os.path.exists(dest_href), msg="File was not written.")
+            assert os.path.exists(dest_href), "File was not written."
 
     def test_read_item(self) -> None:
         item = pystac.read_file(TestCases.get_path("data-files/item/sample-item.json"))
         with tempfile.TemporaryDirectory() as tmp_dir:
             dest_href = os.path.join(tmp_dir, "item.json")
             pystac.write_file(item, dest_href=dest_href)
-            self.assertTrue(os.path.exists(dest_href), msg="File was not written.")
+            assert os.path.exists(dest_href), "File was not written."
 
     def test_read_write_catalog(self) -> None:
         catalog = pystac.read_file(
@@ -45,10 +45,10 @@ class StacIOTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir:
             dest_href = os.path.join(tmp_dir, "catalog.json")
             pystac.write_file(catalog, dest_href=dest_href)
-            self.assertTrue(os.path.exists(dest_href), msg="File was not written.")
+            assert os.path.exists(dest_href), "File was not written."
 
     def test_read_item_collection_raises_exception(self) -> None:
-        with self.assertRaises(pystac.STACTypeError):
+        with pytest.raises(pystac.STACTypeError):
             _ = pystac.read_file(
                 TestCases.get_path(
                     "data-files/item-collection/sample-item-collection.json"
@@ -61,7 +61,7 @@ class StacIOTest(unittest.TestCase):
             TestCases.get_path("data-files/item/sample-item.json")
         )
         item = pystac.read_dict(item_dict)
-        self.assertIsInstance(item, pystac.Item)
+        assert isinstance(item, pystac.Item)
 
     def test_read_collection_dict(self) -> None:
         self.stac_io = StacIO.default()
@@ -69,7 +69,7 @@ class StacIOTest(unittest.TestCase):
             TestCases.get_path("data-files/collections/multi-extent.json")
         )
         collection = pystac.read_dict(collection_dict)
-        self.assertIsInstance(collection, pystac.Collection)
+        assert isinstance(collection, pystac.Collection)
 
     def test_read_catalog_dict(self) -> None:
         self.stac_io = StacIO.default()
@@ -77,13 +77,13 @@ class StacIOTest(unittest.TestCase):
             TestCases.get_path("data-files/catalogs/test-case-1/catalog.json")
         )
         catalog = pystac.read_dict(catalog_dict)
-        self.assertIsInstance(catalog, pystac.Catalog)
+        assert isinstance(catalog, pystac.Catalog)
 
     def test_read_from_stac_object(self) -> None:
         catalog = pystac.STACObject.from_file(
             TestCases.get_path("data-files/catalogs/test-case-1/catalog.json")
         )
-        self.assertIsInstance(catalog, pystac.Catalog)
+        assert isinstance(catalog, pystac.Catalog)
 
     def test_report_duplicate_keys(self) -> None:
         # Directly from dict
@@ -96,9 +96,9 @@ class StacIOTest(unittest.TestCase):
             "key": "value_2"
         }"""
 
-        with self.assertRaises(pystac.DuplicateObjectKeyError) as excinfo:
+        with pytest.raises(pystac.DuplicateObjectKeyError) as excinfo:
             stac_io.json_loads(test_json)
-        self.assertEqual(str(excinfo.exception), 'Found duplicate object name "key"')
+        assert str(excinfo.value) == 'Found duplicate object name "key"'
 
         # From file
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -106,12 +106,9 @@ class StacIOTest(unittest.TestCase):
             with open(src_href, "w") as dst:
                 dst.write(test_json)
 
-            with self.assertRaises(pystac.DuplicateObjectKeyError) as excinfo:
+            with pytest.raises(pystac.DuplicateObjectKeyError) as excinfo:
                 stac_io.read_json(src_href)
-            self.assertEqual(
-                str(excinfo.exception),
-                f'Found duplicate object name "key" in {src_href}',
-            )
+            assert str(excinfo.value), f'Found duplicate object name "key" in {src_href}'
 
     @unittest.mock.patch("pystac.stac_io.urlopen")
     def test_headers_stac_io(self, urlopen_mock: unittest.mock.MagicMock) -> None:
@@ -126,7 +123,7 @@ class StacIOTest(unittest.TestCase):
         pystac.Catalog.from_file("https://example.com/catalog.json", stac_io=stac_io)
 
         request_obj = urlopen_mock.call_args[0][0]
-        self.assertEqual(request_obj.headers, stac_io.headers)
+        assert request_obj.headers == stac_io.headers
 
 
 @pytest.mark.vcr()

--- a/tests/test_stac_io.py
+++ b/tests/test_stac_io.py
@@ -11,119 +11,117 @@ from pystac.stac_io import DefaultStacIO, DuplicateKeyReportingMixin, StacIO
 from tests.utils import TestCases
 
 
-class StacIOTest(unittest.TestCase):
+def test_read_write_collection() -> None:
+    collection = pystac.read_file(
+        TestCases.get_path("data-files/collections/multi-extent.json")
+    )
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        dest_href = os.path.join(tmp_dir, "collection.json")
+        pystac.write_file(collection, dest_href=dest_href)
+        assert os.path.exists(dest_href), "File was not written."
 
-    def test_read_write_collection(self) -> None:
-        collection = pystac.read_file(
-            TestCases.get_path("data-files/collections/multi-extent.json")
-        )
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            dest_href = os.path.join(tmp_dir, "collection.json")
-            pystac.write_file(collection, dest_href=dest_href)
-            assert os.path.exists(dest_href), "File was not written."
+def test_read_write_collection_with_file_protocol() -> None:
+    collection = pystac.read_file(
+        "file://" + TestCases.get_path("data-files/collections/multi-extent.json")
+    )
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        dest_href = os.path.join(tmp_dir, "collection.json")
+        pystac.write_file(collection, dest_href="file://" + dest_href)
+        assert os.path.exists(dest_href), "File was not written."
 
-    def test_read_write_collection_with_file_protocol(self) -> None:
-        collection = pystac.read_file(
-            "file://" + TestCases.get_path("data-files/collections/multi-extent.json")
-        )
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            dest_href = os.path.join(tmp_dir, "collection.json")
-            pystac.write_file(collection, dest_href="file://" + dest_href)
-            assert os.path.exists(dest_href), "File was not written."
+def test_read_item() -> None:
+    item = pystac.read_file(TestCases.get_path("data-files/item/sample-item.json"))
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        dest_href = os.path.join(tmp_dir, "item.json")
+        pystac.write_file(item, dest_href=dest_href)
+        assert os.path.exists(dest_href), "File was not written."
 
-    def test_read_item(self) -> None:
-        item = pystac.read_file(TestCases.get_path("data-files/item/sample-item.json"))
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            dest_href = os.path.join(tmp_dir, "item.json")
-            pystac.write_file(item, dest_href=dest_href)
-            assert os.path.exists(dest_href), "File was not written."
+def test_read_write_catalog() -> None:
+    catalog = pystac.read_file(
+        TestCases.get_path("data-files/catalogs/test-case-1/catalog.json")
+    )
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        dest_href = os.path.join(tmp_dir, "catalog.json")
+        pystac.write_file(catalog, dest_href=dest_href)
+        assert os.path.exists(dest_href), "File was not written."
 
-    def test_read_write_catalog(self) -> None:
-        catalog = pystac.read_file(
-            TestCases.get_path("data-files/catalogs/test-case-1/catalog.json")
-        )
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            dest_href = os.path.join(tmp_dir, "catalog.json")
-            pystac.write_file(catalog, dest_href=dest_href)
-            assert os.path.exists(dest_href), "File was not written."
-
-    def test_read_item_collection_raises_exception(self) -> None:
-        with pytest.raises(pystac.STACTypeError):
-            _ = pystac.read_file(
-                TestCases.get_path(
-                    "data-files/item-collection/sample-item-collection.json"
-                )
+def test_read_item_collection_raises_exception() -> None:
+    with pytest.raises(pystac.STACTypeError):
+        _ = pystac.read_file(
+            TestCases.get_path(
+                "data-files/item-collection/sample-item-collection.json"
             )
-
-    def test_read_item_dict(self) -> None:
-        self.stac_io = StacIO.default()
-        item_dict = self.stac_io.read_json(
-            TestCases.get_path("data-files/item/sample-item.json")
         )
-        item = pystac.read_dict(item_dict)
-        assert isinstance(item, pystac.Item)
 
-    def test_read_collection_dict(self) -> None:
-        self.stac_io = StacIO.default()
-        collection_dict = self.stac_io.read_json(
-            TestCases.get_path("data-files/collections/multi-extent.json")
-        )
-        collection = pystac.read_dict(collection_dict)
-        assert isinstance(collection, pystac.Collection)
+def test_read_item_dict() -> None:
+    stac_io = StacIO.default()
+    item_dict = stac_io.read_json(
+        TestCases.get_path("data-files/item/sample-item.json")
+    )
+    item = pystac.read_dict(item_dict)
+    assert isinstance(item, pystac.Item)
 
-    def test_read_catalog_dict(self) -> None:
-        self.stac_io = StacIO.default()
-        catalog_dict = self.stac_io.read_json(
-            TestCases.get_path("data-files/catalogs/test-case-1/catalog.json")
-        )
-        catalog = pystac.read_dict(catalog_dict)
-        assert isinstance(catalog, pystac.Catalog)
+def test_read_collection_dict() -> None:
+    stac_io = StacIO.default()
+    collection_dict = stac_io.read_json(
+        TestCases.get_path("data-files/collections/multi-extent.json")
+    )
+    collection = pystac.read_dict(collection_dict)
+    assert isinstance(collection, pystac.Collection)
 
-    def test_read_from_stac_object(self) -> None:
-        catalog = pystac.STACObject.from_file(
-            TestCases.get_path("data-files/catalogs/test-case-1/catalog.json")
-        )
-        assert isinstance(catalog, pystac.Catalog)
+def test_read_catalog_dict() -> None:
+    stac_io = StacIO.default()
+    catalog_dict = stac_io.read_json(
+        TestCases.get_path("data-files/catalogs/test-case-1/catalog.json")
+    )
+    catalog = pystac.read_dict(catalog_dict)
+    assert isinstance(catalog, pystac.Catalog)
 
-    def test_report_duplicate_keys(self) -> None:
-        # Directly from dict
-        class ReportingStacIO(DefaultStacIO, DuplicateKeyReportingMixin):
-            pass
+def test_read_from_stac_object() -> None:
+    catalog = pystac.STACObject.from_file(
+        TestCases.get_path("data-files/catalogs/test-case-1/catalog.json")
+    )
+    assert isinstance(catalog, pystac.Catalog)
 
-        stac_io = ReportingStacIO()
-        test_json = """{
-            "key": "value_1",
-            "key": "value_2"
-        }"""
+def test_report_duplicate_keys() -> None:
+    # Directly from dict
+    class ReportingStacIO(DefaultStacIO, DuplicateKeyReportingMixin):
+        pass
+
+    stac_io = ReportingStacIO()
+    test_json = """{
+        "key": "value_1",
+        "key": "value_2"
+    }"""
+
+    with pytest.raises(pystac.DuplicateObjectKeyError) as excinfo:
+        stac_io.json_loads(test_json)
+    assert str(excinfo.value) == 'Found duplicate object name "key"'
+
+    # From file
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        src_href = os.path.join(tmp_dir, "test.json")
+        with open(src_href, "w") as dst:
+            dst.write(test_json)
 
         with pytest.raises(pystac.DuplicateObjectKeyError) as excinfo:
-            stac_io.json_loads(test_json)
-        assert str(excinfo.value) == 'Found duplicate object name "key"'
+            stac_io.read_json(src_href)
+        assert str(excinfo.value), f'Found duplicate object name "key" in {src_href}'
 
-        # From file
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            src_href = os.path.join(tmp_dir, "test.json")
-            with open(src_href, "w") as dst:
-                dst.write(test_json)
+@unittest.mock.patch("pystac.stac_io.urlopen")
+def test_headers_stac_io(urlopen_mock: unittest.mock.MagicMock) -> None:
+    stac_io = DefaultStacIO(headers={"Authorization": "api-key fake-api-key-value"})
 
-            with pytest.raises(pystac.DuplicateObjectKeyError) as excinfo:
-                stac_io.read_json(src_href)
-            assert str(excinfo.value), f'Found duplicate object name "key" in {src_href}'
+    catalog = pystac.Catalog("an-id", "a description").to_dict()
+    # required until https://github.com/stac-utils/pystac/pull/896 is merged
+    catalog["links"] = []
+    urlopen_mock.return_value.__enter__.return_value.read.return_value = json.dumps(
+        catalog
+    ).encode("utf-8")
+    pystac.Catalog.from_file("https://example.com/catalog.json", stac_io=stac_io)
 
-    @unittest.mock.patch("pystac.stac_io.urlopen")
-    def test_headers_stac_io(self, urlopen_mock: unittest.mock.MagicMock) -> None:
-        stac_io = DefaultStacIO(headers={"Authorization": "api-key fake-api-key-value"})
-
-        catalog = pystac.Catalog("an-id", "a description").to_dict()
-        # required until https://github.com/stac-utils/pystac/pull/896 is merged
-        catalog["links"] = []
-        urlopen_mock.return_value.__enter__.return_value.read.return_value = json.dumps(
-            catalog
-        ).encode("utf-8")
-        pystac.Catalog.from_file("https://example.com/catalog.json", stac_io=stac_io)
-
-        request_obj = urlopen_mock.call_args[0][0]
-        assert request_obj.headers == stac_io.headers
+    request_obj = urlopen_mock.call_args[0][0]
+    assert request_obj.headers == stac_io.headers
 
 
 @pytest.mark.vcr()

--- a/tests/test_stac_io.py
+++ b/tests/test_stac_io.py
@@ -12,8 +12,6 @@ from tests.utils import TestCases
 
 
 class StacIOTest(unittest.TestCase):
-    def setUp(self) -> None:
-        self.stac_io = StacIO.default()
 
     def test_read_write_collection(self) -> None:
         collection = pystac.read_file(
@@ -58,6 +56,7 @@ class StacIOTest(unittest.TestCase):
             )
 
     def test_read_item_dict(self) -> None:
+        self.stac_io = StacIO.default()
         item_dict = self.stac_io.read_json(
             TestCases.get_path("data-files/item/sample-item.json")
         )
@@ -65,6 +64,7 @@ class StacIOTest(unittest.TestCase):
         self.assertIsInstance(item, pystac.Item)
 
     def test_read_collection_dict(self) -> None:
+        self.stac_io = StacIO.default()
         collection_dict = self.stac_io.read_json(
             TestCases.get_path("data-files/collections/multi-extent.json")
         )
@@ -72,6 +72,7 @@ class StacIOTest(unittest.TestCase):
         self.assertIsInstance(collection, pystac.Collection)
 
     def test_read_catalog_dict(self) -> None:
+        self.stac_io = StacIO.default()
         catalog_dict = self.stac_io.read_json(
             TestCases.get_path("data-files/catalogs/test-case-1/catalog.json")
         )

--- a/tests/test_summaries.py
+++ b/tests/test_summaries.py
@@ -2,6 +2,8 @@ import socket
 import unittest
 from typing import Any
 
+import pytest
+
 from pystac.summaries import RangeSummary, Summaries, Summarizer, SummaryStrategy
 from tests.utils import TestCases
 
@@ -11,24 +13,24 @@ class SummariesTest(unittest.TestCase):
         coll = TestCases.case_5()
         summaries = Summarizer().summarize(coll.get_items(recursive=True))
         summaries_dict = summaries.to_dict()
-        self.assertEqual(len(summaries_dict["eo:bands"]), 4)
-        self.assertEqual(len(summaries_dict["proj:code"]), 1)
+        assert len(summaries_dict["eo:bands"]) == 4
+        assert len(summaries_dict["proj:code"]) == 1
 
     def test_summary_limit(self) -> None:
         coll = TestCases.case_5()
         summaries = Summarizer().summarize(coll.get_items(recursive=True))
         summaries.maxcount = 2
         summaries_dict = summaries.to_dict()
-        self.assertIsNone(summaries_dict.get("eo:bands"))
-        self.assertEqual(len(summaries_dict["proj:code"]), 1)
+        assert summaries_dict.get("eo:bands") is None
+        assert len(summaries_dict["proj:code"]) == 1
 
     def test_summary_custom_fields_file(self) -> None:
         coll = TestCases.case_5()
         path = TestCases.get_path("data-files/summaries/fields_no_bands.json")
         summaries = Summarizer(path).summarize(coll.get_items(recursive=True))
         summaries_dict = summaries.to_dict()
-        self.assertIsNone(summaries_dict.get("eo:bands"))
-        self.assertEqual(len(summaries_dict["proj:code"]), 1)
+        assert summaries_dict.get("eo:bands") is None
+        assert len(summaries_dict["proj:code"]) == 1
 
     def test_summary_custom_fields_dict(self) -> None:
         coll = TestCases.case_5()
@@ -37,18 +39,18 @@ class SummariesTest(unittest.TestCase):
             "proj:code": SummaryStrategy.ARRAY,
         }
         obj = Summarizer(spec)
-        self.assertTrue("eo:bands" not in obj.summaryfields)
-        self.assertEqual(obj.summaryfields["proj:code"], SummaryStrategy.ARRAY)
+        assert "eo:bands" not in obj.summaryfields
+        assert obj.summaryfields["proj:code"] == SummaryStrategy.ARRAY
         summaries = obj.summarize(coll.get_items(recursive=True))
         summaries_dict = summaries.to_dict()
-        self.assertIsNone(summaries_dict.get("eo:bands"))
-        self.assertEqual(len(summaries_dict["proj:code"]), 1)
+        assert summaries_dict.get("eo:bands") is None
+        assert len(summaries_dict["proj:code"]) == 1
 
     def test_summary_wrong_custom_fields_file(self) -> None:
         coll = TestCases.case_5()
-        with self.assertRaises(FileNotFoundError) as context:
+        with pytest.raises(FileNotFoundError) as context:
             Summarizer("wrong/path").summarize(coll.get_items(recursive=True))
-        self.assertTrue("No such file or directory" in str(context.exception))
+        assert "No such file or directory" in str(context.value)
 
     def test_can_open_fields_file_even_with_no_nework(self) -> None:
         old_socket = socket.socket
@@ -66,21 +68,21 @@ class SummariesTest(unittest.TestCase):
 
     def test_summary_empty(self) -> None:
         summaries = Summaries.empty()
-        self.assertTrue(summaries.is_empty())
+        assert summaries.is_empty()
 
     def test_summary_not_empty(self) -> None:
         coll = TestCases.case_5()
         summaries = Summarizer().summarize(coll.get_items(recursive=True))
-        self.assertFalse(summaries.is_empty())
+        assert not summaries.is_empty()
 
     def test_clone_summary(self) -> None:
         coll = TestCases.case_5()
         summaries = Summarizer().summarize(coll.get_items(recursive=True))
         summaries_dict = summaries.to_dict()
         clone = summaries.clone()
-        self.assertTrue(isinstance(clone, Summaries))
+        assert isinstance(clone, Summaries)
         clone_dict = clone.to_dict()
-        self.assertDictEqual(clone_dict, summaries_dict)
+        assert clone_dict == summaries_dict
 
 
 class RangeSummaryTest(unittest.TestCase):
@@ -89,13 +91,13 @@ class RangeSummaryTest(unittest.TestCase):
 
     def test_repr(self) -> None:
         rs = RangeSummary(5, 10)
-        self.assertEqual("{'minimum': 5, 'maximum': 10}", rs.__repr__())
+        assert "{'minimum': 5, 'maximum': 10}" == rs.__repr__()
 
     def test_equality(self) -> None:
         rs_1 = RangeSummary(5, 10)
         rs_2 = RangeSummary(5, 10)
         rs_3 = RangeSummary(5, 11)
 
-        self.assertEqual(rs_1, rs_2)
-        self.assertNotEqual(rs_1, rs_3)
-        self.assertNotEqual(rs_1, (5, 10))
+        assert rs_1 == rs_2
+        assert rs_1 != rs_3
+        assert rs_1 != (5, 10)

--- a/tests/test_summaries.py
+++ b/tests/test_summaries.py
@@ -1,5 +1,4 @@
 import socket
-import unittest
 from typing import Any
 
 import pytest
@@ -15,6 +14,7 @@ def test_summary() -> None:
     assert len(summaries_dict["eo:bands"]) == 4
     assert len(summaries_dict["proj:code"]) == 1
 
+
 def test_summary_limit() -> None:
     coll = TestCases.case_5()
     summaries = Summarizer().summarize(coll.get_items(recursive=True))
@@ -23,6 +23,7 @@ def test_summary_limit() -> None:
     assert summaries_dict.get("eo:bands") is None
     assert len(summaries_dict["proj:code"]) == 1
 
+
 def test_summary_custom_fields_file() -> None:
     coll = TestCases.case_5()
     path = TestCases.get_path("data-files/summaries/fields_no_bands.json")
@@ -30,6 +31,7 @@ def test_summary_custom_fields_file() -> None:
     summaries_dict = summaries.to_dict()
     assert summaries_dict.get("eo:bands") is None
     assert len(summaries_dict["proj:code"]) == 1
+
 
 def test_summary_custom_fields_dict() -> None:
     coll = TestCases.case_5()
@@ -45,11 +47,13 @@ def test_summary_custom_fields_dict() -> None:
     assert summaries_dict.get("eo:bands") is None
     assert len(summaries_dict["proj:code"]) == 1
 
+
 def test_summary_wrong_custom_fields_file() -> None:
     coll = TestCases.case_5()
     with pytest.raises(FileNotFoundError) as context:
         Summarizer("wrong/path").summarize(coll.get_items(recursive=True))
     assert "No such file or directory" in str(context.value)
+
 
 def test_can_open_fields_file_even_with_no_nework() -> None:
     old_socket = socket.socket
@@ -65,14 +69,17 @@ def test_can_open_fields_file_even_with_no_nework() -> None:
         # even if this test fails, it should not break the whole test suite
         socket.socket = old_socket  # type:ignore
 
+
 def test_summary_empty() -> None:
     summaries = Summaries.empty()
     assert summaries.is_empty()
+
 
 def test_summary_not_empty() -> None:
     coll = TestCases.case_5()
     summaries = Summarizer().summarize(coll.get_items(recursive=True))
     assert not summaries.is_empty()
+
 
 def test_clone_summary() -> None:
     coll = TestCases.case_5()
@@ -87,6 +94,7 @@ def test_clone_summary() -> None:
 def test_RangeSummary_repr() -> None:
     rs = RangeSummary(5, 10)
     assert "{'minimum': 5, 'maximum': 10}" == rs.__repr__()
+
 
 def test_RangeSummary_equality() -> None:
     rs_1 = RangeSummary(5, 10)

--- a/tests/test_summaries.py
+++ b/tests/test_summaries.py
@@ -8,96 +8,91 @@ from pystac.summaries import RangeSummary, Summaries, Summarizer, SummaryStrateg
 from tests.utils import TestCases
 
 
-class SummariesTest(unittest.TestCase):
-    def test_summary(self) -> None:
-        coll = TestCases.case_5()
-        summaries = Summarizer().summarize(coll.get_items(recursive=True))
-        summaries_dict = summaries.to_dict()
-        assert len(summaries_dict["eo:bands"]) == 4
-        assert len(summaries_dict["proj:code"]) == 1
+def test_summary() -> None:
+    coll = TestCases.case_5()
+    summaries = Summarizer().summarize(coll.get_items(recursive=True))
+    summaries_dict = summaries.to_dict()
+    assert len(summaries_dict["eo:bands"]) == 4
+    assert len(summaries_dict["proj:code"]) == 1
 
-    def test_summary_limit(self) -> None:
-        coll = TestCases.case_5()
-        summaries = Summarizer().summarize(coll.get_items(recursive=True))
-        summaries.maxcount = 2
-        summaries_dict = summaries.to_dict()
-        assert summaries_dict.get("eo:bands") is None
-        assert len(summaries_dict["proj:code"]) == 1
+def test_summary_limit() -> None:
+    coll = TestCases.case_5()
+    summaries = Summarizer().summarize(coll.get_items(recursive=True))
+    summaries.maxcount = 2
+    summaries_dict = summaries.to_dict()
+    assert summaries_dict.get("eo:bands") is None
+    assert len(summaries_dict["proj:code"]) == 1
 
-    def test_summary_custom_fields_file(self) -> None:
-        coll = TestCases.case_5()
-        path = TestCases.get_path("data-files/summaries/fields_no_bands.json")
-        summaries = Summarizer(path).summarize(coll.get_items(recursive=True))
-        summaries_dict = summaries.to_dict()
-        assert summaries_dict.get("eo:bands") is None
-        assert len(summaries_dict["proj:code"]) == 1
+def test_summary_custom_fields_file() -> None:
+    coll = TestCases.case_5()
+    path = TestCases.get_path("data-files/summaries/fields_no_bands.json")
+    summaries = Summarizer(path).summarize(coll.get_items(recursive=True))
+    summaries_dict = summaries.to_dict()
+    assert summaries_dict.get("eo:bands") is None
+    assert len(summaries_dict["proj:code"]) == 1
 
-    def test_summary_custom_fields_dict(self) -> None:
-        coll = TestCases.case_5()
-        spec = {
-            "eo:bands": SummaryStrategy.DONT_SUMMARIZE,
-            "proj:code": SummaryStrategy.ARRAY,
-        }
-        obj = Summarizer(spec)
-        assert "eo:bands" not in obj.summaryfields
-        assert obj.summaryfields["proj:code"] == SummaryStrategy.ARRAY
-        summaries = obj.summarize(coll.get_items(recursive=True))
-        summaries_dict = summaries.to_dict()
-        assert summaries_dict.get("eo:bands") is None
-        assert len(summaries_dict["proj:code"]) == 1
+def test_summary_custom_fields_dict() -> None:
+    coll = TestCases.case_5()
+    spec = {
+        "eo:bands": SummaryStrategy.DONT_SUMMARIZE,
+        "proj:code": SummaryStrategy.ARRAY,
+    }
+    obj = Summarizer(spec)
+    assert "eo:bands" not in obj.summaryfields
+    assert obj.summaryfields["proj:code"] == SummaryStrategy.ARRAY
+    summaries = obj.summarize(coll.get_items(recursive=True))
+    summaries_dict = summaries.to_dict()
+    assert summaries_dict.get("eo:bands") is None
+    assert len(summaries_dict["proj:code"]) == 1
 
-    def test_summary_wrong_custom_fields_file(self) -> None:
-        coll = TestCases.case_5()
-        with pytest.raises(FileNotFoundError) as context:
-            Summarizer("wrong/path").summarize(coll.get_items(recursive=True))
-        assert "No such file or directory" in str(context.value)
+def test_summary_wrong_custom_fields_file() -> None:
+    coll = TestCases.case_5()
+    with pytest.raises(FileNotFoundError) as context:
+        Summarizer("wrong/path").summarize(coll.get_items(recursive=True))
+    assert "No such file or directory" in str(context.value)
 
-    def test_can_open_fields_file_even_with_no_nework(self) -> None:
-        old_socket = socket.socket
-        try:
+def test_can_open_fields_file_even_with_no_nework() -> None:
+    old_socket = socket.socket
+    try:
 
-            class no_network(socket.socket):
-                def __init__(self, *args: Any, **kwargs: Any):
-                    raise Exception("Network call blocked")
+        class no_network(socket.socket):
+            def __init__(self, *args: Any, **kwargs: Any):
+                raise Exception("Network call blocked")
 
-            socket.socket = no_network  # type:ignore
-            Summarizer()
-        finally:
-            # even if this test fails, it should not break the whole test suite
-            socket.socket = old_socket  # type:ignore
+        socket.socket = no_network  # type:ignore
+        Summarizer()
+    finally:
+        # even if this test fails, it should not break the whole test suite
+        socket.socket = old_socket  # type:ignore
 
-    def test_summary_empty(self) -> None:
-        summaries = Summaries.empty()
-        assert summaries.is_empty()
+def test_summary_empty() -> None:
+    summaries = Summaries.empty()
+    assert summaries.is_empty()
 
-    def test_summary_not_empty(self) -> None:
-        coll = TestCases.case_5()
-        summaries = Summarizer().summarize(coll.get_items(recursive=True))
-        assert not summaries.is_empty()
+def test_summary_not_empty() -> None:
+    coll = TestCases.case_5()
+    summaries = Summarizer().summarize(coll.get_items(recursive=True))
+    assert not summaries.is_empty()
 
-    def test_clone_summary(self) -> None:
-        coll = TestCases.case_5()
-        summaries = Summarizer().summarize(coll.get_items(recursive=True))
-        summaries_dict = summaries.to_dict()
-        clone = summaries.clone()
-        assert isinstance(clone, Summaries)
-        clone_dict = clone.to_dict()
-        assert clone_dict == summaries_dict
+def test_clone_summary() -> None:
+    coll = TestCases.case_5()
+    summaries = Summarizer().summarize(coll.get_items(recursive=True))
+    summaries_dict = summaries.to_dict()
+    clone = summaries.clone()
+    assert isinstance(clone, Summaries)
+    clone_dict = clone.to_dict()
+    assert clone_dict == summaries_dict
 
 
-class RangeSummaryTest(unittest.TestCase):
-    def setUp(self) -> None:
-        self.maxDiff = None
+def test_RangeSummary_repr() -> None:
+    rs = RangeSummary(5, 10)
+    assert "{'minimum': 5, 'maximum': 10}" == rs.__repr__()
 
-    def test_repr(self) -> None:
-        rs = RangeSummary(5, 10)
-        assert "{'minimum': 5, 'maximum': 10}" == rs.__repr__()
+def test_RangeSummary_equality() -> None:
+    rs_1 = RangeSummary(5, 10)
+    rs_2 = RangeSummary(5, 10)
+    rs_3 = RangeSummary(5, 11)
 
-    def test_equality(self) -> None:
-        rs_1 = RangeSummary(5, 10)
-        rs_2 = RangeSummary(5, 10)
-        rs_3 = RangeSummary(5, 11)
-
-        assert rs_1 == rs_2
-        assert rs_1 != rs_3
-        assert rs_1 != (5, 10)
+    assert rs_1 == rs_2
+    assert rs_1 != rs_3
+    assert rs_1 != (5, 10)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,26 +23,23 @@ from pystac.utils import (
 )
 from tests.utils import TestCases, path_includes_drive_letter
 
+@pytest.mark.parametrize(
+    "source_href, start_href, expected", (
+    ("/a/b/c/d/catalog.json", "/a/b/c/catalog.json", "./d/catalog.json"),
+    ("/a/b/catalog.json", "/a/b/c/catalog.json", "../catalog.json"),
+    ("/a/catalog.json", "/a/b/c/catalog.json", "../../catalog.json"),
+    ("/a/b/c/d/", "/a/b/c/catalog.json", "./d/"),
+    ("/a/b/c/d/.dotfile", "/a/b/c/d/catalog.json", "./.dotfile"),
+    ("file:///a/b/c/d/catalog.json", "file:///a/b/c/catalog.json", "./d/catalog.json"),
+))
+def test_make_relative_href(
+    source_href: str, start_href: str, expected: str
+) -> None:
+    actual = make_relative_href(source_href, start_href)
+    assert actual == expected
+
 
 class UtilsTest(unittest.TestCase):
-    def test_make_relative_href(self) -> None:
-        # Test cases of (source_href, start_href, expected)
-        test_cases = [
-            ("/a/b/c/d/catalog.json", "/a/b/c/catalog.json", "./d/catalog.json"),
-            ("/a/b/catalog.json", "/a/b/c/catalog.json", "../catalog.json"),
-            ("/a/catalog.json", "/a/b/c/catalog.json", "../../catalog.json"),
-            ("/a/b/c/d/", "/a/b/c/catalog.json", "./d/"),
-            ("/a/b/c/d/.dotfile", "/a/b/c/d/catalog.json", "./.dotfile"),
-            (
-                "file:///a/b/c/d/catalog.json",
-                "file:///a/b/c/catalog.json",
-                "./d/catalog.json",
-            ),
-        ]
-
-        for source_href, start_href, expected in test_cases:
-            actual = make_relative_href(source_href, start_href)
-            self.assertEqual(actual, expected)
 
     def test_make_relative_href_url(self) -> None:
         test_cases = [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,159 +24,121 @@ from tests.utils import TestCases, path_includes_drive_letter
 
 @pytest.mark.parametrize(
     "source_href, start_href, expected", (
+    # relative href
     ("/a/b/c/d/catalog.json", "/a/b/c/catalog.json", "./d/catalog.json"),
     ("/a/b/catalog.json", "/a/b/c/catalog.json", "../catalog.json"),
     ("/a/catalog.json", "/a/b/c/catalog.json", "../../catalog.json"),
     ("/a/b/c/d/", "/a/b/c/catalog.json", "./d/"),
     ("/a/b/c/d/.dotfile", "/a/b/c/d/catalog.json", "./.dotfile"),
     ("file:///a/b/c/d/catalog.json", "file:///a/b/c/catalog.json", "./d/catalog.json"),
-))
+    # relative href url
+    (
+            "http://stacspec.org/a/b/c/d/catalog.json",
+            "http://stacspec.org/a/b/c/catalog.json",
+            "./d/catalog.json",
+    ),
+    (
+            "http://stacspec.org/a/b/catalog.json",
+            "http://stacspec.org/a/b/c/catalog.json",
+            "../catalog.json",
+    ),
+    (
+            "http://stacspec.org/a/catalog.json",
+            "http://stacspec.org/a/b/c/catalog.json",
+            "../../catalog.json",
+    ),
+    (
+            "http://stacspec.org/a/catalog.json",
+            "http://cogeo.org/a/b/c/catalog.json",
+            "http://stacspec.org/a/catalog.json",
+    ),
+    (
+            "http://stacspec.org/a/catalog.json",
+            "https://stacspec.org/a/b/c/catalog.json",
+            "http://stacspec.org/a/catalog.json",
+    ),
+    (
+            "http://stacspec.org/a/",
+            "https://stacspec.org/a/b/c/catalog.json",
+            "http://stacspec.org/a/",
+    ),
+    (
+            "http://stacspec.org/a/b/.dotfile",
+            "http://stacspec.org/a/b/catalog.json",
+            "./.dotfile",
+    ),
+    # relative href under windows
+    (
+        "C:\\a\\b\\c\\d\\catalog.json",
+        "C:\\a\\b\\c\\catalog.json",
+        "./d/catalog.json",
+    ),
+    (
+        "C:\\a\\b\\catalog.json",
+        "C:\\a\\b\\c\\catalog.json",
+        "../catalog.json",
+    ),
+    (
+        "C:\\a\\catalog.json",
+        "C:\\a\\b\\c\\catalog.json",
+        "../../catalog.json",
+    ),
+    ("a\\b\\c\\catalog.json", "a\\b\\catalog.json", "./c/catalog.json"),
+    ("a\\b\\catalog.json", "a\\b\\c\\catalog.json", "../catalog.json"),
+    )
+)
 def test_make_relative_href(
-    source_href: str, start_href: str, expected: str
+        source_href: str, start_href: str, expected: str
 ) -> None:
     actual = make_relative_href(source_href, start_href)
     assert actual == expected
 
 
-def test_make_relative_href_url() -> None:
-    test_cases = [
-        (
-            "http://stacspec.org/a/b/c/d/catalog.json",
-            "http://stacspec.org/a/b/c/catalog.json",
-            "./d/catalog.json",
-        ),
-        (
-            "http://stacspec.org/a/b/catalog.json",
-            "http://stacspec.org/a/b/c/catalog.json",
-            "../catalog.json",
-        ),
-        (
-            "http://stacspec.org/a/catalog.json",
-            "http://stacspec.org/a/b/c/catalog.json",
-            "../../catalog.json",
-        ),
-        (
-            "http://stacspec.org/a/catalog.json",
-            "http://cogeo.org/a/b/c/catalog.json",
-            "http://stacspec.org/a/catalog.json",
-        ),
-        (
-            "http://stacspec.org/a/catalog.json",
-            "https://stacspec.org/a/b/c/catalog.json",
-            "http://stacspec.org/a/catalog.json",
-        ),
-        (
-            "http://stacspec.org/a/",
-            "https://stacspec.org/a/b/c/catalog.json",
-            "http://stacspec.org/a/",
-        ),
-        (
-            "http://stacspec.org/a/b/.dotfile",
-            "http://stacspec.org/a/b/catalog.json",
-            "./.dotfile",
-        ),
-    ]
-
-    for source_href, start_href, expected in test_cases:
-        actual = make_relative_href(source_href, start_href)
-        assert actual == expected
-
-def test_make_relative_href_windows() -> None:
-    # Test cases of (source_href, start_href, expected)
-    test_cases = [
-        (
-            "C:\\a\\b\\c\\d\\catalog.json",
-            "C:\\a\\b\\c\\catalog.json",
-            "./d/catalog.json",
-        ),
-        (
-            "C:\\a\\b\\catalog.json",
-            "C:\\a\\b\\c\\catalog.json",
-            "../catalog.json",
-        ),
-        (
-            "C:\\a\\catalog.json",
-            "C:\\a\\b\\c\\catalog.json",
-            "../../catalog.json",
-        ),
-        ("a\\b\\c\\catalog.json", "a\\b\\catalog.json", "./c/catalog.json"),
-        ("a\\b\\catalog.json", "a\\b\\c\\catalog.json", "../catalog.json"),
-        (
-            "http://stacspec.org/a/b/c/d/catalog.json",
-            "http://stacspec.org/a/b/c/catalog.json",
-            "./d/catalog.json",
-        ),
-        (
-            "http://stacspec.org/a/b/catalog.json",
-            "http://stacspec.org/a/b/c/catalog.json",
-            "../catalog.json",
-        ),
-        (
-            "http://stacspec.org/a/catalog.json",
-            "http://stacspec.org/a/b/c/catalog.json",
-            "../../catalog.json",
-        ),
-        (
-            "http://stacspec.org/a/catalog.json",
-            "http://cogeo.org/a/b/c/catalog.json",
-            "http://stacspec.org/a/catalog.json",
-        ),
-        (
-            "http://stacspec.org/a/catalog.json",
-            "https://stacspec.org/a/b/c/catalog.json",
-            "http://stacspec.org/a/catalog.json",
-        ),
-    ]
-
-    for source_href, start_href, expected in test_cases:
-        actual = make_relative_href(source_href, start_href)
-        assert actual == expected
-
-def test_make_absolute_href() -> None:
-    # Test cases of (source_href, start_href, expected)
-    test_cases = [
-        ("item.json", "/a/b/c/catalog.json", "/a/b/c/item.json"),
-        ("./item.json", "/a/b/c/catalog.json", "/a/b/c/item.json"),
-        ("./z/item.json", "/a/b/c/catalog.json", "/a/b/c/z/item.json"),
-        ("../item.json", "/a/b/c/catalog.json", "/a/b/item.json"),
-        (
-            "item.json",
-            "https://stacspec.org/a/b/c/catalog.json",
-            "https://stacspec.org/a/b/c/item.json",
-        ),
-        (
-            "./item.json",
-            "https://stacspec.org/a/b/c/catalog.json",
-            "https://stacspec.org/a/b/c/item.json",
-        ),
-        (
-            "./z/item.json",
-            "https://stacspec.org/a/b/c/catalog.json",
-            "https://stacspec.org/a/b/c/z/item.json",
-        ),
-        (
-            "../item.json",
-            "https://stacspec.org/a/b/c/catalog.json",
-            "https://stacspec.org/a/b/item.json",
-        ),
-        ("http://localhost:8000", None, "http://localhost:8000"),
-        ("item.json", "file:///a/b/c/catalog.json", "file:///a/b/c/item.json"),
-        (
-            "./z/item.json",
-            "file:///a/b/c/catalog.json",
-            "file:///a/b/c/z/item.json",
-        ),
-        ("file:///a/b/c/item.json", None, "file:///a/b/c/item.json"),
-    ]
-
-    for source_href, start_href, expected in test_cases:
-        actual = make_absolute_href(source_href, start_href)
-        if expected.startswith("file://"):
-            _, actual = os.path.splitdrive(actual.replace("file://", ""))
-            actual = f"file://{actual}"
-        else:
-            _, actual = os.path.splitdrive(actual)
-        assert actual == expected
+@pytest.mark.parametrize(
+    "source_href, start_href, expected", (
+            ("item.json", "/a/b/c/catalog.json", "/a/b/c/item.json"),
+            ("./item.json", "/a/b/c/catalog.json", "/a/b/c/item.json"),
+            ("./z/item.json", "/a/b/c/catalog.json", "/a/b/c/z/item.json"),
+            ("../item.json", "/a/b/c/catalog.json", "/a/b/item.json"),
+            (
+                    "item.json",
+                    "https://stacspec.org/a/b/c/catalog.json",
+                    "https://stacspec.org/a/b/c/item.json",
+            ),
+            (
+                    "./item.json",
+                    "https://stacspec.org/a/b/c/catalog.json",
+                    "https://stacspec.org/a/b/c/item.json",
+            ),
+            (
+                    "./z/item.json",
+                    "https://stacspec.org/a/b/c/catalog.json",
+                    "https://stacspec.org/a/b/c/z/item.json",
+            ),
+            (
+                    "../item.json",
+                    "https://stacspec.org/a/b/c/catalog.json",
+                    "https://stacspec.org/a/b/item.json",
+            ),
+            ("http://localhost:8000", None, "http://localhost:8000"),
+            ("item.json", "file:///a/b/c/catalog.json", "file:///a/b/c/item.json"),
+            (
+                    "./z/item.json",
+                    "file:///a/b/c/catalog.json",
+                    "file:///a/b/c/z/item.json",
+            ),
+            ("file:///a/b/c/item.json", None, "file:///a/b/c/item.json"),
+    ))
+def test_make_absolute_href(
+        source_href: str, start_href: str, expected: str
+) -> None:
+    actual = make_absolute_href(source_href, start_href)
+    if expected.startswith("file://"):
+        _, actual = os.path.splitdrive(actual.replace("file://", ""))
+        actual = f"file://{actual}"
+    else:
+        _, actual = os.path.splitdrive(actual)
+    assert actual == expected
 
 def test_make_absolute_href_on_vsitar() -> None:
     rel_path = "some/item.json"
@@ -186,42 +148,43 @@ def test_make_absolute_href_on_vsitar() -> None:
     assert expected, make_absolute_href(rel_path == cat_path)
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows only test")
-def test_make_absolute_href_windows() -> None:
-    # Test cases of (source_href, start_href, expected)
-    test_cases = [
-        ("item.json", "C:\\a\\b\\c\\catalog.json", "C:/a/b/c/item.json"),
-        (".\\item.json", "C:\\a\\b\\c\\catalog.json", "C:/a/b/c/item.json"),
-        (
-            ".\\z\\item.json",
-            "Z:\\a\\b\\c\\catalog.json",
-            "Z:/a/b/c/z/item.json",
-        ),
-        ("..\\item.json", "a:\\a\\b\\c\\catalog.json", "a:/a/b/item.json"),
-        (
-            "item.json",
-            "HTTPS://stacspec.org/a/b/c/catalog.json",
-            "https://stacspec.org/a/b/c/item.json",
-        ),
-        (
-            "./item.json",
-            "https://stacspec.org/a/b/c/catalog.json",
-            "https://stacspec.org/a/b/c/item.json",
-        ),
-        (
-            "./z/item.json",
-            "https://stacspec.org/a/b/c/catalog.json",
-            "https://stacspec.org/a/b/c/z/item.json",
-        ),
-        (
-            "../item.json",
-            "https://stacspec.org/a/b/c/catalog.json",
-            "https://stacspec.org/a/b/item.json",
-        ),
-    ]
+@pytest.mark.parametrize(
+    "source_href, start_href, expected", (
+            ("item.json", "C:\\a\\b\\c\\catalog.json", "C:/a/b/c/item.json"),
+            (".\\item.json", "C:\\a\\b\\c\\catalog.json", "C:/a/b/c/item.json"),
+            (
+                    ".\\z\\item.json",
+                    "Z:\\a\\b\\c\\catalog.json",
+                    "Z:/a/b/c/z/item.json",
+            ),
+            ("..\\item.json", "a:\\a\\b\\c\\catalog.json", "a:/a/b/item.json"),
+            (
+                    "item.json",
+                    "HTTPS://stacspec.org/a/b/c/catalog.json",
+                    "https://stacspec.org/a/b/c/item.json",
+            ),
+            (
+                    "./item.json",
+                    "https://stacspec.org/a/b/c/catalog.json",
+                    "https://stacspec.org/a/b/c/item.json",
+            ),
+            (
+                    "./z/item.json",
+                    "https://stacspec.org/a/b/c/catalog.json",
+                    "https://stacspec.org/a/b/c/z/item.json",
+            ),
+            (
+                    "../item.json",
+                    "https://stacspec.org/a/b/c/catalog.json",
+                    "https://stacspec.org/a/b/item.json",
+            ),
 
-    for source_href, start_href, expected in test_cases:
-        actual = make_absolute_href(source_href, start_href)
-        assert actual == expected
+    ))
+def test_make_absolute_href_windows(
+        source_href: str, start_href: str, expected: str
+) -> None:
+    actual = make_absolute_href(source_href, start_href)
+    assert actual == expected
 
 def test_is_absolute_href() -> None:
     # Test cases of (href, expected)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,6 @@
 import json
 import os
 import time
-import unittest
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -39,333 +38,331 @@ def test_make_relative_href(
     assert actual == expected
 
 
-class UtilsTest(unittest.TestCase):
+def test_make_relative_href_url() -> None:
+    test_cases = [
+        (
+            "http://stacspec.org/a/b/c/d/catalog.json",
+            "http://stacspec.org/a/b/c/catalog.json",
+            "./d/catalog.json",
+        ),
+        (
+            "http://stacspec.org/a/b/catalog.json",
+            "http://stacspec.org/a/b/c/catalog.json",
+            "../catalog.json",
+        ),
+        (
+            "http://stacspec.org/a/catalog.json",
+            "http://stacspec.org/a/b/c/catalog.json",
+            "../../catalog.json",
+        ),
+        (
+            "http://stacspec.org/a/catalog.json",
+            "http://cogeo.org/a/b/c/catalog.json",
+            "http://stacspec.org/a/catalog.json",
+        ),
+        (
+            "http://stacspec.org/a/catalog.json",
+            "https://stacspec.org/a/b/c/catalog.json",
+            "http://stacspec.org/a/catalog.json",
+        ),
+        (
+            "http://stacspec.org/a/",
+            "https://stacspec.org/a/b/c/catalog.json",
+            "http://stacspec.org/a/",
+        ),
+        (
+            "http://stacspec.org/a/b/.dotfile",
+            "http://stacspec.org/a/b/catalog.json",
+            "./.dotfile",
+        ),
+    ]
 
-    def test_make_relative_href_url(self) -> None:
-        test_cases = [
-            (
-                "http://stacspec.org/a/b/c/d/catalog.json",
-                "http://stacspec.org/a/b/c/catalog.json",
-                "./d/catalog.json",
-            ),
-            (
-                "http://stacspec.org/a/b/catalog.json",
-                "http://stacspec.org/a/b/c/catalog.json",
-                "../catalog.json",
-            ),
-            (
-                "http://stacspec.org/a/catalog.json",
-                "http://stacspec.org/a/b/c/catalog.json",
-                "../../catalog.json",
-            ),
-            (
-                "http://stacspec.org/a/catalog.json",
-                "http://cogeo.org/a/b/c/catalog.json",
-                "http://stacspec.org/a/catalog.json",
-            ),
-            (
-                "http://stacspec.org/a/catalog.json",
-                "https://stacspec.org/a/b/c/catalog.json",
-                "http://stacspec.org/a/catalog.json",
-            ),
-            (
-                "http://stacspec.org/a/",
-                "https://stacspec.org/a/b/c/catalog.json",
-                "http://stacspec.org/a/",
-            ),
-            (
-                "http://stacspec.org/a/b/.dotfile",
-                "http://stacspec.org/a/b/catalog.json",
-                "./.dotfile",
-            ),
-        ]
+    for source_href, start_href, expected in test_cases:
+        actual = make_relative_href(source_href, start_href)
+        assert actual == expected
 
-        for source_href, start_href, expected in test_cases:
-            actual = make_relative_href(source_href, start_href)
-            assert actual == expected
+def test_make_relative_href_windows() -> None:
+    # Test cases of (source_href, start_href, expected)
+    test_cases = [
+        (
+            "C:\\a\\b\\c\\d\\catalog.json",
+            "C:\\a\\b\\c\\catalog.json",
+            "./d/catalog.json",
+        ),
+        (
+            "C:\\a\\b\\catalog.json",
+            "C:\\a\\b\\c\\catalog.json",
+            "../catalog.json",
+        ),
+        (
+            "C:\\a\\catalog.json",
+            "C:\\a\\b\\c\\catalog.json",
+            "../../catalog.json",
+        ),
+        ("a\\b\\c\\catalog.json", "a\\b\\catalog.json", "./c/catalog.json"),
+        ("a\\b\\catalog.json", "a\\b\\c\\catalog.json", "../catalog.json"),
+        (
+            "http://stacspec.org/a/b/c/d/catalog.json",
+            "http://stacspec.org/a/b/c/catalog.json",
+            "./d/catalog.json",
+        ),
+        (
+            "http://stacspec.org/a/b/catalog.json",
+            "http://stacspec.org/a/b/c/catalog.json",
+            "../catalog.json",
+        ),
+        (
+            "http://stacspec.org/a/catalog.json",
+            "http://stacspec.org/a/b/c/catalog.json",
+            "../../catalog.json",
+        ),
+        (
+            "http://stacspec.org/a/catalog.json",
+            "http://cogeo.org/a/b/c/catalog.json",
+            "http://stacspec.org/a/catalog.json",
+        ),
+        (
+            "http://stacspec.org/a/catalog.json",
+            "https://stacspec.org/a/b/c/catalog.json",
+            "http://stacspec.org/a/catalog.json",
+        ),
+    ]
 
-    def test_make_relative_href_windows(self) -> None:
-        # Test cases of (source_href, start_href, expected)
-        test_cases = [
-            (
-                "C:\\a\\b\\c\\d\\catalog.json",
-                "C:\\a\\b\\c\\catalog.json",
-                "./d/catalog.json",
-            ),
-            (
-                "C:\\a\\b\\catalog.json",
-                "C:\\a\\b\\c\\catalog.json",
-                "../catalog.json",
-            ),
-            (
-                "C:\\a\\catalog.json",
-                "C:\\a\\b\\c\\catalog.json",
-                "../../catalog.json",
-            ),
-            ("a\\b\\c\\catalog.json", "a\\b\\catalog.json", "./c/catalog.json"),
-            ("a\\b\\catalog.json", "a\\b\\c\\catalog.json", "../catalog.json"),
-            (
-                "http://stacspec.org/a/b/c/d/catalog.json",
-                "http://stacspec.org/a/b/c/catalog.json",
-                "./d/catalog.json",
-            ),
-            (
-                "http://stacspec.org/a/b/catalog.json",
-                "http://stacspec.org/a/b/c/catalog.json",
-                "../catalog.json",
-            ),
-            (
-                "http://stacspec.org/a/catalog.json",
-                "http://stacspec.org/a/b/c/catalog.json",
-                "../../catalog.json",
-            ),
-            (
-                "http://stacspec.org/a/catalog.json",
-                "http://cogeo.org/a/b/c/catalog.json",
-                "http://stacspec.org/a/catalog.json",
-            ),
-            (
-                "http://stacspec.org/a/catalog.json",
-                "https://stacspec.org/a/b/c/catalog.json",
-                "http://stacspec.org/a/catalog.json",
-            ),
-        ]
+    for source_href, start_href, expected in test_cases:
+        actual = make_relative_href(source_href, start_href)
+        assert actual == expected
 
-        for source_href, start_href, expected in test_cases:
-            actual = make_relative_href(source_href, start_href)
-            assert actual == expected
+def test_make_absolute_href() -> None:
+    # Test cases of (source_href, start_href, expected)
+    test_cases = [
+        ("item.json", "/a/b/c/catalog.json", "/a/b/c/item.json"),
+        ("./item.json", "/a/b/c/catalog.json", "/a/b/c/item.json"),
+        ("./z/item.json", "/a/b/c/catalog.json", "/a/b/c/z/item.json"),
+        ("../item.json", "/a/b/c/catalog.json", "/a/b/item.json"),
+        (
+            "item.json",
+            "https://stacspec.org/a/b/c/catalog.json",
+            "https://stacspec.org/a/b/c/item.json",
+        ),
+        (
+            "./item.json",
+            "https://stacspec.org/a/b/c/catalog.json",
+            "https://stacspec.org/a/b/c/item.json",
+        ),
+        (
+            "./z/item.json",
+            "https://stacspec.org/a/b/c/catalog.json",
+            "https://stacspec.org/a/b/c/z/item.json",
+        ),
+        (
+            "../item.json",
+            "https://stacspec.org/a/b/c/catalog.json",
+            "https://stacspec.org/a/b/item.json",
+        ),
+        ("http://localhost:8000", None, "http://localhost:8000"),
+        ("item.json", "file:///a/b/c/catalog.json", "file:///a/b/c/item.json"),
+        (
+            "./z/item.json",
+            "file:///a/b/c/catalog.json",
+            "file:///a/b/c/z/item.json",
+        ),
+        ("file:///a/b/c/item.json", None, "file:///a/b/c/item.json"),
+    ]
 
-    def test_make_absolute_href(self) -> None:
-        # Test cases of (source_href, start_href, expected)
-        test_cases = [
-            ("item.json", "/a/b/c/catalog.json", "/a/b/c/item.json"),
-            ("./item.json", "/a/b/c/catalog.json", "/a/b/c/item.json"),
-            ("./z/item.json", "/a/b/c/catalog.json", "/a/b/c/z/item.json"),
-            ("../item.json", "/a/b/c/catalog.json", "/a/b/item.json"),
-            (
-                "item.json",
-                "https://stacspec.org/a/b/c/catalog.json",
-                "https://stacspec.org/a/b/c/item.json",
-            ),
-            (
-                "./item.json",
-                "https://stacspec.org/a/b/c/catalog.json",
-                "https://stacspec.org/a/b/c/item.json",
-            ),
-            (
-                "./z/item.json",
-                "https://stacspec.org/a/b/c/catalog.json",
-                "https://stacspec.org/a/b/c/z/item.json",
-            ),
-            (
-                "../item.json",
-                "https://stacspec.org/a/b/c/catalog.json",
-                "https://stacspec.org/a/b/item.json",
-            ),
-            ("http://localhost:8000", None, "http://localhost:8000"),
-            ("item.json", "file:///a/b/c/catalog.json", "file:///a/b/c/item.json"),
-            (
-                "./z/item.json",
-                "file:///a/b/c/catalog.json",
-                "file:///a/b/c/z/item.json",
-            ),
-            ("file:///a/b/c/item.json", None, "file:///a/b/c/item.json"),
-        ]
+    for source_href, start_href, expected in test_cases:
+        actual = make_absolute_href(source_href, start_href)
+        if expected.startswith("file://"):
+            _, actual = os.path.splitdrive(actual.replace("file://", ""))
+            actual = f"file://{actual}"
+        else:
+            _, actual = os.path.splitdrive(actual)
+        assert actual == expected
 
-        for source_href, start_href, expected in test_cases:
-            actual = make_absolute_href(source_href, start_href)
-            if expected.startswith("file://"):
-                _, actual = os.path.splitdrive(actual.replace("file://", ""))
-                actual = f"file://{actual}"
-            else:
-                _, actual = os.path.splitdrive(actual)
-            assert actual == expected
+def test_make_absolute_href_on_vsitar() -> None:
+    rel_path = "some/item.json"
+    cat_path = "/vsitar//tmp/catalog.tar/catalog.json"
+    expected = "/vsitar//tmp/catalog.tar/some/item.json"
 
-    def test_make_absolute_href_on_vsitar(self) -> None:
-        rel_path = "some/item.json"
-        cat_path = "/vsitar//tmp/catalog.tar/catalog.json"
-        expected = "/vsitar//tmp/catalog.tar/some/item.json"
+    assert expected, make_absolute_href(rel_path == cat_path)
 
-        assert expected, make_absolute_href(rel_path == cat_path)
+@pytest.mark.skipif(os.name != "nt", reason="Windows only test")
+def test_make_absolute_href_windows() -> None:
+    # Test cases of (source_href, start_href, expected)
+    test_cases = [
+        ("item.json", "C:\\a\\b\\c\\catalog.json", "C:/a/b/c/item.json"),
+        (".\\item.json", "C:\\a\\b\\c\\catalog.json", "C:/a/b/c/item.json"),
+        (
+            ".\\z\\item.json",
+            "Z:\\a\\b\\c\\catalog.json",
+            "Z:/a/b/c/z/item.json",
+        ),
+        ("..\\item.json", "a:\\a\\b\\c\\catalog.json", "a:/a/b/item.json"),
+        (
+            "item.json",
+            "HTTPS://stacspec.org/a/b/c/catalog.json",
+            "https://stacspec.org/a/b/c/item.json",
+        ),
+        (
+            "./item.json",
+            "https://stacspec.org/a/b/c/catalog.json",
+            "https://stacspec.org/a/b/c/item.json",
+        ),
+        (
+            "./z/item.json",
+            "https://stacspec.org/a/b/c/catalog.json",
+            "https://stacspec.org/a/b/c/z/item.json",
+        ),
+        (
+            "../item.json",
+            "https://stacspec.org/a/b/c/catalog.json",
+            "https://stacspec.org/a/b/item.json",
+        ),
+    ]
 
-    @pytest.mark.skipif(os.name != "nt", reason="Windows only test")
-    def test_make_absolute_href_windows(self) -> None:
-        # Test cases of (source_href, start_href, expected)
-        test_cases = [
-            ("item.json", "C:\\a\\b\\c\\catalog.json", "C:/a/b/c/item.json"),
-            (".\\item.json", "C:\\a\\b\\c\\catalog.json", "C:/a/b/c/item.json"),
-            (
-                ".\\z\\item.json",
-                "Z:\\a\\b\\c\\catalog.json",
-                "Z:/a/b/c/z/item.json",
-            ),
-            ("..\\item.json", "a:\\a\\b\\c\\catalog.json", "a:/a/b/item.json"),
-            (
-                "item.json",
-                "HTTPS://stacspec.org/a/b/c/catalog.json",
-                "https://stacspec.org/a/b/c/item.json",
-            ),
-            (
-                "./item.json",
-                "https://stacspec.org/a/b/c/catalog.json",
-                "https://stacspec.org/a/b/c/item.json",
-            ),
-            (
-                "./z/item.json",
-                "https://stacspec.org/a/b/c/catalog.json",
-                "https://stacspec.org/a/b/c/z/item.json",
-            ),
-            (
-                "../item.json",
-                "https://stacspec.org/a/b/c/catalog.json",
-                "https://stacspec.org/a/b/item.json",
-            ),
-        ]
+    for source_href, start_href, expected in test_cases:
+        actual = make_absolute_href(source_href, start_href)
+        assert actual == expected
 
-        for source_href, start_href, expected in test_cases:
-            actual = make_absolute_href(source_href, start_href)
-            assert actual == expected
+def test_is_absolute_href() -> None:
+    # Test cases of (href, expected)
+    test_cases = [
+        ("item.json", False),
+        ("./item.json", False),
+        ("../item.json", False),
+        ("http://stacspec.org/item.json", True),
+    ]
 
-    def test_is_absolute_href(self) -> None:
-        # Test cases of (href, expected)
-        test_cases = [
-            ("item.json", False),
-            ("./item.json", False),
-            ("../item.json", False),
-            ("http://stacspec.org/item.json", True),
-        ]
+    for href, expected in test_cases:
+        actual = is_absolute_href(href)
+        assert actual == expected
 
-        for href, expected in test_cases:
-            actual = is_absolute_href(href)
-            assert actual == expected
+def test_is_absolute_href_os_aware() -> None:
+    # Test cases of (href, expected)
 
-    def test_is_absolute_href_os_aware(self) -> None:
-        # Test cases of (href, expected)
+    is_windows = os.name == "nt"
+    incl_drive_letter = path_includes_drive_letter()
+    test_cases = [
+        ("/item.json", not incl_drive_letter),
+        ("/home/someuser/Downloads/item.json", not incl_drive_letter),
+        ("file:///home/someuser/Downloads/item.json", not incl_drive_letter),
+        ("d:/item.json", is_windows),
+        ("c:/files/more_files/item.json", is_windows),
+    ]
 
-        is_windows = os.name == "nt"
-        incl_drive_letter = path_includes_drive_letter()
-        test_cases = [
-            ("/item.json", not incl_drive_letter),
-            ("/home/someuser/Downloads/item.json", not incl_drive_letter),
-            ("file:///home/someuser/Downloads/item.json", not incl_drive_letter),
-            ("d:/item.json", is_windows),
-            ("c:/files/more_files/item.json", is_windows),
-        ]
+    for href, expected in test_cases:
+        actual = is_absolute_href(href)
+        assert actual == expected
 
-        for href, expected in test_cases:
-            actual = is_absolute_href(href)
-            assert actual == expected
+@pytest.mark.skipif(os.name != "nt", reason="Windows only test")
+def test_is_absolute_href_windows() -> None:
+    # Test cases of (href, expected)
 
-    @pytest.mark.skipif(os.name != "nt", reason="Windows only test")
-    def test_is_absolute_href_windows(self) -> None:
-        # Test cases of (href, expected)
+    test_cases = [
+        ("item.json", False),
+        (".\\item.json", False),
+        ("..\\item.json", False),
+        ("c:\\item.json", True),
+        ("http://stacspec.org/item.json", True),
+    ]
 
-        test_cases = [
-            ("item.json", False),
-            (".\\item.json", False),
-            ("..\\item.json", False),
-            ("c:\\item.json", True),
-            ("http://stacspec.org/item.json", True),
-        ]
+    for href, expected in test_cases:
+        actual = is_absolute_href(href)
+        assert actual == expected
 
-        for href, expected in test_cases:
-            actual = is_absolute_href(href)
-            assert actual == expected
+def test_datetime_to_str() -> None:
+    cases = (
+        (
+            "timezone naive, assume utc",
+            datetime(2000, 1, 1),
+            "2000-01-01T00:00:00Z",
+        ),
+        (
+            "timezone aware, utc",
+            datetime(2000, 1, 1, tzinfo=timezone.utc),
+            "2000-01-01T00:00:00Z",
+        ),
+        (
+            "timezone aware, utc -7",
+            datetime(2000, 1, 1, tzinfo=timezone(timedelta(hours=-7))),
+            "2000-01-01T00:00:00-07:00",
+        ),
+    )
 
-    def test_datetime_to_str(self) -> None:
-        cases = (
-            (
-                "timezone naive, assume utc",
-                datetime(2000, 1, 1),
-                "2000-01-01T00:00:00Z",
-            ),
-            (
-                "timezone aware, utc",
-                datetime(2000, 1, 1, tzinfo=timezone.utc),
-                "2000-01-01T00:00:00Z",
-            ),
-            (
-                "timezone aware, utc -7",
-                datetime(2000, 1, 1, tzinfo=timezone(timedelta(hours=-7))),
-                "2000-01-01T00:00:00-07:00",
-            ),
-        )
+    for title, dt, expected in cases:
+        #with self.subTest(title=title):
+        got = utils.datetime_to_str(dt)
+        assert expected == got
 
-        for title, dt, expected in cases:
-            with self.subTest(title=title):
-                got = utils.datetime_to_str(dt)
-                assert expected == got
+def test_datetime_to_str_with_microseconds_timespec() -> None:
+    cases = (
+        (
+            "timezone naive, assume utc",
+            datetime(2000, 1, 1, 0, 0, 0, 0),
+            "2000-01-01T00:00:00.000000Z",
+        ),
+        (
+            "timezone aware, utc",
+            datetime(2000, 1, 1, 0, 0, 0, 0, tzinfo=timezone.utc),
+            "2000-01-01T00:00:00.000000Z",
+        ),
+        (
+            "timezone aware, utc -7",
+            datetime(2000, 1, 1, 0, 0, 0, 0, tzinfo=timezone(timedelta(hours=-7))),
+            "2000-01-01T00:00:00.000000-07:00",
+        ),
+    )
 
-    def test_datetime_to_str_with_microseconds_timespec(self) -> None:
-        cases = (
-            (
-                "timezone naive, assume utc",
-                datetime(2000, 1, 1, 0, 0, 0, 0),
-                "2000-01-01T00:00:00.000000Z",
-            ),
-            (
-                "timezone aware, utc",
-                datetime(2000, 1, 1, 0, 0, 0, 0, tzinfo=timezone.utc),
-                "2000-01-01T00:00:00.000000Z",
-            ),
-            (
-                "timezone aware, utc -7",
-                datetime(2000, 1, 1, 0, 0, 0, 0, tzinfo=timezone(timedelta(hours=-7))),
-                "2000-01-01T00:00:00.000000-07:00",
-            ),
-        )
+    for title, dt, expected in cases:
+        # with self.subTest(title=title):
+        got = utils.datetime_to_str(dt, timespec="microseconds")
+        assert expected == got
 
-        for title, dt, expected in cases:
-            with self.subTest(title=title):
-                got = utils.datetime_to_str(dt, timespec="microseconds")
-                assert expected == got
+def test_str_to_datetime() -> None:
+    def _set_tzinfo(tz_str: str | None) -> None:
+        if tz_str is None:
+            if "TZ" in os.environ:
+                del os.environ["TZ"]
+        else:
+            os.environ["TZ"] = tz_str
+        # time.tzset() only available for Unix/Linux
+        if hasattr(time, "tzset"):
+            time.tzset()
 
-    def test_str_to_datetime(self) -> None:
-        def _set_tzinfo(tz_str: str | None) -> None:
-            if tz_str is None:
-                if "TZ" in os.environ:
-                    del os.environ["TZ"]
-            else:
-                os.environ["TZ"] = tz_str
-            # time.tzset() only available for Unix/Linux
-            if hasattr(time, "tzset"):
-                time.tzset()
+    utc_timestamp = "2015-06-27T10:25:31Z"
 
-        utc_timestamp = "2015-06-27T10:25:31Z"
+    prev_tz = os.environ.get("TZ")
 
-        prev_tz = os.environ.get("TZ")
+    # with self.subTest(tz=None):
+    _set_tzinfo(None)
+    utc_datetime = str_to_datetime(utc_timestamp)
+    assert utc_datetime.tzinfo is tz.tzutc()
+    assert utc_datetime.tzinfo is not tz.tzlocal()
 
-        with self.subTest(tz=None):
-            _set_tzinfo(None)
-            utc_datetime = str_to_datetime(utc_timestamp)
-            assert utc_datetime.tzinfo is tz.tzutc()
-            assert utc_datetime.tzinfo is not tz.tzlocal()
+    # with self.subTest(tz="UTC"):
+    _set_tzinfo("UTC")
+    utc_datetime = str_to_datetime(utc_timestamp)
+    assert utc_datetime.tzinfo is tz.tzutc()
+    assert utc_datetime.tzinfo is not tz.tzlocal()
 
-        with self.subTest(tz="UTC"):
-            _set_tzinfo("UTC")
-            utc_datetime = str_to_datetime(utc_timestamp)
-            assert utc_datetime.tzinfo is tz.tzutc()
-            assert utc_datetime.tzinfo is not tz.tzlocal()
+    # with self.subTest(tz="US/Central"):
+    _set_tzinfo("US/Central")
+    utc_datetime = str_to_datetime(utc_timestamp)
+    assert utc_datetime.tzinfo is tz.tzutc()
+    assert utc_datetime.tzinfo is not tz.tzlocal()
 
-        with self.subTest(tz="US/Central"):
-            _set_tzinfo("US/Central")
-            utc_datetime = str_to_datetime(utc_timestamp)
-            assert utc_datetime.tzinfo is tz.tzutc()
-            assert utc_datetime.tzinfo is not tz.tzlocal()
+    if prev_tz is not None:
+        _set_tzinfo(prev_tz)
 
-        if prev_tz is not None:
-            _set_tzinfo(prev_tz)
-
-    def test_geojson_bbox(self) -> None:
-        # Use sample Geojson from https://en.wikipedia.org/wiki/GeoJSON
-        with open(
-            TestCases.get_path("data-files/geojson/sample.geojson")
-        ) as sample_geojson:
-            all_features = json.load(sample_geojson)
-            geom_dicts = [f["geometry"] for f in all_features["features"]]
-            for geom in geom_dicts:
-                got = utils.geometry_to_bbox(geom)
-                assert got != None
+def test_geojson_bbox() -> None:
+    # Use sample Geojson from https://en.wikipedia.org/wiki/GeoJSON
+    with open(
+        TestCases.get_path("data-files/geojson/sample.geojson")
+    ) as sample_geojson:
+        all_features = json.load(sample_geojson)
+        geom_dicts = [f["geometry"] for f in all_features["features"]]
+        for geom in geom_dicts:
+            got = utils.geometry_to_bbox(geom)
+            assert got != None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -252,9 +252,8 @@ def test_datetime_to_str() -> None:
     )
 
     for title, dt, expected in cases:
-        #with self.subTest(title=title):
         got = utils.datetime_to_str(dt)
-        assert expected == got
+        assert expected == got, f"Failure: {title}"
 
 def test_datetime_to_str_with_microseconds_timespec() -> None:
     cases = (
@@ -276,9 +275,8 @@ def test_datetime_to_str_with_microseconds_timespec() -> None:
     )
 
     for title, dt, expected in cases:
-        # with self.subTest(title=title):
         got = utils.datetime_to_str(dt, timespec="microseconds")
-        assert expected == got
+        assert expected == got, f"Failure: {title}"
 
 def test_str_to_datetime() -> None:
     def _set_tzinfo(tz_str: str | None) -> None:
@@ -295,19 +293,16 @@ def test_str_to_datetime() -> None:
 
     prev_tz = os.environ.get("TZ")
 
-    # with self.subTest(tz=None):
     _set_tzinfo(None)
     utc_datetime = str_to_datetime(utc_timestamp)
     assert utc_datetime.tzinfo is tz.tzutc()
     assert utc_datetime.tzinfo is not tz.tzlocal()
 
-    # with self.subTest(tz="UTC"):
     _set_tzinfo("UTC")
     utc_datetime = str_to_datetime(utc_timestamp)
     assert utc_datetime.tzinfo is tz.tzutc()
     assert utc_datetime.tzinfo is not tz.tzlocal()
 
-    # with self.subTest(tz="US/Central"):
     _set_tzinfo("US/Central")
     utc_datetime = str_to_datetime(utc_timestamp)
     assert utc_datetime.tzinfo is tz.tzutc()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,116 +22,120 @@ from pystac.utils import (
 )
 from tests.utils import TestCases, path_includes_drive_letter
 
+
 @pytest.mark.parametrize(
-    "source_href, start_href, expected", (
-    # relative href
-    ("/a/b/c/d/catalog.json", "/a/b/c/catalog.json", "./d/catalog.json"),
-    ("/a/b/catalog.json", "/a/b/c/catalog.json", "../catalog.json"),
-    ("/a/catalog.json", "/a/b/c/catalog.json", "../../catalog.json"),
-    ("/a/b/c/d/", "/a/b/c/catalog.json", "./d/"),
-    ("/a/b/c/d/.dotfile", "/a/b/c/d/catalog.json", "./.dotfile"),
-    ("file:///a/b/c/d/catalog.json", "file:///a/b/c/catalog.json", "./d/catalog.json"),
-    # relative href url
+    "source_href, start_href, expected",
     (
+        # relative href
+        ("/a/b/c/d/catalog.json", "/a/b/c/catalog.json", "./d/catalog.json"),
+        ("/a/b/catalog.json", "/a/b/c/catalog.json", "../catalog.json"),
+        ("/a/catalog.json", "/a/b/c/catalog.json", "../../catalog.json"),
+        ("/a/b/c/d/", "/a/b/c/catalog.json", "./d/"),
+        ("/a/b/c/d/.dotfile", "/a/b/c/d/catalog.json", "./.dotfile"),
+        (
+            "file:///a/b/c/d/catalog.json",
+            "file:///a/b/c/catalog.json",
+            "./d/catalog.json",
+        ),
+        # relative href url
+        (
             "http://stacspec.org/a/b/c/d/catalog.json",
             "http://stacspec.org/a/b/c/catalog.json",
             "./d/catalog.json",
-    ),
-    (
+        ),
+        (
             "http://stacspec.org/a/b/catalog.json",
             "http://stacspec.org/a/b/c/catalog.json",
             "../catalog.json",
-    ),
-    (
+        ),
+        (
             "http://stacspec.org/a/catalog.json",
             "http://stacspec.org/a/b/c/catalog.json",
             "../../catalog.json",
-    ),
-    (
+        ),
+        (
             "http://stacspec.org/a/catalog.json",
             "http://cogeo.org/a/b/c/catalog.json",
             "http://stacspec.org/a/catalog.json",
-    ),
-    (
+        ),
+        (
             "http://stacspec.org/a/catalog.json",
             "https://stacspec.org/a/b/c/catalog.json",
             "http://stacspec.org/a/catalog.json",
-    ),
-    (
+        ),
+        (
             "http://stacspec.org/a/",
             "https://stacspec.org/a/b/c/catalog.json",
             "http://stacspec.org/a/",
-    ),
-    (
+        ),
+        (
             "http://stacspec.org/a/b/.dotfile",
             "http://stacspec.org/a/b/catalog.json",
             "./.dotfile",
+        ),
+        # relative href under windows
+        (
+            "C:\\a\\b\\c\\d\\catalog.json",
+            "C:\\a\\b\\c\\catalog.json",
+            "./d/catalog.json",
+        ),
+        (
+            "C:\\a\\b\\catalog.json",
+            "C:\\a\\b\\c\\catalog.json",
+            "../catalog.json",
+        ),
+        (
+            "C:\\a\\catalog.json",
+            "C:\\a\\b\\c\\catalog.json",
+            "../../catalog.json",
+        ),
+        ("a\\b\\c\\catalog.json", "a\\b\\catalog.json", "./c/catalog.json"),
+        ("a\\b\\catalog.json", "a\\b\\c\\catalog.json", "../catalog.json"),
     ),
-    # relative href under windows
-    (
-        "C:\\a\\b\\c\\d\\catalog.json",
-        "C:\\a\\b\\c\\catalog.json",
-        "./d/catalog.json",
-    ),
-    (
-        "C:\\a\\b\\catalog.json",
-        "C:\\a\\b\\c\\catalog.json",
-        "../catalog.json",
-    ),
-    (
-        "C:\\a\\catalog.json",
-        "C:\\a\\b\\c\\catalog.json",
-        "../../catalog.json",
-    ),
-    ("a\\b\\c\\catalog.json", "a\\b\\catalog.json", "./c/catalog.json"),
-    ("a\\b\\catalog.json", "a\\b\\c\\catalog.json", "../catalog.json"),
-    )
 )
-def test_make_relative_href(
-        source_href: str, start_href: str, expected: str
-) -> None:
+def test_make_relative_href(source_href: str, start_href: str, expected: str) -> None:
     actual = make_relative_href(source_href, start_href)
     assert actual == expected
 
 
 @pytest.mark.parametrize(
-    "source_href, start_href, expected", (
-            ("item.json", "/a/b/c/catalog.json", "/a/b/c/item.json"),
-            ("./item.json", "/a/b/c/catalog.json", "/a/b/c/item.json"),
-            ("./z/item.json", "/a/b/c/catalog.json", "/a/b/c/z/item.json"),
-            ("../item.json", "/a/b/c/catalog.json", "/a/b/item.json"),
-            (
-                    "item.json",
-                    "https://stacspec.org/a/b/c/catalog.json",
-                    "https://stacspec.org/a/b/c/item.json",
-            ),
-            (
-                    "./item.json",
-                    "https://stacspec.org/a/b/c/catalog.json",
-                    "https://stacspec.org/a/b/c/item.json",
-            ),
-            (
-                    "./z/item.json",
-                    "https://stacspec.org/a/b/c/catalog.json",
-                    "https://stacspec.org/a/b/c/z/item.json",
-            ),
-            (
-                    "../item.json",
-                    "https://stacspec.org/a/b/c/catalog.json",
-                    "https://stacspec.org/a/b/item.json",
-            ),
-            ("http://localhost:8000", None, "http://localhost:8000"),
-            ("item.json", "file:///a/b/c/catalog.json", "file:///a/b/c/item.json"),
-            (
-                    "./z/item.json",
-                    "file:///a/b/c/catalog.json",
-                    "file:///a/b/c/z/item.json",
-            ),
-            ("file:///a/b/c/item.json", None, "file:///a/b/c/item.json"),
-    ))
-def test_make_absolute_href(
-        source_href: str, start_href: str, expected: str
-) -> None:
+    "source_href, start_href, expected",
+    (
+        ("item.json", "/a/b/c/catalog.json", "/a/b/c/item.json"),
+        ("./item.json", "/a/b/c/catalog.json", "/a/b/c/item.json"),
+        ("./z/item.json", "/a/b/c/catalog.json", "/a/b/c/z/item.json"),
+        ("../item.json", "/a/b/c/catalog.json", "/a/b/item.json"),
+        (
+            "item.json",
+            "https://stacspec.org/a/b/c/catalog.json",
+            "https://stacspec.org/a/b/c/item.json",
+        ),
+        (
+            "./item.json",
+            "https://stacspec.org/a/b/c/catalog.json",
+            "https://stacspec.org/a/b/c/item.json",
+        ),
+        (
+            "./z/item.json",
+            "https://stacspec.org/a/b/c/catalog.json",
+            "https://stacspec.org/a/b/c/z/item.json",
+        ),
+        (
+            "../item.json",
+            "https://stacspec.org/a/b/c/catalog.json",
+            "https://stacspec.org/a/b/item.json",
+        ),
+        ("http://localhost:8000", None, "http://localhost:8000"),
+        ("item.json", "file:///a/b/c/catalog.json", "file:///a/b/c/item.json"),
+        (
+            "./z/item.json",
+            "file:///a/b/c/catalog.json",
+            "file:///a/b/c/z/item.json",
+        ),
+        ("file:///a/b/c/item.json", None, "file:///a/b/c/item.json"),
+    ),
+)
+def test_make_absolute_href(source_href: str, start_href: str, expected: str) -> None:
     actual = make_absolute_href(source_href, start_href)
     if expected.startswith("file://"):
         _, actual = os.path.splitdrive(actual.replace("file://", ""))
@@ -140,51 +144,55 @@ def test_make_absolute_href(
         _, actual = os.path.splitdrive(actual)
     assert actual == expected
 
+
 def test_make_absolute_href_on_vsitar() -> None:
     rel_path = "some/item.json"
     cat_path = "/vsitar//tmp/catalog.tar/catalog.json"
     expected = "/vsitar//tmp/catalog.tar/some/item.json"
 
-    assert expected, make_absolute_href(rel_path == cat_path)
+    assert expected == make_absolute_href(rel_path, cat_path)
+
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows only test")
 @pytest.mark.parametrize(
-    "source_href, start_href, expected", (
-            ("item.json", "C:\\a\\b\\c\\catalog.json", "C:/a/b/c/item.json"),
-            (".\\item.json", "C:\\a\\b\\c\\catalog.json", "C:/a/b/c/item.json"),
-            (
-                    ".\\z\\item.json",
-                    "Z:\\a\\b\\c\\catalog.json",
-                    "Z:/a/b/c/z/item.json",
-            ),
-            ("..\\item.json", "a:\\a\\b\\c\\catalog.json", "a:/a/b/item.json"),
-            (
-                    "item.json",
-                    "HTTPS://stacspec.org/a/b/c/catalog.json",
-                    "https://stacspec.org/a/b/c/item.json",
-            ),
-            (
-                    "./item.json",
-                    "https://stacspec.org/a/b/c/catalog.json",
-                    "https://stacspec.org/a/b/c/item.json",
-            ),
-            (
-                    "./z/item.json",
-                    "https://stacspec.org/a/b/c/catalog.json",
-                    "https://stacspec.org/a/b/c/z/item.json",
-            ),
-            (
-                    "../item.json",
-                    "https://stacspec.org/a/b/c/catalog.json",
-                    "https://stacspec.org/a/b/item.json",
-            ),
-
-    ))
+    "source_href, start_href, expected",
+    (
+        ("item.json", "C:\\a\\b\\c\\catalog.json", "C:/a/b/c/item.json"),
+        (".\\item.json", "C:\\a\\b\\c\\catalog.json", "C:/a/b/c/item.json"),
+        (
+            ".\\z\\item.json",
+            "Z:\\a\\b\\c\\catalog.json",
+            "Z:/a/b/c/z/item.json",
+        ),
+        ("..\\item.json", "a:\\a\\b\\c\\catalog.json", "a:/a/b/item.json"),
+        (
+            "item.json",
+            "HTTPS://stacspec.org/a/b/c/catalog.json",
+            "https://stacspec.org/a/b/c/item.json",
+        ),
+        (
+            "./item.json",
+            "https://stacspec.org/a/b/c/catalog.json",
+            "https://stacspec.org/a/b/c/item.json",
+        ),
+        (
+            "./z/item.json",
+            "https://stacspec.org/a/b/c/catalog.json",
+            "https://stacspec.org/a/b/c/z/item.json",
+        ),
+        (
+            "../item.json",
+            "https://stacspec.org/a/b/c/catalog.json",
+            "https://stacspec.org/a/b/item.json",
+        ),
+    ),
+)
 def test_make_absolute_href_windows(
-        source_href: str, start_href: str, expected: str
+    source_href: str, start_href: str, expected: str
 ) -> None:
     actual = make_absolute_href(source_href, start_href)
     assert actual == expected
+
 
 def test_is_absolute_href() -> None:
     # Test cases of (href, expected)
@@ -198,6 +206,7 @@ def test_is_absolute_href() -> None:
     for href, expected in test_cases:
         actual = is_absolute_href(href)
         assert actual == expected
+
 
 def test_is_absolute_href_os_aware() -> None:
     # Test cases of (href, expected)
@@ -216,6 +225,7 @@ def test_is_absolute_href_os_aware() -> None:
         actual = is_absolute_href(href)
         assert actual == expected
 
+
 @pytest.mark.skipif(os.name != "nt", reason="Windows only test")
 def test_is_absolute_href_windows() -> None:
     # Test cases of (href, expected)
@@ -231,6 +241,7 @@ def test_is_absolute_href_windows() -> None:
     for href, expected in test_cases:
         actual = is_absolute_href(href)
         assert actual == expected
+
 
 def test_datetime_to_str() -> None:
     cases = (
@@ -255,6 +266,7 @@ def test_datetime_to_str() -> None:
         got = utils.datetime_to_str(dt)
         assert expected == got, f"Failure: {title}"
 
+
 def test_datetime_to_str_with_microseconds_timespec() -> None:
     cases = (
         (
@@ -277,6 +289,7 @@ def test_datetime_to_str_with_microseconds_timespec() -> None:
     for title, dt, expected in cases:
         got = utils.datetime_to_str(dt, timespec="microseconds")
         assert expected == got, f"Failure: {title}"
+
 
 def test_str_to_datetime() -> None:
     def _set_tzinfo(tz_str: str | None) -> None:
@@ -311,6 +324,7 @@ def test_str_to_datetime() -> None:
     if prev_tz is not None:
         _set_tzinfo(prev_tz)
 
+
 def test_geojson_bbox() -> None:
     # Use sample Geojson from https://en.wikipedia.org/wiki/GeoJSON
     with open(
@@ -320,7 +334,7 @@ def test_geojson_bbox() -> None:
         geom_dicts = [f["geometry"] for f in all_features["features"]]
         for geom in geom_dicts:
             got = utils.geometry_to_bbox(geom)
-            assert got != None
+            assert got is not None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -82,7 +82,7 @@ class UtilsTest(unittest.TestCase):
 
         for source_href, start_href, expected in test_cases:
             actual = make_relative_href(source_href, start_href)
-            self.assertEqual(actual, expected)
+            assert actual == expected
 
     def test_make_relative_href_windows(self) -> None:
         # Test cases of (source_href, start_href, expected)
@@ -133,7 +133,7 @@ class UtilsTest(unittest.TestCase):
 
         for source_href, start_href, expected in test_cases:
             actual = make_relative_href(source_href, start_href)
-            self.assertEqual(actual, expected)
+            assert actual == expected
 
     def test_make_absolute_href(self) -> None:
         # Test cases of (source_href, start_href, expected)
@@ -179,14 +179,14 @@ class UtilsTest(unittest.TestCase):
                 actual = f"file://{actual}"
             else:
                 _, actual = os.path.splitdrive(actual)
-            self.assertEqual(actual, expected)
+            assert actual == expected
 
     def test_make_absolute_href_on_vsitar(self) -> None:
         rel_path = "some/item.json"
         cat_path = "/vsitar//tmp/catalog.tar/catalog.json"
         expected = "/vsitar//tmp/catalog.tar/some/item.json"
 
-        self.assertEqual(expected, make_absolute_href(rel_path, cat_path))
+        assert expected, make_absolute_href(rel_path == cat_path)
 
     @pytest.mark.skipif(os.name != "nt", reason="Windows only test")
     def test_make_absolute_href_windows(self) -> None:
@@ -224,7 +224,7 @@ class UtilsTest(unittest.TestCase):
 
         for source_href, start_href, expected in test_cases:
             actual = make_absolute_href(source_href, start_href)
-            self.assertEqual(actual, expected)
+            assert actual == expected
 
     def test_is_absolute_href(self) -> None:
         # Test cases of (href, expected)
@@ -237,7 +237,7 @@ class UtilsTest(unittest.TestCase):
 
         for href, expected in test_cases:
             actual = is_absolute_href(href)
-            self.assertEqual(actual, expected)
+            assert actual == expected
 
     def test_is_absolute_href_os_aware(self) -> None:
         # Test cases of (href, expected)
@@ -254,7 +254,7 @@ class UtilsTest(unittest.TestCase):
 
         for href, expected in test_cases:
             actual = is_absolute_href(href)
-            self.assertEqual(actual, expected)
+            assert actual == expected
 
     @pytest.mark.skipif(os.name != "nt", reason="Windows only test")
     def test_is_absolute_href_windows(self) -> None:
@@ -270,7 +270,7 @@ class UtilsTest(unittest.TestCase):
 
         for href, expected in test_cases:
             actual = is_absolute_href(href)
-            self.assertEqual(actual, expected)
+            assert actual == expected
 
     def test_datetime_to_str(self) -> None:
         cases = (
@@ -294,7 +294,7 @@ class UtilsTest(unittest.TestCase):
         for title, dt, expected in cases:
             with self.subTest(title=title):
                 got = utils.datetime_to_str(dt)
-                self.assertEqual(expected, got)
+                assert expected == got
 
     def test_datetime_to_str_with_microseconds_timespec(self) -> None:
         cases = (
@@ -318,7 +318,7 @@ class UtilsTest(unittest.TestCase):
         for title, dt, expected in cases:
             with self.subTest(title=title):
                 got = utils.datetime_to_str(dt, timespec="microseconds")
-                self.assertEqual(expected, got)
+                assert expected == got
 
     def test_str_to_datetime(self) -> None:
         def _set_tzinfo(tz_str: str | None) -> None:
@@ -338,20 +338,20 @@ class UtilsTest(unittest.TestCase):
         with self.subTest(tz=None):
             _set_tzinfo(None)
             utc_datetime = str_to_datetime(utc_timestamp)
-            self.assertIs(utc_datetime.tzinfo, tz.tzutc())
-            self.assertIsNot(utc_datetime.tzinfo, tz.tzlocal())
+            assert utc_datetime.tzinfo is tz.tzutc()
+            assert utc_datetime.tzinfo is not tz.tzlocal()
 
         with self.subTest(tz="UTC"):
             _set_tzinfo("UTC")
             utc_datetime = str_to_datetime(utc_timestamp)
-            self.assertIs(utc_datetime.tzinfo, tz.tzutc())
-            self.assertIsNot(utc_datetime.tzinfo, tz.tzlocal())
+            assert utc_datetime.tzinfo is tz.tzutc()
+            assert utc_datetime.tzinfo is not tz.tzlocal()
 
         with self.subTest(tz="US/Central"):
             _set_tzinfo("US/Central")
             utc_datetime = str_to_datetime(utc_timestamp)
-            self.assertIs(utc_datetime.tzinfo, tz.tzutc())
-            self.assertIsNot(utc_datetime.tzinfo, tz.tzlocal())
+            assert utc_datetime.tzinfo is tz.tzutc()
+            assert utc_datetime.tzinfo is not tz.tzlocal()
 
         if prev_tz is not None:
             _set_tzinfo(prev_tz)
@@ -365,7 +365,7 @@ class UtilsTest(unittest.TestCase):
             geom_dicts = [f["geometry"] for f in all_features["features"]]
             for geom in geom_dicts:
                 got = utils.geometry_to_bbox(geom)
-                self.assertNotEqual(got, None)
+                assert got != None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Related Issue(s):** #993

**Description:** This time it's `tests/test_stac_io.py`, `tests/test_summaries.py`, and `tests/test_utils.py`. For the latter I converted the biggest of the tests with internal loops to pytest's parametrize; a few tests in `test_utils.py` got collapsed down to one with some redundancy (likely accidental) taken out. That's why it seems to run more tests (and skip more) than previously. Also there's some windows-only tests this time; I assume those will get run when this PR is submitted?

**PR Checklist:**

- [x] Pre-commit hooks pass (run `pre-commit run --all-files`)
- [x] Tests pass (run `pytest`)
- [ ] ~Documentation has been updated to reflect changes, if applicable~
- [x] This PR maintains ~or improves~ overall codebase code coverage.
- [ ] ~Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.~
