### PR TITLE
feat: permissive extent deserialization

### DIFF
--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from copy import deepcopy
 from datetime import datetime, timezone
 from typing import (
@@ -71,7 +71,7 @@ class SpatialExtent:
 
     def __init__(
         self,
-        bboxes: Bboxes | list[float | int],
+        bboxes: Bboxes | Sequence[float | int],
         extra_fields: dict[str, Any] | None = None,
     ) -> None:
         if not isinstance(bboxes, list):
@@ -199,7 +199,7 @@ class TemporalExtent:
 
     def __init__(
         self,
-        intervals: TemporalIntervals | list[datetime | None],
+        intervals: TemporalIntervals | Sequence[datetime | None],
         extra_fields: dict[str, Any] | None = None,
     ):
         if not isinstance(intervals, list):
@@ -652,7 +652,17 @@ class Collection(Catalog, Assets):
         id = d.pop("id")
         description = d.pop("description")
         license = d.pop("license")
-        extent = Extent.from_dict(d.pop("extent"))
+        if extent_dict := d.pop("extent", None):
+            extent = Extent.from_dict(extent_dict)
+        else:
+            warnings.warn(
+                "Collection is missing extent, setting default spatial and "
+                "temporal extents"
+            )
+            extent = Extent(
+                spatial=SpatialExtent([-90, -180, 90, 180]),
+                temporal=TemporalExtent([None, None]),
+            )
         title = d.pop("title", None)
         stac_extensions = d.pop("stac_extensions", None)
         keywords = d.pop("keywords", None)

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -400,7 +400,7 @@ def test_temporal_extent_allows_single_interval() -> None:
     end_datetime = str_to_datetime("2022-01-31T23:59:59Z")
 
     interval = [start_datetime, end_datetime]
-    temporal_extent = TemporalExtent(intervals=interval)  # type: ignore
+    temporal_extent = TemporalExtent(intervals=interval)
 
     assert temporal_extent.intervals == [interval]
 
@@ -820,3 +820,19 @@ def test_from_items_with_providers(sample_item_collection: ItemCollection) -> No
 
     provider = collection.providers[0]
     assert provider and provider.name == "pystac"
+
+
+def test_from_dict_null_extent(collection: Collection) -> None:
+    # https://github.com/stac-utils/pystac/issues/1558
+    # https://github.com/EOPF-Sample-Service/eopf-stac/issues/18
+    d = collection.to_dict()
+    d["extent"] = None
+    with pytest.warns(UserWarning):
+        Collection.from_dict(d)
+
+
+def test_from_dict_missing_extent(collection: Collection) -> None:
+    d = collection.to_dict()
+    del d["extent"]
+    with pytest.warns(UserWarning):
+        Collection.from_dict(d)


### PR DESCRIPTION
**Related Issue(s):**

- Closes #1558 

**Description:**

Relax collection extent serialization, as there's a surprising number of Collections out there in the real world without extents. Includes a sidecar relaxing of the type on the extent constructors.

**PR Checklist:**

- [x] Pre-commit hooks pass (run `pre-commit run --all-files`)
- [x] Tests pass (run `pytest`)
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
