### PR TITLE
release: v1.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [v1.12.2]
+
 ### Fixed
 
 - Make sure that `VersionRange` has `VersionID`s rather than strings ([#1512](https://github.com/stac-utils/pystac/pull/1512))
@@ -908,7 +910,8 @@ use `Band.create`
 
 Initial release.
 
-[Unreleased]: <https://github.com/stac-utils/pystac/compare/v1.12.1..main>
+[Unreleased]: <https://github.com/stac-utils/pystac/compare/v1.12.2..main>
+[v1.12.2]: <https://github.com/stac-utils/pystac/compare/v1.12.1..v1.12.2>
 [v1.12.1]: <https://github.com/stac-utils/pystac/compare/v1.12.0..v1.12.1>
 [v1.12.0]: <https://github.com/stac-utils/pystac/compare/v1.11.0..v1.12.0>
 [v1.11.0]: <https://github.com/stac-utils/pystac/compare/v1.10.1..v1.11.0>

--- a/pystac/version.py
+++ b/pystac/version.py
@@ -1,6 +1,6 @@
 import os
 
-__version__ = "1.12.1"
+__version__ = "1.12.2"
 """Library version"""
 
 


### PR DESCRIPTION
**Related Issue(s):**

- Get https://github.com/stac-utils/pystac/pull/1512 out to release fix for https://github.com/stac-utils/pystac/issues/1506

**Description:**

I went back to the last commit w/o a adding change to make this a "true" PATCH. I'll cut the release pointing at this commit once approved, then resolve merge conflicts and merge this (not squash merge) back to **main**.