### PR TITLE
993 progress: convert last 4 files outside of extensions/

### DIFF
--- a/tests/serialization/test_identify.py
+++ b/tests/serialization/test_identify.py
@@ -1,5 +1,3 @@
-import unittest
-
 import pytest
 
 import pystac
@@ -93,42 +91,43 @@ class TestIdentify:
         assert identify_stac_object_type(not_stac) is None
 
 
-class VersionTest(unittest.TestCase):
-    def test_version_ordering(self) -> None:
-        self.assertEqual(STACVersionID("0.9.0"), STACVersionID("0.9.0"))
-        self.assertFalse(STACVersionID("0.9.0") < STACVersionID("0.9.0"))
-        self.assertFalse(STACVersionID("0.9.0") != STACVersionID("0.9.0"))
-        self.assertFalse(STACVersionID("0.9.0") > STACVersionID("0.9.0"))
-        self.assertTrue(STACVersionID("1.0.0-beta.2") < "1.0.0")
-        self.assertTrue(STACVersionID("0.9.1") > "0.9.0")
-        self.assertFalse(STACVersionID("0.9.0") > "0.9.0")
-        self.assertTrue(STACVersionID("0.9.0") <= "0.9.0")
-        self.assertTrue(STACVersionID("1.0.0-beta.1") <= STACVersionID("1.0.0-beta.2"))
-        self.assertFalse(STACVersionID("1.0.0") < STACVersionID("1.0.0-beta.2"))
+def test_version_ordering() -> None:
+    assert STACVersionID("0.9.0") == STACVersionID("0.9.0")
+    assert not STACVersionID("0.9.0") != STACVersionID("0.9.0")
+    assert not STACVersionID("0.9.0") > STACVersionID("0.9.0")
+    assert STACVersionID("1.0.0-beta.2") < "1.0.0"
+    assert STACVersionID("0.9.1") > "0.9.0"
+    assert not STACVersionID("0.9.0") > "0.9.0"
+    assert STACVersionID("0.9.0") <= "0.9.0"
+    assert STACVersionID("1.0.0-beta.1") <= STACVersionID("1.0.0-beta.2")
+    assert not STACVersionID("1.0.0") < STACVersionID("1.0.0-beta.2")
 
-    def test_version_range_ordering(self) -> None:
-        version_range = STACVersionRange("0.9.0", "1.0.0-beta.2")
-        self.assertIsInstance(str(version_range), str)
-        self.assertTrue(version_range.contains("1.0.0-beta.1"))
-        self.assertFalse(version_range.contains("1.0.0"))
-        self.assertTrue(version_range.is_later_than("0.8.9"))
 
-        version_range = STACVersionRange("0.9.0", "1.0.0-beta.1")
-        self.assertFalse(version_range.contains("1.0.0-beta.2"))
+def test_version_range_ordering() -> None:
+    version_range = STACVersionRange("0.9.0", "1.0.0-beta.2")
+    assert isinstance(str(version_range), str)
+    assert version_range.contains("1.0.0-beta.1")
+    assert not version_range.contains("1.0.0")
+    assert version_range.is_later_than("0.8.9")
 
-        version_range = STACVersionRange(min_version="0.6.0-rc1", max_version="0.9.0")
-        self.assertTrue(version_range.contains("0.9.0"))
+    version_range = STACVersionRange("0.9.0", "1.0.0-beta.1")
+    assert not version_range.contains("1.0.0-beta.2")
 
-    def test_version_range_set_to_single(self) -> None:
-        version_range = STACVersionRange()
-        version_range.set_min("1.0.0-beta.1")
-        version_range.set_to_single("1.0.0")
+    version_range = STACVersionRange(min_version="0.6.0-rc1", max_version="0.9.0")
+    assert version_range.contains("0.9.0")
 
-        self.assertTrue(version_range.contains("1.0.0"))
 
-    def test_version_range_set_min_and_max_directly(self) -> None:
-        version_range = STACVersionRange()
-        version_range.min_version = "1.0.0-beta.1"  # type:ignore
-        version_range.max_version = "1.1.0"  # type:ignore
+def test_version_range_set_to_single() -> None:
+    version_range = STACVersionRange()
+    version_range.set_min("1.0.0-beta.1")
+    version_range.set_to_single("1.0.0")
 
-        self.assertTrue(version_range.contains("1.0.0"))
+    assert version_range.contains("1.0.0")
+
+
+def test_version_range_set_min_and_max_directly() -> None:
+    version_range = STACVersionRange()
+    version_range.min_version = "1.0.0-beta.1"  # type:ignore
+    version_range.max_version = "1.1.0"  # type:ignore
+
+    assert version_range.contains("1.0.0")

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -36,7 +36,6 @@ def test_ResolvedObjectCache_get_or_cache_returns_previously_cached_id() -> None
     assert cache_result_2 is cat
 
 
-# class ResolvedObjectCollectionCacheTest(unittest.TestCase):
 def test_ResolvedObjectCollectionCache_merge() -> None:
     cat1 = create_catalog(1, include_href=False)
     cat2 = create_catalog(2)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -20,21 +20,21 @@ class ResolvedObjectCacheTest(unittest.TestCase):
         cache = ResolvedObjectCache()
         cat = create_catalog(1)
         cache_result_1 = cache.get_or_cache(cat)
-        self.assertIs(cache_result_1, cat)
+        assert cache_result_1 is cat
 
         identical_cat = create_catalog(1)
         cache_result_2 = cache.get_or_cache(identical_cat)
-        self.assertIs(cache_result_2, cat)
+        assert cache_result_2 is cat
 
     def test_get_or_cache_returns_previously_cached_id(self) -> None:
         cache = ResolvedObjectCache()
         cat = create_catalog(1, include_href=False)
         cache_result_1 = cache.get_or_cache(cat)
-        self.assertIs(cache_result_1, cat)
+        assert cache_result_1 is cat
 
         identical_cat = create_catalog(1, include_href=False)
         cache_result_2 = cache.get_or_cache(identical_cat)
-        self.assertIs(cache_result_2, cat)
+        assert cache_result_2 is cat
 
 
 class ResolvedObjectCollectionCacheTest(unittest.TestCase):
@@ -65,15 +65,10 @@ class ResolvedObjectCollectionCacheTest(unittest.TestCase):
             ResolvedObjectCache(), cache1, cache2
         )
 
-        self.assertEqual(
-            set(merged.cached_ids.keys()), {cat.id for cat in [cat1, cat3]}
-        )
-        self.assertIs(merged.get_by_id(cat1.id), cat1)
-        self.assertEqual(
-            set(merged.cached_hrefs.keys()),
-            {cat.get_self_href() for cat in [cat2, cat4]},
-        )
-        self.assertIs(merged.get_by_href(get_opt(cat2.get_self_href())), cat2)
+        assert set(merged.cached_ids.keys()) == {cat.id for cat in [cat1, cat3]}
+        assert merged.get_by_id(cat1.id) is cat1
+        assert set(merged.cached_hrefs.keys()) == {cat.get_self_href() for cat in [cat2, cat4]}
+        assert merged.get_by_href(get_opt(cat2.get_self_href())) is cat2
 
     def test_cache(self) -> None:
         cache = ResolvedObjectCache().as_collection_cache()
@@ -82,4 +77,4 @@ class ResolvedObjectCollectionCacheTest(unittest.TestCase):
         cache.cache(collection_json, collection.get_self_href())
         cached = cache.get_by_id(collection.id)
         assert isinstance(cached, dict)
-        self.assertEqual(cached["id"], collection.id)
+        assert cached["id"] == collection.id

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,4 +1,3 @@
-import unittest
 from typing import Any
 
 import pystac
@@ -24,6 +23,7 @@ def test_ResolvedObjectCache_get_or_cache_returns_previously_cached_href() -> No
     identical_cat = create_catalog(1)
     cache_result_2 = cache.get_or_cache(identical_cat)
     assert cache_result_2 is cat
+
 
 def test_ResolvedObjectCache_get_or_cache_returns_previously_cached_id() -> None:
     cache = ResolvedObjectCache()
@@ -60,14 +60,15 @@ def test_ResolvedObjectCollectionCache_merge() -> None:
         ResolvedObjectCache(), cached_ids=cached_ids_2, cached_hrefs=cached_hrefs_2
     )
 
-    merged = ResolvedObjectCollectionCache.merge(
-        ResolvedObjectCache(), cache1, cache2
-    )
+    merged = ResolvedObjectCollectionCache.merge(ResolvedObjectCache(), cache1, cache2)
 
     assert set(merged.cached_ids.keys()) == {cat.id for cat in [cat1, cat3]}
     assert merged.get_by_id(cat1.id) is cat1
-    assert set(merged.cached_hrefs.keys()) == {cat.get_self_href() for cat in [cat2, cat4]}
+    assert set(merged.cached_hrefs.keys()) == {
+        cat.get_self_href() for cat in [cat2, cat4]
+    }
     assert merged.get_by_href(get_opt(cat2.get_self_href())) is cat2
+
 
 def test_ResolvedObjectCollectionCache_cache() -> None:
     cache = ResolvedObjectCache().as_collection_cache()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -15,66 +15,65 @@ def create_catalog(suffix: Any, include_href: bool = True) -> pystac.Catalog:
     )
 
 
-class ResolvedObjectCacheTest(unittest.TestCase):
-    def tests_get_or_cache_returns_previously_cached_href(self) -> None:
-        cache = ResolvedObjectCache()
-        cat = create_catalog(1)
-        cache_result_1 = cache.get_or_cache(cat)
-        assert cache_result_1 is cat
+def test_ResolvedObjectCache_get_or_cache_returns_previously_cached_href() -> None:
+    cache = ResolvedObjectCache()
+    cat = create_catalog(1)
+    cache_result_1 = cache.get_or_cache(cat)
+    assert cache_result_1 is cat
 
-        identical_cat = create_catalog(1)
-        cache_result_2 = cache.get_or_cache(identical_cat)
-        assert cache_result_2 is cat
+    identical_cat = create_catalog(1)
+    cache_result_2 = cache.get_or_cache(identical_cat)
+    assert cache_result_2 is cat
 
-    def test_get_or_cache_returns_previously_cached_id(self) -> None:
-        cache = ResolvedObjectCache()
-        cat = create_catalog(1, include_href=False)
-        cache_result_1 = cache.get_or_cache(cat)
-        assert cache_result_1 is cat
+def test_ResolvedObjectCache_get_or_cache_returns_previously_cached_id() -> None:
+    cache = ResolvedObjectCache()
+    cat = create_catalog(1, include_href=False)
+    cache_result_1 = cache.get_or_cache(cat)
+    assert cache_result_1 is cat
 
-        identical_cat = create_catalog(1, include_href=False)
-        cache_result_2 = cache.get_or_cache(identical_cat)
-        assert cache_result_2 is cat
+    identical_cat = create_catalog(1, include_href=False)
+    cache_result_2 = cache.get_or_cache(identical_cat)
+    assert cache_result_2 is cat
 
 
-class ResolvedObjectCollectionCacheTest(unittest.TestCase):
-    def test_merge(self) -> None:
-        cat1 = create_catalog(1, include_href=False)
-        cat2 = create_catalog(2)
-        cat3 = create_catalog(3, include_href=False)
-        cat4 = create_catalog(4)
+# class ResolvedObjectCollectionCacheTest(unittest.TestCase):
+def test_ResolvedObjectCollectionCache_merge() -> None:
+    cat1 = create_catalog(1, include_href=False)
+    cat2 = create_catalog(2)
+    cat3 = create_catalog(3, include_href=False)
+    cat4 = create_catalog(4)
 
-        identical_cat1 = create_catalog(1, include_href=False)
-        identical_cat2 = create_catalog(2)
+    identical_cat1 = create_catalog(1, include_href=False)
+    identical_cat2 = create_catalog(2)
 
-        cached_ids_1: dict[str, Any] = {cat1.id: cat1}
-        cached_hrefs_1: dict[str, Any] = {get_opt(cat2.get_self_href()): cat2}
-        cached_ids_2: dict[str, Any] = {cat3.id: cat3, cat1.id: identical_cat1}
-        cached_hrefs_2: dict[str, Any] = {
-            get_opt(cat4.get_self_href()): cat4,
-            get_opt(cat2.get_self_href()): identical_cat2,
-        }
-        cache1 = ResolvedObjectCollectionCache(
-            ResolvedObjectCache(), cached_ids=cached_ids_1, cached_hrefs=cached_hrefs_1
-        )
-        cache2 = ResolvedObjectCollectionCache(
-            ResolvedObjectCache(), cached_ids=cached_ids_2, cached_hrefs=cached_hrefs_2
-        )
+    cached_ids_1: dict[str, Any] = {cat1.id: cat1}
+    cached_hrefs_1: dict[str, Any] = {get_opt(cat2.get_self_href()): cat2}
+    cached_ids_2: dict[str, Any] = {cat3.id: cat3, cat1.id: identical_cat1}
+    cached_hrefs_2: dict[str, Any] = {
+        get_opt(cat4.get_self_href()): cat4,
+        get_opt(cat2.get_self_href()): identical_cat2,
+    }
+    cache1 = ResolvedObjectCollectionCache(
+        ResolvedObjectCache(), cached_ids=cached_ids_1, cached_hrefs=cached_hrefs_1
+    )
+    cache2 = ResolvedObjectCollectionCache(
+        ResolvedObjectCache(), cached_ids=cached_ids_2, cached_hrefs=cached_hrefs_2
+    )
 
-        merged = ResolvedObjectCollectionCache.merge(
-            ResolvedObjectCache(), cache1, cache2
-        )
+    merged = ResolvedObjectCollectionCache.merge(
+        ResolvedObjectCache(), cache1, cache2
+    )
 
-        assert set(merged.cached_ids.keys()) == {cat.id for cat in [cat1, cat3]}
-        assert merged.get_by_id(cat1.id) is cat1
-        assert set(merged.cached_hrefs.keys()) == {cat.get_self_href() for cat in [cat2, cat4]}
-        assert merged.get_by_href(get_opt(cat2.get_self_href())) is cat2
+    assert set(merged.cached_ids.keys()) == {cat.id for cat in [cat1, cat3]}
+    assert merged.get_by_id(cat1.id) is cat1
+    assert set(merged.cached_hrefs.keys()) == {cat.get_self_href() for cat in [cat2, cat4]}
+    assert merged.get_by_href(get_opt(cat2.get_self_href())) is cat2
 
-    def test_cache(self) -> None:
-        cache = ResolvedObjectCache().as_collection_cache()
-        collection = TestCases.case_8()
-        collection_json = collection.to_dict()
-        cache.cache(collection_json, collection.get_self_href())
-        cached = cache.get_by_id(collection.id)
-        assert isinstance(cached, dict)
-        assert cached["id"] == collection.id
+def test_ResolvedObjectCollectionCache_cache() -> None:
+    cache = ResolvedObjectCache().as_collection_cache()
+    collection = TestCases.case_8()
+    collection_json = collection.to_dict()
+    cache.cache(collection_json, collection.get_self_href())
+    cached = cache.get_by_id(collection.id)
+    assert isinstance(cached, dict)
+    assert cached["id"] == collection.id

--- a/tests/test_common_metadata.py
+++ b/tests/test_common_metadata.py
@@ -1,4 +1,3 @@
-import unittest
 from datetime import datetime
 from typing import Any
 
@@ -243,9 +242,7 @@ class TestAssetCommonMetadata:
         assert analytic_cm.title == set_value
         assert analytic.to_dict()["title"] == set_value
 
-class TestOrigAssetCommonMetadata(unittest.TestCase):
-    def test_description(self) -> None:
-        item = self.item
+    def test_description(self, item: Item) -> None:
         cm = item.common_metadata
         analytic = item.assets["analytic"]
         analytic_cm = CommonMetadata(analytic)
@@ -266,8 +263,7 @@ class TestOrigAssetCommonMetadata(unittest.TestCase):
         assert analytic_cm.description == set_value
         assert analytic.to_dict()["description"] == set_value
 
-    def test_start_datetime(self) -> None:
-        item = self.item
+    def test_start_datetime(self, item: Item) -> None:
         item_cm = item.common_metadata
         analytic = item.assets["analytic"]
         analytic_cm = CommonMetadata(analytic)
@@ -288,8 +284,7 @@ class TestOrigAssetCommonMetadata(unittest.TestCase):
         assert analytic_cm.start_datetime == set_value
         assert analytic.to_dict()["start_datetime"] == utils.datetime_to_str(set_value)
 
-    def test_end_datetime(self) -> None:
-        item = self.item
+    def test_end_datetime(self, item: Item) -> None:
         cm = item.common_metadata
         analytic = item.assets["analytic"]
         analytic_cm = CommonMetadata(analytic)
@@ -310,8 +305,7 @@ class TestOrigAssetCommonMetadata(unittest.TestCase):
         assert analytic_cm.end_datetime == set_value
         assert analytic.to_dict()["end_datetime"] == utils.datetime_to_str(set_value)
 
-    def test_license(self) -> None:
-        item = self.item
+    def test_license(self, item: Item) -> None:
         cm = item.common_metadata
         analytic = item.assets["analytic"]
         analytic_cm = CommonMetadata(analytic)
@@ -332,8 +326,7 @@ class TestOrigAssetCommonMetadata(unittest.TestCase):
         assert analytic_cm.license == set_value
         assert analytic.to_dict()["license"] == set_value
 
-    def test_providers(self) -> None:
-        item = self.item
+    def test_providers(self, item: Item) -> None:
         cm = item.common_metadata
         analytic = item.assets["analytic"]
         analytic_cm = CommonMetadata(analytic)
@@ -366,8 +359,7 @@ class TestOrigAssetCommonMetadata(unittest.TestCase):
         assert analytic_cm.providers == set_value
         assert analytic.to_dict()["providers"] == [p.to_dict() for p in set_value]
 
-    def test_platform(self) -> None:
-        item = self.item
+    def test_platform(self, item: Item) -> None:
         cm = item.common_metadata
         analytic = item.assets["analytic"]
         analytic_cm = CommonMetadata(analytic)
@@ -388,8 +380,7 @@ class TestOrigAssetCommonMetadata(unittest.TestCase):
         assert analytic_cm.platform == set_value
         assert analytic.to_dict()["platform"] == set_value
 
-    def test_instruments(self) -> None:
-        item = self.item
+    def test_instruments(self, item: Item) -> None:
         cm = item.common_metadata
         analytic = item.assets["analytic"]
         analytic_cm = CommonMetadata(analytic)
@@ -410,8 +401,7 @@ class TestOrigAssetCommonMetadata(unittest.TestCase):
         assert analytic_cm.instruments == set_value
         assert analytic.to_dict()["instruments"] == set_value
 
-    def test_constellation(self) -> None:
-        item = self.item
+    def test_constellation(self, item: Item) -> None:
         cm = item.common_metadata
         analytic = item.assets["analytic"]
         analytic_cm = CommonMetadata(analytic)
@@ -432,8 +422,7 @@ class TestOrigAssetCommonMetadata(unittest.TestCase):
         assert analytic_cm.constellation == set_value
         assert analytic.to_dict()["constellation"] == set_value
 
-    def test_mission(self) -> None:
-        item = self.item
+    def test_mission(self, item: Item) -> None:
         cm = item.common_metadata
         analytic = item.assets["analytic"]
         analytic_cm = CommonMetadata(analytic)
@@ -454,8 +443,7 @@ class TestOrigAssetCommonMetadata(unittest.TestCase):
         assert analytic_cm.mission == set_value
         assert analytic.to_dict()["mission"] == set_value
 
-    def test_gsd(self) -> None:
-        item = self.item
+    def test_gsd(self, item: Item) -> None:
         cm = item.common_metadata
         analytic = item.assets["analytic"]
         analytic_cm = CommonMetadata(analytic)
@@ -476,8 +464,7 @@ class TestOrigAssetCommonMetadata(unittest.TestCase):
         assert analytic_cm.gsd == set_value
         assert analytic.to_dict()["gsd"] == set_value
 
-    def test_created(self) -> None:
-        item = self.item
+    def test_created(self, item: Item) -> None:
         cm = item.common_metadata
         analytic = item.assets["analytic"]
         analytic_cm = CommonMetadata(analytic)
@@ -498,8 +485,7 @@ class TestOrigAssetCommonMetadata(unittest.TestCase):
         assert analytic_cm.created == set_value
         assert analytic.to_dict()["created"] == utils.datetime_to_str(set_value)
 
-    def test_updated(self) -> None:
-        item = self.item
+    def test_updated(self, item: Item) -> None:
         cm = item.common_metadata
         analytic = item.assets["analytic"]
         analytic_cm = CommonMetadata(analytic)
@@ -520,8 +506,7 @@ class TestOrigAssetCommonMetadata(unittest.TestCase):
         assert analytic_cm.updated == set_value
         assert analytic.to_dict()["updated"] == utils.datetime_to_str(set_value)
 
-    def test_keywords(self) -> None:
-        item = self.item
+    def test_keywords(self, item: Item) -> None:
         cm = item.common_metadata
         analytic = item.assets["analytic"]
         analytic_cm = CommonMetadata(analytic)
@@ -542,8 +527,7 @@ class TestOrigAssetCommonMetadata(unittest.TestCase):
         assert analytic_cm.keywords == set_value
         assert analytic.to_dict()["keywords"] == set_value
 
-    def test_roles(self) -> None:
-        item = self.item
+    def test_roles(self, item: Item) -> None:
         cm = item.common_metadata
         analytic = item.assets["analytic"]
         analytic_cm = CommonMetadata(analytic)
@@ -563,10 +547,3 @@ class TestOrigAssetCommonMetadata(unittest.TestCase):
 
         assert analytic_cm.roles == set_value
         assert analytic.to_dict()["roles"] == set_value
-
-    def setUp(self) -> None:
-        # used in many tests
-        self.item = Item.from_file(
-            TestCases.get_path("data-files/item/sample-item-asset-properties.json")
-        )
-

--- a/tests/test_common_metadata.py
+++ b/tests/test_common_metadata.py
@@ -62,166 +62,158 @@ def test_common_metadata_end_datetime(date_time_range_item: Item) -> None:
     assert x.common_metadata.end_datetime == example_datetime_dt
     assert x.properties["end_datetime"] == example_datetime_str
 
-class TestCommonMetadata(unittest.TestCase):
-    def setUp(self) -> None:
-        # 4 tests
-        self.ITEM_2 = Item.from_file(
-            TestCases.get_path(
-                "data-files/examples/1.0.0-beta.2/item-spec/examples/sample-full.json"
-            )
-        )
 
-    def test_common_metadata_created(self) -> None:
-        x = self.ITEM_2.clone()
-        created_str = "2016-05-04T00:00:01Z"
-        created_dt = utils.str_to_datetime(created_str)
-        example_datetime_str = "2020-01-01T00:00:00Z"
-        example_datetime_dt = utils.str_to_datetime(example_datetime_str)
+def test_common_metadata_created(sample_full_item: Item) -> None:
+    x = sample_full_item.clone()
+    created_str = "2016-05-04T00:00:01Z"
+    created_dt = utils.str_to_datetime(created_str)
+    example_datetime_str = "2020-01-01T00:00:00Z"
+    example_datetime_dt = utils.str_to_datetime(example_datetime_str)
 
-        assert x.common_metadata.created == created_dt
-        assert x.properties["created"] == created_str
+    assert x.common_metadata.created == created_dt
+    assert x.properties["created"] == created_str
 
-        x.common_metadata.created = example_datetime_dt
+    x.common_metadata.created = example_datetime_dt
 
-        assert x.common_metadata.created == example_datetime_dt
-        assert x.properties["created"] == example_datetime_str
+    assert x.common_metadata.created == example_datetime_dt
+    assert x.properties["created"] == example_datetime_str
 
-    def test_common_metadata_updated(self) -> None:
-        x = self.ITEM_2.clone()
-        updated_str = "2017-01-01T00:30:55Z"
-        updated_dt = utils.str_to_datetime(updated_str)
-        example_datetime_str = "2020-01-01T00:00:00Z"
-        example_datetime_dt = utils.str_to_datetime(example_datetime_str)
+def test_common_metadata_updated(sample_full_item: Item) -> None:
+    x = sample_full_item.clone()
+    updated_str = "2017-01-01T00:30:55Z"
+    updated_dt = utils.str_to_datetime(updated_str)
+    example_datetime_str = "2020-01-01T00:00:00Z"
+    example_datetime_dt = utils.str_to_datetime(example_datetime_str)
 
-        assert x.common_metadata.updated == updated_dt
-        assert x.properties["updated"] == updated_str
+    assert x.common_metadata.updated == updated_dt
+    assert x.properties["updated"] == updated_str
 
-        x.common_metadata.updated = example_datetime_dt
+    x.common_metadata.updated = example_datetime_dt
 
-        assert x.common_metadata.updated == example_datetime_dt
-        assert x.properties["updated"] == example_datetime_str
+    assert x.common_metadata.updated == example_datetime_dt
+    assert x.properties["updated"] == example_datetime_str
 
-    def test_common_metadata_providers(self) -> None:
-        x = self.ITEM_2.clone()
+def test_common_metadata_providers(sample_full_item: Item) -> None:
+    x = sample_full_item.clone()
 
-        providers_dict_list: list[dict[str, Any]] = [
-            {
-                "name": "CoolSat",
-                "roles": ["producer", "licensor"],
-                "url": "https://cool-sat.com/",
-            }
-        ]
-        providers_object_list = [Provider.from_dict(d) for d in providers_dict_list]
+    providers_dict_list: list[dict[str, Any]] = [
+        {
+            "name": "CoolSat",
+            "roles": ["producer", "licensor"],
+            "url": "https://cool-sat.com/",
+        }
+    ]
+    providers_object_list = [Provider.from_dict(d) for d in providers_dict_list]
 
-        example_providers_dict_list: list[dict[str, Any]] = [
-            {
-                "name": "ExampleProvider_1",
-                "roles": ["example_role_1", "example_role_2"],
-                "url": "https://exampleprovider1.com/",
-            },
-            {
-                "name": "ExampleProvider_2",
-                "roles": ["example_role_1", "example_role_2"],
-                "url": "https://exampleprovider2.com/",
-            },
-        ]
-        example_providers_object_list = [
-            Provider.from_dict(d) for d in example_providers_dict_list
-        ]
+    example_providers_dict_list: list[dict[str, Any]] = [
+        {
+            "name": "ExampleProvider_1",
+            "roles": ["example_role_1", "example_role_2"],
+            "url": "https://exampleprovider1.com/",
+        },
+        {
+            "name": "ExampleProvider_2",
+            "roles": ["example_role_1", "example_role_2"],
+            "url": "https://exampleprovider2.com/",
+        },
+    ]
+    example_providers_object_list = [
+        Provider.from_dict(d) for d in example_providers_dict_list
+    ]
 
-        for i in range(len(utils.get_opt(x.common_metadata.providers))):
-            p1 = utils.get_opt(x.common_metadata.providers)[i]
-            p2 = providers_object_list[i]
-            assert isinstance(p1, Provider)
-            assert isinstance(p2, Provider)
-            assert p1.to_dict() == p2.to_dict()
+    for i in range(len(utils.get_opt(x.common_metadata.providers))):
+        p1 = utils.get_opt(x.common_metadata.providers)[i]
+        p2 = providers_object_list[i]
+        assert isinstance(p1, Provider)
+        assert isinstance(p2, Provider)
+        assert p1.to_dict() == p2.to_dict()
 
-            pd1 = x.properties["providers"][i]
-            pd2 = providers_dict_list[i]
-            assert isinstance(pd1, dict)
-            assert isinstance(pd2, dict)
-            assert pd1 == pd2
+        pd1 = x.properties["providers"][i]
+        pd2 = providers_dict_list[i]
+        assert isinstance(pd1, dict)
+        assert isinstance(pd2, dict)
+        assert pd1 == pd2
 
-        x.common_metadata.providers = example_providers_object_list
+    x.common_metadata.providers = example_providers_object_list
 
-        for i in range(len(x.common_metadata.providers)):
-            p1 = x.common_metadata.providers[i]
-            p2 = example_providers_object_list[i]
-            assert isinstance(p1, Provider)
-            assert isinstance(p2, Provider)
-            assert p1.to_dict() == p2.to_dict()
+    for i in range(len(x.common_metadata.providers)):
+        p1 = x.common_metadata.providers[i]
+        p2 = example_providers_object_list[i]
+        assert isinstance(p1, Provider)
+        assert isinstance(p2, Provider)
+        assert p1.to_dict() == p2.to_dict()
 
-            pd1 = x.properties["providers"][i]
-            pd2 = example_providers_dict_list[i]
-            assert isinstance(pd1, dict)
-            assert isinstance(pd2, dict)
-            assert pd1 == pd2
+        pd1 = x.properties["providers"][i]
+        pd2 = example_providers_dict_list[i]
+        assert isinstance(pd1, dict)
+        assert isinstance(pd2, dict)
+        assert pd1 == pd2
 
-    def test_common_metadata_basics(self) -> None:
-        x = self.ITEM_2.clone()
+def test_common_metadata_basics(sample_full_item: Item) -> None:
+    x = sample_full_item.clone()
 
-        # Title
-        title = "A CS3 item"
-        example_title = "example title"
-        assert x.common_metadata.title == title
-        x.common_metadata.title = example_title
-        assert x.common_metadata.title == example_title
-        assert x.properties["title"] == example_title
+    # Title
+    title = "A CS3 item"
+    example_title = "example title"
+    assert x.common_metadata.title == title
+    x.common_metadata.title = example_title
+    assert x.common_metadata.title == example_title
+    assert x.properties["title"] == example_title
 
-        # Description
-        example_description = "example description"
-        assert x.common_metadata.description is None
-        x.common_metadata.description = example_description
-        assert x.common_metadata.description == example_description
-        assert x.properties["description"] == example_description
-        with pytest.raises(ValueError):
-            x.common_metadata.description = ""
+    # Description
+    example_description = "example description"
+    assert x.common_metadata.description is None
+    x.common_metadata.description = example_description
+    assert x.common_metadata.description == example_description
+    assert x.properties["description"] == example_description
+    with pytest.raises(ValueError):
+        x.common_metadata.description = ""
 
-        # License
-        license = "PDDL-1.0"
-        example_license = "example license"
-        assert x.common_metadata.license == license
-        x.common_metadata.license = example_license
-        assert x.common_metadata.license == example_license
-        assert x.properties["license"] == example_license
+    # License
+    license = "PDDL-1.0"
+    example_license = "example license"
+    assert x.common_metadata.license == license
+    x.common_metadata.license = example_license
+    assert x.common_metadata.license == example_license
+    assert x.properties["license"] == example_license
 
-        # Platform
-        platform = "coolsat2"
-        example_platform = "example_platform"
-        assert x.common_metadata.platform == platform
-        x.common_metadata.platform = example_platform
-        assert x.common_metadata.platform == example_platform
-        assert x.properties["platform"] == example_platform
+    # Platform
+    platform = "coolsat2"
+    example_platform = "example_platform"
+    assert x.common_metadata.platform == platform
+    x.common_metadata.platform = example_platform
+    assert x.common_metadata.platform == example_platform
+    assert x.properties["platform"] == example_platform
 
-        # Instruments
-        instruments = ["cool_sensor_v1"]
-        example_instruments = ["example instrument 1", "example instrument 2"]
-        assert (x.common_metadata.instruments or []) == instruments
-        x.common_metadata.instruments = example_instruments
-        assert x.common_metadata.instruments == example_instruments
-        assert x.properties["instruments"] == example_instruments
+    # Instruments
+    instruments = ["cool_sensor_v1"]
+    example_instruments = ["example instrument 1", "example instrument 2"]
+    assert (x.common_metadata.instruments or []) == instruments
+    x.common_metadata.instruments = example_instruments
+    assert x.common_metadata.instruments == example_instruments
+    assert x.properties["instruments"] == example_instruments
 
-        # Constellation
-        example_constellation = "example constellation"
-        assert x.common_metadata.constellation is None
-        x.common_metadata.constellation = example_constellation
-        assert x.common_metadata.constellation == example_constellation
-        assert x.properties["constellation"] == example_constellation
+    # Constellation
+    example_constellation = "example constellation"
+    assert x.common_metadata.constellation is None
+    x.common_metadata.constellation = example_constellation
+    assert x.common_metadata.constellation == example_constellation
+    assert x.properties["constellation"] == example_constellation
 
-        # Mission
-        example_mission = "example mission"
-        assert x.common_metadata.mission is None
-        x.common_metadata.mission = example_mission
-        assert x.common_metadata.mission == example_mission
-        assert x.properties["mission"] == example_mission
+    # Mission
+    example_mission = "example mission"
+    assert x.common_metadata.mission is None
+    x.common_metadata.mission = example_mission
+    assert x.common_metadata.mission == example_mission
+    assert x.properties["mission"] == example_mission
 
-        # GSD
-        gsd = 0.512
-        example_gsd = 0.75
-        assert x.common_metadata.gsd == gsd
-        x.common_metadata.gsd = example_gsd
-        assert x.common_metadata.gsd == example_gsd
-        assert x.properties["gsd"] == example_gsd
+    # GSD
+    gsd = 0.512
+    example_gsd = 0.75
+    assert x.common_metadata.gsd == gsd
+    x.common_metadata.gsd = example_gsd
+    assert x.common_metadata.gsd == example_gsd
+    assert x.properties["gsd"] == example_gsd
 
 
 class TestAssetCommonMetadata(unittest.TestCase):

--- a/tests/test_common_metadata.py
+++ b/tests/test_common_metadata.py
@@ -6,29 +6,21 @@ from pystac import CommonMetadata, Item, Provider, ProviderRole, utils
 from tests.utils import TestCases
 
 
-class CommonMetadataTest(unittest.TestCase):
+class TestCommonMetadata(unittest.TestCase):
     def setUp(self) -> None:
-        self.URI_1 = TestCases.get_path(
-            "data-files/examples/1.0.0-beta.2/item-spec/examples/datetimerange.json"
-        )
-        self.ITEM_1 = Item.from_file(self.URI_1)
+        # 3 tests
+        self.ITEM_1 = Item.from_file(
+            TestCases.get_path(
+                "data-files/examples/1.0.0-beta.2/item-spec/examples/datetimerange.json"
+        ))
 
-        self.URI_2 = TestCases.get_path(
-            "data-files/examples/1.0.0-beta.2/item-spec/examples/sample-full.json"
+        # 4 tests
+        self.ITEM_2 = Item.from_file(
+            TestCases.get_path(
+                "data-files/examples/1.0.0-beta.2/item-spec/examples/sample-full.json"
+            )
         )
-        self.ITEM_2 = Item.from_file(self.URI_2)
 
-        self.EXAMPLE_CM_DICT: dict[str, Any] = {
-            "start_datetime": "2020-05-21T16:42:24.896Z",
-            "platform": "example platform",
-            "providers": [
-                {
-                    "name": "example provider",
-                    "roles": ["example roll"],
-                    "url": "https://example-provider.com/",
-                }
-            ],
-        }
 
     def test_datetimes(self) -> None:
         # save dict of original item to check that `common_metadata`
@@ -226,9 +218,9 @@ class CommonMetadataTest(unittest.TestCase):
         self.assertEqual(x.properties["gsd"], example_gsd)
 
 
-class AssetCommonMetadataTest(unittest.TestCase):
+class TestAssetCommonMetadata(unittest.TestCase):
     def setUp(self) -> None:
-        self.maxDiff = None
+        # used in many tests
         self.item = Item.from_file(
             TestCases.get_path("data-files/item/sample-item-asset-properties.json")
         )

--- a/tests/test_common_metadata.py
+++ b/tests/test_common_metadata.py
@@ -9,13 +9,20 @@ from tests.utils import TestCases
 
 @pytest.fixture
 def date_time_range_item() -> Item:
-    return Item.from_file(TestCases.get_path(
-        "data-files/examples/1.0.0-beta.2/item-spec/examples/datetimerange.json"))
+    return Item.from_file(
+        TestCases.get_path(
+            "data-files/examples/1.0.0-beta.2/item-spec/examples/datetimerange.json"
+        )
+    )
+
 
 @pytest.fixture
 def sample_full_item() -> Item:
-    return Item.from_file(TestCases.get_path(
-        "data-files/examples/1.0.0-beta.2/item-spec/examples/sample-full.json"))
+    return Item.from_file(
+        TestCases.get_path(
+            "data-files/examples/1.0.0-beta.2/item-spec/examples/sample-full.json"
+        )
+    )
 
 
 def test_datetimes(date_time_range_item: Item) -> None:
@@ -31,6 +38,7 @@ def test_datetimes(date_time_range_item: Item) -> None:
     assert before == date_time_range_item.to_dict()
     assert cm.providers is None
 
+
 def test_common_metadata_start_datetime(date_time_range_item: Item) -> None:
     x = date_time_range_item.clone()
     start_datetime_str = "2018-01-01T13:21:30Z"
@@ -45,6 +53,7 @@ def test_common_metadata_start_datetime(date_time_range_item: Item) -> None:
 
     assert x.common_metadata.start_datetime == example_datetime_dt
     assert x.properties["start_datetime"] == example_datetime_str
+
 
 def test_common_metadata_end_datetime(date_time_range_item: Item) -> None:
     x = date_time_range_item.clone()
@@ -77,6 +86,7 @@ def test_common_metadata_created(sample_full_item: Item) -> None:
     assert x.common_metadata.created == example_datetime_dt
     assert x.properties["created"] == example_datetime_str
 
+
 def test_common_metadata_updated(sample_full_item: Item) -> None:
     x = sample_full_item.clone()
     updated_str = "2017-01-01T00:30:55Z"
@@ -91,6 +101,7 @@ def test_common_metadata_updated(sample_full_item: Item) -> None:
 
     assert x.common_metadata.updated == example_datetime_dt
     assert x.properties["updated"] == example_datetime_str
+
 
 def test_common_metadata_providers(sample_full_item: Item) -> None:
     x = sample_full_item.clone()
@@ -147,6 +158,7 @@ def test_common_metadata_providers(sample_full_item: Item) -> None:
         assert isinstance(pd1, dict)
         assert isinstance(pd2, dict)
         assert pd1 == pd2
+
 
 def test_common_metadata_basics(sample_full_item: Item) -> None:
     x = sample_full_item.clone()
@@ -219,7 +231,8 @@ class TestAssetCommonMetadata:
     @pytest.fixture
     def item(self) -> Item:
         return Item.from_file(
-            TestCases.get_path("data-files/item/sample-item-asset-properties.json"))
+            TestCases.get_path("data-files/item/sample-item-asset-properties.json")
+        )
 
     def test_title(self, item: Item) -> None:
         cm = item.common_metadata

--- a/tests/test_common_metadata.py
+++ b/tests/test_common_metadata.py
@@ -8,63 +8,68 @@ from pystac import CommonMetadata, Item, Provider, ProviderRole, utils
 from tests.utils import TestCases
 
 
+@pytest.fixture
+def date_time_range_item() -> Item:
+    return Item.from_file(TestCases.get_path(
+        "data-files/examples/1.0.0-beta.2/item-spec/examples/datetimerange.json"))
+
+@pytest.fixture
+def sample_full_item() -> Item:
+    return Item.from_file(TestCases.get_path(
+        "data-files/examples/1.0.0-beta.2/item-spec/examples/sample-full.json"))
+
+
+def test_datetimes(date_time_range_item: Item) -> None:
+    # save dict of original item to check that `common_metadata`
+    # method doesn't mutate self.item_1
+    before = date_time_range_item.clone().to_dict()
+    start_datetime_str = date_time_range_item.properties["start_datetime"]
+    assert isinstance(start_datetime_str, str)
+
+    cm = date_time_range_item.common_metadata
+    assert isinstance(cm, CommonMetadata)
+    assert isinstance(cm.start_datetime, datetime)
+    assert before == date_time_range_item.to_dict()
+    assert cm.providers is None
+
+def test_common_metadata_start_datetime(date_time_range_item: Item) -> None:
+    x = date_time_range_item.clone()
+    start_datetime_str = "2018-01-01T13:21:30Z"
+    start_datetime_dt = utils.str_to_datetime(start_datetime_str)
+    example_datetime_str = "2020-01-01T00:00:00Z"
+    example_datetime_dt = utils.str_to_datetime(example_datetime_str)
+
+    assert x.common_metadata.start_datetime == start_datetime_dt
+    assert x.properties["start_datetime"] == start_datetime_str
+
+    x.common_metadata.start_datetime = example_datetime_dt
+
+    assert x.common_metadata.start_datetime == example_datetime_dt
+    assert x.properties["start_datetime"] == example_datetime_str
+
+def test_common_metadata_end_datetime(date_time_range_item: Item) -> None:
+    x = date_time_range_item.clone()
+    end_datetime_str = "2018-01-01T13:31:30Z"
+    end_datetime_dt = utils.str_to_datetime(end_datetime_str)
+    example_datetime_str = "2020-01-01T00:00:00Z"
+    example_datetime_dt = utils.str_to_datetime(example_datetime_str)
+
+    assert x.common_metadata.end_datetime == end_datetime_dt
+    assert x.properties["end_datetime"] == end_datetime_str
+
+    x.common_metadata.end_datetime = example_datetime_dt
+
+    assert x.common_metadata.end_datetime == example_datetime_dt
+    assert x.properties["end_datetime"] == example_datetime_str
+
 class TestCommonMetadata(unittest.TestCase):
     def setUp(self) -> None:
-        # 3 tests
-        self.ITEM_1 = Item.from_file(
-            TestCases.get_path(
-                "data-files/examples/1.0.0-beta.2/item-spec/examples/datetimerange.json"
-            ))
-
         # 4 tests
         self.ITEM_2 = Item.from_file(
             TestCases.get_path(
                 "data-files/examples/1.0.0-beta.2/item-spec/examples/sample-full.json"
             )
         )
-
-    def test_datetimes(self) -> None:
-        # save dict of original item to check that `common_metadata`
-        # method doesn't mutate self.item_1
-        before = self.ITEM_1.clone().to_dict()
-        start_datetime_str = self.ITEM_1.properties["start_datetime"]
-        assert isinstance(start_datetime_str, str)
-
-        cm = self.ITEM_1.common_metadata
-        assert isinstance(cm, CommonMetadata)
-        assert isinstance(cm.start_datetime, datetime)
-        assert before == self.ITEM_1.to_dict()
-        assert cm.providers is None
-
-    def test_common_metadata_start_datetime(self) -> None:
-        x = self.ITEM_1.clone()
-        start_datetime_str = "2018-01-01T13:21:30Z"
-        start_datetime_dt = utils.str_to_datetime(start_datetime_str)
-        example_datetime_str = "2020-01-01T00:00:00Z"
-        example_datetime_dt = utils.str_to_datetime(example_datetime_str)
-
-        assert x.common_metadata.start_datetime == start_datetime_dt
-        assert x.properties["start_datetime"] == start_datetime_str
-
-        x.common_metadata.start_datetime = example_datetime_dt
-
-        assert x.common_metadata.start_datetime == example_datetime_dt
-        assert x.properties["start_datetime"] == example_datetime_str
-
-    def test_common_metadata_end_datetime(self) -> None:
-        x = self.ITEM_1.clone()
-        end_datetime_str = "2018-01-01T13:31:30Z"
-        end_datetime_dt = utils.str_to_datetime(end_datetime_str)
-        example_datetime_str = "2020-01-01T00:00:00Z"
-        example_datetime_dt = utils.str_to_datetime(example_datetime_str)
-
-        assert x.common_metadata.end_datetime == end_datetime_dt
-        assert x.properties["end_datetime"] == end_datetime_str
-
-        x.common_metadata.end_datetime = example_datetime_dt
-
-        assert x.common_metadata.end_datetime == example_datetime_dt
-        assert x.properties["end_datetime"] == example_datetime_str
 
     def test_common_metadata_created(self) -> None:
         x = self.ITEM_2.clone()

--- a/tests/test_common_metadata.py
+++ b/tests/test_common_metadata.py
@@ -216,15 +216,15 @@ def test_common_metadata_basics(sample_full_item: Item) -> None:
     assert x.properties["gsd"] == example_gsd
 
 
-class TestAssetCommonMetadata(unittest.TestCase):
-    def setUp(self) -> None:
-        # used in many tests
-        self.item = Item.from_file(
-            TestCases.get_path("data-files/item/sample-item-asset-properties.json")
-        )
+@pytest.fixture
+def name() -> Item:
+    return Item.from_file(
+        TestCases.get_path("data-files/item/sample-item-asset-properties.json"))
 
+
+class TestAssetCommonMetadata(unittest.TestCase):
     def test_title(self) -> None:
-        item = self.item.clone()
+        item = self.item
         cm = item.common_metadata
         analytic = item.assets["analytic"]
         analytic_cm = CommonMetadata(analytic)
@@ -246,7 +246,7 @@ class TestAssetCommonMetadata(unittest.TestCase):
         assert analytic.to_dict()["title"] == set_value
 
     def test_description(self) -> None:
-        item = self.item.clone()
+        item = self.item
         cm = item.common_metadata
         analytic = item.assets["analytic"]
         analytic_cm = CommonMetadata(analytic)
@@ -268,7 +268,7 @@ class TestAssetCommonMetadata(unittest.TestCase):
         assert analytic.to_dict()["description"] == set_value
 
     def test_start_datetime(self) -> None:
-        item = self.item.clone()
+        item = self.item
         item_cm = item.common_metadata
         analytic = item.assets["analytic"]
         analytic_cm = CommonMetadata(analytic)
@@ -290,7 +290,7 @@ class TestAssetCommonMetadata(unittest.TestCase):
         assert analytic.to_dict()["start_datetime"] == utils.datetime_to_str(set_value)
 
     def test_end_datetime(self) -> None:
-        item = self.item.clone()
+        item = self.item
         cm = item.common_metadata
         analytic = item.assets["analytic"]
         analytic_cm = CommonMetadata(analytic)
@@ -312,7 +312,7 @@ class TestAssetCommonMetadata(unittest.TestCase):
         assert analytic.to_dict()["end_datetime"] == utils.datetime_to_str(set_value)
 
     def test_license(self) -> None:
-        item = self.item.clone()
+        item = self.item
         cm = item.common_metadata
         analytic = item.assets["analytic"]
         analytic_cm = CommonMetadata(analytic)
@@ -334,7 +334,7 @@ class TestAssetCommonMetadata(unittest.TestCase):
         assert analytic.to_dict()["license"] == set_value
 
     def test_providers(self) -> None:
-        item = self.item.clone()
+        item = self.item
         cm = item.common_metadata
         analytic = item.assets["analytic"]
         analytic_cm = CommonMetadata(analytic)
@@ -368,7 +368,7 @@ class TestAssetCommonMetadata(unittest.TestCase):
         assert analytic.to_dict()["providers"] == [p.to_dict() for p in set_value]
 
     def test_platform(self) -> None:
-        item = self.item.clone()
+        item = self.item
         cm = item.common_metadata
         analytic = item.assets["analytic"]
         analytic_cm = CommonMetadata(analytic)
@@ -390,7 +390,7 @@ class TestAssetCommonMetadata(unittest.TestCase):
         assert analytic.to_dict()["platform"] == set_value
 
     def test_instruments(self) -> None:
-        item = self.item.clone()
+        item = self.item
         cm = item.common_metadata
         analytic = item.assets["analytic"]
         analytic_cm = CommonMetadata(analytic)
@@ -412,7 +412,7 @@ class TestAssetCommonMetadata(unittest.TestCase):
         assert analytic.to_dict()["instruments"] == set_value
 
     def test_constellation(self) -> None:
-        item = self.item.clone()
+        item = self.item
         cm = item.common_metadata
         analytic = item.assets["analytic"]
         analytic_cm = CommonMetadata(analytic)
@@ -434,7 +434,7 @@ class TestAssetCommonMetadata(unittest.TestCase):
         assert analytic.to_dict()["constellation"] == set_value
 
     def test_mission(self) -> None:
-        item = self.item.clone()
+        item = self.item
         cm = item.common_metadata
         analytic = item.assets["analytic"]
         analytic_cm = CommonMetadata(analytic)
@@ -456,7 +456,7 @@ class TestAssetCommonMetadata(unittest.TestCase):
         assert analytic.to_dict()["mission"] == set_value
 
     def test_gsd(self) -> None:
-        item = self.item.clone()
+        item = self.item
         cm = item.common_metadata
         analytic = item.assets["analytic"]
         analytic_cm = CommonMetadata(analytic)
@@ -478,7 +478,7 @@ class TestAssetCommonMetadata(unittest.TestCase):
         assert analytic.to_dict()["gsd"] == set_value
 
     def test_created(self) -> None:
-        item = self.item.clone()
+        item = self.item
         cm = item.common_metadata
         analytic = item.assets["analytic"]
         analytic_cm = CommonMetadata(analytic)
@@ -500,7 +500,7 @@ class TestAssetCommonMetadata(unittest.TestCase):
         assert analytic.to_dict()["created"] == utils.datetime_to_str(set_value)
 
     def test_updated(self) -> None:
-        item = self.item.clone()
+        item = self.item
         cm = item.common_metadata
         analytic = item.assets["analytic"]
         analytic_cm = CommonMetadata(analytic)
@@ -522,7 +522,7 @@ class TestAssetCommonMetadata(unittest.TestCase):
         assert analytic.to_dict()["updated"] == utils.datetime_to_str(set_value)
 
     def test_keywords(self) -> None:
-        item = self.item.clone()
+        item = self.item
         cm = item.common_metadata
         analytic = item.assets["analytic"]
         analytic_cm = CommonMetadata(analytic)
@@ -544,7 +544,7 @@ class TestAssetCommonMetadata(unittest.TestCase):
         assert analytic.to_dict()["keywords"] == set_value
 
     def test_roles(self) -> None:
-        item = self.item.clone()
+        item = self.item
         cm = item.common_metadata
         analytic = item.assets["analytic"]
         analytic_cm = CommonMetadata(analytic)
@@ -564,3 +564,10 @@ class TestAssetCommonMetadata(unittest.TestCase):
 
         assert analytic_cm.roles == set_value
         assert analytic.to_dict()["roles"] == set_value
+
+    def setUp(self) -> None:
+        # used in many tests
+        self.item = Item.from_file(
+            TestCases.get_path("data-files/item/sample-item-asset-properties.json")
+        )
+

--- a/tests/test_common_metadata.py
+++ b/tests/test_common_metadata.py
@@ -216,15 +216,13 @@ def test_common_metadata_basics(sample_full_item: Item) -> None:
     assert x.properties["gsd"] == example_gsd
 
 
-@pytest.fixture
-def name() -> Item:
-    return Item.from_file(
-        TestCases.get_path("data-files/item/sample-item-asset-properties.json"))
+class TestAssetCommonMetadata:
+    @pytest.fixture
+    def item(self) -> Item:
+        return Item.from_file(
+            TestCases.get_path("data-files/item/sample-item-asset-properties.json"))
 
-
-class TestAssetCommonMetadata(unittest.TestCase):
-    def test_title(self) -> None:
-        item = self.item
+    def test_title(self, item: Item) -> None:
         cm = item.common_metadata
         analytic = item.assets["analytic"]
         analytic_cm = CommonMetadata(analytic)
@@ -245,6 +243,7 @@ class TestAssetCommonMetadata(unittest.TestCase):
         assert analytic_cm.title == set_value
         assert analytic.to_dict()["title"] == set_value
 
+class TestOrigAssetCommonMetadata(unittest.TestCase):
     def test_description(self) -> None:
         item = self.item
         cm = item.common_metadata

--- a/tests/test_common_metadata.py
+++ b/tests/test_common_metadata.py
@@ -2,6 +2,8 @@ import unittest
 from datetime import datetime
 from typing import Any
 
+import pytest
+
 from pystac import CommonMetadata, Item, Provider, ProviderRole, utils
 from tests.utils import TestCases
 
@@ -12,7 +14,7 @@ class TestCommonMetadata(unittest.TestCase):
         self.ITEM_1 = Item.from_file(
             TestCases.get_path(
                 "data-files/examples/1.0.0-beta.2/item-spec/examples/datetimerange.json"
-        ))
+            ))
 
         # 4 tests
         self.ITEM_2 = Item.from_file(
@@ -21,19 +23,18 @@ class TestCommonMetadata(unittest.TestCase):
             )
         )
 
-
     def test_datetimes(self) -> None:
         # save dict of original item to check that `common_metadata`
         # method doesn't mutate self.item_1
         before = self.ITEM_1.clone().to_dict()
         start_datetime_str = self.ITEM_1.properties["start_datetime"]
-        self.assertIsInstance(start_datetime_str, str)
+        assert isinstance(start_datetime_str, str)
 
         cm = self.ITEM_1.common_metadata
-        self.assertIsInstance(cm, CommonMetadata)
-        self.assertIsInstance(cm.start_datetime, datetime)
-        self.assertDictEqual(before, self.ITEM_1.to_dict())
-        self.assertIsNone(cm.providers)
+        assert isinstance(cm, CommonMetadata)
+        assert isinstance(cm.start_datetime, datetime)
+        assert before == self.ITEM_1.to_dict()
+        assert cm.providers is None
 
     def test_common_metadata_start_datetime(self) -> None:
         x = self.ITEM_1.clone()
@@ -42,13 +43,13 @@ class TestCommonMetadata(unittest.TestCase):
         example_datetime_str = "2020-01-01T00:00:00Z"
         example_datetime_dt = utils.str_to_datetime(example_datetime_str)
 
-        self.assertEqual(x.common_metadata.start_datetime, start_datetime_dt)
-        self.assertEqual(x.properties["start_datetime"], start_datetime_str)
+        assert x.common_metadata.start_datetime == start_datetime_dt
+        assert x.properties["start_datetime"] == start_datetime_str
 
         x.common_metadata.start_datetime = example_datetime_dt
 
-        self.assertEqual(x.common_metadata.start_datetime, example_datetime_dt)
-        self.assertEqual(x.properties["start_datetime"], example_datetime_str)
+        assert x.common_metadata.start_datetime == example_datetime_dt
+        assert x.properties["start_datetime"] == example_datetime_str
 
     def test_common_metadata_end_datetime(self) -> None:
         x = self.ITEM_1.clone()
@@ -57,13 +58,13 @@ class TestCommonMetadata(unittest.TestCase):
         example_datetime_str = "2020-01-01T00:00:00Z"
         example_datetime_dt = utils.str_to_datetime(example_datetime_str)
 
-        self.assertEqual(x.common_metadata.end_datetime, end_datetime_dt)
-        self.assertEqual(x.properties["end_datetime"], end_datetime_str)
+        assert x.common_metadata.end_datetime == end_datetime_dt
+        assert x.properties["end_datetime"] == end_datetime_str
 
         x.common_metadata.end_datetime = example_datetime_dt
 
-        self.assertEqual(x.common_metadata.end_datetime, example_datetime_dt)
-        self.assertEqual(x.properties["end_datetime"], example_datetime_str)
+        assert x.common_metadata.end_datetime == example_datetime_dt
+        assert x.properties["end_datetime"] == example_datetime_str
 
     def test_common_metadata_created(self) -> None:
         x = self.ITEM_2.clone()
@@ -72,13 +73,13 @@ class TestCommonMetadata(unittest.TestCase):
         example_datetime_str = "2020-01-01T00:00:00Z"
         example_datetime_dt = utils.str_to_datetime(example_datetime_str)
 
-        self.assertEqual(x.common_metadata.created, created_dt)
-        self.assertEqual(x.properties["created"], created_str)
+        assert x.common_metadata.created == created_dt
+        assert x.properties["created"] == created_str
 
         x.common_metadata.created = example_datetime_dt
 
-        self.assertEqual(x.common_metadata.created, example_datetime_dt)
-        self.assertEqual(x.properties["created"], example_datetime_str)
+        assert x.common_metadata.created == example_datetime_dt
+        assert x.properties["created"] == example_datetime_str
 
     def test_common_metadata_updated(self) -> None:
         x = self.ITEM_2.clone()
@@ -87,13 +88,13 @@ class TestCommonMetadata(unittest.TestCase):
         example_datetime_str = "2020-01-01T00:00:00Z"
         example_datetime_dt = utils.str_to_datetime(example_datetime_str)
 
-        self.assertEqual(x.common_metadata.updated, updated_dt)
-        self.assertEqual(x.properties["updated"], updated_str)
+        assert x.common_metadata.updated == updated_dt
+        assert x.properties["updated"] == updated_str
 
         x.common_metadata.updated = example_datetime_dt
 
-        self.assertEqual(x.common_metadata.updated, example_datetime_dt)
-        self.assertEqual(x.properties["updated"], example_datetime_str)
+        assert x.common_metadata.updated == example_datetime_dt
+        assert x.properties["updated"] == example_datetime_str
 
     def test_common_metadata_providers(self) -> None:
         x = self.ITEM_2.clone()
@@ -126,30 +127,30 @@ class TestCommonMetadata(unittest.TestCase):
         for i in range(len(utils.get_opt(x.common_metadata.providers))):
             p1 = utils.get_opt(x.common_metadata.providers)[i]
             p2 = providers_object_list[i]
-            self.assertIsInstance(p1, Provider)
-            self.assertIsInstance(p2, Provider)
-            self.assertDictEqual(p1.to_dict(), p2.to_dict())
+            assert isinstance(p1, Provider)
+            assert isinstance(p2, Provider)
+            assert p1.to_dict() == p2.to_dict()
 
             pd1 = x.properties["providers"][i]
             pd2 = providers_dict_list[i]
-            self.assertIsInstance(pd1, dict)
-            self.assertIsInstance(pd2, dict)
-            self.assertDictEqual(pd1, pd2)
+            assert isinstance(pd1, dict)
+            assert isinstance(pd2, dict)
+            assert pd1 == pd2
 
         x.common_metadata.providers = example_providers_object_list
 
         for i in range(len(x.common_metadata.providers)):
             p1 = x.common_metadata.providers[i]
             p2 = example_providers_object_list[i]
-            self.assertIsInstance(p1, Provider)
-            self.assertIsInstance(p2, Provider)
-            self.assertDictEqual(p1.to_dict(), p2.to_dict())
+            assert isinstance(p1, Provider)
+            assert isinstance(p2, Provider)
+            assert p1.to_dict() == p2.to_dict()
 
             pd1 = x.properties["providers"][i]
             pd2 = example_providers_dict_list[i]
-            self.assertIsInstance(pd1, dict)
-            self.assertIsInstance(pd2, dict)
-            self.assertDictEqual(pd1, pd2)
+            assert isinstance(pd1, dict)
+            assert isinstance(pd2, dict)
+            assert pd1 == pd2
 
     def test_common_metadata_basics(self) -> None:
         x = self.ITEM_2.clone()
@@ -157,65 +158,65 @@ class TestCommonMetadata(unittest.TestCase):
         # Title
         title = "A CS3 item"
         example_title = "example title"
-        self.assertEqual(x.common_metadata.title, title)
+        assert x.common_metadata.title == title
         x.common_metadata.title = example_title
-        self.assertEqual(x.common_metadata.title, example_title)
-        self.assertEqual(x.properties["title"], example_title)
+        assert x.common_metadata.title == example_title
+        assert x.properties["title"] == example_title
 
         # Description
         example_description = "example description"
-        self.assertIsNone(x.common_metadata.description)
+        assert x.common_metadata.description is None
         x.common_metadata.description = example_description
-        self.assertEqual(x.common_metadata.description, example_description)
-        self.assertEqual(x.properties["description"], example_description)
-        with self.assertRaises(ValueError):
+        assert x.common_metadata.description == example_description
+        assert x.properties["description"] == example_description
+        with pytest.raises(ValueError):
             x.common_metadata.description = ""
 
         # License
         license = "PDDL-1.0"
         example_license = "example license"
-        self.assertEqual(x.common_metadata.license, license)
+        assert x.common_metadata.license == license
         x.common_metadata.license = example_license
-        self.assertEqual(x.common_metadata.license, example_license)
-        self.assertEqual(x.properties["license"], example_license)
+        assert x.common_metadata.license == example_license
+        assert x.properties["license"] == example_license
 
         # Platform
         platform = "coolsat2"
         example_platform = "example_platform"
-        self.assertEqual(x.common_metadata.platform, platform)
+        assert x.common_metadata.platform == platform
         x.common_metadata.platform = example_platform
-        self.assertEqual(x.common_metadata.platform, example_platform)
-        self.assertEqual(x.properties["platform"], example_platform)
+        assert x.common_metadata.platform == example_platform
+        assert x.properties["platform"] == example_platform
 
         # Instruments
         instruments = ["cool_sensor_v1"]
         example_instruments = ["example instrument 1", "example instrument 2"]
-        self.assertListEqual(x.common_metadata.instruments or [], instruments)
+        assert (x.common_metadata.instruments or []) == instruments
         x.common_metadata.instruments = example_instruments
-        self.assertListEqual(x.common_metadata.instruments, example_instruments)
-        self.assertListEqual(x.properties["instruments"], example_instruments)
+        assert x.common_metadata.instruments == example_instruments
+        assert x.properties["instruments"] == example_instruments
 
         # Constellation
         example_constellation = "example constellation"
-        self.assertIsNone(x.common_metadata.constellation)
+        assert x.common_metadata.constellation is None
         x.common_metadata.constellation = example_constellation
-        self.assertEqual(x.common_metadata.constellation, example_constellation)
-        self.assertEqual(x.properties["constellation"], example_constellation)
+        assert x.common_metadata.constellation == example_constellation
+        assert x.properties["constellation"] == example_constellation
 
         # Mission
         example_mission = "example mission"
-        self.assertIsNone(x.common_metadata.mission)
+        assert x.common_metadata.mission is None
         x.common_metadata.mission = example_mission
-        self.assertEqual(x.common_metadata.mission, example_mission)
-        self.assertEqual(x.properties["mission"], example_mission)
+        assert x.common_metadata.mission == example_mission
+        assert x.properties["mission"] == example_mission
 
         # GSD
         gsd = 0.512
         example_gsd = 0.75
-        self.assertEqual(x.common_metadata.gsd, gsd)
+        assert x.common_metadata.gsd == gsd
         x.common_metadata.gsd = example_gsd
-        self.assertEqual(x.common_metadata.gsd, example_gsd)
-        self.assertEqual(x.properties["gsd"], example_gsd)
+        assert x.common_metadata.gsd == example_gsd
+        assert x.properties["gsd"] == example_gsd
 
 
 class TestAssetCommonMetadata(unittest.TestCase):
@@ -237,15 +238,15 @@ class TestAssetCommonMetadata(unittest.TestCase):
         a2_known_value = "Thumbnail"
 
         # Get
-        self.assertNotEqual(thumbnail_cm.title, item_value)
-        self.assertEqual(thumbnail_cm.title, a2_known_value)
+        assert thumbnail_cm.title != item_value
+        assert thumbnail_cm.title == a2_known_value
 
         # Set
         set_value = "Just Another Asset"
         analytic_cm.title = set_value
 
-        self.assertEqual(analytic_cm.title, set_value)
-        self.assertEqual(analytic.to_dict()["title"], set_value)
+        assert analytic_cm.title == set_value
+        assert analytic.to_dict()["title"] == set_value
 
     def test_description(self) -> None:
         item = self.item.clone()
@@ -259,15 +260,15 @@ class TestAssetCommonMetadata(unittest.TestCase):
         a2_known_value = "Thumbnail of the item"
 
         # Get
-        self.assertNotEqual(thumbnail_cm.description, item_value)
-        self.assertEqual(thumbnail_cm.description, a2_known_value)
+        assert thumbnail_cm.description != item_value
+        assert thumbnail_cm.description == a2_known_value
 
         # Set
         set_value = "Yet another description."
         analytic_cm.description = set_value
 
-        self.assertEqual(analytic_cm.description, set_value)
-        self.assertEqual(analytic.to_dict()["description"], set_value)
+        assert analytic_cm.description == set_value
+        assert analytic.to_dict()["description"] == set_value
 
     def test_start_datetime(self) -> None:
         item = self.item.clone()
@@ -281,17 +282,15 @@ class TestAssetCommonMetadata(unittest.TestCase):
         a2_known_value = utils.str_to_datetime("2017-05-01T13:22:30.040Z")
 
         # Get
-        self.assertNotEqual(thumbnail_cm.start_datetime, item_value)
-        self.assertEqual(thumbnail_cm.start_datetime, a2_known_value)
+        assert thumbnail_cm.start_datetime != item_value
+        assert thumbnail_cm.start_datetime == a2_known_value
 
         # Set
         set_value = utils.str_to_datetime("2014-05-01T13:22:30.040Z")
         analytic_cm.start_datetime = set_value
 
-        self.assertEqual(analytic_cm.start_datetime, set_value)
-        self.assertEqual(
-            analytic.to_dict()["start_datetime"], utils.datetime_to_str(set_value)
-        )
+        assert analytic_cm.start_datetime == set_value
+        assert analytic.to_dict()["start_datetime"] == utils.datetime_to_str(set_value)
 
     def test_end_datetime(self) -> None:
         item = self.item.clone()
@@ -305,17 +304,15 @@ class TestAssetCommonMetadata(unittest.TestCase):
         a2_known_value = utils.str_to_datetime("2017-05-02T13:22:30.040Z")
 
         # Get
-        self.assertNotEqual(thumbnail_cm.end_datetime, item_value)
-        self.assertEqual(thumbnail_cm.end_datetime, a2_known_value)
+        assert thumbnail_cm.end_datetime != item_value
+        assert thumbnail_cm.end_datetime == a2_known_value
 
         # Set
         set_value = utils.str_to_datetime("2014-05-01T13:22:30.040Z")
         analytic_cm.end_datetime = set_value
 
-        self.assertEqual(analytic_cm.end_datetime, set_value)
-        self.assertEqual(
-            analytic.to_dict()["end_datetime"], utils.datetime_to_str(set_value)
-        )
+        assert analytic_cm.end_datetime == set_value
+        assert analytic.to_dict()["end_datetime"] == utils.datetime_to_str(set_value)
 
     def test_license(self) -> None:
         item = self.item.clone()
@@ -329,15 +326,15 @@ class TestAssetCommonMetadata(unittest.TestCase):
         a2_known_value = "CC-BY-4.0"
 
         # Get
-        self.assertNotEqual(thumbnail_cm.license, item_value)
-        self.assertEqual(thumbnail_cm.license, a2_known_value)
+        assert thumbnail_cm.license != item_value
+        assert thumbnail_cm.license == a2_known_value
 
         # Set
         set_value = "various"
         analytic_cm.license = set_value
 
-        self.assertEqual(analytic_cm.license, set_value)
-        self.assertEqual(analytic.to_dict()["license"], set_value)
+        assert analytic_cm.license == set_value
+        assert analytic.to_dict()["license"] == set_value
 
     def test_providers(self) -> None:
         item = self.item.clone()
@@ -357,8 +354,8 @@ class TestAssetCommonMetadata(unittest.TestCase):
         ]
 
         # Get
-        self.assertNotEqual(thumbnail_cm.providers, item_value)
-        self.assertEqual(thumbnail_cm.providers, a2_known_value)
+        assert thumbnail_cm.providers != item_value
+        assert thumbnail_cm.providers == a2_known_value
 
         # Set
         set_value = [
@@ -370,10 +367,8 @@ class TestAssetCommonMetadata(unittest.TestCase):
         ]
         analytic_cm.providers = set_value
 
-        self.assertEqual(analytic_cm.providers, set_value)
-        self.assertEqual(
-            analytic.to_dict()["providers"], [p.to_dict() for p in set_value]
-        )
+        assert analytic_cm.providers == set_value
+        assert analytic.to_dict()["providers"] == [p.to_dict() for p in set_value]
 
     def test_platform(self) -> None:
         item = self.item.clone()
@@ -387,15 +382,15 @@ class TestAssetCommonMetadata(unittest.TestCase):
         a2_known_value = "shoes"
 
         # Get
-        self.assertNotEqual(thumbnail_cm.platform, item_value)
-        self.assertEqual(thumbnail_cm.platform, a2_known_value)
+        assert thumbnail_cm.platform != item_value
+        assert thumbnail_cm.platform == a2_known_value
 
         # Set
         set_value = "brick"
         analytic_cm.platform = set_value
 
-        self.assertEqual(analytic_cm.platform, set_value)
-        self.assertEqual(analytic.to_dict()["platform"], set_value)
+        assert analytic_cm.platform == set_value
+        assert analytic.to_dict()["platform"] == set_value
 
     def test_instruments(self) -> None:
         item = self.item.clone()
@@ -409,15 +404,15 @@ class TestAssetCommonMetadata(unittest.TestCase):
         a2_known_value = ["caliper"]
 
         # Get
-        self.assertNotEqual(thumbnail_cm.instruments, item_value)
-        self.assertEqual(thumbnail_cm.instruments, a2_known_value)
+        assert thumbnail_cm.instruments != item_value
+        assert thumbnail_cm.instruments == a2_known_value
 
         # Set
         set_value = ["horns"]
         analytic_cm.instruments = set_value
 
-        self.assertEqual(analytic_cm.instruments, set_value)
-        self.assertEqual(analytic.to_dict()["instruments"], set_value)
+        assert analytic_cm.instruments == set_value
+        assert analytic.to_dict()["instruments"] == set_value
 
     def test_constellation(self) -> None:
         item = self.item.clone()
@@ -431,15 +426,15 @@ class TestAssetCommonMetadata(unittest.TestCase):
         a2_known_value = "little dipper"
 
         # Get
-        self.assertNotEqual(thumbnail_cm.constellation, item_value)
-        self.assertEqual(thumbnail_cm.constellation, a2_known_value)
+        assert thumbnail_cm.constellation != item_value
+        assert thumbnail_cm.constellation == a2_known_value
 
         # Set
         set_value = "orion"
         analytic_cm.constellation = set_value
 
-        self.assertEqual(analytic_cm.constellation, set_value)
-        self.assertEqual(analytic.to_dict()["constellation"], set_value)
+        assert analytic_cm.constellation == set_value
+        assert analytic.to_dict()["constellation"] == set_value
 
     def test_mission(self) -> None:
         item = self.item.clone()
@@ -453,15 +448,15 @@ class TestAssetCommonMetadata(unittest.TestCase):
         a2_known_value = "possible"
 
         # Get
-        self.assertNotEqual(thumbnail_cm.mission, item_value)
-        self.assertEqual(thumbnail_cm.mission, a2_known_value)
+        assert thumbnail_cm.mission != item_value
+        assert thumbnail_cm.mission == a2_known_value
 
         # Set
         set_value = "critical"
         analytic_cm.mission = set_value
 
-        self.assertEqual(analytic_cm.mission, set_value)
-        self.assertEqual(analytic.to_dict()["mission"], set_value)
+        assert analytic_cm.mission == set_value
+        assert analytic.to_dict()["mission"] == set_value
 
     def test_gsd(self) -> None:
         item = self.item.clone()
@@ -475,15 +470,15 @@ class TestAssetCommonMetadata(unittest.TestCase):
         a2_known_value = 40
 
         # Get
-        self.assertNotEqual(thumbnail_cm.gsd, item_value)
-        self.assertEqual(thumbnail_cm.gsd, a2_known_value)
+        assert thumbnail_cm.gsd != item_value
+        assert thumbnail_cm.gsd == a2_known_value
 
         # Set
         set_value = 100
         analytic_cm.gsd = set_value
 
-        self.assertEqual(analytic_cm.gsd, set_value)
-        self.assertEqual(analytic.to_dict()["gsd"], set_value)
+        assert analytic_cm.gsd == set_value
+        assert analytic.to_dict()["gsd"] == set_value
 
     def test_created(self) -> None:
         item = self.item.clone()
@@ -497,17 +492,15 @@ class TestAssetCommonMetadata(unittest.TestCase):
         a2_known_value = utils.str_to_datetime("2017-05-17T13:22:30.040Z")
 
         # Get
-        self.assertNotEqual(thumbnail_cm.created, item_value)
-        self.assertEqual(thumbnail_cm.created, a2_known_value)
+        assert thumbnail_cm.created != item_value
+        assert thumbnail_cm.created == a2_known_value
 
         # Set
         set_value = utils.str_to_datetime("2014-05-17T13:22:30.040Z")
         analytic_cm.created = set_value
 
-        self.assertEqual(analytic_cm.created, set_value)
-        self.assertEqual(
-            analytic.to_dict()["created"], utils.datetime_to_str(set_value)
-        )
+        assert analytic_cm.created == set_value
+        assert analytic.to_dict()["created"] == utils.datetime_to_str(set_value)
 
     def test_updated(self) -> None:
         item = self.item.clone()
@@ -521,17 +514,15 @@ class TestAssetCommonMetadata(unittest.TestCase):
         a2_known_value = utils.str_to_datetime("2017-05-18T13:22:30.040Z")
 
         # Get
-        self.assertNotEqual(thumbnail_cm.updated, item_value)
-        self.assertEqual(thumbnail_cm.updated, a2_known_value)
+        assert thumbnail_cm.updated != item_value
+        assert thumbnail_cm.updated == a2_known_value
 
         # Set
         set_value = utils.str_to_datetime("2014-05-18T13:22:30.040Z")
         analytic_cm.updated = set_value
 
-        self.assertEqual(analytic_cm.updated, set_value)
-        self.assertEqual(
-            analytic.to_dict()["updated"], utils.datetime_to_str(set_value)
-        )
+        assert analytic_cm.updated == set_value
+        assert analytic.to_dict()["updated"] == utils.datetime_to_str(set_value)
 
     def test_keywords(self) -> None:
         item = self.item.clone()
@@ -545,15 +536,15 @@ class TestAssetCommonMetadata(unittest.TestCase):
         a2_known_value = ["keyword_a"]
 
         # Get
-        self.assertNotEqual(thumbnail_cm.keywords, item_value)
-        self.assertEqual(thumbnail_cm.keywords, a2_known_value)
+        assert thumbnail_cm.keywords != item_value
+        assert thumbnail_cm.keywords == a2_known_value
 
         # Set
         set_value = ["keyword_b"]
         analytic_cm.keywords = set_value
 
-        self.assertEqual(analytic_cm.keywords, set_value)
-        self.assertEqual(analytic.to_dict()["keywords"], set_value)
+        assert analytic_cm.keywords == set_value
+        assert analytic.to_dict()["keywords"] == set_value
 
     def test_roles(self) -> None:
         item = self.item.clone()
@@ -567,12 +558,12 @@ class TestAssetCommonMetadata(unittest.TestCase):
         a2_known_value = ["a_role"]
 
         # Get
-        self.assertNotEqual(thumbnail_cm.roles, item_value)
-        self.assertEqual(thumbnail_cm.roles, a2_known_value)
+        assert thumbnail_cm.roles != item_value
+        assert thumbnail_cm.roles == a2_known_value
 
         # Set
         set_value = ["another_role"]
         analytic_cm.roles = set_value
 
-        self.assertEqual(analytic_cm.roles, set_value)
-        self.assertEqual(analytic.to_dict()["roles"], set_value)
+        assert analytic_cm.roles == set_value
+        assert analytic.to_dict()["roles"] == set_value

--- a/tests/validation/test_schema_uri_map.py
+++ b/tests/validation/test_schema_uri_map.py
@@ -1,16 +1,12 @@
-import unittest
-
 import pystac
 from pystac.validation.schema_uri_map import DefaultSchemaUriMap
 
 
-class SchemaUriMapTest(unittest.TestCase):
-    def test_gets_schema_uri_for_old_version(self) -> None:
-        d = DefaultSchemaUriMap()
-        uri = d.get_object_schema_uri(pystac.STACObjectType.ITEM, "0.8.0")
+def test_gets_schema_uri_for_old_version() -> None:
+    d = DefaultSchemaUriMap()
+    uri = d.get_object_schema_uri(pystac.STACObjectType.ITEM, "0.8.0")
 
-        self.assertEqual(
-            uri,
-            "https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.0/"
-            "item-spec/json-schema/item.json",
-        )
+    assert uri == (
+        "https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.0/"
+        "item-spec/json-schema/item.json"
+    )


### PR DESCRIPTION
**Related Issue(s):** #993 

**Description:** Another round of conversion to pytest. In `test_common_metadata.py`, I assumed the several calls to `self.item.clone()` were unneeded because the original object was never used.

**PR Checklist:**

- [x] Pre-commit hooks pass (run `pre-commit run --all-files`)
- [x] Tests pass (run `pytest`)
- [ ] ~Documentation has been updated to reflect changes, if applicable~
- [x] This PR maintains ~or improves~ overall codebase code coverage.
- [ ] ~Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.~
