### PR TITLE
Projection extension: migrate Assets on Items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Projection extension: migrate Assets and Item-Assets ([#1549](https://github.com/stac-utils/pystac/pull/1549))
 - `Collection.from_items` for creating a `pystac.Collection` from an `ItemCollection` ([#1522](https://github.com/stac-utils/pystac/pull/1522))
 
 ### Fixed

--- a/pystac/extensions/projection.py
+++ b/pystac/extensions/projection.py
@@ -480,9 +480,10 @@ class ProjectionExtensionHooks(ExtensionHooks):
         if epsg := obj["properties"].pop("proj:epsg", None):
             obj["properties"]["proj:code"] = f"EPSG:{epsg}"
 
-        for asset in obj.get("assets", obj.get("item_assets", {})).values():
-            if epsg := asset.pop("proj:epsg", None):
-                asset["proj:code"] = f"EPSG:{epsg}"
+        for key in ["assets", "item_assets"]:
+            for asset in obj.get(key, {}).values():
+                if epsg := asset.pop("proj:epsg", None):
+                    asset["proj:code"] = f"EPSG:{epsg}"
 
         super().migrate(obj, version, info)
 

--- a/pystac/extensions/projection.py
+++ b/pystac/extensions/projection.py
@@ -480,6 +480,10 @@ class ProjectionExtensionHooks(ExtensionHooks):
         if epsg := obj["properties"].pop("proj:epsg", None):
             obj["properties"]["proj:code"] = f"EPSG:{epsg}"
 
+        for asset in obj.get("assets", {}).values():
+            if epsg := asset.pop("proj:epsg", None):
+                asset["proj:code"] = f"EPSG:{epsg}"
+
         super().migrate(obj, version, info)
 
 

--- a/pystac/extensions/projection.py
+++ b/pystac/extensions/projection.py
@@ -480,7 +480,7 @@ class ProjectionExtensionHooks(ExtensionHooks):
         if epsg := obj["properties"].pop("proj:epsg", None):
             obj["properties"]["proj:code"] = f"EPSG:{epsg}"
 
-        for asset in obj.get("assets", {}).values():
+        for asset in obj.get("assets", obj.get("item_assets", {})).values():
             if epsg := asset.pop("proj:epsg", None):
                 asset["proj:code"] = f"EPSG:{epsg}"
 

--- a/tests/data-files/projection/collection-with-summaries.json
+++ b/tests/data-files/projection/collection-with-summaries.json
@@ -20,8 +20,35 @@
       "type": "application/json"
     }
   ],
+  "item_assets": {
+    "analytic": {
+      "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+      "title": "4-Band Analytic",
+      "roles": [
+        "data"
+      ],
+      "gsd": 0.66,
+      "proj:code": "EPSG:32659",
+      "proj:shape": [
+        5558,
+        9559
+      ],
+      "proj:transform": [
+        0.5,
+        0,
+        712710,
+        0,
+        -0.5,
+        151406,
+        0,
+        0,
+        1
+      ]
+    }
+  },
   "stac_extensions": [
-    "https://stac-extensions.github.io/projection/v2.0.0/schema.json"
+    "https://stac-extensions.github.io/projection/v2.0.0/schema.json",
+    "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
   ],
   "summaries": {
     "proj:code": [

--- a/tests/extensions/test_projection.py
+++ b/tests/extensions/test_projection.py
@@ -574,7 +574,7 @@ def test_get_set_code(projection_landsat8_item: Item) -> None:
     assert proj_item.properties["proj:code"] == "IAU_2015:30100"
 
 
-def test_migrate() -> None:
+def test_migrate_item() -> None:
     old = "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
     current = "https://stac-extensions.github.io/projection/v2.0.0/schema.json"
 
@@ -592,6 +592,21 @@ def test_migrate() -> None:
 
     assert item.assets["B8"].ext.proj.epsg == 9999
     assert item.assets["B8"].ext.proj.code == "EPSG:9999"
+
+
+def test_migrate_collection_item_assets() -> None:
+    old = "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+    current = "https://stac-extensions.github.io/projection/v2.0.0/schema.json"
+
+    path = TestCases.get_path("data-files/projection/collection-with-summaries.json")
+    collection = pystac.Collection.from_file(path)
+
+    assert old not in collection.stac_extensions
+    assert current in collection.stac_extensions
+
+    for item_asset in collection.item_assets.values():
+        assert item_asset.ext.proj.epsg == 32659
+        assert item_asset.ext.proj.code == "EPSG:32659"
 
 
 def test_older_extension_version(projection_landsat8_item: Item) -> None:

--- a/tests/extensions/test_projection.py
+++ b/tests/extensions/test_projection.py
@@ -587,6 +587,12 @@ def test_migrate() -> None:
     assert item.ext.proj.epsg == 32614
     assert item.ext.proj.code == "EPSG:32614"
 
+    assert item.assets["B1"].ext.proj.epsg == 32614
+    assert item.assets["B1"].ext.proj.code == "EPSG:32614"
+
+    assert item.assets["B8"].ext.proj.epsg == 9999
+    assert item.assets["B8"].ext.proj.code == "EPSG:9999"
+
 
 def test_older_extension_version(projection_landsat8_item: Item) -> None:
     old = "https://stac-extensions.github.io/projection/v1.0.0/schema.json"


### PR DESCRIPTION
**Related Issue(s):**

- #1548

**Description:**
* Update the Projection extension's `migrate` method to migrate projection fields on Assets on Items and Item-Assets on Collections.
* Rename `test_migrate` to `test_migrate_item` and add `test_migrate_collection_item_assets`


**PR Checklist:**

- [x] Pre-commit hooks pass (run `pre-commit run --all-files`)
- [x] Tests pass (run `pytest`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [x] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
