### PR TITLE
Support older versions of urllib3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dev = [
     "types-orjson>=3.6.2",
     "types-python-dateutil>=2.9.0.20241003",
     "types-urllib3>=1.26.25.14",
-    "urllib3>=2.3.0",
+    "urllib3>=1.26.19",
     "virtualenv>=20.26.6",
 ]
 docs = [

--- a/pystac/stac_io.py
+++ b/pystac/stac_io.py
@@ -286,9 +286,9 @@ class DefaultStacIO(StacIO):
         """Reads file as a UTF-8 string.
 
         If ``href`` has a "scheme" (e.g. if it starts with "https://") then this will
-        use :func:`urllib.request.urlopen` (or func:`urllib3.request` if available)
-        to open the file and read the contents; otherwise, :func:`open` will be used
-        to open a local file.
+        use :func:`urllib.request.urlopen` (or func:`urllib3.PoolManager().request`
+        if available) to open the file and read the contents; otherwise, :func:`open`
+        will be used to open a local file.
 
         Args:
 
@@ -299,7 +299,8 @@ class DefaultStacIO(StacIO):
             try:
                 logger.debug(f"GET {href} Headers: {self.headers}")
                 if HAS_URLLIB3:
-                    with urllib3.request(
+                    http = urllib3.PoolManager()
+                    with http.request(
                         "GET",
                         href,
                         headers={

--- a/tests/test_stac_io.py
+++ b/tests/test_stac_io.py
@@ -117,7 +117,7 @@ def test_report_duplicate_keys() -> None:
         assert str(excinfo.value), f'Found duplicate object name "key" in {src_href}'
 
 
-@unittest.mock.patch("pystac.stac_io.urllib3.request")
+@unittest.mock.patch("pystac.stac_io.urllib3.PoolManager.request")
 def test_headers_stac_io(request_mock: unittest.mock.MagicMock) -> None:
     stac_io = DefaultStacIO(headers={"Authorization": "api-key fake-api-key-value"})
 

--- a/uv.lock
+++ b/uv.lock
@@ -3189,7 +3189,7 @@ dev = [
     { name = "types-orjson", specifier = ">=3.6.2" },
     { name = "types-python-dateutil", specifier = ">=2.9.0.20241003" },
     { name = "types-urllib3", specifier = ">=1.26.25.14" },
-    { name = "urllib3", specifier = ">=2.3.0" },
+    { name = "urllib3", specifier = ">=1.26.19" },
     { name = "virtualenv", specifier = ">=20.26.6" },
 ]
 docs = [


### PR DESCRIPTION
**Related Issue(s):**

- Closes #1579 

**Description:**

This is a really simple tweak that supports v1 of urllib3. 

**PR Checklist:**

- [x] Pre-commit hooks pass (run `pre-commit run --all-files`)
- [x] Tests pass (run `pytest`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
