### PR TITLE
Release v1.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [v1.14.1] - 2025-09-18
+
+### Fixed
+
+- Support older versions of urllib3 ([#1580](https://github.com/stac-utils/pystac/pull/1580))
+
 ## [v1.14.0] - 2025-09-11
 
 ### Added
@@ -943,7 +949,8 @@ use `Band.create`
 
 Initial release.
 
-[Unreleased]: <https://github.com/stac-utils/pystac/compare/v1.14.0..main>
+[Unreleased]: <https://github.com/stac-utils/pystac/compare/v1.14.1..main>
+[v1.14.1]: <https://github.com/stac-utils/pystac/compare/v1.14.0..v1.14.1>
 [v1.14.0]: <https://github.com/stac-utils/pystac/compare/v1.13.0..v1.14.0>
 [v1.13.0]: <https://github.com/stac-utils/pystac/compare/v1.12.2..v1.13.0>
 [v1.12.2]: <https://github.com/stac-utils/pystac/compare/v1.12.1..v1.12.2>

--- a/pystac/version.py
+++ b/pystac/version.py
@@ -1,6 +1,6 @@
 import os
 
-__version__ = "1.14.0"
+__version__ = "1.14.1"
 """Library version"""
 
 

--- a/tests/cassettes/test_catalog/TestCatalog.test_read_remote.yaml
+++ b/tests/cassettes/test_catalog/TestCatalog.test_read_remote.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/catalog.json
   response:
@@ -33,11 +33,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:20 GMT
+      - Thu, 18 Sep 2025 14:55:37 GMT
       ETag:
       - '"e74ebcbc46d43c5b693ecb995381fbeba03583627e6d65b21ed7678a10d94729"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:20 GMT
+      - Thu, 18 Sep 2025 15:00:37 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -47,21 +47,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - b529d376c653063dbe51649d16b4513f9b18c8ca
+      - ac3bc65e8df95cb70374f59a88fd5cb2a3796d3a
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 159F:3ACAF2:F8CE77:1374D7D:68C2EE9E
+      - 95AC:175DD:C1C7B:ECB06:68CC1D68
       X-Served-By:
-      - cache-bos4650-BOS
+      - cache-bos4641-BOS
       X-Timer:
-      - S1757605881.609397,VS0,VE34
+      - S1758207338.739596,VS0,VE85
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -71,7 +71,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/zanzibar/collection.json
   response:
@@ -119,11 +119,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:20 GMT
+      - Thu, 18 Sep 2025 14:55:37 GMT
       ETag:
       - '"ddd340bc27c120dd2e43868bcde0510a326a6223dac1b0c47c05100e20d1397e"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:20 GMT
+      - Thu, 18 Sep 2025 15:00:37 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -133,21 +133,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 3b49c3a05484403c226cd6bf3f5c47020c8fa603
+      - 535459ae7b90c861026f8934ab614c34be0371da
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - E9A4:25E917:F65002:134CF27:68C2EE9F
+      - 6E2B:27CA0A:AE274:D9059:68CC1D69
       X-Served-By:
-      - cache-bos4660-BOS
+      - cache-bos4659-BOS
       X-Timer:
-      - S1757605881.744502,VS0,VE44
+      - S1758207338.893150,VS0,VE67
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -157,7 +157,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/zanzibar/znz001.json
   response:
@@ -215,11 +215,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:20 GMT
+      - Thu, 18 Sep 2025 14:55:38 GMT
       ETag:
       - '"80ec96bc0acf2e604a03f109bd730426aa82e442d44946231cbe82a531b944f7"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:20 GMT
+      - Thu, 18 Sep 2025 15:00:38 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -229,21 +229,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - f022c197150d57ef5d41874f68c5bf2739937624
+      - 410b1deb003782322b5aa10c140b104d64b3a4e7
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - A679:3ACAF2:F8CEAC:1374DBE:68C2EE9F
+      - 6225:3CAE3B:BD380:E8214:68CC1D6A
       X-Served-By:
-      - cache-bos4624-BOS
+      - cache-bos4660-BOS
       X-Timer:
-      - S1757605881.859959,VS0,VE68
+      - S1758207338.033185,VS0,VE181
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -253,7 +253,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/stac-extensions/label/main/examples/multidataset/zanzibar/znz029.json
   response:
@@ -311,11 +311,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:21 GMT
+      - Thu, 18 Sep 2025 14:55:38 GMT
       ETag:
       - '"726870312c74ead0b10c3125045c301e8600929684c49447d64c2db72dc779fc"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:21 GMT
+      - Thu, 18 Sep 2025 15:00:38 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -325,21 +325,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 3fdd9d041aa32f44206789e13a539495a5b9eecb
+      - ee825a75cc33b63da5d5c206b3462823b952405f
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 2E1B:3B0BD:FEBD0E:13D3C78:68C2EEA1
+      - 4B06:3CAE3B:BD3AB:E824E:68CC1D69
       X-Served-By:
-      - cache-bos4639-BOS
+      - cache-bos4646-BOS
       X-Timer:
-      - S1757605881.995906,VS0,VE46
+      - S1758207338.373515,VS0,VE96
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_catalog/TestCatalog.test_validate_all[cat0].yaml
+++ b/tests/cassettes/test_catalog/TestCatalog.test_validate_all[cat0].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/label/v1.0.1/schema.json
   response:
@@ -106,7 +106,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '343'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -116,7 +116,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:21 GMT
+      - Thu, 18 Sep 2025 14:55:39 GMT
       ETag:
       - '"61eb1dc9-1abf"'
       Last-Modified:
@@ -130,19 +130,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
-      - '2'
+      - '0'
       X-Fastly-Request-ID:
-      - e0d61e319033d4fab6702fca038f5074c34cf44e
+      - 2dbbd73d5fb2e22c2d4cf344cef42d6fb76610e9
       X-GitHub-Request-Id:
-      - FE08:128B70:CBB40B:E7523E:68C2EEA2
+      - 600D:C1ED5:D907DA:F3637F:68CC1D6B
       X-Served-By:
-      - cache-bos4620-BOS
+      - cache-bos4629-BOS
       X-Timer:
-      - S1757605882.984425,VS0,VE0
+      - S1758207339.306848,VS0,VE63
       expires:
-      - Thu, 11 Sep 2025 15:55:38 GMT
+      - Thu, 18 Sep 2025 15:05:39 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/cassettes/test_catalog/TestCatalog.test_validate_all[cat1].yaml
+++ b/tests/cassettes/test_catalog/TestCatalog.test_validate_all[cat1].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/label/v1.0.1/schema.json
   response:
@@ -106,7 +106,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -116,7 +116,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:22 GMT
+      - Thu, 18 Sep 2025 14:55:39 GMT
       ETag:
       - '"61eb1dc9-1abf"'
       Last-Modified:
@@ -132,17 +132,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '0'
+      - '1'
       X-Fastly-Request-ID:
-      - 7a6523da33e2950b0e9b8a072a0deb189e9750c9
+      - ede38f489f5289d047d458efcc1dbbb28f168d67
       X-GitHub-Request-Id:
-      - FE08:128B70:CBB40B:E7523E:68C2EEA2
+      - 600D:C1ED5:D907DA:F3637F:68CC1D6B
       X-Served-By:
-      - cache-bos4621-BOS
+      - cache-bos4659-BOS
       X-Timer:
-      - S1757605882.169838,VS0,VE1
+      - S1758207340.529172,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:38 GMT
+      - Thu, 18 Sep 2025 15:05:39 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/cassettes/test_catalog/TestCatalog.test_validate_all[cat3].yaml
+++ b/tests/cassettes/test_catalog/TestCatalog.test_validate_all[cat3].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/label/v1.0.1/schema.json
   response:
@@ -106,7 +106,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -116,7 +116,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:22 GMT
+      - Thu, 18 Sep 2025 14:55:39 GMT
       ETag:
       - '"61eb1dc9-1abf"'
       Last-Modified:
@@ -134,15 +134,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 575bca7664d347a7fca925d3c89f8d28a79f4915
+      - 02fa4dd0636454c3f7c924a3b9686edf0b57ca68
       X-GitHub-Request-Id:
-      - FE08:128B70:CBB40B:E7523E:68C2EEA2
+      - 600D:C1ED5:D907DA:F3637F:68CC1D6B
       X-Served-By:
-      - cache-bos4631-BOS
+      - cache-bos4667-BOS
       X-Timer:
-      - S1757605882.314284,VS0,VE1
+      - S1758207340.657557,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:38 GMT
+      - Thu, 18 Sep 2025 15:05:39 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/cassettes/test_catalog/TestCatalog.test_validate_all[cat4].yaml
+++ b/tests/cassettes/test_catalog/TestCatalog.test_validate_all[cat4].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/eo/v1.1.0/schema.json
   response:
@@ -81,7 +81,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '368'
+      - '156'
       Cache-Control:
       - max-age=600
       Connection:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:23 GMT
+      - Thu, 18 Sep 2025 14:55:40 GMT
       ETag:
       - '"66df1c53-13bc"'
       Last-Modified:
@@ -107,17 +107,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '3'
       X-Fastly-Request-ID:
-      - b6683c4a92f190a8bbe93f00007f037cd1f3079e
+      - 6d58f4288f85ec5dd6c3968f6fdabe4b4398ff99
       X-GitHub-Request-Id:
-      - BE8A:14434E:B836A2:D3D600:68C2EE8A
+      - 98DE:39A2ED:1DBAAC:1F56C3:68CC1CD0
       X-Served-By:
-      - cache-bos4651-BOS
+      - cache-bos4672-BOS
       X-Timer:
-      - S1757605883.120598,VS0,VE1
+      - S1758207340.455114,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -127,7 +127,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/projection/v2.0.0/schema.json
   response:
@@ -195,7 +195,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '368'
+      - '156'
       Cache-Control:
       - max-age=600
       Connection:
@@ -205,7 +205,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:23 GMT
+      - Thu, 18 Sep 2025 14:55:40 GMT
       ETag:
       - '"669e563b-1116"'
       Last-Modified:
@@ -221,17 +221,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '5'
+      - '1'
       X-Fastly-Request-ID:
-      - a050cdc815725f559afd70fcbb02d1d6dbed27cc
+      - b74aa42137295d210ca3fd209e9ec759239e4439
       X-GitHub-Request-Id:
-      - 21B3:2B753C:1E14E8F:2148802:68C2D6FB
+      - 224F:32B3EB:191F90:1ABAB3:68CC1CCF
       X-Served-By:
-      - cache-bos4677-BOS
+      - cache-bos4672-BOS
       X-Timer:
-      - S1757605883.191988,VS0,VE0
+      - S1758207341.517305,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 14:14:44 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -241,7 +241,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/view/v1.0.0/schema.json
   response:
@@ -299,7 +299,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '369'
+      - '156'
       Cache-Control:
       - max-age=600
       Connection:
@@ -309,7 +309,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:23 GMT
+      - Thu, 18 Sep 2025 14:55:40 GMT
       ETag:
       - '"689f5434-dff"'
       Last-Modified:
@@ -325,17 +325,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '1'
       X-Fastly-Request-ID:
-      - a8cd15fd1c380b2872a836dccb42f3c241365e1e
+      - 51dd043ca80ec7bf92effaaede5105d24e8f63f9
       X-GitHub-Request-Id:
-      - EACF:1C0114:1BE6594:1F22786:68C2EE8A
+      - 624D:BA176:74CE5:7ED3C:68CC1CD0
       X-Served-By:
-      - cache-bos4656-BOS
+      - cache-bos4623-BOS
       X-Timer:
-      - S1757605883.254248,VS0,VE0
+      - S1758207341.579188,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/cassettes/test_catalog/TestCatalog.test_validate_all[cat5].yaml
+++ b/tests/cassettes/test_catalog/TestCatalog.test_validate_all[cat5].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/label/v1.0.1/schema.json
   response:
@@ -106,7 +106,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '345'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -116,7 +116,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:23 GMT
+      - Thu, 18 Sep 2025 14:55:40 GMT
       ETag:
       - '"61eb1dc9-1abf"'
       Last-Modified:
@@ -132,17 +132,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 0ae257005d67f079967d810f8e49557ad385d97f
+      - ef8d454b23ad381af5df617ebb1331638663245b
       X-GitHub-Request-Id:
-      - FE08:128B70:CBB40B:E7523E:68C2EEA2
+      - 600D:C1ED5:D907DA:F3637F:68CC1D6B
       X-Served-By:
-      - cache-bos4673-BOS
+      - cache-bos4634-BOS
       X-Timer:
-      - S1757605883.356225,VS0,VE0
+      - S1758207341.672006,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:38 GMT
+      - Thu, 18 Sep 2025 15:05:39 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/cassettes/test_catalog/TestCatalog.test_validate_all[cat6].yaml
+++ b/tests/cassettes/test_catalog/TestCatalog.test_validate_all[cat6].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/eo/v1.1.0/schema.json
   response:
@@ -81,7 +81,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '370'
+      - '157'
       Cache-Control:
       - max-age=600
       Connection:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:24 GMT
+      - Thu, 18 Sep 2025 14:55:41 GMT
       ETag:
       - '"66df1c53-13bc"'
       Last-Modified:
@@ -107,17 +107,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 530d76fd631d4e3e543fe447b557d5fd4d063712
+      - d6da74ecc1861261eaaeaa7a47aea8f63fff6b89
       X-GitHub-Request-Id:
-      - BE8A:14434E:B836A2:D3D600:68C2EE8A
+      - 98DE:39A2ED:1DBAAC:1F56C3:68CC1CD0
       X-Served-By:
-      - cache-bos4639-BOS
+      - cache-bos4631-BOS
       X-Timer:
-      - S1757605884.201744,VS0,VE1
+      - S1758207342.530834,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -127,7 +127,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/view/v1.0.0/schema.json
   response:
@@ -185,7 +185,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '369'
+      - '157'
       Cache-Control:
       - max-age=600
       Connection:
@@ -195,7 +195,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:24 GMT
+      - Thu, 18 Sep 2025 14:55:41 GMT
       ETag:
       - '"689f5434-dff"'
       Last-Modified:
@@ -213,15 +213,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 6fda52bd25933dcf96b304875de2e06466d3442f
+      - 4c83495a609f6918502b83074f22a15a8a694023
       X-GitHub-Request-Id:
-      - EACF:1C0114:1BE6594:1F22786:68C2EE8A
+      - 624D:BA176:74CE5:7ED3C:68CC1CD0
       X-Served-By:
-      - cache-bos4680-BOS
+      - cache-bos4675-BOS
       X-Timer:
-      - S1757605884.274620,VS0,VE2
+      - S1758207342.607074,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -231,7 +231,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/projection/v2.0.0/schema.json
   response:
@@ -299,7 +299,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '369'
+      - '157'
       Cache-Control:
       - max-age=600
       Connection:
@@ -309,7 +309,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:24 GMT
+      - Thu, 18 Sep 2025 14:55:41 GMT
       ETag:
       - '"669e563b-1116"'
       Last-Modified:
@@ -325,17 +325,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Fastly-Request-ID:
-      - ffe5a0835ed16ded190bff8d34715faac65e69ea
+      - d26d55b64a9ac49f1c12709bbc7dc1fbf485efe8
       X-GitHub-Request-Id:
-      - 21B3:2B753C:1E14E8F:2148802:68C2D6FB
+      - 224F:32B3EB:191F90:1ABAB3:68CC1CCF
       X-Served-By:
-      - cache-bos4628-BOS
+      - cache-bos4646-BOS
       X-Timer:
-      - S1757605884.370236,VS0,VE1
+      - S1758207342.701111,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 14:14:44 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/cassettes/test_catalog/test_validate_all_with_max_n.yaml
+++ b/tests/cassettes/test_catalog/test_validate_all_with_max_n.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/label/v1.0.1/schema.json
   response:
@@ -106,7 +106,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '347'
+      - '3'
       Cache-Control:
       - max-age=600
       Connection:
@@ -116,7 +116,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:24 GMT
+      - Thu, 18 Sep 2025 14:55:42 GMT
       ETag:
       - '"61eb1dc9-1abf"'
       Last-Modified:
@@ -134,15 +134,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 226eb6e07ce5fd9b7b529f2cc4094d3592e1c652
+      - f7eb6ffd606ddb19700486f35f1916220ecf4eed
       X-GitHub-Request-Id:
-      - FE08:128B70:CBB40B:E7523E:68C2EEA2
+      - 600D:C1ED5:D907DA:F3637F:68CC1D6B
       X-Served-By:
-      - cache-bos4621-BOS
+      - cache-bos4630-BOS
       X-Timer:
-      - S1757605885.721734,VS0,VE1
+      - S1758207342.079246,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:38 GMT
+      - Thu, 18 Sep 2025 15:05:39 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/cassettes/test_catalog/test_validate_all_with_recusive_off.yaml
+++ b/tests/cassettes/test_catalog/test_validate_all_with_recusive_off.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/label/v1.0.1/schema.json
   response:
@@ -106,7 +106,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '347'
+      - '3'
       Cache-Control:
       - max-age=600
       Connection:
@@ -116,7 +116,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:24 GMT
+      - Thu, 18 Sep 2025 14:55:42 GMT
       ETag:
       - '"61eb1dc9-1abf"'
       Last-Modified:
@@ -134,15 +134,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - d11ae9c9b4f71336beb2c39e9ce6d16c678d7c8e
+      - 70a68fc04ea88b678bc324e45aa3d2aba2d1a277
       X-GitHub-Request-Id:
-      - FE08:128B70:CBB40B:E7523E:68C2EEA2
+      - 600D:C1ED5:D907DA:F3637F:68CC1D6B
       X-Served-By:
-      - cache-bos4672-BOS
+      - cache-bos4645-BOS
       X-Timer:
-      - S1757605885.987623,VS0,VE2
+      - S1758207342.349463,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:38 GMT
+      - Thu, 18 Sep 2025 15:05:39 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/cassettes/test_item/test_non_hierarchical_relative_link.yaml
+++ b/tests/cassettes/test_item/test_non_hierarchical_relative_link.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/collection-spec/examples/sentinel2.json
   response:
@@ -90,11 +90,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:25 GMT
+      - Thu, 18 Sep 2025 14:55:44 GMT
       ETag:
       - '"7b5b9590049813a43b1a9c064eb61dd6b9c25e8e649fff820d3ac83580b7e559"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:25 GMT
+      - Thu, 18 Sep 2025 15:00:44 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -104,21 +104,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - dfc83047c67598317344fa0aecf2030541f09a84
+      - 317fc71de5f4be989affd463ca39e1182e2d512b
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 0F0F:9DF63:14AF5F:192194:68C2EEA6
+      - 3B4B:48527:C2A46:EDA72:68CC1D6E
       X-Served-By:
-      - cache-bos4624-BOS
+      - cache-bos4682-BOS
       X-Timer:
-      - S1757605886.932207,VS0,VE49
+      - S1758207344.251079,VS0,VE102
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/cassettes/test_item/test_null_geometry.yaml
+++ b/tests/cassettes/test_item/test_null_geometry.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/item.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:25 GMT
+      - Thu, 18 Sep 2025 14:55:43 GMT
       ETag:
       - '"66e1651c-147c"'
       Last-Modified:
@@ -107,19 +107,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 44b3f0a2316a7900685b9e44c48fcd7bd4596d19
+      - 43b14da1afb8316ddafcf9222c910c1a37743084
       X-GitHub-Request-Id:
-      - 9540:197FBB:BCDCFE:D8897B:68C2EEA5
+      - A3C0:BAEAA:C84169:E2AD23:68CC1D6E
       X-Served-By:
-      - cache-bos4656-BOS
+      - cache-bos4637-BOS
       X-Timer:
-      - S1757605885.356386,VS0,VE1
+      - S1758207343.987241,VS0,VE27
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/basics.json
   response:
@@ -148,7 +148,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -158,7 +158,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:25 GMT
+      - Thu, 18 Sep 2025 14:55:43 GMT
       ETag:
       - '"66e1651c-21c"'
       Last-Modified:
@@ -170,19 +170,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 7c20cf581f241245b41a36ad7a8d72924d582cd6
+      - 2778a2f91715f30004f3fc21f6d16fc4f78ab03a
       X-GitHub-Request-Id:
-      - E1F2:14AA27:C232A6:DDCD4A:68C2EEA4
+      - 2F53:A07A9:C8C99E:E32E77:68CC1D6E
       X-Served-By:
-      - cache-bos4634-BOS
+      - cache-bos4631-BOS
       X-Timer:
-      - S1757605885.449766,VS0,VE1
+      - S1758207343.101100,VS0,VE53
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -192,7 +192,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/datetime.json
   response:
@@ -241,7 +241,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '343'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -251,7 +251,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:25 GMT
+      - Thu, 18 Sep 2025 14:55:43 GMT
       ETag:
       - '"66e1651c-a82"'
       Last-Modified:
@@ -263,19 +263,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 7b6c408875ffdc8c6e674e2951655d985656850c
+      - dbbe4905d6d5662785af1c608d96b7eaff9510ff
       X-GitHub-Request-Id:
-      - 1865:153265:C4294F:DFCE98:68C2EEA5
+      - 3E81:0D6F:C30426:DD705D:68CC1D6F
       X-Served-By:
       - cache-bos4645-BOS
       X-Timer:
-      - S1757605886.536442,VS0,VE1
+      - S1758207344.581499,VS0,VE51
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -285,7 +287,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/instrument.json
   response:
@@ -306,7 +308,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '343'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -316,7 +318,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:25 GMT
+      - Thu, 18 Sep 2025 14:55:43 GMT
       ETag:
       - '"66e1651c-2a2"'
       Last-Modified:
@@ -328,19 +330,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 9cc6111c479e5d68b3a9da6d5d9a4ffde8746173
+      - 8e2eb7089916d25ce693b858775b4d497d146556
       X-GitHub-Request-Id:
-      - 4500:CA757:1EF5208:22C6B31:68C2EEA5
+      - 7C03:3CD2C3:DA5DDA:F4BC38:68CC1D6F
       X-Served-By:
-      - cache-bos4643-BOS
+      - cache-bos4689-BOS
       X-Timer:
-      - S1757605886.621146,VS0,VE1
+      - S1758207344.709054,VS0,VE47
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -350,7 +354,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/licensing.json
   response:
@@ -366,7 +370,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '343'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -376,7 +380,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:25 GMT
+      - Thu, 18 Sep 2025 14:55:43 GMT
       ETag:
       - '"66e1651c-135"'
       Last-Modified:
@@ -388,19 +392,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - f6cbffa8343fb2b41166baa5343d843488f13a64
+      - 3ba2180eb41273637f48187edf1340062f64d288
       X-GitHub-Request-Id:
-      - ED10:15FE94:C5AB5F:E14C22:68C2EEA5
+      - C4E5:1D3617:CA3033:E4A206:68CC1D6F
       X-Served-By:
-      - cache-bos4638-BOS
+      - cache-bos4637-BOS
       X-Timer:
-      - S1757605886.710423,VS0,VE1
+      - S1758207344.941399,VS0,VE41
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -412,7 +416,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/provider.json
   response:
@@ -438,7 +442,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '343'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -448,7 +452,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:25 GMT
+      - Thu, 18 Sep 2025 14:55:44 GMT
       ETag:
       - '"66e1651c-40e"'
       Last-Modified:
@@ -460,19 +464,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 7e3b0a03ead46ab4d3dea34febc727160722a61e
+      - d53162fad8750abc20c1cd8fa2adceccd928f6be
       X-GitHub-Request-Id:
-      - F8AD:14A94E:C2C9FE:DE6C58:68C2EEA4
+      - 5805:B21BA:AD266F:C78835:68CC1D6F
       X-Served-By:
-      - cache-bos4641-BOS
+      - cache-bos4677-BOS
       X-Timer:
-      - S1757605886.795976,VS0,VE1
+      - S1758207344.061574,VS0,VE43
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:44 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:

--- a/tests/cassettes/test_stac_io/test_proj_json_schema_is_readable.yaml
+++ b/tests/cassettes/test_stac_io/test_proj_json_schema_is_readable.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://proj.org/schemas/v0.7/projjson.schema.json
   response:
@@ -13,11 +13,11 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '1036'
+      - '722'
       CF-Cache-Status:
       - HIT
       CF-Ray:
-      - 97d8539f5e1f3725-IAD
+      - 9811afaa89a129b8-IAD
       Cache-Control:
       - max-age=1200
       Connection:
@@ -29,16 +29,16 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:27 GMT
+      - Thu, 18 Sep 2025 14:55:46 GMT
       Location:
       - https://proj.org/en/latest/schemas/v0.7/projjson.schema.json
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=pffCmUEWVOIrGzNslmq3bhZzc.TGV.GMdOp4SAaO7tc-1757605887-1.0.1.1-1R2d2q5_RL0JlpzZCn.2S7qcN_XMxuxJRkxzB1i8aNpqNCzVnR7ZoMckP4nApMgtt85M2EQnAtjEwzJBIjFzLaaxCGGqDG3JYRlYbSpLuGk;
-        path=/; expires=Thu, 11-Sep-25 16:21:27 GMT; domain=.proj.org; HttpOnly; Secure;
+      - __cf_bm=A8l9uNyuByIpWA5ky2tfPNHv3suiNB8A24Zp6uqHgDE-1758207346-1.0.1.1-W1zGzxaO.N26KnieNK_VOSeYv9BEZOmjSZBMsyTfpxmQQyE9G.t9dtvsyyg6K9mO7Rjj6tvuPCZn3FS2HzKaeqwISqS3FNpX0JD9eTOz.u0;
+        path=/; expires=Thu, 18-Sep-25 15:25:46 GMT; domain=.proj.org; HttpOnly; Secure;
         SameSite=None
-      - _cfuvid=8bcauOXwDNavl0K0yP.M8DS4W6eIZ45Gxzin08aHL3E-1757605887932-0.0.1.1-604800000;
+      - _cfuvid=ZICoBss1Xpupg2_dPfHJQqMNRxYRWXVAg8W7uxFNBM8-1758207346364-0.0.1.1-604800000;
         path=/; domain=.proj.org; HttpOnly; Secure; SameSite=None
       Vary:
       - Accept-Language, Accept-Encoding
@@ -53,7 +53,7 @@ interactions:
       referrer-policy:
       - no-referrer-when-downgrade
       x-backend:
-      - web-i-032144a96d20fd642
+      - web-i-046a40256d6a3b46c
       x-content-type-options:
       - nosniff
       x-rtd-domain:
@@ -77,7 +77,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://proj.org/en/latest/schemas/v0.7/projjson.schema.json
   response:
@@ -606,11 +606,11 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '580'
+      - '4659'
       CF-Cache-Status:
       - HIT
       CF-Ray:
-      - 97d853a039dd1777-IAD
+      - 9811afab5a4cd639-IAD
       Cache-Control:
       - max-age=1200
       Connection:
@@ -618,7 +618,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 11 Sep 2025 15:51:28 GMT
+      - Thu, 18 Sep 2025 14:55:46 GMT
       ETag:
       - W/"b36c7ce9824d274cfd711a16ef45d221"
       Last-Modified:
@@ -626,10 +626,10 @@ interactions:
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=QM20anIice6rtuegHAmlg6MtIQyy2LovMnP_A5xlTF0-1757605888-1.0.1.1-JN0U_vfefTJfDw5mjBssxxDxWL.zR1Yi.AI0nbg1_WGkkFPDyiLKgTLW9HIN8GJIutYMnE6MQIC6VNg0Bl3y0pXO0zaluh7b99aaDFfiFyg;
-        path=/; expires=Thu, 11-Sep-25 16:21:28 GMT; domain=.proj.org; HttpOnly; Secure;
+      - __cf_bm=QQt0N2EkC.wL5HtR.iA3R4evP0cG4yjK5aHH2AzGwsI-1758207346-1.0.1.1-VvuvkCyPKUwxeffciS4_vqF3hi9kZRN6CMcOxLSrxkLoQzGWh72c5cZq0.zD0DOWT0GUJqvFk599FjkJMcKqTVKiE96QLoSePkHHVdH51xY;
+        path=/; expires=Thu, 18-Sep-25 15:25:46 GMT; domain=.proj.org; HttpOnly; Secure;
         SameSite=None
-      - _cfuvid=KIeciD6mVLpfaYSnVBvmQWwH.vvw.Qie2IxRifYjgBQ-1757605888085-0.0.1.1-604800000;
+      - _cfuvid=d2tBdjUsMPV1GpK4pAV1NtLuUTVFyLTDRkSS5OVoh5g-1758207346481-0.0.1.1-604800000;
         path=/; domain=.proj.org; HttpOnly; Secure; SameSite=None
       Transfer-Encoding:
       - chunked
@@ -644,15 +644,15 @@ interactions:
       referrer-policy:
       - no-referrer-when-downgrade
       x-amz-id-2:
-      - 4CqUgAmdf2KJHeNFOeM5b06wSNvruKF2lIJzahRPcLccmToa5RuePCq61GcMLumrjEh4f144QTg=
+      - wq6M1yZwJIx72g0bu4iZIqB+T9hOmWOv1FfzWTgBKB1TbMZ30Ydon1RMGSDDCK+jALCUKViQfNEPgSiC2QHfaEtHxEE2g0MYvKvIxiq7DyA=
       x-amz-meta-mtime:
       - '1714074779.458591481'
       x-amz-request-id:
-      - 7J1TVVY6X3T9P0V9
+      - N37TE359KA2AHSV6
       x-amz-server-side-encryption:
       - AES256
       x-backend:
-      - web-i-0642c5cf0fa7f07c2
+      - web-i-0d85dbf6e0a8f4cc9
       x-content-type-options:
       - nosniff
       x-rtd-domain:

--- a/tests/cassettes/test_stac_io/test_retry_stac_io.yaml
+++ b/tests/cassettes/test_stac_io/test_retry_stac_io.yaml
@@ -3,14 +3,14 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://planetarycomputer.microsoft.com/api/stac/v1
   response:
     body:
       string: '{"type":"Catalog","id":"microsoft-pc","title":"Microsoft Planetary
         Computer STAC API","description":"Searchable spatiotemporal metadata describing
-        Earth science datasets hosted by the Microsoft Planetary Computer","stac_version":"1.0.0","conformsTo":["http://www.opengis.net/spec/cql2/1.0/conf/basic-cql2","https://api.stacspec.org/v1.0.0/item-search#sort","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30","https://api.stacspec.org/v1.0.0/item-search#fields","https://api.stacspec.org/v1.0.0/ogcapi-features","https://api.stacspec.org/v1.0.0/core","https://api.stacspec.org/v1.0.0-rc.2/item-search#filter","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core","http://www.opengis.net/spec/cql2/1.0/conf/cql2-json","https://api.stacspec.org/v1.0.0/item-search","http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/filter","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson","https://api.stacspec.org/v1.0.0/collections","http://www.opengis.net/spec/cql2/1.0/conf/cql2-text","https://api.stacspec.org/v1.0.0/item-search#query"],"links":[{"rel":"self","type":"application/json","href":"https://planetarycomputer.microsoft.com/api/stac/v1/"},{"rel":"root","type":"application/json","href":"https://planetarycomputer.microsoft.com/api/stac/v1/"},{"rel":"data","type":"application/json","href":"https://planetarycomputer.microsoft.com/api/stac/v1/collections"},{"rel":"conformance","type":"application/json","title":"STAC/OGC
+        Earth science datasets hosted by the Microsoft Planetary Computer","stac_version":"1.0.0","conformsTo":["http://www.opengis.net/spec/cql2/1.0/conf/cql2-text","https://api.stacspec.org/v1.0.0/item-search","https://api.stacspec.org/v1.0.0/item-search#query","http://www.opengis.net/spec/ogcapi-features-3/1.0/conf/filter","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30","https://api.stacspec.org/v1.0.0/item-search#fields","http://www.opengis.net/spec/cql2/1.0/conf/cql2-json","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core","https://api.stacspec.org/v1.0.0-rc.2/item-search#filter","http://www.opengis.net/spec/cql2/1.0/conf/basic-cql2","http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson","https://api.stacspec.org/v1.0.0/ogcapi-features","https://api.stacspec.org/v1.0.0/collections","https://api.stacspec.org/v1.0.0/core","https://api.stacspec.org/v1.0.0/item-search#sort"],"links":[{"rel":"self","type":"application/json","href":"https://planetarycomputer.microsoft.com/api/stac/v1/"},{"rel":"root","type":"application/json","href":"https://planetarycomputer.microsoft.com/api/stac/v1/"},{"rel":"data","type":"application/json","href":"https://planetarycomputer.microsoft.com/api/stac/v1/collections"},{"rel":"conformance","type":"application/json","title":"STAC/OGC
         conformance classes implemented by this server","href":"https://planetarycomputer.microsoft.com/api/stac/v1/conformance"},{"rel":"search","type":"application/geo+json","title":"STAC
         search","href":"https://planetarycomputer.microsoft.com/api/stac/v1/search","method":"GET"},{"rel":"search","type":"application/geo+json","title":"STAC
         search","href":"https://planetarycomputer.microsoft.com/api/stac/v1/search","method":"POST"},{"rel":"http://www.opengis.net/def/rel/ogc/1.0/queryables","type":"application/schema+json","title":"Queryables","href":"https://planetarycomputer.microsoft.com/api/stac/v1/queryables","method":"GET"},{"rel":"child","type":"application/json","title":"Daymet
@@ -159,13 +159,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 11 Sep 2025 15:51:26 GMT
+      - Thu, 18 Sep 2025 14:55:45 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Cache:
       - CONFIG_NOCACHE
       x-azure-ref:
-      - 20250911T155126Z-1559d5d4df5vpng5hC1TEBcq4c00000002rg000000005zfp
+      - 20250918T145544Z-16f4dbf99cfvg8vnhC1TEB10zg00000004bg000000004a9s
     status:
       code: 200
       message: OK

--- a/tests/cassettes/test_stac_io/test_retry_stac_io_404.yaml
+++ b/tests/cassettes/test_stac_io/test_retry_stac_io_404.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://planetarycomputer.microsoft.com/api/stac/v1/collections/not-a-collection-id
   response:
@@ -28,13 +28,13 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 11 Sep 2025 15:51:27 GMT
+      - Thu, 18 Sep 2025 14:55:45 GMT
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Cache:
       - CONFIG_NOCACHE
       x-azure-ref:
-      - 20250911T155126Z-r1b4b56c586x2q2vhC1TEBrc90000000010g00000000duxc
+      - 20250918T145545Z-17db9869998gc5l6hC1TEBg2rg00000005x0000000001nee
     status:
       code: 404
       message: Not Found

--- a/tests/cassettes/test_stac_io/test_urls_with_non_ascii_characters.yaml
+++ b/tests/cassettes/test_stac_io/test_urls_with_non_ascii_characters.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://capella-open-data.s3.us-west-2.amazonaws.com/stac/capella-open-data-by-capital/capella-open-data-mal%C3%A9/collection.json
   response:
@@ -68,17 +68,17 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 11 Sep 2025 15:51:28 GMT
+      - Thu, 18 Sep 2025 14:55:47 GMT
       ETag:
       - '"97688a98c449dfb3e9e1e90352e3e8e1"'
       Last-Modified:
-      - Thu, 11 Sep 2025 07:08:31 GMT
+      - Thu, 18 Sep 2025 07:07:22 GMT
       Server:
       - AmazonS3
       x-amz-id-2:
-      - qdM/LQERI9vcQKkaI6JhESK74YgqoqF0nYANzPVhWNtVCysNl5wXC3HUScBE27aNvnrObaS8aErciveXh0K56w==
+      - COTHOREpyll/7k3ulEh3Pi5yLkRpwl6k0AlNBBzfYQFwS6gOUy4jM6RRbglorYJkN13UQ98sk9c=
       x-amz-request-id:
-      - DD0AS56389NVP1CJ
+      - R36SSDJ4ZBGMZ0AQ
       x-amz-server-side-encryption:
       - AES256
     status:

--- a/tests/cassettes/test_writing/TestSTACWriting.test_testcases[ABSOLUTE_PUBLISHED-catalog0].yaml
+++ b/tests/cassettes/test_writing/TestSTACWriting.test_testcases[ABSOLUTE_PUBLISHED-catalog0].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/label/v1.0.1/schema.json
   response:
@@ -106,7 +106,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '351'
+      - '8'
       Cache-Control:
       - max-age=600
       Connection:
@@ -116,7 +116,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:29 GMT
+      - Thu, 18 Sep 2025 14:55:47 GMT
       ETag:
       - '"61eb1dc9-1abf"'
       Last-Modified:
@@ -134,15 +134,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 322a25696363970b72db18ab8f562bc925627c2c
+      - 2ed5bc8ee206ada5398b91de953a6697650d7e63
       X-GitHub-Request-Id:
-      - FE08:128B70:CBB40B:E7523E:68C2EEA2
+      - 600D:C1ED5:D907DA:F3637F:68CC1D6B
       X-Served-By:
-      - cache-bos4626-BOS
+      - cache-bos4644-BOS
       X-Timer:
-      - S1757605889.291804,VS0,VE1
+      - S1758207348.739528,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:38 GMT
+      - Thu, 18 Sep 2025 15:05:39 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/cassettes/test_writing/TestSTACWriting.test_testcases[ABSOLUTE_PUBLISHED-catalog1].yaml
+++ b/tests/cassettes/test_writing/TestSTACWriting.test_testcases[ABSOLUTE_PUBLISHED-catalog1].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/label/v1.0.1/schema.json
   response:
@@ -106,7 +106,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '351'
+      - '9'
       Cache-Control:
       - max-age=600
       Connection:
@@ -116,7 +116,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:29 GMT
+      - Thu, 18 Sep 2025 14:55:48 GMT
       ETag:
       - '"61eb1dc9-1abf"'
       Last-Modified:
@@ -132,17 +132,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - b0fe7d7b61a49af2a3bc2e69cfc09ccd7ea44fe7
+      - 01aa88ca3defd8a64d4dd6241ae8fe2ea20c443d
       X-GitHub-Request-Id:
-      - FE08:128B70:CBB40B:E7523E:68C2EEA2
+      - 600D:C1ED5:D907DA:F3637F:68CC1D6B
       X-Served-By:
-      - cache-bos4636-BOS
+      - cache-bos4681-BOS
       X-Timer:
-      - S1757605890.542069,VS0,VE0
+      - S1758207348.017154,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:38 GMT
+      - Thu, 18 Sep 2025 15:05:39 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/cassettes/test_writing/TestSTACWriting.test_testcases[ABSOLUTE_PUBLISHED-catalog3].yaml
+++ b/tests/cassettes/test_writing/TestSTACWriting.test_testcases[ABSOLUTE_PUBLISHED-catalog3].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/label/v1.0.1/schema.json
   response:
@@ -106,7 +106,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '352'
+      - '9'
       Cache-Control:
       - max-age=600
       Connection:
@@ -116,7 +116,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:29 GMT
+      - Thu, 18 Sep 2025 14:55:48 GMT
       ETag:
       - '"61eb1dc9-1abf"'
       Last-Modified:
@@ -134,15 +134,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - e0d02165657c4ccd05667e79299fcdc718b19368
+      - 42fd611109a348b8b316ba937b1a737da8b5a63c
       X-GitHub-Request-Id:
-      - FE08:128B70:CBB40B:E7523E:68C2EEA2
+      - 600D:C1ED5:D907DA:F3637F:68CC1D6B
       X-Served-By:
-      - cache-bos4677-BOS
+      - cache-bos4693-BOS
       X-Timer:
-      - S1757605890.784489,VS0,VE1
+      - S1758207348.287269,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:38 GMT
+      - Thu, 18 Sep 2025 15:05:39 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/cassettes/test_writing/TestSTACWriting.test_testcases[ABSOLUTE_PUBLISHED-catalog4].yaml
+++ b/tests/cassettes/test_writing/TestSTACWriting.test_testcases[ABSOLUTE_PUBLISHED-catalog4].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/eo/v1.1.0/schema.json
   response:
@@ -81,7 +81,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '377'
+      - '165'
       Cache-Control:
       - max-age=600
       Connection:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:31 GMT
+      - Thu, 18 Sep 2025 14:55:49 GMT
       ETag:
       - '"66df1c53-13bc"'
       Last-Modified:
@@ -107,17 +107,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 096365d528b8a823615b1f27d4d347284bef6f10
+      - e5b6093d137dc3cf80a89beff878ca5628019a37
       X-GitHub-Request-Id:
-      - BE8A:14434E:B836A2:D3D600:68C2EE8A
+      - 98DE:39A2ED:1DBAAC:1F56C3:68CC1CD0
       X-Served-By:
-      - cache-bos4657-BOS
+      - cache-bos4637-BOS
       X-Timer:
-      - S1757605891.318099,VS0,VE0
+      - S1758207350.885119,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -127,7 +127,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/projection/v2.0.0/schema.json
   response:
@@ -195,7 +195,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '376'
+      - '165'
       Cache-Control:
       - max-age=600
       Connection:
@@ -205,7 +205,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:31 GMT
+      - Thu, 18 Sep 2025 14:55:49 GMT
       ETag:
       - '"669e563b-1116"'
       Last-Modified:
@@ -223,15 +223,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 8ac32e8cb2a9782c4198aac957d2b37f90e3b0b4
+      - 2ffcc1a1f60cbcd047931ba086ae3f6c7320516a
       X-GitHub-Request-Id:
-      - 21B3:2B753C:1E14E8F:2148802:68C2D6FB
+      - 224F:32B3EB:191F90:1ABAB3:68CC1CCF
       X-Served-By:
-      - cache-bos4667-BOS
+      - cache-bos4685-BOS
       X-Timer:
-      - S1757605891.388391,VS0,VE2
+      - S1758207350.953146,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 14:14:44 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -241,7 +241,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/view/v1.0.0/schema.json
   response:
@@ -299,7 +299,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '377'
+      - '165'
       Cache-Control:
       - max-age=600
       Connection:
@@ -309,7 +309,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:31 GMT
+      - Thu, 18 Sep 2025 14:55:50 GMT
       ETag:
       - '"689f5434-dff"'
       Last-Modified:
@@ -325,17 +325,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '4'
+      - '1'
       X-Fastly-Request-ID:
-      - 24786c37f6359bf871c7c580b5946e8fc8e9b642
+      - 0e84cc1a4559c907e2dc31ce419e35ef53b013e9
       X-GitHub-Request-Id:
-      - EACF:1C0114:1BE6594:1F22786:68C2EE8A
+      - 624D:BA176:74CE5:7ED3C:68CC1CD0
       X-Served-By:
-      - cache-bos4656-BOS
+      - cache-bos4624-BOS
       X-Timer:
-      - S1757605891.464402,VS0,VE0
+      - S1758207350.031192,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/cassettes/test_writing/TestSTACWriting.test_testcases[ABSOLUTE_PUBLISHED-catalog5].yaml
+++ b/tests/cassettes/test_writing/TestSTACWriting.test_testcases[ABSOLUTE_PUBLISHED-catalog5].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/label/v1.0.1/schema.json
   response:
@@ -106,7 +106,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '353'
+      - '11'
       Cache-Control:
       - max-age=600
       Connection:
@@ -116,7 +116,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:31 GMT
+      - Thu, 18 Sep 2025 14:55:50 GMT
       ETag:
       - '"61eb1dc9-1abf"'
       Last-Modified:
@@ -132,17 +132,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - c55eecb94bbfc310c2e69b71e4fa2d8b55fa53d0
+      - 6aec7fcb6032edd43b6ce45ac0fec2e803f3b8f6
       X-GitHub-Request-Id:
-      - FE08:128B70:CBB40B:E7523E:68C2EEA2
+      - 600D:C1ED5:D907DA:F3637F:68CC1D6B
       X-Served-By:
-      - cache-bos4670-BOS
+      - cache-bos4629-BOS
       X-Timer:
-      - S1757605892.657917,VS0,VE0
+      - S1758207350.317481,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:38 GMT
+      - Thu, 18 Sep 2025 15:05:39 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/cassettes/test_writing/TestSTACWriting.test_testcases[ABSOLUTE_PUBLISHED-catalog6].yaml
+++ b/tests/cassettes/test_writing/TestSTACWriting.test_testcases[ABSOLUTE_PUBLISHED-catalog6].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/eo/v1.1.0/schema.json
   response:
@@ -81,7 +81,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '379'
+      - '167'
       Cache-Control:
       - max-age=600
       Connection:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:33 GMT
+      - Thu, 18 Sep 2025 14:55:51 GMT
       ETag:
       - '"66df1c53-13bc"'
       Last-Modified:
@@ -107,17 +107,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '4'
+      - '1'
       X-Fastly-Request-ID:
-      - bea68938e24694e547018cdf2d6baf68dcbc961d
+      - 226641462be931f07bb6232f1597737a5678c36c
       X-GitHub-Request-Id:
-      - BE8A:14434E:B836A2:D3D600:68C2EE8A
+      - 98DE:39A2ED:1DBAAC:1F56C3:68CC1CD0
       X-Served-By:
-      - cache-bos4643-BOS
+      - cache-bos4620-BOS
       X-Timer:
-      - S1757605893.241896,VS0,VE0
+      - S1758207352.873143,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -127,7 +127,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/view/v1.0.0/schema.json
   response:
@@ -185,7 +185,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '378'
+      - '167'
       Cache-Control:
       - max-age=600
       Connection:
@@ -195,7 +195,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:33 GMT
+      - Thu, 18 Sep 2025 14:55:51 GMT
       ETag:
       - '"689f5434-dff"'
       Last-Modified:
@@ -211,17 +211,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - a45311ee107f0ecb1b03107345b0f64a1673cdc8
+      - 799893d40efeccab3a33622852ef033ad9caf00e
       X-GitHub-Request-Id:
-      - EACF:1C0114:1BE6594:1F22786:68C2EE8A
+      - 624D:BA176:74CE5:7ED3C:68CC1CD0
       X-Served-By:
-      - cache-bos4668-BOS
+      - cache-bos4686-BOS
       X-Timer:
-      - S1757605893.309807,VS0,VE1
+      - S1758207352.947321,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -231,7 +231,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/projection/v2.0.0/schema.json
   response:
@@ -299,7 +299,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '378'
+      - '167'
       Cache-Control:
       - max-age=600
       Connection:
@@ -309,7 +309,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:33 GMT
+      - Thu, 18 Sep 2025 14:55:52 GMT
       ETag:
       - '"669e563b-1116"'
       Last-Modified:
@@ -325,17 +325,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Fastly-Request-ID:
-      - ccdaf84f632c9a54f3c43589404653ec455d0b2b
+      - da78cb60c11935ce4ed5f57271cae03963ba07a2
       X-GitHub-Request-Id:
-      - 21B3:2B753C:1E14E8F:2148802:68C2D6FB
+      - 224F:32B3EB:191F90:1ABAB3:68CC1CCF
       X-Served-By:
-      - cache-bos4676-BOS
+      - cache-bos4666-BOS
       X-Timer:
-      - S1757605893.389599,VS0,VE1
+      - S1758207352.039026,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 14:14:44 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/cassettes/test_writing/TestSTACWriting.test_testcases[RELATIVE_PUBLISHED-catalog0].yaml
+++ b/tests/cassettes/test_writing/TestSTACWriting.test_testcases[RELATIVE_PUBLISHED-catalog0].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/label/v1.0.1/schema.json
   response:
@@ -106,7 +106,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '355'
+      - '13'
       Cache-Control:
       - max-age=600
       Connection:
@@ -116,7 +116,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:33 GMT
+      - Thu, 18 Sep 2025 14:55:52 GMT
       ETag:
       - '"61eb1dc9-1abf"'
       Last-Modified:
@@ -134,15 +134,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 1d23aafd23e456da5867a8ea6978fd7fdc671575
+      - d33bd432a6c021d5e12d07899bb1e9c44b7e816e
       X-GitHub-Request-Id:
-      - FE08:128B70:CBB40B:E7523E:68C2EEA2
+      - 600D:C1ED5:D907DA:F3637F:68CC1D6B
       X-Served-By:
-      - cache-bos4657-BOS
+      - cache-bos4680-BOS
       X-Timer:
-      - S1757605894.610858,VS0,VE2
+      - S1758207352.289268,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:38 GMT
+      - Thu, 18 Sep 2025 15:05:39 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/cassettes/test_writing/TestSTACWriting.test_testcases[RELATIVE_PUBLISHED-catalog1].yaml
+++ b/tests/cassettes/test_writing/TestSTACWriting.test_testcases[RELATIVE_PUBLISHED-catalog1].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/label/v1.0.1/schema.json
   response:
@@ -106,7 +106,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '356'
+      - '13'
       Cache-Control:
       - max-age=600
       Connection:
@@ -116,7 +116,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:33 GMT
+      - Thu, 18 Sep 2025 14:55:52 GMT
       ETag:
       - '"61eb1dc9-1abf"'
       Last-Modified:
@@ -132,17 +132,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 90d20b2408dd4b42ca3cf2fad251e8d58e946908
+      - 80cade3eb4085240975efcc7a7580deab1ef5a9f
       X-GitHub-Request-Id:
-      - FE08:128B70:CBB40B:E7523E:68C2EEA2
+      - 600D:C1ED5:D907DA:F3637F:68CC1D6B
       X-Served-By:
-      - cache-bos4679-BOS
+      - cache-bos4687-BOS
       X-Timer:
-      - S1757605894.874080,VS0,VE0
+      - S1758207353.545043,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:38 GMT
+      - Thu, 18 Sep 2025 15:05:39 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/cassettes/test_writing/TestSTACWriting.test_testcases[RELATIVE_PUBLISHED-catalog3].yaml
+++ b/tests/cassettes/test_writing/TestSTACWriting.test_testcases[RELATIVE_PUBLISHED-catalog3].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/label/v1.0.1/schema.json
   response:
@@ -106,7 +106,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '356'
+      - '13'
       Cache-Control:
       - max-age=600
       Connection:
@@ -116,7 +116,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:34 GMT
+      - Thu, 18 Sep 2025 14:55:52 GMT
       ETag:
       - '"61eb1dc9-1abf"'
       Last-Modified:
@@ -132,17 +132,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Fastly-Request-ID:
-      - 4d77d95547f3683c315fbd02c7913d3d600a7bf1
+      - 80eaab33723ac1ac218042cb0c9398915e2529f5
       X-GitHub-Request-Id:
-      - FE08:128B70:CBB40B:E7523E:68C2EEA2
+      - 600D:C1ED5:D907DA:F3637F:68CC1D6B
       X-Served-By:
-      - cache-bos4684-BOS
+      - cache-bos4634-BOS
       X-Timer:
-      - S1757605894.127687,VS0,VE1
+      - S1758207353.799219,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:38 GMT
+      - Thu, 18 Sep 2025 15:05:39 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/cassettes/test_writing/TestSTACWriting.test_testcases[RELATIVE_PUBLISHED-catalog4].yaml
+++ b/tests/cassettes/test_writing/TestSTACWriting.test_testcases[RELATIVE_PUBLISHED-catalog4].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/eo/v1.1.0/schema.json
   response:
@@ -81,7 +81,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '381'
+      - '170'
       Cache-Control:
       - max-age=600
       Connection:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:35 GMT
+      - Thu, 18 Sep 2025 14:55:54 GMT
       ETag:
       - '"66df1c53-13bc"'
       Last-Modified:
@@ -107,17 +107,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '3'
       X-Fastly-Request-ID:
-      - 5ae88b8684076ba2d22bb61c51039a1622af408f
+      - 6be5d92ed7b93abaf7526ca01c1c9234ca769417
       X-GitHub-Request-Id:
-      - BE8A:14434E:B836A2:D3D600:68C2EE8A
+      - 98DE:39A2ED:1DBAAC:1F56C3:68CC1CD0
       X-Served-By:
-      - cache-bos4681-BOS
+      - cache-bos4627-BOS
       X-Timer:
-      - S1757605896.679805,VS0,VE0
+      - S1758207354.290813,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -127,7 +127,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/projection/v2.0.0/schema.json
   response:
@@ -195,7 +195,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '381'
+      - '170'
       Cache-Control:
       - max-age=600
       Connection:
@@ -205,7 +205,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:35 GMT
+      - Thu, 18 Sep 2025 14:55:54 GMT
       ETag:
       - '"669e563b-1116"'
       Last-Modified:
@@ -223,15 +223,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 1e8bc8c9a7dbd44e21a336feee7f4a3eb8cb3938
+      - de54331f689b1347c3bd1460f33ebebbb369777a
       X-GitHub-Request-Id:
-      - 21B3:2B753C:1E14E8F:2148802:68C2D6FB
+      - 224F:32B3EB:191F90:1ABAB3:68CC1CCF
       X-Served-By:
-      - cache-bos4634-BOS
+      - cache-bos4665-BOS
       X-Timer:
-      - S1757605896.749302,VS0,VE2
+      - S1758207354.351029,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 14:14:44 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -241,7 +241,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/view/v1.0.0/schema.json
   response:
@@ -299,7 +299,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '381'
+      - '170'
       Cache-Control:
       - max-age=600
       Connection:
@@ -309,7 +309,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:35 GMT
+      - Thu, 18 Sep 2025 14:55:54 GMT
       ETag:
       - '"689f5434-dff"'
       Last-Modified:
@@ -325,17 +325,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '1'
       X-Fastly-Request-ID:
-      - 996098440700475df4fa40d8fec1ee4d600d7ad6
+      - 2b311f7c62a4f71517db67390071626d28d2022e
       X-GitHub-Request-Id:
-      - EACF:1C0114:1BE6594:1F22786:68C2EE8A
+      - 624D:BA176:74CE5:7ED3C:68CC1CD0
       X-Served-By:
-      - cache-bos4621-BOS
+      - cache-bos4672-BOS
       X-Timer:
-      - S1757605896.813822,VS0,VE0
+      - S1758207354.413372,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/cassettes/test_writing/TestSTACWriting.test_testcases[RELATIVE_PUBLISHED-catalog5].yaml
+++ b/tests/cassettes/test_writing/TestSTACWriting.test_testcases[RELATIVE_PUBLISHED-catalog5].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/label/v1.0.1/schema.json
   response:
@@ -106,7 +106,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '358'
+      - '15'
       Cache-Control:
       - max-age=600
       Connection:
@@ -116,7 +116,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:35 GMT
+      - Thu, 18 Sep 2025 14:55:54 GMT
       ETag:
       - '"61eb1dc9-1abf"'
       Last-Modified:
@@ -134,15 +134,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - b408380c29a357035037b13b755992d153f1c2a0
+      - c4efd43ca0dc256627c6038a66efc61fe27dfdf0
       X-GitHub-Request-Id:
-      - FE08:128B70:CBB40B:E7523E:68C2EEA2
+      - 600D:C1ED5:D907DA:F3637F:68CC1D6B
       X-Served-By:
-      - cache-bos4653-BOS
+      - cache-bos4648-BOS
       X-Timer:
-      - S1757605896.997579,VS0,VE2
+      - S1758207355.603560,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:38 GMT
+      - Thu, 18 Sep 2025 15:05:39 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/cassettes/test_writing/TestSTACWriting.test_testcases[RELATIVE_PUBLISHED-catalog6].yaml
+++ b/tests/cassettes/test_writing/TestSTACWriting.test_testcases[RELATIVE_PUBLISHED-catalog6].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/eo/v1.1.0/schema.json
   response:
@@ -81,7 +81,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '383'
+      - '172'
       Cache-Control:
       - max-age=600
       Connection:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:37 GMT
+      - Thu, 18 Sep 2025 14:55:56 GMT
       ETag:
       - '"66df1c53-13bc"'
       Last-Modified:
@@ -107,17 +107,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '4'
       X-Fastly-Request-ID:
-      - 7c39f222446e229fadf0f036ee846fbc4c5e928d
+      - bae1cb72027e566da288d383aa3318a2affd349c
       X-GitHub-Request-Id:
-      - BE8A:14434E:B836A2:D3D600:68C2EE8A
+      - 98DE:39A2ED:1DBAAC:1F56C3:68CC1CD0
       X-Served-By:
-      - cache-bos4653-BOS
+      - cache-bos4672-BOS
       X-Timer:
-      - S1757605897.486948,VS0,VE0
+      - S1758207356.111271,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -127,7 +127,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/view/v1.0.0/schema.json
   response:
@@ -185,7 +185,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '383'
+      - '172'
       Cache-Control:
       - max-age=600
       Connection:
@@ -195,7 +195,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:37 GMT
+      - Thu, 18 Sep 2025 14:55:56 GMT
       ETag:
       - '"689f5434-dff"'
       Last-Modified:
@@ -213,15 +213,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - b8b080bb4162c98f7e4aeb8d90050e365f2ec359
+      - 3922a2431d7e6fb1f743d82315cf39fdae21f403
       X-GitHub-Request-Id:
-      - EACF:1C0114:1BE6594:1F22786:68C2EE8A
+      - 624D:BA176:74CE5:7ED3C:68CC1CD0
       X-Served-By:
-      - cache-bos4648-BOS
+      - cache-bos4670-BOS
       X-Timer:
-      - S1757605898.556407,VS0,VE2
+      - S1758207356.187239,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -231,7 +231,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/projection/v2.0.0/schema.json
   response:
@@ -299,7 +299,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '383'
+      - '172'
       Cache-Control:
       - max-age=600
       Connection:
@@ -309,7 +309,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:37 GMT
+      - Thu, 18 Sep 2025 14:55:56 GMT
       ETag:
       - '"669e563b-1116"'
       Last-Modified:
@@ -327,15 +327,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 953d4a2b9a7e76a7d4b4d5d30f6ad650b96e4ce3
+      - 9350432d708c7b9e2ee34e1c009aea5499f7724b
       X-GitHub-Request-Id:
-      - 21B3:2B753C:1E14E8F:2148802:68C2D6FB
+      - 224F:32B3EB:191F90:1ABAB3:68CC1CCF
       X-Served-By:
-      - cache-bos4626-BOS
+      - cache-bos4663-BOS
       X-Timer:
-      - S1757605898.645314,VS0,VE1
+      - S1758207356.279786,VS0,VE6
       expires:
-      - Thu, 11 Sep 2025 14:14:44 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/cassettes/test_writing/TestSTACWriting.test_testcases[SELF_CONTAINED-catalog0].yaml
+++ b/tests/cassettes/test_writing/TestSTACWriting.test_testcases[SELF_CONTAINED-catalog0].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/label/v1.0.1/schema.json
   response:
@@ -106,7 +106,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '360'
+      - '17'
       Cache-Control:
       - max-age=600
       Connection:
@@ -116,7 +116,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:37 GMT
+      - Thu, 18 Sep 2025 14:55:56 GMT
       ETag:
       - '"61eb1dc9-1abf"'
       Last-Modified:
@@ -132,17 +132,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 10380a097dca5fc762840748e3b0eca09b9a6858
+      - ecace24f4debdd99b0101df97806c743544f2f06
       X-GitHub-Request-Id:
-      - FE08:128B70:CBB40B:E7523E:68C2EEA2
+      - 600D:C1ED5:D907DA:F3637F:68CC1D6B
       X-Served-By:
-      - cache-bos4669-BOS
+      - cache-bos4649-BOS
       X-Timer:
-      - S1757605898.869352,VS0,VE0
+      - S1758207357.528513,VS0,VE49
       expires:
-      - Thu, 11 Sep 2025 15:55:38 GMT
+      - Thu, 18 Sep 2025 15:05:39 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/cassettes/test_writing/TestSTACWriting.test_testcases[SELF_CONTAINED-catalog1].yaml
+++ b/tests/cassettes/test_writing/TestSTACWriting.test_testcases[SELF_CONTAINED-catalog1].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/label/v1.0.1/schema.json
   response:
@@ -106,7 +106,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '359'
+      - '17'
       Cache-Control:
       - max-age=600
       Connection:
@@ -116,7 +116,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:38 GMT
+      - Thu, 18 Sep 2025 14:55:56 GMT
       ETag:
       - '"61eb1dc9-1abf"'
       Last-Modified:
@@ -132,17 +132,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '1'
       X-Fastly-Request-ID:
-      - 3844087cd5ab5cf48f281e4a3cfeaad67d91183d
+      - 515eff73cab257c3e41ce81e59a138d2527a86a6
       X-GitHub-Request-Id:
-      - FE08:128B70:CBB40B:E7523E:68C2EEA2
+      - 600D:C1ED5:D907DA:F3637F:68CC1D6B
       X-Served-By:
-      - cache-bos4670-BOS
+      - cache-bos4632-BOS
       X-Timer:
-      - S1757605898.112134,VS0,VE0
+      - S1758207357.845573,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:38 GMT
+      - Thu, 18 Sep 2025 15:05:39 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/cassettes/test_writing/TestSTACWriting.test_testcases[SELF_CONTAINED-catalog3].yaml
+++ b/tests/cassettes/test_writing/TestSTACWriting.test_testcases[SELF_CONTAINED-catalog3].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/label/v1.0.1/schema.json
   response:
@@ -106,7 +106,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '360'
+      - '18'
       Cache-Control:
       - max-age=600
       Connection:
@@ -116,7 +116,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:38 GMT
+      - Thu, 18 Sep 2025 14:55:57 GMT
       ETag:
       - '"61eb1dc9-1abf"'
       Last-Modified:
@@ -132,17 +132,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Fastly-Request-ID:
-      - f42ef52c13f6c44d3215bf4f65112eadf746dbd9
+      - c9c47d520bc9f4de1eabab73ff21113ade735093
       X-GitHub-Request-Id:
-      - FE08:128B70:CBB40B:E7523E:68C2EEA2
+      - 600D:C1ED5:D907DA:F3637F:68CC1D6B
       X-Served-By:
-      - cache-bos4660-BOS
+      - cache-bos4648-BOS
       X-Timer:
-      - S1757605898.348004,VS0,VE1
+      - S1758207357.105180,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:38 GMT
+      - Thu, 18 Sep 2025 15:05:39 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/cassettes/test_writing/TestSTACWriting.test_testcases[SELF_CONTAINED-catalog4].yaml
+++ b/tests/cassettes/test_writing/TestSTACWriting.test_testcases[SELF_CONTAINED-catalog4].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/eo/v1.1.0/schema.json
   response:
@@ -81,7 +81,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '385'
+      - '174'
       Cache-Control:
       - max-age=600
       Connection:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:39 GMT
+      - Thu, 18 Sep 2025 14:55:58 GMT
       ETag:
       - '"66df1c53-13bc"'
       Last-Modified:
@@ -109,15 +109,15 @@ interactions:
       X-Cache-Hits:
       - '2'
       X-Fastly-Request-ID:
-      - 9c1ab2b96acbfad87d0f1758651278a6f87d818a
+      - 5f1b7e872c548d44284ba6d8e5cc3c606d2f9875
       X-GitHub-Request-Id:
-      - BE8A:14434E:B836A2:D3D600:68C2EE8A
+      - 98DE:39A2ED:1DBAAC:1F56C3:68CC1CD0
       X-Served-By:
-      - cache-bos4674-BOS
+      - cache-bos4681-BOS
       X-Timer:
-      - S1757605900.897886,VS0,VE1
+      - S1758207359.710934,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -127,7 +127,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/projection/v2.0.0/schema.json
   response:
@@ -195,7 +195,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '385'
+      - '174'
       Cache-Control:
       - max-age=600
       Connection:
@@ -205,7 +205,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:39 GMT
+      - Thu, 18 Sep 2025 14:55:58 GMT
       ETag:
       - '"669e563b-1116"'
       Last-Modified:
@@ -221,17 +221,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 80cff7bff09600aafc67b88f9473e2480a8d289c
+      - 631183eec2a5eb340796a564c51e5dc91b32a980
       X-GitHub-Request-Id:
-      - 21B3:2B753C:1E14E8F:2148802:68C2D6FB
+      - 224F:32B3EB:191F90:1ABAB3:68CC1CCF
       X-Served-By:
-      - cache-bos4627-BOS
+      - cache-bos4642-BOS
       X-Timer:
-      - S1757605900.972270,VS0,VE0
+      - S1758207359.779803,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 14:14:44 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -241,7 +241,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/view/v1.0.0/schema.json
   response:
@@ -299,7 +299,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '385'
+      - '174'
       Cache-Control:
       - max-age=600
       Connection:
@@ -309,7 +309,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:40 GMT
+      - Thu, 18 Sep 2025 14:55:58 GMT
       ETag:
       - '"689f5434-dff"'
       Last-Modified:
@@ -325,17 +325,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Fastly-Request-ID:
-      - fbf882a04be61b9ee8423b18f878adf1fbe3a710
+      - 73912c73983100c25a661dffdf13cf038c304fcb
       X-GitHub-Request-Id:
-      - EACF:1C0114:1BE6594:1F22786:68C2EE8A
+      - 624D:BA176:74CE5:7ED3C:68CC1CD0
       X-Served-By:
-      - cache-bos4671-BOS
+      - cache-bos4650-BOS
       X-Timer:
-      - S1757605900.044344,VS0,VE1
+      - S1758207359.841188,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/cassettes/test_writing/TestSTACWriting.test_testcases[SELF_CONTAINED-catalog5].yaml
+++ b/tests/cassettes/test_writing/TestSTACWriting.test_testcases[SELF_CONTAINED-catalog5].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/label/v1.0.1/schema.json
   response:
@@ -106,7 +106,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '362'
+      - '20'
       Cache-Control:
       - max-age=600
       Connection:
@@ -116,7 +116,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:40 GMT
+      - Thu, 18 Sep 2025 14:55:59 GMT
       ETag:
       - '"61eb1dc9-1abf"'
       Last-Modified:
@@ -134,15 +134,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 2f94888b83a628cdb6bfabbfca8911b6d5b52ed0
+      - fe00cb467b9c5a0409286b464ef83c40928ead8d
       X-GitHub-Request-Id:
-      - FE08:128B70:CBB40B:E7523E:68C2EEA2
+      - 600D:C1ED5:D907DA:F3637F:68CC1D6B
       X-Served-By:
-      - cache-bos4692-BOS
+      - cache-bos4689-BOS
       X-Timer:
-      - S1757605900.243862,VS0,VE1
+      - S1758207359.037597,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:38 GMT
+      - Thu, 18 Sep 2025 15:05:39 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/cassettes/test_writing/TestSTACWriting.test_testcases[SELF_CONTAINED-catalog6].yaml
+++ b/tests/cassettes/test_writing/TestSTACWriting.test_testcases[SELF_CONTAINED-catalog6].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/eo/v1.1.0/schema.json
   response:
@@ -81,7 +81,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '387'
+      - '176'
       Cache-Control:
       - max-age=600
       Connection:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:41 GMT
+      - Thu, 18 Sep 2025 14:56:00 GMT
       ETag:
       - '"66df1c53-13bc"'
       Last-Modified:
@@ -107,17 +107,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '41'
+      - '1'
       X-Fastly-Request-ID:
-      - 1f6f53fa8cecd8877d792e6bb63ba663253c1456
+      - f09da8a2e0b6ff3107b842dc3eb45e06613df28a
       X-GitHub-Request-Id:
-      - BE8A:14434E:B836A2:D3D600:68C2EE8A
+      - 98DE:39A2ED:1DBAAC:1F56C3:68CC1CD0
       X-Served-By:
-      - cache-bos4642-BOS
+      - cache-bos4690-BOS
       X-Timer:
-      - S1757605902.768781,VS0,VE0
+      - S1758207361.559241,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -127,7 +127,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/view/v1.0.0/schema.json
   response:
@@ -185,7 +185,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '387'
+      - '176'
       Cache-Control:
       - max-age=600
       Connection:
@@ -195,7 +195,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:41 GMT
+      - Thu, 18 Sep 2025 14:56:00 GMT
       ETag:
       - '"689f5434-dff"'
       Last-Modified:
@@ -213,15 +213,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 9f5efde74f7c8138ff046ad79853c664eadceede
+      - 7b8200f0521b09845f153fe699c9217afa255f86
       X-GitHub-Request-Id:
-      - EACF:1C0114:1BE6594:1F22786:68C2EE8A
+      - 624D:BA176:74CE5:7ED3C:68CC1CD0
       X-Served-By:
-      - cache-bos4650-BOS
+      - cache-bos4637-BOS
       X-Timer:
-      - S1757605902.827640,VS0,VE4
+      - S1758207361.627194,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -231,7 +231,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/projection/v2.0.0/schema.json
   response:
@@ -299,7 +299,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '387'
+      - '176'
       Cache-Control:
       - max-age=600
       Connection:
@@ -309,7 +309,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:41 GMT
+      - Thu, 18 Sep 2025 14:56:00 GMT
       ETag:
       - '"669e563b-1116"'
       Last-Modified:
@@ -325,17 +325,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Fastly-Request-ID:
-      - cd8bb58cbab92e86f80afddc8353b425c6b56ba5
+      - dd535df0b4b4740d6c0582b4c62a80b906c003ce
       X-GitHub-Request-Id:
-      - 21B3:2B753C:1E14E8F:2148802:68C2D6FB
+      - 224F:32B3EB:191F90:1ABAB3:68CC1CCF
       X-Served-By:
-      - cache-bos4647-BOS
+      - cache-bos4642-BOS
       X-Timer:
-      - S1757605902.908089,VS0,VE1
+      - S1758207361.717280,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 14:14:44 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_classification/test_apply_bitfields.yaml
+++ b/tests/extensions/cassettes/test_classification/test_apply_bitfields.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/classification/v2.0.0/schema.json
   response:
@@ -102,7 +102,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -112,7 +112,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:50:57 GMT
+      - Thu, 18 Sep 2025 14:53:04 GMT
       ETag:
       - '"66487a48-199a"'
       Last-Modified:
@@ -126,19 +126,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 3f7d1e254fbf58339654264d73c66f242d157d16
+      - 8d29d3906354fa35c79074daf7d34a88235b4d4e
       X-GitHub-Request-Id:
-      - 621C:19FF07:BB1F9D:D6BC90:68C2EE89
+      - 6BBC:3C31CF:180620:19A107:68CC1CCF
       X-Served-By:
-      - cache-bos4669-BOS
+      - cache-bos4631-BOS
       X-Timer:
-      - S1757605858.893698,VS0,VE1
+      - S1758207184.048625,VS0,VE41
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_classification/test_apply_classes.yaml
+++ b/tests/extensions/cassettes/test_classification/test_apply_classes.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/classification/v2.0.0/schema.json
   response:
@@ -102,7 +102,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -112,7 +112,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:50:57 GMT
+      - Thu, 18 Sep 2025 14:53:04 GMT
       ETag:
       - '"66487a48-199a"'
       Last-Modified:
@@ -130,15 +130,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 5ba8c2dc7162b9b369ac6e38808eef0456d3b49a
+      - d2d3de7ad546c77c155ef36f3c231751a85ed710
       X-GitHub-Request-Id:
-      - 621C:19FF07:BB1F9D:D6BC90:68C2EE89
+      - 6BBC:3C31CF:180620:19A107:68CC1CCF
       X-Served-By:
-      - cache-bos4643-BOS
+      - cache-bos4667-BOS
       X-Timer:
-      - S1757605858.991691,VS0,VE1
+      - S1758207184.179068,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_classification/test_validate_classification.yaml
+++ b/tests/extensions/cassettes/test_classification/test_validate_classification.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/raster/v1.1.0/schema.json
   response:
@@ -100,7 +100,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -110,7 +110,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:50:58 GMT
+      - Thu, 18 Sep 2025 14:53:04 GMT
       ETag:
       - '"66df5c80-18ae"'
       Last-Modified:
@@ -124,19 +124,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - e55ce978a83219ddeabfe9cdd02d4d0376b181b7
+      - fb36456c8f97e0fd5528e458d026f7b977be634d
       X-GitHub-Request-Id:
-      - 6F8C:14A94E:C2B049:DE4F27:68C2EE8A
+      - 17F6:239986:1B3CB6:1CD810:68CC1CD0
       X-Served-By:
-      - cache-bos4664-BOS
+      - cache-bos4671-BOS
       X-Timer:
-      - S1757605858.091801,VS0,VE1
+      - S1758207184.269130,VS0,VE62
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -146,7 +146,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/eo/v1.1.0/schema.json
   response:
@@ -224,7 +224,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '343'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -234,7 +234,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:50:58 GMT
+      - Thu, 18 Sep 2025 14:53:04 GMT
       ETag:
       - '"66df1c53-13bc"'
       Last-Modified:
@@ -248,19 +248,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 28106379c5c2bb7978d39116a4c9e1744922c8bc
+      - d06038b246536f89cffd3d9be5f7bc7dbe1761af
       X-GitHub-Request-Id:
-      - BE8A:14434E:B836A2:D3D600:68C2EE8A
+      - 98DE:39A2ED:1DBAAC:1F56C3:68CC1CD0
       X-Served-By:
-      - cache-bos4663-BOS
+      - cache-bos4631-BOS
       X-Timer:
-      - S1757605858.174127,VS0,VE1
+      - S1758207184.397073,VS0,VE52
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -270,7 +270,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/view/v1.0.0/schema.json
   response:
@@ -328,7 +328,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '343'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -338,7 +338,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:50:58 GMT
+      - Thu, 18 Sep 2025 14:53:04 GMT
       ETag:
       - '"689f5434-dff"'
       Last-Modified:
@@ -352,19 +352,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
-      - '1'
+      - '0'
       X-Fastly-Request-ID:
-      - d341b85c6be9025b7d2e448a3ce5515b7214c1ab
+      - 23681b64cbbaaa7203877f36b6239edbcd5363c2
       X-GitHub-Request-Id:
-      - EACF:1C0114:1BE6594:1F22786:68C2EE8A
+      - 624D:BA176:74CE5:7ED3C:68CC1CD0
       X-Served-By:
-      - cache-bos4682-BOS
+      - cache-bos4624-BOS
       X-Timer:
-      - S1757605858.249470,VS0,VE1
+      - S1758207185.517033,VS0,VE53
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -374,7 +374,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/projection/v2.0.0/schema.json
   response:
@@ -442,7 +442,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -452,7 +452,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:50:58 GMT
+      - Thu, 18 Sep 2025 14:53:04 GMT
       ETag:
       - '"669e563b-1116"'
       Last-Modified:
@@ -466,19 +466,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
-      - '2'
+      - '0'
       X-Fastly-Request-ID:
-      - ad3c34da45d9d2b4103449404c0eb2006b7e6765
+      - 374987e315acbf02588141e7aee6af871dae73bc
       X-GitHub-Request-Id:
-      - 21B3:2B753C:1E14E8F:2148802:68C2D6FB
+      - 224F:32B3EB:191F90:1ABAB3:68CC1CCF
       X-Served-By:
       - cache-bos4648-BOS
       X-Timer:
-      - S1757605858.320109,VS0,VE0
+      - S1758207185.632694,VS0,VE26
       expires:
-      - Thu, 11 Sep 2025 14:14:44 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -488,7 +488,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://landsat.usgs.gov/stac/landsat-extension/v1.1.1/schema.json
   response:
@@ -552,7 +552,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 11 Sep 2025 15:51:01 GMT
+      - Thu, 18 Sep 2025 14:55:17 GMT
       ETag:
       - '"f5d-5c78e5c04950e"'
       Last-Modified:
@@ -560,8 +560,8 @@ interactions:
       Server:
       - Apache
       Set-Cookie:
-      - fwb=429bb9b17ca48ed3eeddde07e5efc268;max-age=300;Path=/;Secure;HttpOnly
-      - cookiesession1=678A3E64A730825799B7B09C0F0BD006;Expires=Fri, 11 Sep 2026 15:51:01
+      - fwb=429bb9b17ca48ed3eeddde07551dcc68;max-age=300;Path=/;Secure;HttpOnly
+      - cookiesession1=678A3E641F57F5A605C479A6955F16A7;Expires=Fri, 18 Sep 2026 14:55:17
         GMT;Path=/;HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
@@ -576,7 +576,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/scientific/v1.0.0/schema.json
   response:
@@ -662,7 +662,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '343'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -672,7 +672,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:01 GMT
+      - Thu, 18 Sep 2025 14:55:17 GMT
       ETag:
       - '"60febab7-15fa"'
       Last-Modified:
@@ -686,19 +686,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
-      - '2'
+      - '0'
       X-Fastly-Request-ID:
-      - 1c89f3a999224cfa04f691135cd44108527fb6ac
+      - f4725d9de198926d3e5e1113d98d27c3573a383a
       X-GitHub-Request-Id:
-      - 3922:128B70:CB9EFB:E73AAF:68C2EE8E
+      - 5CF5:3D35AC:C4B412:DF1A74:68CC1D55
       X-Served-By:
-      - cache-bos4641-BOS
+      - cache-bos4679-BOS
       X-Timer:
-      - S1757605862.628648,VS0,VE0
+      - S1758207318.955264,VS0,VE24
       expires:
-      - Thu, 11 Sep 2025 15:55:18 GMT
+      - Thu, 18 Sep 2025 15:05:17 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -708,7 +708,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/classification/v2.0.0/schema.json
   response:
@@ -807,7 +807,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '347'
+      - '134'
       Cache-Control:
       - max-age=600
       Connection:
@@ -817,7 +817,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:01 GMT
+      - Thu, 18 Sep 2025 14:55:18 GMT
       ETag:
       - '"66487a48-199a"'
       Last-Modified:
@@ -833,17 +833,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '0'
       X-Fastly-Request-ID:
-      - d58d2d235a322f8f1f963c081e91134e10b0b7e9
+      - bdf9d1f2af6f217034a8f06179f50d0fd7260d29
       X-GitHub-Request-Id:
-      - 621C:19FF07:BB1F9D:D6BC90:68C2EE89
+      - 6BBC:3C31CF:180620:19A107:68CC1CCF
       X-Served-By:
-      - cache-bos4651-BOS
+      - cache-bos4686-BOS
       X-Timer:
-      - S1757605862.708876,VS0,VE1
+      - S1758207318.053280,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_datacube/test_set_dimensions.yaml
+++ b/tests/extensions/cassettes/test_datacube/test_set_dimensions.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/datacube/v2.2.0/schema.json
   response:
@@ -201,7 +201,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -211,7 +211,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:02 GMT
+      - Thu, 18 Sep 2025 14:55:19 GMT
       ETag:
       - '"6852a0c7-36ad"'
       Last-Modified:
@@ -229,15 +229,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 137d8c34d9878ad95fe82b202e30e59acbab7be8
+      - 4bc4e175a372fd234ec8ce5d0e93d1d319bb29a0
       X-GitHub-Request-Id:
-      - A142:1321F0:B9423B:D4EF9E:68C2EE8C
+      - E5BA:358B9B:CCBE53:E723BF:68CC1D55
       X-Served-By:
-      - cache-bos4622-BOS
+      - cache-bos4668-BOS
       X-Timer:
-      - S1757605863.697863,VS0,VE2
+      - S1758207320.551758,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:18 GMT
+      - Thu, 18 Sep 2025 15:05:18 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_datacube/test_set_variables.yaml
+++ b/tests/extensions/cassettes/test_datacube/test_set_variables.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/datacube/v2.2.0/schema.json
   response:
@@ -201,7 +201,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -211,7 +211,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:02 GMT
+      - Thu, 18 Sep 2025 14:55:19 GMT
       ETag:
       - '"6852a0c7-36ad"'
       Last-Modified:
@@ -229,15 +229,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 5f5490e1bd9e338ef50225b14b592e81451595ad
+      - 57d01cb3823f401943077b1bc9be02f109291678
       X-GitHub-Request-Id:
-      - A142:1321F0:B9423B:D4EF9E:68C2EE8C
+      - E5BA:358B9B:CCBE53:E723BF:68CC1D55
       X-Served-By:
-      - cache-bos4688-BOS
+      - cache-bos4689-BOS
       X-Timer:
-      - S1757605862.258373,VS0,VE1
+      - S1758207319.155142,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:18 GMT
+      - Thu, 18 Sep 2025 15:05:18 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -247,7 +247,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://proj.org/schemas/v0.4/projjson.schema.json
   response:
@@ -257,11 +257,11 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '1'
       CF-Cache-Status:
       - HIT
       CF-Ray:
-      - 97d852ffcf90432f-IAD
+      - 9811af0159f1d6a5-IAD
       Cache-Control:
       - max-age=1200
       Connection:
@@ -273,16 +273,16 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:02 GMT
+      - Thu, 18 Sep 2025 14:55:19 GMT
       Location:
       - https://proj.org/en/latest/schemas/v0.4/projjson.schema.json
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=Wv2SP0aelWAL_R1lNBeN7MTTC.B18htXWgX8si29594-1757605862-1.0.1.1-19.RAhxPdBXInioEu93arIN.ByHmBJUtiYNXuMYNEPgO4WvH5t1madQXMx5mJ3kJLj_hnnW54bay0ltu.wqcFj1kI.tmB8k3VuZGRf0iYB0;
-        path=/; expires=Thu, 11-Sep-25 16:21:02 GMT; domain=.proj.org; HttpOnly; Secure;
+      - __cf_bm=gpjuwW7R.ubtnCdhpnhY1IQi035GWLgYZDIO1BAdJfk-1758207319-1.0.1.1-.4LkKqeQBHvhpYIJcrR1N_SMc9lIiH44YgxI.pcvxWKz1eJnSFKwQL_XUB2KMK3UWb8D.x6lcrWa767cq16HJ4kE0Q6Vaekqry0x6eO1dX8;
+        path=/; expires=Thu, 18-Sep-25 15:25:19 GMT; domain=.proj.org; HttpOnly; Secure;
         SameSite=None
-      - _cfuvid=071bnzQqAEcxDzNOMJqNXHYYvfOfeKG4BcHzt19ArGk-1757605862405-0.0.1.1-604800000;
+      - _cfuvid=zy0aJkSZLIrXmCsyzwsSIqN9AmkU06dwkv9ghgN0rjU-1758207319333-0.0.1.1-604800000;
         path=/; domain=.proj.org; HttpOnly; Secure; SameSite=None
       Vary:
       - Accept-Language, Accept-Encoding
@@ -297,7 +297,7 @@ interactions:
       referrer-policy:
       - no-referrer-when-downgrade
       x-backend:
-      - web-i-0861821c4e19773fc
+      - web-i-0705f04ea68d55778
       x-content-type-options:
       - nosniff
       x-rtd-domain:
@@ -321,7 +321,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://proj.org/en/latest/schemas/v0.4/projjson.schema.json
   response:
@@ -774,11 +774,11 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       CF-Cache-Status:
       - HIT
       CF-Ray:
-      - 97d85300a9c07ff3-IAD
+      - 9811af026e21d674-IAD
       Cache-Control:
       - max-age=1200
       Connection:
@@ -786,7 +786,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 11 Sep 2025 15:51:02 GMT
+      - Thu, 18 Sep 2025 14:55:19 GMT
       ETag:
       - W/"c5bc7ca065287598bed5404a0ec79ce0"
       Last-Modified:
@@ -794,10 +794,10 @@ interactions:
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=DlWmDiwd10XgjUk0Lz1e8RObCS9Tp8q0irufXC2JZaA-1757605862-1.0.1.1-R4Ph2awqA6og5qfWU28Zsw6tfjW35BpFEuQh0S1MtJWe0BtTef4zjMhRLdmLqJOEGSEr2m1aUWcXODqdo_Wlu8PvrhOBMIV2Mw7FnSIZHUs;
-        path=/; expires=Thu, 11-Sep-25 16:21:02 GMT; domain=.proj.org; HttpOnly; Secure;
+      - __cf_bm=SfeJ2au3z5ofOh0x16WWAZL6P3DFbeNwotWCcedlYXo-1758207319-1.0.1.1-CfeIL_iiAvBb0GUNlRBI8Mpdnmz2HIcMD0oCmZl.9sF5KWtzUuuwOALgN0CLWvuvgI1H6KXcKQ2BPHtIA_Cb6FQyT4p2rWOeBTfkRjxch7Y;
+        path=/; expires=Thu, 18-Sep-25 15:25:19 GMT; domain=.proj.org; HttpOnly; Secure;
         SameSite=None
-      - _cfuvid=SjMxvcTGlOG97HGxfCsmW8ulC28Jv7Ref6IIspxF59E-1757605862574-0.0.1.1-604800000;
+      - _cfuvid=Tqgf55Q0FJQw4XhU0BceCwNzbC97W01t8q_.fDCD07k-1758207319456-0.0.1.1-604800000;
         path=/; domain=.proj.org; HttpOnly; Secure; SameSite=None
       Transfer-Encoding:
       - chunked
@@ -812,15 +812,15 @@ interactions:
       referrer-policy:
       - no-referrer-when-downgrade
       x-amz-id-2:
-      - 4HZJGQCHfHcbH0osDWqFlssLAaX4Bw07M/0j9neOqsywL+Q1etLBhKeNHOiBASaJUz+4RK5ALVA=
+      - cuQRBCsv7FhoWAoTU1hGn/0cttUlA2RF3VKGaU6nA3xpUNksjI5Qfugj4uVuN4ajHvdsfb/PHFhuweu8wKU0X5uRJTycYHHjyPwi0Etrz1I=
       x-amz-meta-mtime:
       - '1714074779.458591481'
       x-amz-request-id:
-      - 6VYH6KS2SWMXN8DB
+      - G7121WD0AK9F1CME
       x-amz-server-side-encryption:
       - AES256
       x-backend:
-      - web-i-0e706dc222c808ea4
+      - web-i-088faff751a7543b1
       x-content-type-options:
       - nosniff
       x-rtd-domain:

--- a/tests/extensions/cassettes/test_datacube/test_validate.yaml
+++ b/tests/extensions/cassettes/test_datacube/test_validate.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/datacube/v2.2.0/schema.json
   response:
@@ -201,7 +201,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '343'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -211,7 +211,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:01 GMT
+      - Thu, 18 Sep 2025 14:55:18 GMT
       ETag:
       - '"6852a0c7-36ad"'
       Last-Modified:
@@ -225,19 +225,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 9b7ac5798114401ba14210607f0312468e30e02d
+      - ee03da12961389c05b238dd71a3bd78e8055f386
       X-GitHub-Request-Id:
-      - A142:1321F0:B9423B:D4EF9E:68C2EE8C
+      - E5BA:358B9B:CCBE53:E723BF:68CC1D55
       X-Served-By:
-      - cache-bos4690-BOS
+      - cache-bos4651-BOS
       X-Timer:
-      - S1757605862.835817,VS0,VE1
+      - S1758207318.193263,VS0,VE40
       expires:
-      - Thu, 11 Sep 2025 15:55:18 GMT
+      - Thu, 18 Sep 2025 15:05:18 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -247,7 +247,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://proj.org/schemas/v0.4/projjson.schema.json
   response:
@@ -256,12 +256,10 @@ interactions:
     headers:
       Access-Control-Allow-Origin:
       - '*'
-      Age:
-      - '344'
       CF-Cache-Status:
-      - HIT
+      - EXPIRED
       CF-Ray:
-      - 97d852fd5b74f284-IAD
+      - 9811aefe08270568-IAD
       Cache-Control:
       - max-age=1200
       Connection:
@@ -273,16 +271,16 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:02 GMT
+      - Thu, 18 Sep 2025 14:55:18 GMT
       Location:
       - https://proj.org/en/latest/schemas/v0.4/projjson.schema.json
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=TEBWjV141WFfKiRX9nNUjlF9.ayUyO.8qSFB1WsjhfA-1757605862-1.0.1.1-Rj.57Zj4X3zWCb7p2oOvbHVdMXO8hp7pU0mJJ50iL8RipgTER5j8JrIFEfP7h4JzZYqaIXsvHhGEyTwIsGCmKhPdPMg8FIlpnpvtSAsUshs;
-        path=/; expires=Thu, 11-Sep-25 16:21:02 GMT; domain=.proj.org; HttpOnly; Secure;
+      - __cf_bm=z4k4n7CyUHtNtHO8RULBL4BxHMKPtT2C4hmH.XZQob4-1758207318-1.0.1.1-7nuUhi9z.7Y08woqxqiflBfvlgZuGZIAFWfCFALFjNxJphu8PF.erQzortow_yOQGEChNfpAQAXp6.oIwXavExNSqmjTTucXmDLXS8Oe3go;
+        path=/; expires=Thu, 18-Sep-25 15:25:18 GMT; domain=.proj.org; HttpOnly; Secure;
         SameSite=None
-      - _cfuvid=Wa4g3MwXxjlIqqYYCC.nbn6TljUZTvGcNUKPzXFJORM-1757605862008-0.0.1.1-604800000;
+      - _cfuvid=gIbR4ZSReDkZpVQHztR9RDztKcHnLl_ZR3yuqowM3gY-1758207318864-0.0.1.1-604800000;
         path=/; domain=.proj.org; HttpOnly; Secure; SameSite=None
       Vary:
       - Accept-Language, Accept-Encoding
@@ -297,7 +295,7 @@ interactions:
       referrer-policy:
       - no-referrer-when-downgrade
       x-backend:
-      - web-i-0861821c4e19773fc
+      - web-i-0705f04ea68d55778
       x-content-type-options:
       - nosniff
       x-rtd-domain:
@@ -321,7 +319,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://proj.org/en/latest/schemas/v0.4/projjson.schema.json
   response:
@@ -773,12 +771,10 @@ interactions:
     headers:
       Access-Control-Allow-Origin:
       - '*'
-      Age:
-      - '344'
       CF-Cache-Status:
       - HIT
       CF-Ray:
-      - 97d852fe3d27290e-IAD
+      - 9811aeff8d7ed660-IAD
       Cache-Control:
       - max-age=1200
       Connection:
@@ -786,7 +782,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 11 Sep 2025 15:51:02 GMT
+      - Thu, 18 Sep 2025 14:55:19 GMT
       ETag:
       - W/"c5bc7ca065287598bed5404a0ec79ce0"
       Last-Modified:
@@ -794,10 +790,10 @@ interactions:
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=V6E2dWC1zllxE8OSYuo8ZF7ci6W5JTI6gpkAY_vwPEc-1757605862-1.0.1.1-6G3vRBEfrCEzekhRqpgHaJmrJCIdt.iEJAK6o5n5ePo8qsoc1DwF7oEWl.iXt7A0AEJ1mTfT.2FVVwo6Abo8x2uqvLIyODecwLYfRcsml0c;
-        path=/; expires=Thu, 11-Sep-25 16:21:02 GMT; domain=.proj.org; HttpOnly; Secure;
+      - __cf_bm=MPZVXF7UaUjK5IuqKYosp.TNqqZbg6CCIrS8PLshFPY-1758207319-1.0.1.1-RGqhZVB5eMsmFQNwcwm7wxaO0plibhYi1ed16ltKbMtmMCfhvj5GWC.jt1cHwxVAtOOG9YXF6O7zHaxe1EvM.hFnuEGhCzwc7RB91XNPrIQ;
+        path=/; expires=Thu, 18-Sep-25 15:25:19 GMT; domain=.proj.org; HttpOnly; Secure;
         SameSite=None
-      - _cfuvid=oi0TXLNr1pkyEqFdR2xO..okqdZ3e13Ja4HpP6dXs2w-1757605862158-0.0.1.1-604800000;
+      - _cfuvid=x551WBwwGCoQkT9AczM6F2zUjpkMcisjKHw3Udnm_zs-1758207319041-0.0.1.1-604800000;
         path=/; domain=.proj.org; HttpOnly; Secure; SameSite=None
       Transfer-Encoding:
       - chunked
@@ -812,15 +808,15 @@ interactions:
       referrer-policy:
       - no-referrer-when-downgrade
       x-amz-id-2:
-      - 4HZJGQCHfHcbH0osDWqFlssLAaX4Bw07M/0j9neOqsywL+Q1etLBhKeNHOiBASaJUz+4RK5ALVA=
+      - cuQRBCsv7FhoWAoTU1hGn/0cttUlA2RF3VKGaU6nA3xpUNksjI5Qfugj4uVuN4ajHvdsfb/PHFhuweu8wKU0X5uRJTycYHHjyPwi0Etrz1I=
       x-amz-meta-mtime:
       - '1714074779.458591481'
       x-amz-request-id:
-      - 6VYH6KS2SWMXN8DB
+      - G7121WD0AK9F1CME
       x-amz-server-side-encryption:
       - AES256
       x-backend:
-      - web-i-0e706dc222c808ea4
+      - web-i-088faff751a7543b1
       x-content-type-options:
       - nosniff
       x-rtd-domain:

--- a/tests/extensions/cassettes/test_eo/test_asset_bands.yaml
+++ b/tests/extensions/cassettes/test_eo/test_asset_bands.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/eo/v1.1.0/schema.json
   response:
@@ -81,7 +81,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '349'
+      - '136'
       Cache-Control:
       - max-age=600
       Connection:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:03 GMT
+      - Thu, 18 Sep 2025 14:55:19 GMT
       ETag:
       - '"66df1c53-13bc"'
       Last-Modified:
@@ -107,17 +107,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - ee9063d4aee73d21dfaffae550a1a25d75ec767f
+      - c722751fc37337648c77aaa6caf49a22b45a6693
       X-GitHub-Request-Id:
-      - BE8A:14434E:B836A2:D3D600:68C2EE8A
+      - 98DE:39A2ED:1DBAAC:1F56C3:68CC1CD0
       X-Served-By:
-      - cache-bos4637-BOS
+      - cache-bos4649-BOS
       X-Timer:
-      - S1757605863.149939,VS0,VE0
+      - S1758207320.963340,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -127,7 +127,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/view/v1.0.0/schema.json
   response:
@@ -185,7 +185,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '349'
+      - '135'
       Cache-Control:
       - max-age=600
       Connection:
@@ -195,7 +195,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:03 GMT
+      - Thu, 18 Sep 2025 14:55:20 GMT
       ETag:
       - '"689f5434-dff"'
       Last-Modified:
@@ -211,17 +211,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - cbd40eb243cd2c3fa19a32fbb89cff3965361f41
+      - 9f17fc25090274b692ed7d86ab11578790bc0dcd
       X-GitHub-Request-Id:
-      - EACF:1C0114:1BE6594:1F22786:68C2EE8A
+      - 624D:BA176:74CE5:7ED3C:68CC1CD0
       X-Served-By:
-      - cache-bos4656-BOS
+      - cache-bos4663-BOS
       X-Timer:
-      - S1757605863.228097,VS0,VE0
+      - S1758207320.033673,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_eo/test_bands.yaml
+++ b/tests/extensions/cassettes/test_eo/test_bands.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/eo/v1.1.0/schema.json
   response:
@@ -81,7 +81,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '348'
+      - '135'
       Cache-Control:
       - max-age=600
       Connection:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:02 GMT
+      - Thu, 18 Sep 2025 14:55:19 GMT
       ETag:
       - '"66df1c53-13bc"'
       Last-Modified:
@@ -109,15 +109,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 7d52778f8bf311d171af4855cc073a57a75365ef
+      - 5ec7e71ebba15aa06401db8fc287c858d73cabaf
       X-GitHub-Request-Id:
-      - BE8A:14434E:B836A2:D3D600:68C2EE8A
+      - 98DE:39A2ED:1DBAAC:1F56C3:68CC1CD0
       X-Served-By:
-      - cache-bos4632-BOS
+      - cache-bos4621-BOS
       X-Timer:
-      - S1757605863.972189,VS0,VE2
+      - S1758207320.807546,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -127,7 +127,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/view/v1.0.0/schema.json
   response:
@@ -185,7 +185,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '348'
+      - '135'
       Cache-Control:
       - max-age=600
       Connection:
@@ -195,7 +195,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:03 GMT
+      - Thu, 18 Sep 2025 14:55:19 GMT
       ETag:
       - '"689f5434-dff"'
       Last-Modified:
@@ -213,15 +213,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - b58ccc098c0b9db7ab2bc3bbadf145f99c2cf9c8
+      - 1403b5963d729463d0f9effcb94191313cc78ca9
       X-GitHub-Request-Id:
-      - EACF:1C0114:1BE6594:1F22786:68C2EE8A
+      - 624D:BA176:74CE5:7ED3C:68CC1CD0
       X-Served-By:
-      - cache-bos4638-BOS
+      - cache-bos4676-BOS
       X-Timer:
-      - S1757605863.047733,VS0,VE1
+      - S1758207320.871433,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_eo/test_cloud_cover.yaml
+++ b/tests/extensions/cassettes/test_eo/test_cloud_cover.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/eo/v1.1.0/schema.json
   response:
@@ -81,7 +81,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '349'
+      - '136'
       Cache-Control:
       - max-age=600
       Connection:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:03 GMT
+      - Thu, 18 Sep 2025 14:55:20 GMT
       ETag:
       - '"66df1c53-13bc"'
       Last-Modified:
@@ -107,17 +107,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '1'
       X-Fastly-Request-ID:
-      - e67b1afa489991fb9b790a9547bc09d7b0956c65
+      - d68c506ce5fa4597f7c0169a88b9aa183c5e2a46
       X-GitHub-Request-Id:
-      - BE8A:14434E:B836A2:D3D600:68C2EE8A
+      - 98DE:39A2ED:1DBAAC:1F56C3:68CC1CD0
       X-Served-By:
-      - cache-bos4647-BOS
+      - cache-bos4680-BOS
       X-Timer:
-      - S1757605863.325858,VS0,VE0
+      - S1758207320.176894,VS0,VE3
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -127,7 +127,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/view/v1.0.0/schema.json
   response:
@@ -185,7 +185,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '349'
+      - '136'
       Cache-Control:
       - max-age=600
       Connection:
@@ -195,7 +195,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:03 GMT
+      - Thu, 18 Sep 2025 14:55:20 GMT
       ETag:
       - '"689f5434-dff"'
       Last-Modified:
@@ -211,17 +211,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - d6141c164f082e429d96588f5da5ea097506f408
+      - e83377855f610733c07f04b338f228c6955a808b
       X-GitHub-Request-Id:
-      - EACF:1C0114:1BE6594:1F22786:68C2EE8A
+      - 624D:BA176:74CE5:7ED3C:68CC1CD0
       X-Served-By:
-      - cache-bos4621-BOS
+      - cache-bos4678-BOS
       X-Timer:
-      - S1757605863.404074,VS0,VE1
+      - S1758207320.258899,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_eo/test_set_field[cloud_cover-7.8].yaml
+++ b/tests/extensions/cassettes/test_eo/test_set_field[cloud_cover-7.8].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/eo/v1.1.0/schema.json
   response:
@@ -81,7 +81,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '349'
+      - '136'
       Cache-Control:
       - max-age=600
       Connection:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:03 GMT
+      - Thu, 18 Sep 2025 14:55:20 GMT
       ETag:
       - '"66df1c53-13bc"'
       Last-Modified:
@@ -109,15 +109,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 82ae02dbef8ff8a2f931d71d73b23a09bf7d63ee
+      - 5d24530c7fa8a9a39eb0f26c964c8019625c44e8
       X-GitHub-Request-Id:
-      - BE8A:14434E:B836A2:D3D600:68C2EE8A
+      - 98DE:39A2ED:1DBAAC:1F56C3:68CC1CD0
       X-Served-By:
-      - cache-bos4663-BOS
+      - cache-bos4650-BOS
       X-Timer:
-      - S1757605864.501917,VS0,VE2
+      - S1758207320.377575,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -127,7 +127,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/view/v1.0.0/schema.json
   response:
@@ -185,7 +185,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '349'
+      - '136'
       Cache-Control:
       - max-age=600
       Connection:
@@ -195,7 +195,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:03 GMT
+      - Thu, 18 Sep 2025 14:55:20 GMT
       ETag:
       - '"689f5434-dff"'
       Last-Modified:
@@ -213,15 +213,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 6be01a613c12d3d3c53284d6b2cdf4f3fd38f70e
+      - 597c8c069447fe7eae7060cb984a04973fd4b3ff
       X-GitHub-Request-Id:
-      - EACF:1C0114:1BE6594:1F22786:68C2EE8A
+      - 624D:BA176:74CE5:7ED3C:68CC1CD0
       X-Served-By:
-      - cache-bos4652-BOS
+      - cache-bos4691-BOS
       X-Timer:
-      - S1757605864.573744,VS0,VE1
+      - S1758207320.460769,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_eo/test_set_field[snow_cover-99].yaml
+++ b/tests/extensions/cassettes/test_eo/test_set_field[snow_cover-99].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/eo/v1.1.0/schema.json
   response:
@@ -81,7 +81,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '349'
+      - '136'
       Cache-Control:
       - max-age=600
       Connection:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:03 GMT
+      - Thu, 18 Sep 2025 14:55:20 GMT
       ETag:
       - '"66df1c53-13bc"'
       Last-Modified:
@@ -109,15 +109,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 739a587e5b22e9b4a7d6c703fb64f4db36a07a65
+      - 508b53a67de2c5dce22cbd1904c575e8d40628b5
       X-GitHub-Request-Id:
-      - BE8A:14434E:B836A2:D3D600:68C2EE8A
+      - 98DE:39A2ED:1DBAAC:1F56C3:68CC1CD0
       X-Served-By:
-      - cache-bos4684-BOS
+      - cache-bos4677-BOS
       X-Timer:
-      - S1757605864.733650,VS0,VE1
+      - S1758207321.555563,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -127,7 +127,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/view/v1.0.0/schema.json
   response:
@@ -185,7 +185,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '349'
+      - '136'
       Cache-Control:
       - max-age=600
       Connection:
@@ -195,7 +195,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:03 GMT
+      - Thu, 18 Sep 2025 14:55:20 GMT
       ETag:
       - '"689f5434-dff"'
       Last-Modified:
@@ -213,15 +213,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 9909b934ee185870ee4bd6e78480d0d14aab7bcc
+      - b863035b3155f32cee1cf9271c6b1dceeae546c3
       X-GitHub-Request-Id:
-      - EACF:1C0114:1BE6594:1F22786:68C2EE8A
+      - 624D:BA176:74CE5:7ED3C:68CC1CD0
       X-Served-By:
-      - cache-bos4683-BOS
+      - cache-bos4666-BOS
       X-Timer:
-      - S1757605864.813820,VS0,VE1
+      - S1758207321.634927,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_eo/test_validate_eo.yaml
+++ b/tests/extensions/cassettes/test_eo/test_validate_eo.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/eo/v1.1.0/schema.json
   response:
@@ -81,7 +81,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '349'
+      - '135'
       Cache-Control:
       - max-age=600
       Connection:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:02 GMT
+      - Thu, 18 Sep 2025 14:55:19 GMT
       ETag:
       - '"66df1c53-13bc"'
       Last-Modified:
@@ -107,17 +107,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '0'
       X-Fastly-Request-ID:
-      - ca79c577267aae0059bf052745b6bdb249ec4be1
+      - cc92bd7f424ae0cf4ae990db94a240b91059746d
       X-GitHub-Request-Id:
-      - BE8A:14434E:B836A2:D3D600:68C2EE8A
+      - 98DE:39A2ED:1DBAAC:1F56C3:68CC1CD0
       X-Served-By:
-      - cache-bos4647-BOS
+      - cache-bos4675-BOS
       X-Timer:
-      - S1757605863.800200,VS0,VE0
+      - S1758207320.649042,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -127,7 +127,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/view/v1.0.0/schema.json
   response:
@@ -185,7 +185,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '348'
+      - '135'
       Cache-Control:
       - max-age=600
       Connection:
@@ -195,7 +195,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:02 GMT
+      - Thu, 18 Sep 2025 14:55:19 GMT
       ETag:
       - '"689f5434-dff"'
       Last-Modified:
@@ -211,17 +211,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '0'
       X-Fastly-Request-ID:
-      - 4bd3e093bb572cfe1b56b1a21576292d5fd440a3
+      - 5429e3d96df0793459d26012559aeacea585e605
       X-GitHub-Request-Id:
-      - EACF:1C0114:1BE6594:1F22786:68C2EE8A
+      - 624D:BA176:74CE5:7ED3C:68CC1CD0
       X-Served-By:
-      - cache-bos4642-BOS
+      - cache-bos4663-BOS
       X-Timer:
-      - S1757605863.868069,VS0,VE0
+      - S1758207320.713697,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_file/test_migrate_from_v1_0_0.yaml
+++ b/tests/extensions/cassettes/test_file/test_migrate_from_v1_0_0.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/stac-extensions/file/v1.0.0/examples/item.json
   response:
@@ -61,11 +61,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:05 GMT
+      - Thu, 18 Sep 2025 14:55:22 GMT
       ETag:
       - '"d86613d81195c6b4fdebc2055d91ce4921bbc44d99ad6206c5ffdf7518eb89f2"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:05 GMT
+      - Thu, 18 Sep 2025 15:00:22 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -75,21 +75,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 91d7d08ab0879cfc8fe4b6846360baef07eefa9f
+      - fa669480f9dbc6ddfa2a1532880d58adca212cce
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 7EDA:286B02:100D847:13F5656:68C2EE8E
+      - E90D:B9EE0:781D6F:967D97:68CC1D59
       X-Served-By:
-      - cache-bos4650-BOS
+      - cache-bos4640-BOS
       X-Timer:
-      - S1757605865.263788,VS0,VE54
+      - S1758207322.049362,VS0,VE111
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/extensions/cassettes/test_file/test_migrate_from_v2_0_0.yaml
+++ b/tests/extensions/cassettes/test_file/test_migrate_from_v2_0_0.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/stac-extensions/file/v2.0.0/examples/item.json
   response:
@@ -60,11 +60,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:05 GMT
+      - Thu, 18 Sep 2025 14:55:21 GMT
       ETag:
       - '"2bad008be3e01a9750cc4e04bc605bca80229906ad21f17c6e7573fb367bb781"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:05 GMT
+      - Thu, 18 Sep 2025 15:00:21 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -74,21 +74,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - f26d07de8490a9a69bef95ea2820bde940733652
+      - fcac68f938700c18b5b1cf32687a5bd5c6c21a36
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 1827:249F1D:79E68A:9AAC2F:68C2EE91
+      - 0AF3:3C536F:770E11:956C3F:68CC1D59
       X-Served-By:
-      - cache-bos4683-BOS
+      - cache-bos4638-BOS
       X-Timer:
-      - S1757605865.133747,VS0,VE53
+      - S1758207322.899299,VS0,VE89
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/extensions/cassettes/test_file/test_set_field_on_asset[calibrations-local_path-different-file.xml].yaml
+++ b/tests/extensions/cassettes/test_file/test_set_field_on_asset[calibrations-local_path-different-file.xml].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/file/v2.1.0/schema.json
   response:
@@ -75,7 +75,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -85,7 +85,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:04 GMT
+      - Thu, 18 Sep 2025 14:55:21 GMT
       ETag:
       - '"61b4cf00-11b8"'
       Last-Modified:
@@ -103,15 +103,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - b74539a8948d8bc23b003910bd710de2db99ed6b
+      - 13dfa2b60038cff3d79d9a002f5f876989f9f74f
       X-GitHub-Request-Id:
-      - CC3D:A4A55:2161E65:253329B:68C2EE90
+      - 4944:D006F:CE75D8:E8CE6C:68CC1D58
       X-Served-By:
-      - cache-bos4673-BOS
+      - cache-bos4636-BOS
       X-Timer:
-      - S1757605865.593723,VS0,VE1
+      - S1758207321.419323,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:20 GMT
+      - Thu, 18 Sep 2025 15:05:20 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_file/test_set_field_on_asset[measurement-header_size-8192].yaml
+++ b/tests/extensions/cassettes/test_file/test_set_field_on_asset[measurement-header_size-8192].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/file/v2.1.0/schema.json
   response:
@@ -75,7 +75,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -85,7 +85,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:04 GMT
+      - Thu, 18 Sep 2025 14:55:21 GMT
       ETag:
       - '"61b4cf00-11b8"'
       Last-Modified:
@@ -101,17 +101,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '4'
       X-Fastly-Request-ID:
-      - 60e21ad56b17441d548c39c5b3264dcfe723e8ef
+      - 8269e9d5cc7255566410edf5a795cda2caad5f9a
       X-GitHub-Request-Id:
-      - CC3D:A4A55:2161E65:253329B:68C2EE90
+      - 4944:D006F:CE75D8:E8CE6C:68CC1D58
       X-Served-By:
-      - cache-bos4682-BOS
+      - cache-bos4668-BOS
       X-Timer:
-      - S1757605864.335943,VS0,VE2
+      - S1758207321.192480,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:20 GMT
+      - Thu, 18 Sep 2025 15:05:20 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_file/test_set_field_on_asset[thumbnail-byte_order-little-endian].yaml
+++ b/tests/extensions/cassettes/test_file/test_set_field_on_asset[thumbnail-byte_order-little-endian].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/file/v2.1.0/schema.json
   response:
@@ -75,7 +75,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -85,7 +85,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:04 GMT
+      - Thu, 18 Sep 2025 14:55:21 GMT
       ETag:
       - '"61b4cf00-11b8"'
       Last-Modified:
@@ -103,15 +103,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - d9de28fbb95144e86fd07080a962d43504c559a9
+      - 89817e1fe7e71f167bce88d94a51c49a8fcf9068
       X-GitHub-Request-Id:
-      - CC3D:A4A55:2161E65:253329B:68C2EE90
+      - 4944:D006F:CE75D8:E8CE6C:68CC1D58
       X-Served-By:
-      - cache-bos4688-BOS
+      - cache-bos4677-BOS
       X-Timer:
-      - S1757605865.510164,VS0,VE1
+      - S1758207321.345630,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:20 GMT
+      - Thu, 18 Sep 2025 15:05:20 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_file/test_set_field_on_asset[thumbnail-checksum-90e40210163700a8a6501eccd00b6d3b44ddaed0].yaml
+++ b/tests/extensions/cassettes/test_file/test_set_field_on_asset[thumbnail-checksum-90e40210163700a8a6501eccd00b6d3b44ddaed0].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/file/v2.1.0/schema.json
   response:
@@ -75,7 +75,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -85,7 +85,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:04 GMT
+      - Thu, 18 Sep 2025 14:55:21 GMT
       ETag:
       - '"61b4cf00-11b8"'
       Last-Modified:
@@ -103,15 +103,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - af43dbc2cca7732773c46a744921772144ff1435
+      - 51514eba95039735b5f533b242fab47e94c93cb9
       X-GitHub-Request-Id:
-      - CC3D:A4A55:2161E65:253329B:68C2EE90
+      - 4944:D006F:CE75D8:E8CE6C:68CC1D58
       X-Served-By:
-      - cache-bos4632-BOS
+      - cache-bos4638-BOS
       X-Timer:
-      - S1757605864.423782,VS0,VE1
+      - S1758207321.269517,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:20 GMT
+      - Thu, 18 Sep 2025 15:05:20 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_file/test_set_field_on_asset[thumbnail-size-1].yaml
+++ b/tests/extensions/cassettes/test_file/test_set_field_on_asset[thumbnail-size-1].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/file/v2.1.0/schema.json
   response:
@@ -75,7 +75,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -85,7 +85,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:04 GMT
+      - Thu, 18 Sep 2025 14:55:21 GMT
       ETag:
       - '"61b4cf00-11b8"'
       Last-Modified:
@@ -103,15 +103,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 5350831db5fb112ebca57a9101f28dc60a994ae2
+      - 0ec83ff6f1bafe55a073b8c5a303b1a16ac872a7
       X-GitHub-Request-Id:
-      - CC3D:A4A55:2161E65:253329B:68C2EE90
+      - 4944:D006F:CE75D8:E8CE6C:68CC1D58
       X-Served-By:
-      - cache-bos4656-BOS
+      - cache-bos4623-BOS
       X-Timer:
-      - S1757605864.233748,VS0,VE3
+      - S1758207321.109551,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:20 GMT
+      - Thu, 18 Sep 2025 15:05:20 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_file/test_set_field_on_link[about-byte_order-big-endian].yaml
+++ b/tests/extensions/cassettes/test_file/test_set_field_on_link[about-byte_order-big-endian].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/file/v2.1.0/schema.json
   response:
@@ -75,7 +75,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -85,7 +85,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:04 GMT
+      - Thu, 18 Sep 2025 14:55:21 GMT
       ETag:
       - '"61b4cf00-11b8"'
       Last-Modified:
@@ -101,17 +101,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Fastly-Request-ID:
-      - 774648256cc213d7a938439457ecb6ad22e442a2
+      - ee37c23f8b96b22bd351c5e850638b9a83f8e7d4
       X-GitHub-Request-Id:
-      - CC3D:A4A55:2161E65:253329B:68C2EE90
+      - 4944:D006F:CE75D8:E8CE6C:68CC1D58
       X-Served-By:
-      - cache-bos4687-BOS
+      - cache-bos4636-BOS
       X-Timer:
-      - S1757605865.956046,VS0,VE1
+      - S1758207322.721292,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:20 GMT
+      - Thu, 18 Sep 2025 15:05:20 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_file/test_set_field_on_link[about-checksum-90e40210163700a8a6501eccd00b6d3b44ddaedb].yaml
+++ b/tests/extensions/cassettes/test_file/test_set_field_on_link[about-checksum-90e40210163700a8a6501eccd00b6d3b44ddaedb].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/file/v2.1.0/schema.json
   response:
@@ -75,7 +75,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -85,7 +85,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:04 GMT
+      - Thu, 18 Sep 2025 14:55:21 GMT
       ETag:
       - '"61b4cf00-11b8"'
       Last-Modified:
@@ -103,15 +103,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 9d7e9455e1ed0cf4d16e2f3729da08416d8fe8bb
+      - 18dabb9bf353116d2c3dce0a966b1901c2f38f1d
       X-GitHub-Request-Id:
-      - CC3D:A4A55:2161E65:253329B:68C2EE90
+      - 4944:D006F:CE75D8:E8CE6C:68CC1D58
       X-Served-By:
-      - cache-bos4654-BOS
+      - cache-bos4656-BOS
       X-Timer:
-      - S1757605865.855407,VS0,VE11
+      - S1758207322.647086,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:20 GMT
+      - Thu, 18 Sep 2025 15:05:20 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_file/test_set_field_on_link[about-header_size-4092].yaml
+++ b/tests/extensions/cassettes/test_file/test_set_field_on_link[about-header_size-4092].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/file/v2.1.0/schema.json
   response:
@@ -75,7 +75,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -85,7 +85,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:04 GMT
+      - Thu, 18 Sep 2025 14:55:21 GMT
       ETag:
       - '"61b4cf00-11b8"'
       Last-Modified:
@@ -101,17 +101,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Fastly-Request-ID:
-      - 71349d34ba925440ffcdb9d9eb190c28a9a9d063
+      - 8a2432416787f8732f046d18dda8873d9c3c1f5e
       X-GitHub-Request-Id:
-      - CC3D:A4A55:2161E65:253329B:68C2EE90
+      - 4944:D006F:CE75D8:E8CE6C:68CC1D58
       X-Served-By:
-      - cache-bos4666-BOS
+      - cache-bos4638-BOS
       X-Timer:
-      - S1757605865.769846,VS0,VE2
+      - S1758207322.567616,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:20 GMT
+      - Thu, 18 Sep 2025 15:05:20 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_file/test_set_field_on_link[about-local_path-a-path].yaml
+++ b/tests/extensions/cassettes/test_file/test_set_field_on_link[about-local_path-a-path].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/file/v2.1.0/schema.json
   response:
@@ -75,7 +75,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '345'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -85,7 +85,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:05 GMT
+      - Thu, 18 Sep 2025 14:55:21 GMT
       ETag:
       - '"61b4cf00-11b8"'
       Last-Modified:
@@ -101,17 +101,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 46f6eb64508aa604a04856036fd60fe84023c34a
+      - 57180a31babc5e3001c038e6907e9e25122a573e
       X-GitHub-Request-Id:
-      - CC3D:A4A55:2161E65:253329B:68C2EE90
+      - 4944:D006F:CE75D8:E8CE6C:68CC1D58
       X-Served-By:
-      - cache-bos4638-BOS
+      - cache-bos4640-BOS
       X-Timer:
-      - S1757605865.048986,VS0,VE1
+      - S1758207322.797478,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:20 GMT
+      - Thu, 18 Sep 2025 15:05:20 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_file/test_set_field_on_link[about-size-129302].yaml
+++ b/tests/extensions/cassettes/test_file/test_set_field_on_link[about-size-129302].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/file/v2.1.0/schema.json
   response:
@@ -75,7 +75,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -85,7 +85,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:04 GMT
+      - Thu, 18 Sep 2025 14:55:21 GMT
       ETag:
       - '"61b4cf00-11b8"'
       Last-Modified:
@@ -103,15 +103,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 64cc643efa8e24cd13101156bbd4bf2320e605bb
+      - cccbc8bf07d208888b175dd1cefd015d0abe443e
       X-GitHub-Request-Id:
-      - CC3D:A4A55:2161E65:253329B:68C2EE90
+      - 4944:D006F:CE75D8:E8CE6C:68CC1D58
       X-Served-By:
-      - cache-bos4661-BOS
+      - cache-bos4680-BOS
       X-Timer:
-      - S1757605865.683971,VS0,VE1
+      - S1758207321.499613,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:20 GMT
+      - Thu, 18 Sep 2025 15:05:20 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_file/test_validate_catalog.yaml
+++ b/tests/extensions/cassettes/test_file/test_validate_catalog.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/file/v2.1.0/schema.json
   response:
@@ -75,7 +75,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -85,7 +85,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:04 GMT
+      - Thu, 18 Sep 2025 14:55:21 GMT
       ETag:
       - '"61b4cf00-11b8"'
       Last-Modified:
@@ -103,15 +103,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - f995c7c0b713a798d82efd793603728c901fcd85
+      - dad2547fe46b4f9bbb898a6b6e21eedadb6dcc80
       X-GitHub-Request-Id:
-      - CC3D:A4A55:2161E65:253329B:68C2EE90
+      - 4944:D006F:CE75D8:E8CE6C:68CC1D58
       X-Served-By:
-      - cache-bos4655-BOS
+      - cache-bos4642-BOS
       X-Timer:
-      - S1757605864.142166,VS0,VE2
+      - S1758207321.027094,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:20 GMT
+      - Thu, 18 Sep 2025 15:05:20 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_file/test_validate_collection.yaml
+++ b/tests/extensions/cassettes/test_file/test_validate_collection.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/file/v2.1.0/schema.json
   response:
@@ -75,7 +75,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '343'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -85,7 +85,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:04 GMT
+      - Thu, 18 Sep 2025 14:55:20 GMT
       ETag:
       - '"61b4cf00-11b8"'
       Last-Modified:
@@ -101,17 +101,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '1'
       X-Fastly-Request-ID:
-      - df2c67c3feaded58082cc4303ba20f554db5f2ef
+      - 473a074e917734e31eb1cda6151a611456822f29
       X-GitHub-Request-Id:
-      - CC3D:A4A55:2161E65:253329B:68C2EE90
+      - 4944:D006F:CE75D8:E8CE6C:68CC1D58
       X-Served-By:
-      - cache-bos4675-BOS
+      - cache-bos4650-BOS
       X-Timer:
-      - S1757605864.062294,VS0,VE1
+      - S1758207321.947351,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:20 GMT
+      - Thu, 18 Sep 2025 15:05:20 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_file/test_validate_item.yaml
+++ b/tests/extensions/cassettes/test_file/test_validate_item.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/file/v2.1.0/schema.json
   response:
@@ -75,7 +75,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '343'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -85,7 +85,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:03 GMT
+      - Thu, 18 Sep 2025 14:55:20 GMT
       ETag:
       - '"61b4cf00-11b8"'
       Last-Modified:
@@ -99,19 +99,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 6b8fb8a4f9ed61d50054efada5dfc75934a3f37e
+      - ef4d6374a6a78442ac9f203c5786711ba6f7eb9b
       X-GitHub-Request-Id:
-      - CC3D:A4A55:2161E65:253329B:68C2EE90
+      - 4944:D006F:CE75D8:E8CE6C:68CC1D58
       X-Served-By:
-      - cache-bos4684-BOS
+      - cache-bos4667-BOS
       X-Timer:
-      - S1757605864.979563,VS0,VE1
+      - S1758207321.819200,VS0,VE38
       expires:
-      - Thu, 11 Sep 2025 15:55:20 GMT
+      - Thu, 18 Sep 2025 15:05:20 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_grid/test_attributes.yaml
+++ b/tests/extensions/cassettes/test_grid/test_attributes.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/grid/v1.1.0/schema.json
   response:
@@ -37,7 +37,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '343'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -47,7 +47,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:05 GMT
+      - Thu, 18 Sep 2025 14:55:22 GMT
       ETag:
       - '"638a24f0-6d8"'
       Last-Modified:
@@ -61,19 +61,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 0611e938b2367b72875c5d7b26fea133bca927f6
+      - 1995e1c496a1cdd9ea212593610283f5bac6b408
       X-GitHub-Request-Id:
-      - 621C:19FF07:BB26AA:D6C48C:68C2EE91
+      - CAC7:3CD2C3:DA3D96:F49946:68CC1D5A
       X-Served-By:
-      - cache-bos4622-BOS
+      - cache-bos4636-BOS
       X-Timer:
-      - S1757605865.405716,VS0,VE1
+      - S1758207322.231279,VS0,VE26
       expires:
-      - Thu, 11 Sep 2025 15:55:21 GMT
+      - Thu, 18 Sep 2025 15:05:22 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_grid/test_modify.yaml
+++ b/tests/extensions/cassettes/test_grid/test_modify.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/grid/v1.1.0/schema.json
   response:
@@ -37,7 +37,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -47,7 +47,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:05 GMT
+      - Thu, 18 Sep 2025 14:55:22 GMT
       ETag:
       - '"638a24f0-6d8"'
       Last-Modified:
@@ -65,15 +65,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - ddbcc271cf043ca387b3976600a6afa4a664a525
+      - 99afa3b8ff8349de997474b11504fe72b3ac6f9b
       X-GitHub-Request-Id:
-      - 621C:19FF07:BB26AA:D6C48C:68C2EE91
+      - CAC7:3CD2C3:DA3D96:F49946:68CC1D5A
       X-Served-By:
-      - cache-bos4651-BOS
+      - cache-bos4627-BOS
       X-Timer:
-      - S1757605866.508436,VS0,VE2
+      - S1758207322.324483,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:21 GMT
+      - Thu, 18 Sep 2025 15:05:22 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_mgrs/test_set_field[grid_square-ZA].yaml
+++ b/tests/extensions/cassettes/test_mgrs/test_set_field[grid_square-ZA].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/mgrs/v1.0.0/schema.json
   response:
@@ -53,7 +53,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -63,7 +63,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:05 GMT
+      - Thu, 18 Sep 2025 14:55:22 GMT
       ETag:
       - '"60c20ce1-b49"'
       Last-Modified:
@@ -81,15 +81,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - ab2ffc59b0fac9becf6981293657456e53fd7a77
+      - e97cdcfcede0c74f403bf8e6d9c1bed788845910
       X-GitHub-Request-Id:
-      - 8146:41371:C197CC:DD3EA9:68C2EE91
+      - 4494:C5EEF:CC4460:E69E65:68CC1D5A
       X-Served-By:
-      - cache-bos4656-BOS
+      - cache-bos4647-BOS
       X-Timer:
-      - S1757605866.787161,VS0,VE1
+      - S1758207323.619287,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:22 GMT
+      - Thu, 18 Sep 2025 15:05:22 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_mgrs/test_set_field[latitude_band-C].yaml
+++ b/tests/extensions/cassettes/test_mgrs/test_set_field[latitude_band-C].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/mgrs/v1.0.0/schema.json
   response:
@@ -53,7 +53,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -63,7 +63,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:05 GMT
+      - Thu, 18 Sep 2025 14:55:22 GMT
       ETag:
       - '"60c20ce1-b49"'
       Last-Modified:
@@ -81,15 +81,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 11dcac126c083bd0e73460adf8a7b35f1db5d03d
+      - 73fb8ea7c189d546d6ea485b18fb212b819a1d6a
       X-GitHub-Request-Id:
-      - 8146:41371:C197CC:DD3EA9:68C2EE91
+      - 4494:C5EEF:CC4460:E69E65:68CC1D5A
       X-Served-By:
-      - cache-bos4643-BOS
+      - cache-bos4638-BOS
       X-Timer:
-      - S1757605866.698433,VS0,VE1
+      - S1758207323.541915,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:22 GMT
+      - Thu, 18 Sep 2025 15:05:22 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_mgrs/test_set_field[utm_zone-59].yaml
+++ b/tests/extensions/cassettes/test_mgrs/test_set_field[utm_zone-59].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/mgrs/v1.0.0/schema.json
   response:
@@ -53,7 +53,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -63,7 +63,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:05 GMT
+      - Thu, 18 Sep 2025 14:55:22 GMT
       ETag:
       - '"60c20ce1-b49"'
       Last-Modified:
@@ -81,15 +81,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - b19812b1e6b908c05753c92f5be6e10ea452acb0
+      - 2ddc174d3c7d4a2b30a642b61072fdc7cbbdf6f6
       X-GitHub-Request-Id:
-      - 8146:41371:C197CC:DD3EA9:68C2EE91
+      - 4494:C5EEF:CC4460:E69E65:68CC1D5A
       X-Served-By:
-      - cache-bos4682-BOS
+      - cache-bos4636-BOS
       X-Timer:
-      - S1757605866.873674,VS0,VE2
+      - S1758207323.689304,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:22 GMT
+      - Thu, 18 Sep 2025 15:05:22 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_mgrs/test_validate.yaml
+++ b/tests/extensions/cassettes/test_mgrs/test_validate.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/mgrs/v1.0.0/schema.json
   response:
@@ -53,7 +53,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '343'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -63,7 +63,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:05 GMT
+      - Thu, 18 Sep 2025 14:55:22 GMT
       ETag:
       - '"60c20ce1-b49"'
       Last-Modified:
@@ -77,19 +77,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - ec1edcafe1097cdec7dd28d7d9a077c3fb8daee4
+      - 215f1115a9e77a2f87e55c0312ba5ce12c90ed66
       X-GitHub-Request-Id:
-      - 8146:41371:C197CC:DD3EA9:68C2EE91
+      - 4494:C5EEF:CC4460:E69E65:68CC1D5A
       X-Served-By:
-      - cache-bos4668-BOS
+      - cache-bos4663-BOS
       X-Timer:
-      - S1757605866.610553,VS0,VE1
+      - S1758207322.411243,VS0,VE54
       expires:
-      - Thu, 11 Sep 2025 15:55:22 GMT
+      - Thu, 18 Sep 2025 15:05:22 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_mlm/test_apply.yaml
+++ b/tests/extensions/cassettes/test_mlm/test_apply.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/mlm/v1.4.0/schema.json
   response:
@@ -451,7 +451,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '343'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -461,7 +461,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:05 GMT
+      - Thu, 18 Sep 2025 14:55:22 GMT
       ETag:
       - '"68a9213c-82d6"'
       Last-Modified:
@@ -475,19 +475,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 8cc778cdf9c8268e32dd552bfee5c76e3071abd0
+      - ce0583191a3be38701e73485afb4a68d37ea2371
       X-GitHub-Request-Id:
-      - A11F:C20EF:C119A7:DCC218:68C2EE91
+      - FAC8:108384:B94505:D3B00E:68CC1D5A
       X-Served-By:
-      - cache-bos4628-BOS
+      - cache-bos4632-BOS
       X-Timer:
-      - S1757605866.981955,VS0,VE1
+      - S1758207323.807054,VS0,VE63
       expires:
-      - Thu, 11 Sep 2025 15:55:22 GMT
+      - Thu, 18 Sep 2025 15:05:22 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -497,7 +497,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/raster/v1.1.0/schema.json
   response:
@@ -594,7 +594,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '351'
+      - '139'
       Cache-Control:
       - max-age=600
       Connection:
@@ -604,7 +604,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:06 GMT
+      - Thu, 18 Sep 2025 14:55:22 GMT
       ETag:
       - '"66df5c80-18ae"'
       Last-Modified:
@@ -620,17 +620,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '0'
       X-Fastly-Request-ID:
-      - a34f86e947a340df5dccbf1f0e5d9de0216fdbe7
+      - a8b0397f102af42d820ceb440e12e229372540f5
       X-GitHub-Request-Id:
-      - 6F8C:14A94E:C2B049:DE4F27:68C2EE8A
+      - 17F6:239986:1B3CB6:1CD810:68CC1CD0
       X-Served-By:
-      - cache-bos4664-BOS
+      - cache-bos4651-BOS
       X-Timer:
-      - S1757605866.064373,VS0,VE1
+      - S1758207323.951398,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -640,7 +640,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/processing/v1.1.0/schema.json
   response:
@@ -746,7 +746,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '343'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -756,7 +756,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:06 GMT
+      - Thu, 18 Sep 2025 14:55:23 GMT
       ETag:
       - '"663cfd3e-1bea"'
       Last-Modified:
@@ -770,19 +770,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - a0074a46f655579656d5ae15de41d911d35c726b
+      - 80743e3eeb8057b2f71f8c999be35e2c859df8c1
       X-GitHub-Request-Id:
-      - 22ED:F9247:195E240:1C9B8AD:68C2EE91
+      - 9E52:AC86B:C55579:DFB9F1:68CC1D5A
       X-Served-By:
-      - cache-bos4646-BOS
+      - cache-bos4651-BOS
       X-Timer:
-      - S1757605866.138492,VS0,VE1
+      - S1758207323.027563,VS0,VE29
       expires:
-      - Thu, 11 Sep 2025 15:55:22 GMT
+      - Thu, 18 Sep 2025 15:05:23 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_mlm/test_validate_mlm.yaml
+++ b/tests/extensions/cassettes/test_mlm/test_validate_mlm.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/mlm/v1.4.0/schema.json
   response:
@@ -451,7 +451,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -461,7 +461,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:06 GMT
+      - Thu, 18 Sep 2025 14:55:23 GMT
       ETag:
       - '"68a9213c-82d6"'
       Last-Modified:
@@ -479,15 +479,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - a260c1627364839ce91a052965470ffd60984316
+      - 675bbdfead62c04bcb4cf102884feac4de4abdd9
       X-GitHub-Request-Id:
-      - A11F:C20EF:C119A7:DCC218:68C2EE91
+      - FAC8:108384:B94505:D3B00E:68CC1D5A
       X-Served-By:
-      - cache-bos4691-BOS
+      - cache-bos4640-BOS
       X-Timer:
-      - S1757605866.234079,VS0,VE1
+      - S1758207323.149364,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:22 GMT
+      - Thu, 18 Sep 2025 15:05:22 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -497,7 +497,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/raster/v1.1.0/schema.json
   response:
@@ -594,7 +594,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '352'
+      - '139'
       Cache-Control:
       - max-age=600
       Connection:
@@ -604,7 +604,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:06 GMT
+      - Thu, 18 Sep 2025 14:55:23 GMT
       ETag:
       - '"66df5c80-18ae"'
       Last-Modified:
@@ -622,15 +622,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 15bf50b762b6668d7625fffadaaeafe1f7b9556a
+      - daf372743f386f2ced02b67087c3ed7a0fa3b602
       X-GitHub-Request-Id:
-      - 6F8C:14A94E:C2B049:DE4F27:68C2EE8A
+      - 17F6:239986:1B3CB6:1CD810:68CC1CD0
       X-Served-By:
-      - cache-bos4652-BOS
+      - cache-bos4646-BOS
       X-Timer:
-      - S1757605866.312121,VS0,VE2
+      - S1758207323.230345,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_pointcloud/test_count.yaml
+++ b/tests/extensions/cassettes/test_pointcloud/test_count.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json
   response:
@@ -75,7 +75,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -85,7 +85,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:06 GMT
+      - Thu, 18 Sep 2025 14:55:23 GMT
       ETag:
       - '"671aae9d-114a"'
       Last-Modified:
@@ -103,15 +103,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 4f503ff09596043476a3e0f4e84fed27943b0bc0
+      - 9d66ef76906c2305d0280df625d8947f78f0dc75
       X-GitHub-Request-Id:
-      - 7399:2A123F:1DB5E84:20E83A8:68C2D6FB
+      - 4BF1:268A6D:BB0971:D56C32:68CC1D5B
       X-Served-By:
-      - cache-bos4628-BOS
+      - cache-bos4629-BOS
       X-Timer:
-      - S1757605867.513937,VS0,VE2
+      - S1758207324.637182,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 14:14:44 GMT
+      - Thu, 18 Sep 2025 15:05:23 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_pointcloud/test_density.yaml
+++ b/tests/extensions/cassettes/test_pointcloud/test_density.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json
   response:
@@ -75,7 +75,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -85,7 +85,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:06 GMT
+      - Thu, 18 Sep 2025 14:55:24 GMT
       ETag:
       - '"671aae9d-114a"'
       Last-Modified:
@@ -103,15 +103,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 74ab8187d9f34fc311c26c1887ad7b30143150c8
+      - 1c4175b6625c6200566316fcb991087c0061d835
       X-GitHub-Request-Id:
-      - 7399:2A123F:1DB5E84:20E83A8:68C2D6FB
+      - 4BF1:268A6D:BB0971:D56C32:68CC1D5B
       X-Served-By:
-      - cache-bos4653-BOS
+      - cache-bos4642-BOS
       X-Timer:
-      - S1757605867.975381,VS0,VE2
+      - S1758207324.080887,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 14:14:44 GMT
+      - Thu, 18 Sep 2025 15:05:23 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_pointcloud/test_encoding.yaml
+++ b/tests/extensions/cassettes/test_pointcloud/test_encoding.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json
   response:
@@ -75,7 +75,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -85,7 +85,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:06 GMT
+      - Thu, 18 Sep 2025 14:55:23 GMT
       ETag:
       - '"671aae9d-114a"'
       Last-Modified:
@@ -103,15 +103,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 01d548079d85f87abc3836844d5ea369650fe002
+      - cec37b8b7b257a08721e5c4ef4345b3899319595
       X-GitHub-Request-Id:
-      - 7399:2A123F:1DB5E84:20E83A8:68C2D6FB
+      - 4BF1:268A6D:BB0971:D56C32:68CC1D5B
       X-Served-By:
-      - cache-bos4631-BOS
+      - cache-bos4665-BOS
       X-Timer:
-      - S1757605867.706090,VS0,VE1
+      - S1758207324.821590,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 14:14:44 GMT
+      - Thu, 18 Sep 2025 15:05:23 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_pointcloud/test_schemas.yaml
+++ b/tests/extensions/cassettes/test_pointcloud/test_schemas.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json
   response:
@@ -75,7 +75,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -85,7 +85,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:06 GMT
+      - Thu, 18 Sep 2025 14:55:23 GMT
       ETag:
       - '"671aae9d-114a"'
       Last-Modified:
@@ -103,15 +103,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 49592b019d1fa82bf2cde3d967e50fe2a26dbcba
+      - 9592a2e7d23d9f106a0e3b09c26527dd223653d0
       X-GitHub-Request-Id:
-      - 7399:2A123F:1DB5E84:20E83A8:68C2D6FB
+      - 4BF1:268A6D:BB0971:D56C32:68CC1D5B
       X-Served-By:
-      - cache-bos4649-BOS
+      - cache-bos4688-BOS
       X-Timer:
-      - S1757605867.796723,VS0,VE1
+      - S1758207324.911374,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 14:14:44 GMT
+      - Thu, 18 Sep 2025 15:05:23 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_pointcloud/test_statistics.yaml
+++ b/tests/extensions/cassettes/test_pointcloud/test_statistics.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json
   response:
@@ -75,7 +75,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -85,7 +85,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:06 GMT
+      - Thu, 18 Sep 2025 14:55:24 GMT
       ETag:
       - '"671aae9d-114a"'
       Last-Modified:
@@ -103,15 +103,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 0d49df578ca3a3ab8b729c7bf90bcc782ecc541d
+      - 0dc53d5dec56d4cae02f22984571f58007e77a15
       X-GitHub-Request-Id:
-      - 7399:2A123F:1DB5E84:20E83A8:68C2D6FB
+      - 4BF1:268A6D:BB0971:D56C32:68CC1D5B
       X-Served-By:
-      - cache-bos4685-BOS
+      - cache-bos4628-BOS
       X-Timer:
-      - S1757605867.884071,VS0,VE1
+      - S1758207324.003053,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 14:14:44 GMT
+      - Thu, 18 Sep 2025 15:05:23 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_pointcloud/test_type.yaml
+++ b/tests/extensions/cassettes/test_pointcloud/test_type.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json
   response:
@@ -75,7 +75,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -85,7 +85,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:06 GMT
+      - Thu, 18 Sep 2025 14:55:23 GMT
       ETag:
       - '"671aae9d-114a"'
       Last-Modified:
@@ -103,15 +103,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 1c572f1c0e44971343a8ead864ff9c9573fa17fd
+      - d78e365a312282ec0f49c96f9f54eba91ca5b044
       X-GitHub-Request-Id:
-      - 7399:2A123F:1DB5E84:20E83A8:68C2D6FB
+      - 4BF1:268A6D:BB0971:D56C32:68CC1D5B
       X-Served-By:
-      - cache-bos4623-BOS
+      - cache-bos4632-BOS
       X-Timer:
-      - S1757605867.620162,VS0,VE1
+      - S1758207324.739438,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 14:14:44 GMT
+      - Thu, 18 Sep 2025 15:05:23 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_pointcloud/test_validate_pointcloud.yaml
+++ b/tests/extensions/cassettes/test_pointcloud/test_validate_pointcloud.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/pointcloud/v1.0.0/schema.json
   response:
@@ -75,7 +75,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '343'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -85,7 +85,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:06 GMT
+      - Thu, 18 Sep 2025 14:55:23 GMT
       ETag:
       - '"671aae9d-114a"'
       Last-Modified:
@@ -99,19 +99,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 2ae1ac58266f386b3829501bde7522e2117b49c0
+      - 06a65e883d6ab6b32ef03543eb81061c4fa2a1ba
       X-GitHub-Request-Id:
-      - 7399:2A123F:1DB5E84:20E83A8:68C2D6FB
+      - 4BF1:268A6D:BB0971:D56C32:68CC1D5B
       X-Served-By:
-      - cache-bos4641-BOS
+      - cache-bos4646-BOS
       X-Timer:
-      - S1757605866.430234,VS0,VE1
+      - S1758207323.333456,VS0,VE135
       expires:
-      - Thu, 11 Sep 2025 14:14:44 GMT
+      - Thu, 18 Sep 2025 15:05:23 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_projection/test_bbox.yaml
+++ b/tests/extensions/cassettes/test_projection/test_bbox.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/eo/v1.1.0/schema.json
   response:
@@ -81,7 +81,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '356'
+      - '143'
       Cache-Control:
       - max-age=600
       Connection:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:10 GMT
+      - Thu, 18 Sep 2025 14:55:27 GMT
       ETag:
       - '"66df1c53-13bc"'
       Last-Modified:
@@ -107,17 +107,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '1'
       X-Fastly-Request-ID:
-      - 6f8ab419e94c529156773f23289fdab94ab5ac27
+      - 67b6540f4e8d41f90c1d244dd252dbca1a1a06ee
       X-GitHub-Request-Id:
-      - BE8A:14434E:B836A2:D3D600:68C2EE8A
+      - 98DE:39A2ED:1DBAAC:1F56C3:68CC1CD0
       X-Served-By:
-      - cache-bos4643-BOS
+      - cache-bos4667-BOS
       X-Timer:
-      - S1757605870.397980,VS0,VE1
+      - S1758207327.351249,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -127,7 +127,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/projection/v2.0.0/schema.json
   response:
@@ -195,7 +195,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '356'
+      - '143'
       Cache-Control:
       - max-age=600
       Connection:
@@ -205,7 +205,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:10 GMT
+      - Thu, 18 Sep 2025 14:55:27 GMT
       ETag:
       - '"669e563b-1116"'
       Last-Modified:
@@ -223,15 +223,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - e26813882e5b6e8c656a2e45d895992cdc4769a1
+      - 552a28fae2dd59e57d90a6dd4ccedf23a83788a4
       X-GitHub-Request-Id:
-      - 21B3:2B753C:1E14E8F:2148802:68C2D6FB
+      - 224F:32B3EB:191F90:1ABAB3:68CC1CCF
       X-Served-By:
-      - cache-bos4638-BOS
+      - cache-bos4675-BOS
       X-Timer:
-      - S1757605870.466552,VS0,VE2
+      - S1758207327.417407,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 14:14:44 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -241,7 +241,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://proj.org/schemas/v0.7/projjson.schema.json
   response:
@@ -251,11 +251,11 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '1019'
+      - '703'
       CF-Cache-Status:
       - HIT
       CF-Ray:
-      - 97d853330fb5d688-IAD
+      - 9811af34ea8213c9-IAD
       Cache-Control:
       - max-age=1200
       Connection:
@@ -267,16 +267,16 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:10 GMT
+      - Thu, 18 Sep 2025 14:55:27 GMT
       Location:
       - https://proj.org/en/latest/schemas/v0.7/projjson.schema.json
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=xZpbEWAq7Wm9BxtEUicCnJhB8t5Q8UuFXx39r6HC9lg-1757605870-1.0.1.1-Df.g9fpQ1IabXV2dUPRgwpfTovWY3Dml0JgtUS2g0dmHw25mqr74MAu05qbkzhDn_C_L2iEsataY0LusTEXb4EovDzugR1A7qV32jpbdobc;
-        path=/; expires=Thu, 11-Sep-25 16:21:10 GMT; domain=.proj.org; HttpOnly; Secure;
+      - __cf_bm=2Xl4xRqD61dK43NhFl8pVk2i_r3kzHKQEbILLMvHh3A-1758207327-1.0.1.1-ChVSRkZKv11IS4hoRsUC96zdfTlPK4mg3CxWdXhn8.NSxkuFBC.5qskJNx7ZVCmXL85vMdh_e6FSqFYkZMCf1gecuyHqKvtKI7EzTAJg5KY;
+        path=/; expires=Thu, 18-Sep-25 15:25:27 GMT; domain=.proj.org; HttpOnly; Secure;
         SameSite=None
-      - _cfuvid=4qpKTfzccbPseA1vpE_2uCoKTOO1d6VOc.hIrjy0f0I-1757605870598-0.0.1.1-604800000;
+      - _cfuvid=ORHVm5t3HNYLgI8unSva46irW90ycElC.mvlYSvm9DY-1758207327548-0.0.1.1-604800000;
         path=/; domain=.proj.org; HttpOnly; Secure; SameSite=None
       Vary:
       - Accept-Language, Accept-Encoding
@@ -291,7 +291,7 @@ interactions:
       referrer-policy:
       - no-referrer-when-downgrade
       x-backend:
-      - web-i-032144a96d20fd642
+      - web-i-046a40256d6a3b46c
       x-content-type-options:
       - nosniff
       x-rtd-domain:
@@ -315,7 +315,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://proj.org/en/latest/schemas/v0.7/projjson.schema.json
   response:
@@ -844,11 +844,11 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '562'
+      - '4640'
       CF-Cache-Status:
       - HIT
       CF-Ray:
-      - 97d85333df31d67c-IAD
+      - 9811af35cd3cc956-IAD
       Cache-Control:
       - max-age=1200
       Connection:
@@ -856,7 +856,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 11 Sep 2025 15:51:10 GMT
+      - Thu, 18 Sep 2025 14:55:27 GMT
       ETag:
       - W/"b36c7ce9824d274cfd711a16ef45d221"
       Last-Modified:
@@ -864,10 +864,10 @@ interactions:
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=ffzmqa6Li.zqTaS2Z7nwlZsIpn220AcxrCVuFPNGlH8-1757605870-1.0.1.1-MuAsA_TZz9KD1690P8V5QkFDsWw8JnPMR3tvwUhv9wEFUzi2ehk3UvfKsyN.vtw8qxNGArHxYTuh7XuAEvrr2Ms4ZDcDwTtqfoqUbBsMC68;
-        path=/; expires=Thu, 11-Sep-25 16:21:10 GMT; domain=.proj.org; HttpOnly; Secure;
+      - __cf_bm=Iopqmiy4UVS1HRwN1RF.AJrwC0AdzAdKOiAMxhXI6B4-1758207327-1.0.1.1-4xdayVRVi8b6YnMP9C6pegzLtIVS4.Z5LQfI8MfUsnRcFGIk_VD1939y05QTkIkfntvPmhGQpWoK7q1TogbVwCl4yQwNp32lbnsg6lvD83s;
+        path=/; expires=Thu, 18-Sep-25 15:25:27 GMT; domain=.proj.org; HttpOnly; Secure;
         SameSite=None
-      - _cfuvid=NU0pwUNRGLVMjG0.n8jeAiWdpaiQUOhfoNXbwV9EKVc-1757605870725-0.0.1.1-604800000;
+      - _cfuvid=FBNg.5f0csn1Sl6NZz4.eQyLZHABFMc0RuNmdUuyC4Y-1758207327681-0.0.1.1-604800000;
         path=/; domain=.proj.org; HttpOnly; Secure; SameSite=None
       Transfer-Encoding:
       - chunked
@@ -882,15 +882,15 @@ interactions:
       referrer-policy:
       - no-referrer-when-downgrade
       x-amz-id-2:
-      - 4CqUgAmdf2KJHeNFOeM5b06wSNvruKF2lIJzahRPcLccmToa5RuePCq61GcMLumrjEh4f144QTg=
+      - wq6M1yZwJIx72g0bu4iZIqB+T9hOmWOv1FfzWTgBKB1TbMZ30Ydon1RMGSDDCK+jALCUKViQfNEPgSiC2QHfaEtHxEE2g0MYvKvIxiq7DyA=
       x-amz-meta-mtime:
       - '1714074779.458591481'
       x-amz-request-id:
-      - 7J1TVVY6X3T9P0V9
+      - N37TE359KA2AHSV6
       x-amz-server-side-encryption:
       - AES256
       x-backend:
-      - web-i-0642c5cf0fa7f07c2
+      - web-i-0d85dbf6e0a8f4cc9
       x-content-type-options:
       - nosniff
       x-rtd-domain:

--- a/tests/extensions/cassettes/test_projection/test_centroid.yaml
+++ b/tests/extensions/cassettes/test_projection/test_centroid.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/eo/v1.1.0/schema.json
   response:
@@ -81,7 +81,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '356'
+      - '143'
       Cache-Control:
       - max-age=600
       Connection:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:10 GMT
+      - Thu, 18 Sep 2025 14:55:27 GMT
       ETag:
       - '"66df1c53-13bc"'
       Last-Modified:
@@ -109,15 +109,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - cd1cead4b29b516d2715df76c68b7437e8819f30
+      - 07c34afb36d4e0232b25ea5705c351f0d9e3c985
       X-GitHub-Request-Id:
-      - BE8A:14434E:B836A2:D3D600:68C2EE8A
+      - 98DE:39A2ED:1DBAAC:1F56C3:68CC1CD0
       X-Served-By:
-      - cache-bos4672-BOS
+      - cache-bos4691-BOS
       X-Timer:
-      - S1757605871.855283,VS0,VE2
+      - S1758207328.797729,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -127,7 +127,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/projection/v2.0.0/schema.json
   response:
@@ -195,7 +195,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '356'
+      - '143'
       Cache-Control:
       - max-age=600
       Connection:
@@ -205,7 +205,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:10 GMT
+      - Thu, 18 Sep 2025 14:55:27 GMT
       ETag:
       - '"669e563b-1116"'
       Last-Modified:
@@ -223,15 +223,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - b787f9a69b85e50db7b0c7f0b308fe0df98ecfc9
+      - 9d648fd0054ab434542c5fffbeccb8a412a40255
       X-GitHub-Request-Id:
-      - 21B3:2B753C:1E14E8F:2148802:68C2D6FB
+      - 224F:32B3EB:191F90:1ABAB3:68CC1CCF
       X-Served-By:
-      - cache-bos4623-BOS
+      - cache-bos4666-BOS
       X-Timer:
-      - S1757605871.926968,VS0,VE2
+      - S1758207328.863199,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 14:14:44 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -241,7 +241,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://proj.org/schemas/v0.7/projjson.schema.json
   response:
@@ -251,11 +251,11 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '1020'
+      - '703'
       CF-Cache-Status:
       - HIT
       CF-Ray:
-      - 97d85335f896d631-IAD
+      - 9811af37ceef5967-IAD
       Cache-Control:
       - max-age=1200
       Connection:
@@ -267,16 +267,16 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:11 GMT
+      - Thu, 18 Sep 2025 14:55:27 GMT
       Location:
       - https://proj.org/en/latest/schemas/v0.7/projjson.schema.json
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=XFM4Ii37mEa850hKC9UWV7J4fYRazWEpYD1Ib8tiIC4-1757605871-1.0.1.1-Bml2gDayL3.qvj.UFjuul0cEl4oMskcznwcDw8rt7XPXE6M6eSa_AsH_P4FIx7xHYy8SUAl.n._P_hBOxy4CSzMLnXrYOk_5Bkz2LfwsuGw;
-        path=/; expires=Thu, 11-Sep-25 16:21:11 GMT; domain=.proj.org; HttpOnly; Secure;
+      - __cf_bm=o7qqLbzdbQd9HeS_zvoJSDrgKgeijCLEbLMW95ODSXY-1758207327-1.0.1.1-fXMYENDIm7asHTbX4GpmknzAZpnFeG9gM3zEnPSWrwNCipZPGEZIAH0jKCNanDb9iTFNi7vkDXkMBu1jNHkzWjRaEUSOo173xgNq0endA_s;
+        path=/; expires=Thu, 18-Sep-25 15:25:27 GMT; domain=.proj.org; HttpOnly; Secure;
         SameSite=None
-      - _cfuvid=OSw6h0dYil_mzOUMGualSek7Bp.Wkc0v0.YYHD__Wsc-1757605871105-0.0.1.1-604800000;
+      - _cfuvid=OZVIRXH9sAtJVluFFZFvAiwx4OIvdLSCjmkTSl8vw8g-1758207327992-0.0.1.1-604800000;
         path=/; domain=.proj.org; HttpOnly; Secure; SameSite=None
       Vary:
       - Accept-Language, Accept-Encoding
@@ -291,7 +291,7 @@ interactions:
       referrer-policy:
       - no-referrer-when-downgrade
       x-backend:
-      - web-i-032144a96d20fd642
+      - web-i-046a40256d6a3b46c
       x-content-type-options:
       - nosniff
       x-rtd-domain:
@@ -315,7 +315,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://proj.org/en/latest/schemas/v0.7/projjson.schema.json
   response:
@@ -844,11 +844,11 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '563'
+      - '4641'
       CF-Cache-Status:
       - HIT
       CF-Ray:
-      - 97d8533719c4d6cd-IAD
+      - 9811af389e0329b6-IAD
       Cache-Control:
       - max-age=1200
       Connection:
@@ -856,7 +856,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 11 Sep 2025 15:51:11 GMT
+      - Thu, 18 Sep 2025 14:55:28 GMT
       ETag:
       - W/"b36c7ce9824d274cfd711a16ef45d221"
       Last-Modified:
@@ -864,10 +864,10 @@ interactions:
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=CqNPFebftmtG2E7Pk5EU5OgaqD5YWlamzfWgZCgnArI-1757605871-1.0.1.1-eTHh2g9RNCF5gRrP36yL.obq06qPWY6Sk4BUKAfhZNl9FKKPn4u_njRXM_oOquwiGlwmVK1HsDcETExtuXXafbBy3VBFFxw8mVFuxuEeyzk;
-        path=/; expires=Thu, 11-Sep-25 16:21:11 GMT; domain=.proj.org; HttpOnly; Secure;
+      - __cf_bm=yXW9BC85l5ULZ9k4XOC5c5U2BzLTRR4EPc9puqLMPhM-1758207328-1.0.1.1-mrgr33_ERIhftd7H9vAtF.MfxO8pPsNGITYjR8rP7neEOe9vpSMLS4GNCTWvRIkxVOMxYBzmB0T8gko9AglLgU9eO.s5pdqy6Igi.MRLfZU;
+        path=/; expires=Thu, 18-Sep-25 15:25:28 GMT; domain=.proj.org; HttpOnly; Secure;
         SameSite=None
-      - _cfuvid=_HgivTrXlTSi7OAejdbMsxZbikEBYArwIAnzN1iwdEc-1757605871255-0.0.1.1-604800000;
+      - _cfuvid=BCRUlrYZRE2va4wtS63DXpLrDMn6dfDYATOJWvrp0l4-1758207328132-0.0.1.1-604800000;
         path=/; domain=.proj.org; HttpOnly; Secure; SameSite=None
       Transfer-Encoding:
       - chunked
@@ -882,15 +882,15 @@ interactions:
       referrer-policy:
       - no-referrer-when-downgrade
       x-amz-id-2:
-      - 4CqUgAmdf2KJHeNFOeM5b06wSNvruKF2lIJzahRPcLccmToa5RuePCq61GcMLumrjEh4f144QTg=
+      - wq6M1yZwJIx72g0bu4iZIqB+T9hOmWOv1FfzWTgBKB1TbMZ30Ydon1RMGSDDCK+jALCUKViQfNEPgSiC2QHfaEtHxEE2g0MYvKvIxiq7DyA=
       x-amz-meta-mtime:
       - '1714074779.458591481'
       x-amz-request-id:
-      - 7J1TVVY6X3T9P0V9
+      - N37TE359KA2AHSV6
       x-amz-server-side-encryption:
       - AES256
       x-backend:
-      - web-i-0642c5cf0fa7f07c2
+      - web-i-0d85dbf6e0a8f4cc9
       x-content-type-options:
       - nosniff
       x-rtd-domain:

--- a/tests/extensions/cassettes/test_projection/test_epsg.yaml
+++ b/tests/extensions/cassettes/test_projection/test_epsg.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/eo/v1.1.0/schema.json
   response:
@@ -81,7 +81,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '353'
+      - '141'
       Cache-Control:
       - max-age=600
       Connection:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:08 GMT
+      - Thu, 18 Sep 2025 14:55:25 GMT
       ETag:
       - '"66df1c53-13bc"'
       Last-Modified:
@@ -109,15 +109,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - a8f92af665debb2b586f1732c4ee1e3425a70da6
+      - 04ad74fc85280b5eaa5c0791cbdac0b09be7aef8
       X-GitHub-Request-Id:
-      - BE8A:14434E:B836A2:D3D600:68C2EE8A
+      - 98DE:39A2ED:1DBAAC:1F56C3:68CC1CD0
       X-Served-By:
       - cache-bos4681-BOS
       X-Timer:
-      - S1757605868.054165,VS0,VE2
+      - S1758207325.329413,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -127,7 +127,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/projection/v2.0.0/schema.json
   response:
@@ -195,7 +195,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '353'
+      - '141'
       Cache-Control:
       - max-age=600
       Connection:
@@ -205,7 +205,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:08 GMT
+      - Thu, 18 Sep 2025 14:55:25 GMT
       ETag:
       - '"669e563b-1116"'
       Last-Modified:
@@ -223,15 +223,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 781298adeb80ecbc23aa8a7e174a3b38b39e346d
+      - 246df9b8d5082df65cff8c337a46a2fee43cfad1
       X-GitHub-Request-Id:
-      - 21B3:2B753C:1E14E8F:2148802:68C2D6FB
+      - 224F:32B3EB:191F90:1ABAB3:68CC1CCF
       X-Served-By:
-      - cache-bos4620-BOS
+      - cache-bos4646-BOS
       X-Timer:
-      - S1757605868.137335,VS0,VE3
+      - S1758207325.391235,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 14:14:44 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -241,7 +241,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://proj.org/schemas/v0.7/projjson.schema.json
   response:
@@ -251,11 +251,11 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '1017'
+      - '701'
       CF-Cache-Status:
       - HIT
       CF-Ray:
-      - 97d8532488171771-IAD
+      - 9811af28395fc9a9-IAD
       Cache-Control:
       - max-age=1200
       Connection:
@@ -267,16 +267,16 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:08 GMT
+      - Thu, 18 Sep 2025 14:55:25 GMT
       Location:
       - https://proj.org/en/latest/schemas/v0.7/projjson.schema.json
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=aPLmrij2Wob1ZHok4IR.cvd2U2P6rGbOKaquQERX8RY-1757605868-1.0.1.1-fFiqeC2EWMeuw8Qy2CHa7cETV1CdDgeRW0MgQ6HB08rh9YvwSt8E.xfby6IB_Wp0_OybM3w0TRqSDb7DzOs97JA16O9YEr34aBU1xOW..Ck;
-        path=/; expires=Thu, 11-Sep-25 16:21:08 GMT; domain=.proj.org; HttpOnly; Secure;
+      - __cf_bm=vJQjkUbfYwPNVAgasmpvuHQ6rDEXkHNopka3BYyGW44-1758207325-1.0.1.1-GkoD7uJ9boEavQ7hETqQxUuoRKWiXK7.H0wd2P_ki_2masqMSyjjNT_TysEKRbdPEUHp7rFLQOHpwThGNMxzfoJRWA_cSyl.pclLRtvmIKg;
+        path=/; expires=Thu, 18-Sep-25 15:25:25 GMT; domain=.proj.org; HttpOnly; Secure;
         SameSite=None
-      - _cfuvid=jJ08tx04Z0M.fdlSp8WRQa9sgmE1e2LT6g2XjqyIlKo-1757605868303-0.0.1.1-604800000;
+      - _cfuvid=mLOaq.MaXYU8uxHxNoULup81EIPnhqmM_6nRrGpIZvM-1758207325511-0.0.1.1-604800000;
         path=/; domain=.proj.org; HttpOnly; Secure; SameSite=None
       Vary:
       - Accept-Language, Accept-Encoding
@@ -291,7 +291,7 @@ interactions:
       referrer-policy:
       - no-referrer-when-downgrade
       x-backend:
-      - web-i-032144a96d20fd642
+      - web-i-046a40256d6a3b46c
       x-content-type-options:
       - nosniff
       x-rtd-domain:
@@ -315,7 +315,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://proj.org/en/latest/schemas/v0.7/projjson.schema.json
   response:
@@ -844,11 +844,11 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '560'
+      - '4638'
       CF-Cache-Status:
       - HIT
       CF-Ray:
-      - 97d853258b71d67b-IAD
+      - 9811af290ca456c2-IAD
       Cache-Control:
       - max-age=1200
       Connection:
@@ -856,7 +856,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 11 Sep 2025 15:51:08 GMT
+      - Thu, 18 Sep 2025 14:55:25 GMT
       ETag:
       - W/"b36c7ce9824d274cfd711a16ef45d221"
       Last-Modified:
@@ -864,10 +864,10 @@ interactions:
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=PXbV2CB9ryMhA7AqSciSjx2af5A.EfJAhyMIoZ9Ddqk-1757605868-1.0.1.1-6w_34ix7D8GppCfpcREACHe96kfPUK9bCaa4IgZzy7H0oLyJK0kHSAC6JO.1GuiF1Z67Ugi9nXsxvNGg65fB_wn4PYkS2PkmMKozpqgHXfM;
-        path=/; expires=Thu, 11-Sep-25 16:21:08 GMT; domain=.proj.org; HttpOnly; Secure;
+      - __cf_bm=Gd572fzWMGU35LSPzz5VwTU6rP8NWJug85Ni.Ns7fA0-1758207325-1.0.1.1-J0E3FYc18MF7M0TEjRj6zAT93P3A3LGSsVDI4gG85vh1vK9LGgWBf.EnTDZ.0koseVHXAyXcY.uoDS0b.AvS.RtkDpq3Q2sXNrKYyI9iwxk;
+        path=/; expires=Thu, 18-Sep-25 15:25:25 GMT; domain=.proj.org; HttpOnly; Secure;
         SameSite=None
-      - _cfuvid=aShIy.ct5ZV20sxcQLKWxVyV65YLV1yvh1k0Ah2Anb0-1757605868432-0.0.1.1-604800000;
+      - _cfuvid=h.TtYmk9OibnI8EynTjwqZWcP1gIZ48plQpcjyHtys4-1758207325645-0.0.1.1-604800000;
         path=/; domain=.proj.org; HttpOnly; Secure; SameSite=None
       Transfer-Encoding:
       - chunked
@@ -882,15 +882,15 @@ interactions:
       referrer-policy:
       - no-referrer-when-downgrade
       x-amz-id-2:
-      - 4CqUgAmdf2KJHeNFOeM5b06wSNvruKF2lIJzahRPcLccmToa5RuePCq61GcMLumrjEh4f144QTg=
+      - wq6M1yZwJIx72g0bu4iZIqB+T9hOmWOv1FfzWTgBKB1TbMZ30Ydon1RMGSDDCK+jALCUKViQfNEPgSiC2QHfaEtHxEE2g0MYvKvIxiq7DyA=
       x-amz-meta-mtime:
       - '1714074779.458591481'
       x-amz-request-id:
-      - 7J1TVVY6X3T9P0V9
+      - N37TE359KA2AHSV6
       x-amz-server-side-encryption:
       - AES256
       x-backend:
-      - web-i-0642c5cf0fa7f07c2
+      - web-i-0d85dbf6e0a8f4cc9
       x-content-type-options:
       - nosniff
       x-rtd-domain:

--- a/tests/extensions/cassettes/test_projection/test_geometry.yaml
+++ b/tests/extensions/cassettes/test_projection/test_geometry.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/eo/v1.1.0/schema.json
   response:
@@ -81,7 +81,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '355'
+      - '142'
       Cache-Control:
       - max-age=600
       Connection:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:09 GMT
+      - Thu, 18 Sep 2025 14:55:26 GMT
       ETag:
       - '"66df1c53-13bc"'
       Last-Modified:
@@ -109,15 +109,15 @@ interactions:
       X-Cache-Hits:
       - '2'
       X-Fastly-Request-ID:
-      - f84bf8cee44f37bc13b4e7b7e7e75c36f4b27b26
+      - ba2d51a39412ee2700d49dfcc2787fdd11a4dd1b
       X-GitHub-Request-Id:
-      - BE8A:14434E:B836A2:D3D600:68C2EE8A
+      - 98DE:39A2ED:1DBAAC:1F56C3:68CC1CD0
       X-Served-By:
-      - cache-bos4691-BOS
+      - cache-bos4621-BOS
       X-Timer:
-      - S1757605870.852111,VS0,VE0
+      - S1758207327.783176,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -127,7 +127,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/projection/v2.0.0/schema.json
   response:
@@ -195,7 +195,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '355'
+      - '142'
       Cache-Control:
       - max-age=600
       Connection:
@@ -205,7 +205,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:09 GMT
+      - Thu, 18 Sep 2025 14:55:26 GMT
       ETag:
       - '"669e563b-1116"'
       Last-Modified:
@@ -221,17 +221,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '6'
       X-Fastly-Request-ID:
-      - 90ea36422cf3cc075e7e91a09f889199d39d0c44
+      - 006edd44c7153e23d09c9863d4203d0159c48649
       X-GitHub-Request-Id:
-      - 21B3:2B753C:1E14E8F:2148802:68C2D6FB
+      - 224F:32B3EB:191F90:1ABAB3:68CC1CCF
       X-Served-By:
-      - cache-bos4691-BOS
+      - cache-bos4670-BOS
       X-Timer:
-      - S1757605870.918534,VS0,VE1
+      - S1758207327.858996,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 14:14:44 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -241,7 +241,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://proj.org/schemas/v0.7/projjson.schema.json
   response:
@@ -251,11 +251,11 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '1019'
+      - '703'
       CF-Cache-Status:
       - HIT
       CF-Ray:
-      - 97d8532faee6602a-IAD
+      - 9811af318de5c9a7-IAD
       Cache-Control:
       - max-age=1200
       Connection:
@@ -267,16 +267,16 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:10 GMT
+      - Thu, 18 Sep 2025 14:55:27 GMT
       Location:
       - https://proj.org/en/latest/schemas/v0.7/projjson.schema.json
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=e2DZcVacEW5ox2wpX0Ye9dVM9eoUKo4F.Xz0irIH9VI-1757605870-1.0.1.1-zuyEs3mSBSHXyzjQy0BXKfrkcA2lSnal2wjBMPCwRwXb5p80vQDsfXHO48UfZz2nmLVyi7IYLAIhbph4VaZa_E7J3nLEWwNTA79WmW0GJA8;
-        path=/; expires=Thu, 11-Sep-25 16:21:10 GMT; domain=.proj.org; HttpOnly; Secure;
+      - __cf_bm=.OSuXMYppbdxc6idsTLlAd3dcmSCdFRfGrIKwFZBsw0-1758207327-1.0.1.1-lDn9FUNeoHVoyaTMXWG8scMYIpdr4rgS2zBCoyhIRVg4YptUQvJ1cq6js9mIOaLy5478uhtySNYrHZQfqvN_YI8gKutbVtiU6QbV.Sit4uc;
+        path=/; expires=Thu, 18-Sep-25 15:25:27 GMT; domain=.proj.org; HttpOnly; Secure;
         SameSite=None
-      - _cfuvid=opKKMQWJAD5btP..SVsuaqyA3UN4xtuUrgeBl3C8HMY-1757605870081-0.0.1.1-604800000;
+      - _cfuvid=3jrCJzZkqOZ7ibAAHAq6wc4Rys.IpY_wfoko8OcyiG8-1758207327007-0.0.1.1-604800000;
         path=/; domain=.proj.org; HttpOnly; Secure; SameSite=None
       Vary:
       - Accept-Language, Accept-Encoding
@@ -291,7 +291,7 @@ interactions:
       referrer-policy:
       - no-referrer-when-downgrade
       x-backend:
-      - web-i-032144a96d20fd642
+      - web-i-046a40256d6a3b46c
       x-content-type-options:
       - nosniff
       x-rtd-domain:
@@ -315,7 +315,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://proj.org/en/latest/schemas/v0.7/projjson.schema.json
   response:
@@ -844,11 +844,11 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '562'
+      - '4640'
       CF-Cache-Status:
       - HIT
       CF-Ray:
-      - 97d853309f33fe99-IAD
+      - 9811af326b8ee642-IAD
       Cache-Control:
       - max-age=1200
       Connection:
@@ -856,7 +856,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 11 Sep 2025 15:51:10 GMT
+      - Thu, 18 Sep 2025 14:55:27 GMT
       ETag:
       - W/"b36c7ce9824d274cfd711a16ef45d221"
       Last-Modified:
@@ -864,10 +864,10 @@ interactions:
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=UEG0g8S3bONjenA36_WULY.Zpp5ITwiHvp_E9ZMUepo-1757605870-1.0.1.1-WBPMUILibVWdYXmzN0XH0DJoilVmWcuHWXEdZ88kaEUm5QO3_CnhtRApA9PHvtQ4mXE3Fp1vGV4nXjkUVdUmhYxQqhy7_I0euFFqYzteK.U;
-        path=/; expires=Thu, 11-Sep-25 16:21:10 GMT; domain=.proj.org; HttpOnly; Secure;
+      - __cf_bm=zEbfKHf0tw6nLxzRTAy2NPd3msvcIyTKVU2O77Ev.HE-1758207327-1.0.1.1-.oxHbeqsulxAUfxU3dli9aYiFIeQCf0uv.ZoA_ILDC10G1k1K1VOKG3MABJJEBAsYfMiz0Ps4Pkll.ep20NP._drDkT38hBgjOOwz2WFc0M;
+        path=/; expires=Thu, 18-Sep-25 15:25:27 GMT; domain=.proj.org; HttpOnly; Secure;
         SameSite=None
-      - _cfuvid=wnVeU2iYAXUpZToI0QztI4H.nIO.csN1IuWk3rok5hs-1757605870212-0.0.1.1-604800000;
+      - _cfuvid=iHzMaQBjrPX0z3WglDL8LZrdK.ZmzHgudN_qXr.mKyI-1758207327145-0.0.1.1-604800000;
         path=/; domain=.proj.org; HttpOnly; Secure; SameSite=None
       Transfer-Encoding:
       - chunked
@@ -882,15 +882,15 @@ interactions:
       referrer-policy:
       - no-referrer-when-downgrade
       x-amz-id-2:
-      - 4CqUgAmdf2KJHeNFOeM5b06wSNvruKF2lIJzahRPcLccmToa5RuePCq61GcMLumrjEh4f144QTg=
+      - wq6M1yZwJIx72g0bu4iZIqB+T9hOmWOv1FfzWTgBKB1TbMZ30Ydon1RMGSDDCK+jALCUKViQfNEPgSiC2QHfaEtHxEE2g0MYvKvIxiq7DyA=
       x-amz-meta-mtime:
       - '1714074779.458591481'
       x-amz-request-id:
-      - 7J1TVVY6X3T9P0V9
+      - N37TE359KA2AHSV6
       x-amz-server-side-encryption:
       - AES256
       x-backend:
-      - web-i-0642c5cf0fa7f07c2
+      - web-i-0d85dbf6e0a8f4cc9
       x-content-type-options:
       - nosniff
       x-rtd-domain:

--- a/tests/extensions/cassettes/test_projection/test_partial_apply.yaml
+++ b/tests/extensions/cassettes/test_projection/test_partial_apply.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/eo/v1.1.0/schema.json
   response:
@@ -81,7 +81,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '352'
+      - '140'
       Cache-Control:
       - max-age=600
       Connection:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:07 GMT
+      - Thu, 18 Sep 2025 14:55:24 GMT
       ETag:
       - '"66df1c53-13bc"'
       Last-Modified:
@@ -109,15 +109,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 309adb372da9154e49d0dcf34905f233d788d2f6
+      - eb5258235eaa88c656a7b8436844c36b71ebb369
       X-GitHub-Request-Id:
-      - BE8A:14434E:B836A2:D3D600:68C2EE8A
+      - 98DE:39A2ED:1DBAAC:1F56C3:68CC1CD0
       X-Served-By:
       - cache-bos4627-BOS
       X-Timer:
-      - S1757605867.082129,VS0,VE1
+      - S1758207324.176953,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -127,7 +127,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/projection/v2.0.0/schema.json
   response:
@@ -195,7 +195,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '352'
+      - '140'
       Cache-Control:
       - max-age=600
       Connection:
@@ -205,7 +205,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:07 GMT
+      - Thu, 18 Sep 2025 14:55:24 GMT
       ETag:
       - '"669e563b-1116"'
       Last-Modified:
@@ -223,15 +223,15 @@ interactions:
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 844428a507132532e11ec0a7577daabe3eb75bf2
+      - 4315a7579caeb245e0eb7d23e9633993ef2f3281
       X-GitHub-Request-Id:
-      - 21B3:2B753C:1E14E8F:2148802:68C2D6FB
+      - 224F:32B3EB:191F90:1ABAB3:68CC1CCF
       X-Served-By:
-      - cache-bos4632-BOS
+      - cache-bos4650-BOS
       X-Timer:
-      - S1757605867.156951,VS0,VE1
+      - S1758207324.241574,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 14:14:44 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -241,7 +241,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://proj.org/schemas/v0.7/projjson.schema.json
   response:
@@ -251,11 +251,11 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '1016'
+      - '700'
       CF-Cache-Status:
       - HIT
       CF-Ray:
-      - 97d8531e6f0c1e81-IAD
+      - 9811af211fffd65b-IAD
       Cache-Control:
       - max-age=1200
       Connection:
@@ -267,16 +267,16 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:07 GMT
+      - Thu, 18 Sep 2025 14:55:24 GMT
       Location:
       - https://proj.org/en/latest/schemas/v0.7/projjson.schema.json
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=sBsd0Y5ofoTnGxsU_JaV1fkHF6EpI7InZiQqgI4oCpA-1757605867-1.0.1.1-NzeEgLixzCWngwGXalaIzvcF8VhdDbZmnYiSWWM9bIUAx6PDqzQVq9GF18XJm1_089r0pqHXbA4kALegO46E_kXGgZheEoCi5VSHvyr1LqE;
-        path=/; expires=Thu, 11-Sep-25 16:21:07 GMT; domain=.proj.org; HttpOnly; Secure;
+      - __cf_bm=b7fuLn6isN3R8MX0jIFycMC_v7fji6_ydPSLswkH7p8-1758207324-1.0.1.1-vujsGCQW56I8Dq2QdXaBZuhZBrPOq5FlsbUrlCZx_vG.OQExUBkLpuFUJRkskjWQwg.ppBtQayOizSs.j6Rt5SSq2ZrwOstzmInZ9hiDYIw;
+        path=/; expires=Thu, 18-Sep-25 15:25:24 GMT; domain=.proj.org; HttpOnly; Secure;
         SameSite=None
-      - _cfuvid=K1xIWEAJ6K484Rs0aDb6oQO4zzo4q4xT7wTSZhxhzT4-1757605867300-0.0.1.1-604800000;
+      - _cfuvid=IMhAjVNcoFdncL4tVE2pZcdafKOkTRIh4mzpWy9Jjh0-1758207324370-0.0.1.1-604800000;
         path=/; domain=.proj.org; HttpOnly; Secure; SameSite=None
       Vary:
       - Accept-Language, Accept-Encoding
@@ -291,7 +291,7 @@ interactions:
       referrer-policy:
       - no-referrer-when-downgrade
       x-backend:
-      - web-i-032144a96d20fd642
+      - web-i-046a40256d6a3b46c
       x-content-type-options:
       - nosniff
       x-rtd-domain:
@@ -315,7 +315,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://proj.org/en/latest/schemas/v0.7/projjson.schema.json
   response:
@@ -844,11 +844,11 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '559'
+      - '4637'
       CF-Cache-Status:
       - HIT
       CF-Ray:
-      - 97d8531f3bebe5ed-IAD
+      - 9811af21ef4e658c-IAD
       Cache-Control:
       - max-age=1200
       Connection:
@@ -856,7 +856,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 11 Sep 2025 15:51:07 GMT
+      - Thu, 18 Sep 2025 14:55:24 GMT
       ETag:
       - W/"b36c7ce9824d274cfd711a16ef45d221"
       Last-Modified:
@@ -864,10 +864,10 @@ interactions:
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=V97EC82Q3UD8DO_4.Yvs1USIrHUCqvnWcfGEkq47rWg-1757605867-1.0.1.1-.S856gcx2FWWmx0swWhO8A_pUiWdqLuwZ92vuqi3_EhS6iXa2bi5jam9mhd9ZN5zS8TFA0z.y_AyurfobqFSYDA..8NvZzQcWT6uZfJ5b4A;
-        path=/; expires=Thu, 11-Sep-25 16:21:07 GMT; domain=.proj.org; HttpOnly; Secure;
+      - __cf_bm=cQr6LHx9pY2pM17jD4k2mtrd9N7Xhrx.sd2xixe85dM-1758207324-1.0.1.1-yCT8VxNGzg_WUwFH9WANS7n.BGr6Lz8dr7EYXJ2rhtQ63.rMpHmZlVMaev9y_Ht18Vo3bawI6cqy9yhz87S4DumOv7RjAYrTVypmcWoxKWo;
+        path=/; expires=Thu, 18-Sep-25 15:25:24 GMT; domain=.proj.org; HttpOnly; Secure;
         SameSite=None
-      - _cfuvid=yhkOxGdQT4ByaY8fEAcoagjKPrUVMkfUcmxJkxFGZfU-1757605867441-0.0.1.1-604800000;
+      - _cfuvid=AFJmbMYJqgNiGY2CK61wPzy0eXcQxsfajHgpM0hl4_k-1758207324605-0.0.1.1-604800000;
         path=/; domain=.proj.org; HttpOnly; Secure; SameSite=None
       Transfer-Encoding:
       - chunked
@@ -882,15 +882,15 @@ interactions:
       referrer-policy:
       - no-referrer-when-downgrade
       x-amz-id-2:
-      - 4CqUgAmdf2KJHeNFOeM5b06wSNvruKF2lIJzahRPcLccmToa5RuePCq61GcMLumrjEh4f144QTg=
+      - wq6M1yZwJIx72g0bu4iZIqB+T9hOmWOv1FfzWTgBKB1TbMZ30Ydon1RMGSDDCK+jALCUKViQfNEPgSiC2QHfaEtHxEE2g0MYvKvIxiq7DyA=
       x-amz-meta-mtime:
       - '1714074779.458591481'
       x-amz-request-id:
-      - 7J1TVVY6X3T9P0V9
+      - N37TE359KA2AHSV6
       x-amz-server-side-encryption:
       - AES256
       x-backend:
-      - web-i-0642c5cf0fa7f07c2
+      - web-i-0d85dbf6e0a8f4cc9
       x-content-type-options:
       - nosniff
       x-rtd-domain:

--- a/tests/extensions/cassettes/test_projection/test_projjson.yaml
+++ b/tests/extensions/cassettes/test_projection/test_projjson.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/eo/v1.1.0/schema.json
   response:
@@ -81,7 +81,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '355'
+      - '142'
       Cache-Control:
       - max-age=600
       Connection:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:09 GMT
+      - Thu, 18 Sep 2025 14:55:26 GMT
       ETag:
       - '"66df1c53-13bc"'
       Last-Modified:
@@ -107,17 +107,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '2'
       X-Fastly-Request-ID:
-      - ea1d343cf3590d634fd39c2ea66f15d8c3c47df4
+      - 74e1072e7bee74df2fee012173cd8372b39f9317
       X-GitHub-Request-Id:
-      - BE8A:14434E:B836A2:D3D600:68C2EE8A
+      - 98DE:39A2ED:1DBAAC:1F56C3:68CC1CD0
       X-Served-By:
-      - cache-bos4630-BOS
+      - cache-bos4677-BOS
       X-Timer:
-      - S1757605869.039828,VS0,VE1
+      - S1758207326.205376,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -127,7 +127,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/projection/v2.0.0/schema.json
   response:
@@ -195,7 +195,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '354'
+      - '142'
       Cache-Control:
       - max-age=600
       Connection:
@@ -205,7 +205,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:09 GMT
+      - Thu, 18 Sep 2025 14:55:26 GMT
       ETag:
       - '"669e563b-1116"'
       Last-Modified:
@@ -223,15 +223,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 05bb084184175784194a6d515cdab6ca2b88e5e9
+      - c186bae3839bdd808e5c8928e8e5eb061bea50d3
       X-GitHub-Request-Id:
-      - 21B3:2B753C:1E14E8F:2148802:68C2D6FB
+      - 224F:32B3EB:191F90:1ABAB3:68CC1CCF
       X-Served-By:
-      - cache-bos4682-BOS
+      - cache-bos4688-BOS
       X-Timer:
-      - S1757605869.115548,VS0,VE2
+      - S1758207326.281464,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 14:14:44 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -241,7 +241,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://proj.org/schemas/v0.7/projjson.schema.json
   response:
@@ -251,11 +251,11 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '1018'
+      - '702'
       CF-Cache-Status:
       - HIT
       CF-Ray:
-      - 97d8532aafccfe99-IAD
+      - 9811af2de9ee1b39-IAD
       Cache-Control:
       - max-age=1200
       Connection:
@@ -267,16 +267,16 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:09 GMT
+      - Thu, 18 Sep 2025 14:55:26 GMT
       Location:
       - https://proj.org/en/latest/schemas/v0.7/projjson.schema.json
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=K8Q40560a2EgSUVGNWtFnlfakUhlbknF.GBUsf.CdPU-1757605869-1.0.1.1-7m80FZ53cDz9kYsdKYYi5LwXaQ1Gd0CtcupGiGntps28KmLsgDPKxtASD.Rw.xKqGBprlXfWxHsQDw_PnFyoq7bA5P.i10wKdsgeQ11ja3c;
-        path=/; expires=Thu, 11-Sep-25 16:21:09 GMT; domain=.proj.org; HttpOnly; Secure;
+      - __cf_bm=3PoRSDXp0NUB2uRCf7AsIYQnuw24psvJiwf2CMIuCs4-1758207326-1.0.1.1-5SnWgzm4ZwTt252srchr0aEiiBU9o1.a1S4v2q4FK1mGnKcmI_r26EkjVoeKFVg7vQkd3xcwXkGcx9GXgZqcZp3zVP5yG5A__YRc5fqC.h0;
+        path=/; expires=Thu, 18-Sep-25 15:25:26 GMT; domain=.proj.org; HttpOnly; Secure;
         SameSite=None
-      - _cfuvid=wWL_HdAbxT2EnDeEPJWFm0yJ4cKHh2CKaJyLk.NdXLs-1757605869263-0.0.1.1-604800000;
+      - _cfuvid=q.jUW4zdsmAPZf8bowzo7eC3MxxCNlf6pQLDmlwigW8-1758207326429-0.0.1.1-604800000;
         path=/; domain=.proj.org; HttpOnly; Secure; SameSite=None
       Vary:
       - Accept-Language, Accept-Encoding
@@ -291,7 +291,7 @@ interactions:
       referrer-policy:
       - no-referrer-when-downgrade
       x-backend:
-      - web-i-032144a96d20fd642
+      - web-i-046a40256d6a3b46c
       x-content-type-options:
       - nosniff
       x-rtd-domain:
@@ -315,7 +315,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://proj.org/en/latest/schemas/v0.7/projjson.schema.json
   response:
@@ -844,11 +844,11 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '561'
+      - '4639'
       CF-Cache-Status:
       - HIT
       CF-Ray:
-      - 97d8532b8b30397f-IAD
+      - 9811af2ecc65c55a-IAD
       Cache-Control:
       - max-age=1200
       Connection:
@@ -856,7 +856,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 11 Sep 2025 15:51:09 GMT
+      - Thu, 18 Sep 2025 14:55:26 GMT
       ETag:
       - W/"b36c7ce9824d274cfd711a16ef45d221"
       Last-Modified:
@@ -864,10 +864,10 @@ interactions:
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=TbxQJcFbL5.01HWdsSTZ7Z0QFf_c7cG5brorG7htXTA-1757605869-1.0.1.1-KwMixeQphGU6SMyvD8RU6xFX_5st1UX98kv.fZttKQVZevhoL3ONToJym_0_OM8TP.bFc4bKnWfyRYWW34iMEe0UH4FGS.o4PTPbJyC2wcQ;
-        path=/; expires=Thu, 11-Sep-25 16:21:09 GMT; domain=.proj.org; HttpOnly; Secure;
+      - __cf_bm=EugVKSRiTzrbJMSS5zCVtsfRYRZDYb.BoiGtHKTtxP4-1758207326-1.0.1.1-d83JxciLLO_7T6ylQPbB044o8JKCioj5pJQV5HLBUXFTZ_A9RiVJH5VCCxYutrsVd3D3BgMd5Wi0g9CLJAZzesoSUOJvTvZZu7dthgT0otw;
+        path=/; expires=Thu, 18-Sep-25 15:25:26 GMT; domain=.proj.org; HttpOnly; Secure;
         SameSite=None
-      - _cfuvid=HqT60q2x75SDgojAG1XXyj_7UDZ1uO4v.Sk4fNVjCag-1757605869550-0.0.1.1-604800000;
+      - _cfuvid=awAFYeV9E35afqqizRCt8If8fGO6y69aGCbiARvJsDc-1758207326587-0.0.1.1-604800000;
         path=/; domain=.proj.org; HttpOnly; Secure; SameSite=None
       Transfer-Encoding:
       - chunked
@@ -882,15 +882,15 @@ interactions:
       referrer-policy:
       - no-referrer-when-downgrade
       x-amz-id-2:
-      - 4CqUgAmdf2KJHeNFOeM5b06wSNvruKF2lIJzahRPcLccmToa5RuePCq61GcMLumrjEh4f144QTg=
+      - wq6M1yZwJIx72g0bu4iZIqB+T9hOmWOv1FfzWTgBKB1TbMZ30Ydon1RMGSDDCK+jALCUKViQfNEPgSiC2QHfaEtHxEE2g0MYvKvIxiq7DyA=
       x-amz-meta-mtime:
       - '1714074779.458591481'
       x-amz-request-id:
-      - 7J1TVVY6X3T9P0V9
+      - N37TE359KA2AHSV6
       x-amz-server-side-encryption:
       - AES256
       x-backend:
-      - web-i-0642c5cf0fa7f07c2
+      - web-i-0d85dbf6e0a8f4cc9
       x-content-type-options:
       - nosniff
       x-rtd-domain:

--- a/tests/extensions/cassettes/test_projection/test_shape.yaml
+++ b/tests/extensions/cassettes/test_projection/test_shape.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/eo/v1.1.0/schema.json
   response:
@@ -81,7 +81,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '357'
+      - '144'
       Cache-Control:
       - max-age=600
       Connection:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:11 GMT
+      - Thu, 18 Sep 2025 14:55:28 GMT
       ETag:
       - '"66df1c53-13bc"'
       Last-Modified:
@@ -109,15 +109,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 8c3ac086e41e9ac552f1d5a7bff440e1bda65163
+      - 11509eecc00eb6ae32474c6a7355b6ad45aa92e5
       X-GitHub-Request-Id:
-      - BE8A:14434E:B836A2:D3D600:68C2EE8A
+      - 98DE:39A2ED:1DBAAC:1F56C3:68CC1CD0
       X-Served-By:
-      - cache-bos4674-BOS
+      - cache-bos4672-BOS
       X-Timer:
-      - S1757605871.441874,VS0,VE1
+      - S1758207328.325294,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -127,7 +127,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/projection/v2.0.0/schema.json
   response:
@@ -195,7 +195,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '357'
+      - '144'
       Cache-Control:
       - max-age=600
       Connection:
@@ -205,7 +205,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:11 GMT
+      - Thu, 18 Sep 2025 14:55:28 GMT
       ETag:
       - '"669e563b-1116"'
       Last-Modified:
@@ -221,17 +221,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Fastly-Request-ID:
-      - ddc23dc9bca6aa787c5e1b71327c52836f393a01
+      - 7bef4724ef2f019ae0276e0709cd8d8b41f06a66
       X-GitHub-Request-Id:
-      - 21B3:2B753C:1E14E8F:2148802:68C2D6FB
+      - 224F:32B3EB:191F90:1ABAB3:68CC1CCF
       X-Served-By:
-      - cache-bos4666-BOS
+      - cache-bos4688-BOS
       X-Timer:
-      - S1757605872.519663,VS0,VE1
+      - S1758207328.393239,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 14:14:44 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -241,7 +241,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://proj.org/schemas/v0.7/projjson.schema.json
   response:
@@ -251,11 +251,11 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '1020'
+      - '704'
       CF-Cache-Status:
       - HIT
       CF-Ray:
-      - 97d85339ab4dc973-IAD
+      - 9811af3b0ce0883c-IAD
       Cache-Control:
       - max-age=1200
       Connection:
@@ -267,16 +267,16 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:11 GMT
+      - Thu, 18 Sep 2025 14:55:28 GMT
       Location:
       - https://proj.org/en/latest/schemas/v0.7/projjson.schema.json
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=oAPz0ScYpyhK9h6unNXppDzut6iu8kqN5LvAEK9annY-1757605871-1.0.1.1-D5MW9X47As5AW3P_0YcHph9GfZ4116UtnKohe4pwpUrRDmsveBPox0TawajpbonB00.3yuaYx3P4GYXlNOvJBsCRi18vTJYVJgreKmG1Sbc;
-        path=/; expires=Thu, 11-Sep-25 16:21:11 GMT; domain=.proj.org; HttpOnly; Secure;
+      - __cf_bm=rVwpPzw_hYOnMD3S7zKsuCr1Lub2KQvzSnBVg02As4I-1758207328-1.0.1.1-ssMszDbjV13BTboheFTHxLy3sj2O_n4Lp5MCjK5UD6CaeiCVO1LxUkhMjz5lW4gPx8XbUGeiWxDiWh22Sz8bZ3QuRnjfaie0XC2yMvN.cuw;
+        path=/; expires=Thu, 18-Sep-25 15:25:28 GMT; domain=.proj.org; HttpOnly; Secure;
         SameSite=None
-      - _cfuvid=HfiqtP.64BxUbNXsPE1noxWhD7b0J5HNIx99e3sEnW0-1757605871682-0.0.1.1-604800000;
+      - _cfuvid=SPQYHkQ.DjMYG6YrAOX0.b3JjGnSE9oalN_0RSIBegg-1758207328516-0.0.1.1-604800000;
         path=/; domain=.proj.org; HttpOnly; Secure; SameSite=None
       Vary:
       - Accept-Language, Accept-Encoding
@@ -291,7 +291,7 @@ interactions:
       referrer-policy:
       - no-referrer-when-downgrade
       x-backend:
-      - web-i-032144a96d20fd642
+      - web-i-046a40256d6a3b46c
       x-content-type-options:
       - nosniff
       x-rtd-domain:
@@ -315,7 +315,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://proj.org/en/latest/schemas/v0.7/projjson.schema.json
   response:
@@ -844,11 +844,11 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '563'
+      - '4641'
       CF-Cache-Status:
       - HIT
       CF-Ray:
-      - 97d8533aabb0d6c0-IAD
+      - 9811af3bcedd8214-IAD
       Cache-Control:
       - max-age=1200
       Connection:
@@ -856,7 +856,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 11 Sep 2025 15:51:11 GMT
+      - Thu, 18 Sep 2025 14:55:28 GMT
       ETag:
       - W/"b36c7ce9824d274cfd711a16ef45d221"
       Last-Modified:
@@ -864,10 +864,10 @@ interactions:
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=mjZ_gTIZDODvKzxh2F8fiKO3K.Uv3CtuxxENQ_bepSk-1757605871-1.0.1.1-keCX3M8pCYrQrqfMYb_Mx10pa2t.G0jVLrZX8Qtqj0mWRyEi3RVthq4SJkEL3z5LvyD_kGYZHMneXJ704EzpnmEycAQ1nfRv5BJECBhwVU4;
-        path=/; expires=Thu, 11-Sep-25 16:21:11 GMT; domain=.proj.org; HttpOnly; Secure;
+      - __cf_bm=sfaZJH7DeyeCOB1TzqGUNrGxd8TFmZsKcQuh2.2s334-1758207328-1.0.1.1-AeWF5kU6utqbgcyWLV2Y5LudgeoKuDd2slZrMPuLIMpnkPCdyzqA6ICUvPAldeYyiN7kOHq.nHhGBIp6wzEtOTkIXL7paizoAJ9I5kA.nYY;
+        path=/; expires=Thu, 18-Sep-25 15:25:28 GMT; domain=.proj.org; HttpOnly; Secure;
         SameSite=None
-      - _cfuvid=Dw8zsOn2msYQMLsdJdQUhEgZb6t8KAaPxehviFQ3.N8-1757605871809-0.0.1.1-604800000;
+      - _cfuvid=WctMOck8E_T15UG1gTLje2ftFi.gLegfuMhsBwizNn4-1758207328662-0.0.1.1-604800000;
         path=/; domain=.proj.org; HttpOnly; Secure; SameSite=None
       Transfer-Encoding:
       - chunked
@@ -882,15 +882,15 @@ interactions:
       referrer-policy:
       - no-referrer-when-downgrade
       x-amz-id-2:
-      - 4CqUgAmdf2KJHeNFOeM5b06wSNvruKF2lIJzahRPcLccmToa5RuePCq61GcMLumrjEh4f144QTg=
+      - wq6M1yZwJIx72g0bu4iZIqB+T9hOmWOv1FfzWTgBKB1TbMZ30Ydon1RMGSDDCK+jALCUKViQfNEPgSiC2QHfaEtHxEE2g0MYvKvIxiq7DyA=
       x-amz-meta-mtime:
       - '1714074779.458591481'
       x-amz-request-id:
-      - 7J1TVVY6X3T9P0V9
+      - N37TE359KA2AHSV6
       x-amz-server-side-encryption:
       - AES256
       x-backend:
-      - web-i-0642c5cf0fa7f07c2
+      - web-i-0d85dbf6e0a8f4cc9
       x-content-type-options:
       - nosniff
       x-rtd-domain:

--- a/tests/extensions/cassettes/test_projection/test_transform.yaml
+++ b/tests/extensions/cassettes/test_projection/test_transform.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/eo/v1.1.0/schema.json
   response:
@@ -81,7 +81,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '358'
+      - '144'
       Cache-Control:
       - max-age=600
       Connection:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:11 GMT
+      - Thu, 18 Sep 2025 14:55:28 GMT
       ETag:
       - '"66df1c53-13bc"'
       Last-Modified:
@@ -107,17 +107,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 726256211b975e8f20f60bc4f2af6fd93b1cb53f
+      - 86ad4b399b9913471a50cf1ac8cb27edaab10c45
       X-GitHub-Request-Id:
-      - BE8A:14434E:B836A2:D3D600:68C2EE8A
+      - 98DE:39A2ED:1DBAAC:1F56C3:68CC1CD0
       X-Served-By:
-      - cache-bos4687-BOS
+      - cache-bos4692-BOS
       X-Timer:
-      - S1757605872.944111,VS0,VE0
+      - S1758207329.781011,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -127,7 +127,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/projection/v2.0.0/schema.json
   response:
@@ -195,7 +195,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '357'
+      - '144'
       Cache-Control:
       - max-age=600
       Connection:
@@ -205,7 +205,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:12 GMT
+      - Thu, 18 Sep 2025 14:55:28 GMT
       ETag:
       - '"669e563b-1116"'
       Last-Modified:
@@ -223,15 +223,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 5ca48098c013320043a4a04e9bb41d7f0adb79fb
+      - 4ef7f8e2d79739b9fa84cc60874ede1289c62096
       X-GitHub-Request-Id:
-      - 21B3:2B753C:1E14E8F:2148802:68C2D6FB
+      - 224F:32B3EB:191F90:1ABAB3:68CC1CCF
       X-Served-By:
-      - cache-bos4673-BOS
+      - cache-bos4626-BOS
       X-Timer:
-      - S1757605872.011696,VS0,VE2
+      - S1758207329.839411,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 14:14:44 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -241,7 +241,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://proj.org/schemas/v0.7/projjson.schema.json
   response:
@@ -251,11 +251,11 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '1021'
+      - '704'
       CF-Cache-Status:
       - HIT
       CF-Ray:
-      - 97d8533cbca305c2-IAD
+      - 9811af3def1822ef-IAD
       Cache-Control:
       - max-age=1200
       Connection:
@@ -267,16 +267,16 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:12 GMT
+      - Thu, 18 Sep 2025 14:55:28 GMT
       Location:
       - https://proj.org/en/latest/schemas/v0.7/projjson.schema.json
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=pb.lMMWnKef1OI.2ULrqjdPyrPufr2.1R8GSXQOYsnE-1757605872-1.0.1.1-AokjluIjaEpDAASf7i0hS2DT4SmsxRtZkjgBfwBlBdro8iTZLITJaeNKkBazPX44TTyFO7Qw.UmYHLvR5Qgz3kQzry3Eae64MmrUEPaz0HM;
-        path=/; expires=Thu, 11-Sep-25 16:21:12 GMT; domain=.proj.org; HttpOnly; Secure;
+      - __cf_bm=5tHmx6tXuRDiJ4fapio2QlbIy7IrMlWxldYBFw0b4dI-1758207328-1.0.1.1-L79tIr_xh_IR.kBReezJfr1uTKOm0uOn1UgdNNLT3H8lasXYeV0O7YTpDESglfNFoDDN.Ks35aSp1B8I5_60Hp0ItKtbnjdYOEvzn3Peflk;
+        path=/; expires=Thu, 18-Sep-25 15:25:28 GMT; domain=.proj.org; HttpOnly; Secure;
         SameSite=None
-      - _cfuvid=ohC7bNScf4QJJQNC0cnPOKopLP6bcVJ_PZhCwycmd14-1757605872179-0.0.1.1-604800000;
+      - _cfuvid=33rM0gzEpnMjWzFC7ZRrIUASM7xZBt2Lun2ezrVAnHE-1758207328993-0.0.1.1-604800000;
         path=/; domain=.proj.org; HttpOnly; Secure; SameSite=None
       Vary:
       - Accept-Language, Accept-Encoding
@@ -291,7 +291,7 @@ interactions:
       referrer-policy:
       - no-referrer-when-downgrade
       x-backend:
-      - web-i-032144a96d20fd642
+      - web-i-046a40256d6a3b46c
       x-content-type-options:
       - nosniff
       x-rtd-domain:
@@ -315,7 +315,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://proj.org/en/latest/schemas/v0.7/projjson.schema.json
   response:
@@ -844,11 +844,11 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '564'
+      - '4642'
       CF-Cache-Status:
       - HIT
       CF-Ray:
-      - 97d8533db901a568-IAD
+      - 9811af3ed9e6e93c-IAD
       Cache-Control:
       - max-age=1200
       Connection:
@@ -856,7 +856,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 11 Sep 2025 15:51:12 GMT
+      - Thu, 18 Sep 2025 14:55:29 GMT
       ETag:
       - W/"b36c7ce9824d274cfd711a16ef45d221"
       Last-Modified:
@@ -864,10 +864,10 @@ interactions:
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=ktbUJHUTn3qDnsTmBonvj80s6p7MqD7W1YnkrBClWrg-1757605872-1.0.1.1-6Bzr6Zo8CXIDstwnyeWbgNK90EMgqGgZVGRLwO52WUXo22fPaO_7MUv27jpaoZfflNoiZqz5thJUHc9IHnoUpncfun0DSkiLKaRiuYg_kEM;
-        path=/; expires=Thu, 11-Sep-25 16:21:12 GMT; domain=.proj.org; HttpOnly; Secure;
+      - __cf_bm=sv5yFjn5juZ0SyP2kC.lt5uokzdKixYJX3ylu4B1cQ0-1758207329-1.0.1.1-l.sPpQRU9OopUsSKkbgNHvR0FX19wmDXOSk3dFE0vCehci1ZDnzqP2Wr4R3vckYKjshzwdOJp4usKr2j7LsurL_88yNJeH6BG0TIFKYgP34;
+        path=/; expires=Thu, 18-Sep-25 15:25:29 GMT; domain=.proj.org; HttpOnly; Secure;
         SameSite=None
-      - _cfuvid=D4Gv7gKLMG_vGCPdSRxH.legsuoEkiEGAHfy.WF2yuM-1757605872331-0.0.1.1-604800000;
+      - _cfuvid=OyrkqFK8Q7Dy_MBVmo.2TozIzPiR6SCqhtYPfhp3T3I-1758207329138-0.0.1.1-604800000;
         path=/; domain=.proj.org; HttpOnly; Secure; SameSite=None
       Transfer-Encoding:
       - chunked
@@ -882,15 +882,15 @@ interactions:
       referrer-policy:
       - no-referrer-when-downgrade
       x-amz-id-2:
-      - 4CqUgAmdf2KJHeNFOeM5b06wSNvruKF2lIJzahRPcLccmToa5RuePCq61GcMLumrjEh4f144QTg=
+      - wq6M1yZwJIx72g0bu4iZIqB+T9hOmWOv1FfzWTgBKB1TbMZ30Ydon1RMGSDDCK+jALCUKViQfNEPgSiC2QHfaEtHxEE2g0MYvKvIxiq7DyA=
       x-amz-meta-mtime:
       - '1714074779.458591481'
       x-amz-request-id:
-      - 7J1TVVY6X3T9P0V9
+      - N37TE359KA2AHSV6
       x-amz-server-side-encryption:
       - AES256
       x-backend:
-      - web-i-0642c5cf0fa7f07c2
+      - web-i-0d85dbf6e0a8f4cc9
       x-content-type-options:
       - nosniff
       x-rtd-domain:

--- a/tests/extensions/cassettes/test_projection/test_validate_proj.yaml
+++ b/tests/extensions/cassettes/test_projection/test_validate_proj.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/eo/v1.1.0/schema.json
   response:
@@ -81,7 +81,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '353'
+      - '141'
       Cache-Control:
       - max-age=600
       Connection:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:07 GMT
+      - Thu, 18 Sep 2025 14:55:24 GMT
       ETag:
       - '"66df1c53-13bc"'
       Last-Modified:
@@ -107,17 +107,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Fastly-Request-ID:
-      - 0036a46df442ecc31ed73686b5f38839b482ed9a
+      - 41905fea894464aacf8ccdb3e65a26fa9c900c02
       X-GitHub-Request-Id:
-      - BE8A:14434E:B836A2:D3D600:68C2EE8A
+      - 98DE:39A2ED:1DBAAC:1F56C3:68CC1CD0
       X-Served-By:
-      - cache-bos4639-BOS
+      - cache-bos4627-BOS
       X-Timer:
-      - S1757605868.555966,VS0,VE1
+      - S1758207325.768259,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -127,7 +127,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/projection/v2.0.0/schema.json
   response:
@@ -195,7 +195,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '353'
+      - '140'
       Cache-Control:
       - max-age=600
       Connection:
@@ -205,7 +205,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:07 GMT
+      - Thu, 18 Sep 2025 14:55:24 GMT
       ETag:
       - '"669e563b-1116"'
       Last-Modified:
@@ -223,15 +223,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 5a4f25f44e368bb147dad589450e3d10a8ea85c8
+      - 333c93be7f0003393440382b68cb26bb37d83da4
       X-GitHub-Request-Id:
-      - 21B3:2B753C:1E14E8F:2148802:68C2D6FB
+      - 224F:32B3EB:191F90:1ABAB3:68CC1CCF
       X-Served-By:
-      - cache-bos4643-BOS
+      - cache-bos4686-BOS
       X-Timer:
-      - S1757605868.626343,VS0,VE2
+      - S1758207325.839344,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 14:14:44 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -241,7 +241,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://proj.org/schemas/v0.7/projjson.schema.json
   response:
@@ -251,11 +251,11 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '1016'
+      - '701'
       CF-Cache-Status:
       - HIT
       CF-Ray:
-      - 97d853213a33d6a4-IAD
+      - 9811af24eca60a09-IAD
       Cache-Control:
       - max-age=1200
       Connection:
@@ -267,16 +267,16 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:07 GMT
+      - Thu, 18 Sep 2025 14:55:25 GMT
       Location:
       - https://proj.org/en/latest/schemas/v0.7/projjson.schema.json
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=S3SUxELBQ6.bZ.fIp3Jo0AptjymGDlzIwkrYhcT..PE-1757605867-1.0.1.1-A47BElJGd114oRgJsoTCyNGwflUpkFuE6HQpBWqphX.Qx6DH5x8Bl3MJtfjgaMzL4HakOrpGpfHw7RomGDDv7L0gJbvT3z8KmWn51Ss928Y;
-        path=/; expires=Thu, 11-Sep-25 16:21:07 GMT; domain=.proj.org; HttpOnly; Secure;
+      - __cf_bm=5vnQE9f_NOnEzvfpAO5oQ58pLggbwWmE7fWFDPgprvM-1758207325-1.0.1.1-BKvTLCe3QQEdE22fWtQyIDKtvo6GpkTrVqXWmt_MS959i4OJzrEvLWVM4fWIwzaNbmU0OVe_9DNXk9V0iop2e960rr9DCzLJ440_78HxpdE;
+        path=/; expires=Thu, 18-Sep-25 15:25:25 GMT; domain=.proj.org; HttpOnly; Secure;
         SameSite=None
-      - _cfuvid=O94C1DfpCiCcb2y2XTGWAZ6VfJJfqmmgKlwO8r_5fh4-1757605867770-0.0.1.1-604800000;
+      - _cfuvid=uoO0AzuCMjWgM.sYj15KrpD8SGkm.GjVBU0UjaWMPxQ-1758207325021-0.0.1.1-604800000;
         path=/; domain=.proj.org; HttpOnly; Secure; SameSite=None
       Vary:
       - Accept-Language, Accept-Encoding
@@ -291,7 +291,7 @@ interactions:
       referrer-policy:
       - no-referrer-when-downgrade
       x-backend:
-      - web-i-032144a96d20fd642
+      - web-i-046a40256d6a3b46c
       x-content-type-options:
       - nosniff
       x-rtd-domain:
@@ -315,7 +315,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://proj.org/en/latest/schemas/v0.7/projjson.schema.json
   response:
@@ -844,11 +844,11 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '559'
+      - '4638'
       CF-Cache-Status:
       - HIT
       CF-Ray:
-      - 97d8532228a7d6d4-IAD
+      - 9811af25f8e30614-IAD
       Cache-Control:
       - max-age=1200
       Connection:
@@ -856,7 +856,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 11 Sep 2025 15:51:07 GMT
+      - Thu, 18 Sep 2025 14:55:25 GMT
       ETag:
       - W/"b36c7ce9824d274cfd711a16ef45d221"
       Last-Modified:
@@ -864,10 +864,10 @@ interactions:
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=UB6M3gq3hczFJTnOkyOra17CiRoGn6Ocl9ZUnUQhip8-1757605867-1.0.1.1-PCRcQlypdCYGoQlTdcT60Mh1EWiNFAhxZsVN4I8wp5suul_CqlVFouiEcDyEINeVddNlP3KKz5HR9q85LtKP2DdqP3kzmRJ.8fhprMgyOeQ;
-        path=/; expires=Thu, 11-Sep-25 16:21:07 GMT; domain=.proj.org; HttpOnly; Secure;
+      - __cf_bm=sYTSIc.8b9s1uy2mPfajDsGdOjDdAgGa9cx5rhcXRhE-1758207325-1.0.1.1-7YX8qpb4iTXSRzYYbVAjnMRGgyvMY1JsXfkRFs4d7rcg7t_on8uTAzCGyfRW_jPRK6fLhhJwTlSe8mBdbvbgE2.WyX8.6K4ZBfboNtrxDuk;
+        path=/; expires=Thu, 18-Sep-25 15:25:25 GMT; domain=.proj.org; HttpOnly; Secure;
         SameSite=None
-      - _cfuvid=eT1eWHI39cQXOYh_vOFbn8D49EtcqupBdrqHZ_74T8M-1757605867919-0.0.1.1-604800000;
+      - _cfuvid=TsNV80u7KJt5eCyRnCtx0EslWwO_xfDHK5buyNyV2qk-1758207325219-0.0.1.1-604800000;
         path=/; domain=.proj.org; HttpOnly; Secure; SameSite=None
       Transfer-Encoding:
       - chunked
@@ -882,15 +882,15 @@ interactions:
       referrer-policy:
       - no-referrer-when-downgrade
       x-amz-id-2:
-      - 4CqUgAmdf2KJHeNFOeM5b06wSNvruKF2lIJzahRPcLccmToa5RuePCq61GcMLumrjEh4f144QTg=
+      - wq6M1yZwJIx72g0bu4iZIqB+T9hOmWOv1FfzWTgBKB1TbMZ30Ydon1RMGSDDCK+jALCUKViQfNEPgSiC2QHfaEtHxEE2g0MYvKvIxiq7DyA=
       x-amz-meta-mtime:
       - '1714074779.458591481'
       x-amz-request-id:
-      - 7J1TVVY6X3T9P0V9
+      - N37TE359KA2AHSV6
       x-amz-server-side-encryption:
       - AES256
       x-backend:
-      - web-i-0642c5cf0fa7f07c2
+      - web-i-0d85dbf6e0a8f4cc9
       x-content-type-options:
       - nosniff
       x-rtd-domain:

--- a/tests/extensions/cassettes/test_projection/test_wkt2.yaml
+++ b/tests/extensions/cassettes/test_projection/test_wkt2.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/eo/v1.1.0/schema.json
   response:
@@ -81,7 +81,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '354'
+      - '141'
       Cache-Control:
       - max-age=600
       Connection:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:08 GMT
+      - Thu, 18 Sep 2025 14:55:25 GMT
       ETag:
       - '"66df1c53-13bc"'
       Last-Modified:
@@ -109,15 +109,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 9fc5455e810e0a2c516824a07c2deb1748e0f130
+      - 4d4b3fd9892b50c50d02d11a1044e7c5c3e29060
       X-GitHub-Request-Id:
-      - BE8A:14434E:B836A2:D3D600:68C2EE8A
+      - 98DE:39A2ED:1DBAAC:1F56C3:68CC1CD0
       X-Served-By:
-      - cache-bos4691-BOS
+      - cache-bos4641-BOS
       X-Timer:
-      - S1757605869.566328,VS0,VE1
+      - S1758207326.767105,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -127,7 +127,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/projection/v2.0.0/schema.json
   response:
@@ -195,7 +195,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '354'
+      - '141'
       Cache-Control:
       - max-age=600
       Connection:
@@ -205,7 +205,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:08 GMT
+      - Thu, 18 Sep 2025 14:55:25 GMT
       ETag:
       - '"669e563b-1116"'
       Last-Modified:
@@ -221,17 +221,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 62ba0d7e4be6be9392562c02c8e1f0e9b06f61f9
+      - 65dd769f5d058d1b6c9386a6f1ef3a6c0c27f3d6
       X-GitHub-Request-Id:
-      - 21B3:2B753C:1E14E8F:2148802:68C2D6FB
+      - 224F:32B3EB:191F90:1ABAB3:68CC1CCF
       X-Served-By:
-      - cache-bos4657-BOS
+      - cache-bos4678-BOS
       X-Timer:
-      - S1757605869.636281,VS0,VE0
+      - S1758207326.831382,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 14:14:44 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -241,7 +241,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://proj.org/schemas/v0.7/projjson.schema.json
   response:
@@ -251,11 +251,11 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '1017'
+      - '701'
       CF-Cache-Status:
       - HIT
       CF-Ray:
-      - 97d853279e53d62c-IAD
+      - 9811af2b0f43a9d6-IAD
       Cache-Control:
       - max-age=1200
       Connection:
@@ -267,16 +267,16 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:08 GMT
+      - Thu, 18 Sep 2025 14:55:25 GMT
       Location:
       - https://proj.org/en/latest/schemas/v0.7/projjson.schema.json
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=bZBFJTK59ceYCgBKnS4yorNdxeZ1rW3ziGs5rxloGH4-1757605868-1.0.1.1-4sq0X4ZTyw0dcXrCftG1pMtGS4mA58CmCgbjxuOkr0t9kivriibSOs3oFDJgtkH8iERpwfxulLmQ9lSM2VweA48WVgxvQEvIsTvaMpsz24k;
-        path=/; expires=Thu, 11-Sep-25 16:21:08 GMT; domain=.proj.org; HttpOnly; Secure;
+      - __cf_bm=Eiy96havje7zQPDHfumQcz5z2VESW12NcuFMhezFssQ-1758207325-1.0.1.1-C11XieqpkfKwW1SiAK0wL1.hwdrtUtZ1lMTVPJdjOpf8cz1mt8W2hBvG1sIm_TD.wEk.vnU65L_TVpvI8BJ7Fl_7TmZ1jdAALpBoNMtf64Y;
+        path=/; expires=Thu, 18-Sep-25 15:25:25 GMT; domain=.proj.org; HttpOnly; Secure;
         SameSite=None
-      - _cfuvid=Tx46o9YMz3THrfJsgKRhLPlLvmnS92FAaDWIPcopv_E-1757605868773-0.0.1.1-604800000;
+      - _cfuvid=iZVHremhSsr7T1ghj8BUDV.BDitP7UzrnaUuJJbyiL0-1758207325957-0.0.1.1-604800000;
         path=/; domain=.proj.org; HttpOnly; Secure; SameSite=None
       Vary:
       - Accept-Language, Accept-Encoding
@@ -291,7 +291,7 @@ interactions:
       referrer-policy:
       - no-referrer-when-downgrade
       x-backend:
-      - web-i-032144a96d20fd642
+      - web-i-046a40256d6a3b46c
       x-content-type-options:
       - nosniff
       x-rtd-domain:
@@ -315,7 +315,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://proj.org/en/latest/schemas/v0.7/projjson.schema.json
   response:
@@ -844,11 +844,11 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '560'
+      - '4639'
       CF-Cache-Status:
       - HIT
       CF-Ray:
-      - 97d8532879e5f276-IAD
+      - 9811af2bd9768c9d-IAD
       Cache-Control:
       - max-age=1200
       Connection:
@@ -856,7 +856,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 11 Sep 2025 15:51:08 GMT
+      - Thu, 18 Sep 2025 14:55:26 GMT
       ETag:
       - W/"b36c7ce9824d274cfd711a16ef45d221"
       Last-Modified:
@@ -864,10 +864,10 @@ interactions:
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=oGumYuLyuMh6ix.xXUjMz_eITlPVxQ5PGnQ2YgPofoA-1757605868-1.0.1.1-NNv94hfpshe.WOHiV4VoGdlKXGkFf9d4ni9IZ7pBbyBzJ_SJH0f2JAYqg9mSqP3QOh4Qo1Hvv5o3UfyspLL0QnR9gVe8f6R00znU0tW5EAk;
-        path=/; expires=Thu, 11-Sep-25 16:21:08 GMT; domain=.proj.org; HttpOnly; Secure;
+      - __cf_bm=iNP00nclejAY7viRG7OoyNcDDyX1SzWa22KfuWsGwqw-1758207326-1.0.1.1-YxEso1NsdVuIeSSxzKSZTx9zR4EygBse2b5sWYFW7ubsj6XylZAaUgdYyJzQviI0K5Gy564lrYWRLfV7QWC1zNi76YtTLiuxeDPOXxSQqSk;
+        path=/; expires=Thu, 18-Sep-25 15:25:26 GMT; domain=.proj.org; HttpOnly; Secure;
         SameSite=None
-      - _cfuvid=U9e1r2Use4jqb0oDJ2MOknfxA6o7fp0ZU3_XkOzLHdU-1757605868909-0.0.1.1-604800000;
+      - _cfuvid=O3RDsspJV3GUfvKOSImg.eZ_gdPt_cIz2TE8o8OthpI-1758207326077-0.0.1.1-604800000;
         path=/; domain=.proj.org; HttpOnly; Secure; SameSite=None
       Transfer-Encoding:
       - chunked
@@ -882,15 +882,15 @@ interactions:
       referrer-policy:
       - no-referrer-when-downgrade
       x-amz-id-2:
-      - 4CqUgAmdf2KJHeNFOeM5b06wSNvruKF2lIJzahRPcLccmToa5RuePCq61GcMLumrjEh4f144QTg=
+      - wq6M1yZwJIx72g0bu4iZIqB+T9hOmWOv1FfzWTgBKB1TbMZ30Ydon1RMGSDDCK+jALCUKViQfNEPgSiC2QHfaEtHxEE2g0MYvKvIxiq7DyA=
       x-amz-meta-mtime:
       - '1714074779.458591481'
       x-amz-request-id:
-      - 7J1TVVY6X3T9P0V9
+      - N37TE359KA2AHSV6
       x-amz-server-side-encryption:
       - AES256
       x-backend:
-      - web-i-0642c5cf0fa7f07c2
+      - web-i-0d85dbf6e0a8f4cc9
       x-content-type-options:
       - nosniff
       x-rtd-domain:

--- a/tests/extensions/cassettes/test_raster/test_asset_bands.yaml
+++ b/tests/extensions/cassettes/test_raster/test_asset_bands.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/eo/v1.1.0/schema.json
   response:
@@ -81,7 +81,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '358'
+      - '145'
       Cache-Control:
       - max-age=600
       Connection:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:12 GMT
+      - Thu, 18 Sep 2025 14:55:29 GMT
       ETag:
       - '"66df1c53-13bc"'
       Last-Modified:
@@ -107,17 +107,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '14'
       X-Fastly-Request-ID:
-      - 34148e7461c8b53ffc78fd252da2eacc66ba319d
+      - fb010a302d69cd4414bf621db4f627a1fd097543
       X-GitHub-Request-Id:
-      - BE8A:14434E:B836A2:D3D600:68C2EE8A
+      - 98DE:39A2ED:1DBAAC:1F56C3:68CC1CD0
       X-Served-By:
-      - cache-bos4656-BOS
+      - cache-bos4642-BOS
       X-Timer:
-      - S1757605873.974424,VS0,VE0
+      - S1758207330.873215,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -127,7 +127,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/view/v1.0.0/schema.json
   response:
@@ -185,7 +185,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '358'
+      - '145'
       Cache-Control:
       - max-age=600
       Connection:
@@ -195,7 +195,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:13 GMT
+      - Thu, 18 Sep 2025 14:55:29 GMT
       ETag:
       - '"689f5434-dff"'
       Last-Modified:
@@ -213,15 +213,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - b2dfb80470d7363e836f3c8e78ae1d16a10e02ab
+      - e1b75f524e5d4f52cdb50a55cfe691a8b946caba
       X-GitHub-Request-Id:
-      - EACF:1C0114:1BE6594:1F22786:68C2EE8A
+      - 624D:BA176:74CE5:7ED3C:68CC1CD0
       X-Served-By:
-      - cache-bos4668-BOS
+      - cache-bos4690-BOS
       X-Timer:
-      - S1757605873.052296,VS0,VE1
+      - S1758207330.947050,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -231,7 +231,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/projection/v2.0.0/schema.json
   response:
@@ -299,7 +299,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '358'
+      - '145'
       Cache-Control:
       - max-age=600
       Connection:
@@ -309,7 +309,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:13 GMT
+      - Thu, 18 Sep 2025 14:55:30 GMT
       ETag:
       - '"669e563b-1116"'
       Last-Modified:
@@ -327,15 +327,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - b369660ed4faede7604825f750e9e0aea398def2
+      - 9ffcb77b41aec7fd3cbb2a880b5f0742d24e450d
       X-GitHub-Request-Id:
-      - 21B3:2B753C:1E14E8F:2148802:68C2D6FB
+      - 224F:32B3EB:191F90:1ABAB3:68CC1CCF
       X-Served-By:
-      - cache-bos4688-BOS
+      - cache-bos4622-BOS
       X-Timer:
-      - S1757605873.117869,VS0,VE1
+      - S1758207330.029556,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 14:14:44 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -345,7 +345,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/raster/v1.1.0/schema.json
   response:
@@ -442,7 +442,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '359'
+      - '146'
       Cache-Control:
       - max-age=600
       Connection:
@@ -452,7 +452,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:13 GMT
+      - Thu, 18 Sep 2025 14:55:30 GMT
       ETag:
       - '"66df5c80-18ae"'
       Last-Modified:
@@ -470,15 +470,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 8745484379de4e6040eaad0b34f5727a82714ad8
+      - 6ea15a6781c807239864cf23980e1b2ae2c5b817
       X-GitHub-Request-Id:
-      - 6F8C:14A94E:C2B049:DE4F27:68C2EE8A
+      - 17F6:239986:1B3CB6:1CD810:68CC1CD0
       X-Served-By:
-      - cache-bos4624-BOS
+      - cache-bos4649-BOS
       X-Timer:
-      - S1757605873.189893,VS0,VE1
+      - S1758207330.113222,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_raster/test_validate_raster.yaml
+++ b/tests/extensions/cassettes/test_raster/test_validate_raster.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/sat/v1.0.0/schema.json
   response:
@@ -63,7 +63,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -73,7 +73,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:12 GMT
+      - Thu, 18 Sep 2025 14:55:29 GMT
       ETag:
       - '"67627e9d-e82"'
       Last-Modified:
@@ -87,19 +87,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 3a0c5b8a042b2b46bd622239d991a5d7ccea1e2e
+      - 756ad1f52f9d44db7dd8a19d58ceaad0f473f3b3
       X-GitHub-Request-Id:
-      - 621C:19FF07:BB2CFC:D6CBD0:68C2EE98
+      - 4F00:BAEAA:C82DD6:E297E0:68CC1D60
       X-Served-By:
-      - cache-bos4645-BOS
+      - cache-bos4621-BOS
       X-Timer:
-      - S1757605872.490567,VS0,VE1
+      - S1758207329.294934,VS0,VE37
       expires:
-      - Thu, 11 Sep 2025 15:55:28 GMT
+      - Thu, 18 Sep 2025 15:05:29 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -109,7 +109,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/view/v1.0.0/schema.json
   response:
@@ -167,7 +167,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '358'
+      - '145'
       Cache-Control:
       - max-age=600
       Connection:
@@ -177,7 +177,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:12 GMT
+      - Thu, 18 Sep 2025 14:55:29 GMT
       ETag:
       - '"689f5434-dff"'
       Last-Modified:
@@ -195,15 +195,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 3740c8e73a9e9b9c02a7c1f76e906261b9535e63
+      - d8091e7c45a463bc7a40aabbb5ddc986601d4e3f
       X-GitHub-Request-Id:
-      - EACF:1C0114:1BE6594:1F22786:68C2EE8A
+      - 624D:BA176:74CE5:7ED3C:68CC1CD0
       X-Served-By:
-      - cache-bos4630-BOS
+      - cache-bos4625-BOS
       X-Timer:
-      - S1757605873.558516,VS0,VE2
+      - S1758207329.407448,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -213,7 +213,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/projection/v2.0.0/schema.json
   response:
@@ -281,7 +281,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '358'
+      - '145'
       Cache-Control:
       - max-age=600
       Connection:
@@ -291,7 +291,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:12 GMT
+      - Thu, 18 Sep 2025 14:55:29 GMT
       ETag:
       - '"669e563b-1116"'
       Last-Modified:
@@ -309,15 +309,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 4d810d48b43dcf1f73d35b5503e6037d90d79d46
+      - cd3d8b638199eea1b3a14ad2486fb59833f5e2e9
       X-GitHub-Request-Id:
-      - 21B3:2B753C:1E14E8F:2148802:68C2D6FB
+      - 224F:32B3EB:191F90:1ABAB3:68CC1CCF
       X-Served-By:
-      - cache-bos4654-BOS
+      - cache-bos4687-BOS
       X-Timer:
-      - S1757605873.633250,VS0,VE2
+      - S1758207329.481838,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 14:14:44 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -327,7 +327,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/eo/v1.1.0/schema.json
   response:
@@ -405,7 +405,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '358'
+      - '145'
       Cache-Control:
       - max-age=600
       Connection:
@@ -415,7 +415,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:12 GMT
+      - Thu, 18 Sep 2025 14:55:29 GMT
       ETag:
       - '"66df1c53-13bc"'
       Last-Modified:
@@ -433,15 +433,15 @@ interactions:
       X-Cache-Hits:
       - '2'
       X-Fastly-Request-ID:
-      - a50844db26e5679225196bed565b867b98072fb6
+      - 8cb51194d0837ce819e6842d5bbe5f2b4c7b3716
       X-GitHub-Request-Id:
-      - BE8A:14434E:B836A2:D3D600:68C2EE8A
+      - 98DE:39A2ED:1DBAAC:1F56C3:68CC1CD0
       X-Served-By:
-      - cache-bos4684-BOS
+      - cache-bos4672-BOS
       X-Timer:
-      - S1757605873.711649,VS0,VE0
+      - S1758207330.555447,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -451,7 +451,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/processing/v1.0.0/schema.json
   response:
@@ -536,7 +536,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -546,7 +546,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:12 GMT
+      - Thu, 18 Sep 2025 14:55:29 GMT
       ETag:
       - '"663cfd3e-1661"'
       Last-Modified:
@@ -560,21 +560,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
-      - '1'
+      - '0'
       X-Fastly-Request-ID:
-      - bcf7d9a893a04f185540f680bbaaf4a6054097e4
+      - a6f91cd4fe0a23d34b910e04daceedbb8c36891b
       X-GitHub-Request-Id:
-      - 175A:14434E:B843F9:D3E52E:68C2EE98
+      - 50F3:CFF2E:C99CBA:E3DEB7:68CC1D61
       X-Served-By:
-      - cache-bos4679-BOS
+      - cache-bos4652-BOS
       X-Timer:
-      - S1757605873.781878,VS0,VE0
+      - S1758207330.631097,VS0,VE43
       expires:
-      - Thu, 11 Sep 2025 15:55:29 GMT
-      x-origin-cache:
-      - HIT
+      - Thu, 18 Sep 2025 15:05:29 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -584,7 +582,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/raster/v1.1.0/schema.json
   response:
@@ -681,7 +679,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '358'
+      - '145'
       Cache-Control:
       - max-age=600
       Connection:
@@ -691,7 +689,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:12 GMT
+      - Thu, 18 Sep 2025 14:55:29 GMT
       ETag:
       - '"66df5c80-18ae"'
       Last-Modified:
@@ -709,15 +707,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - a088a5243c99b7e8991368a306e590d400433e00
+      - c508c21f7c5b67ba058629338565b41a32e86f80
       X-GitHub-Request-Id:
-      - 6F8C:14A94E:C2B049:DE4F27:68C2EE8A
+      - 17F6:239986:1B3CB6:1CD810:68CC1CD0
       X-Served-By:
-      - cache-bos4687-BOS
+      - cache-bos4677-BOS
       X-Timer:
-      - S1757605873.852413,VS0,VE1
+      - S1758207330.747241,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_render/test_collection_validate.yaml
+++ b/tests/extensions/cassettes/test_render/test_collection_validate.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/render/v2.0.0/schema.json
   response:
@@ -97,7 +97,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -107,7 +107,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:13 GMT
+      - Thu, 18 Sep 2025 14:55:30 GMT
       ETag:
       - '"673d1188-1888"'
       Last-Modified:
@@ -125,15 +125,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 2cfdb602306dc2a6fd0c12abd09550ccf5d4d4cb
+      - 379d79b212982e8fba773c6f9f1119ab5507a219
       X-GitHub-Request-Id:
-      - 1865:153265:C41CFD:DFC0BB:68C2EE99
+      - 3E81:0D6F:C2F46C:DD5EF0:68CC1D62
       X-Served-By:
-      - cache-bos4672-BOS
+      - cache-bos4670-BOS
       X-Timer:
-      - S1757605873.403542,VS0,VE1
+      - S1758207330.381772,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:29 GMT
+      - Thu, 18 Sep 2025 15:05:30 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_render/test_item_validate.yaml
+++ b/tests/extensions/cassettes/test_render/test_item_validate.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/render/v2.0.0/schema.json
   response:
@@ -97,7 +97,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '343'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -107,7 +107,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:13 GMT
+      - Thu, 18 Sep 2025 14:55:30 GMT
       ETag:
       - '"673d1188-1888"'
       Last-Modified:
@@ -121,19 +121,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - dfd4dade812e20d40138a6da810eb3c4d0547d81
+      - 03f0093f67360a49a38c5642093e61307aa92b28
       X-GitHub-Request-Id:
-      - 1865:153265:C41CFD:DFC0BB:68C2EE99
+      - 3E81:0D6F:C2F46C:DD5EF0:68CC1D62
       X-Served-By:
-      - cache-bos4664-BOS
+      - cache-bos4632-BOS
       X-Timer:
-      - S1757605873.312142,VS0,VE1
+      - S1758207330.231143,VS0,VE70
       expires:
-      - Thu, 11 Sep 2025 15:55:29 GMT
+      - Thu, 18 Sep 2025 15:05:30 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_sar/test_all.yaml
+++ b/tests/extensions/cassettes/test_sar/test_all.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/sar/v1.0.0/schema.json
   response:
@@ -82,7 +82,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -92,7 +92,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:13 GMT
+      - Thu, 18 Sep 2025 14:55:30 GMT
       ETag:
       - '"687775e1-13df"'
       Last-Modified:
@@ -110,15 +110,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - f7385b3127c6025fc2ed0163911ff886de3ac0e5
+      - 0a6b5b0559766b33af0e8ac6b6a472250a828797
       X-GitHub-Request-Id:
-      - ED10:15FE94:C59F45:E13E7A:68C2EE97
+      - C4E5:1D3617:CA1CFB:E48D12:68CC1D62
       X-Served-By:
-      - cache-bos4673-BOS
+      - cache-bos4685-BOS
       X-Timer:
-      - S1757605874.575968,VS0,VE1
+      - S1758207331.586997,VS0,VE12
       expires:
-      - Thu, 11 Sep 2025 15:55:30 GMT
+      - Thu, 18 Sep 2025 15:05:30 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_sar/test_required.yaml
+++ b/tests/extensions/cassettes/test_sar/test_required.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/sar/v1.0.0/schema.json
   response:
@@ -82,7 +82,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '343'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -92,7 +92,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:13 GMT
+      - Thu, 18 Sep 2025 14:55:30 GMT
       ETag:
       - '"687775e1-13df"'
       Last-Modified:
@@ -106,19 +106,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - bfe9edf2e1931e06b6de9f8bd440a594df27b84a
+      - 581754361e1dbd2b57eab92c544d0da80cfba5c2
       X-GitHub-Request-Id:
-      - ED10:15FE94:C59F45:E13E7A:68C2EE97
+      - C4E5:1D3617:CA1CFB:E48D12:68CC1D62
       X-Served-By:
-      - cache-bos4679-BOS
+      - cache-bos4666-BOS
       X-Timer:
-      - S1757605873.493736,VS0,VE2
+      - S1758207330.467280,VS0,VE48
       expires:
-      - Thu, 11 Sep 2025 15:55:30 GMT
+      - Thu, 18 Sep 2025 15:05:30 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_sat/test_absolute_orbit.yaml
+++ b/tests/extensions/cassettes/test_sat/test_absolute_orbit.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/sat/v1.0.0/schema.json
   response:
@@ -63,7 +63,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '345'
+      - '2'
       Cache-Control:
       - max-age=600
       Connection:
@@ -73,7 +73,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:13 GMT
+      - Thu, 18 Sep 2025 14:55:30 GMT
       ETag:
       - '"67627e9d-e82"'
       Last-Modified:
@@ -89,17 +89,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 1323840dabcbd3f4b37ff9a1fb2ad5cd80eb4ec3
+      - 574b9a779db00f76f9216623e9bf141ae44a5e14
       X-GitHub-Request-Id:
-      - 621C:19FF07:BB2CFC:D6CBD0:68C2EE98
+      - 4F00:BAEAA:C82DD6:E297E0:68CC1D60
       X-Served-By:
-      - cache-bos4657-BOS
+      - cache-bos4690-BOS
       X-Timer:
-      - S1757605874.923953,VS0,VE0
+      - S1758207331.957320,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:28 GMT
+      - Thu, 18 Sep 2025 15:05:29 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_sat/test_anx_datetime.yaml
+++ b/tests/extensions/cassettes/test_sat/test_anx_datetime.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/sat/v1.0.0/schema.json
   response:
@@ -63,7 +63,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '345'
+      - '2'
       Cache-Control:
       - max-age=600
       Connection:
@@ -73,7 +73,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:13 GMT
+      - Thu, 18 Sep 2025 14:55:31 GMT
       ETag:
       - '"67627e9d-e82"'
       Last-Modified:
@@ -89,17 +89,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 57bbff1f623a865391e3ac440315ab0a07b8626f
+      - 03d7f1c4253f2c297422e7a131d442cc29cf9d92
       X-GitHub-Request-Id:
-      - 621C:19FF07:BB2CFC:D6CBD0:68C2EE98
+      - 4F00:BAEAA:C82DD6:E297E0:68CC1D60
       X-Served-By:
-      - cache-bos4623-BOS
+      - cache-bos4666-BOS
       X-Timer:
-      - S1757605874.992404,VS0,VE1
+      - S1758207331.025107,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:28 GMT
+      - Thu, 18 Sep 2025 15:05:29 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_sat/test_both.yaml
+++ b/tests/extensions/cassettes/test_sat/test_both.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/sat/v1.0.0/schema.json
   response:
@@ -63,7 +63,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '345'
+      - '2'
       Cache-Control:
       - max-age=600
       Connection:
@@ -73,7 +73,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:14 GMT
+      - Thu, 18 Sep 2025 14:55:31 GMT
       ETag:
       - '"67627e9d-e82"'
       Last-Modified:
@@ -91,15 +91,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 3b00a94f7a91354aed63702ab91136573b1df07c
+      - a6c68a90f4aa07147f404de2190b39defdbf17d5
       X-GitHub-Request-Id:
-      - 621C:19FF07:BB2CFC:D6CBD0:68C2EE98
+      - 4F00:BAEAA:C82DD6:E297E0:68CC1D60
       X-Served-By:
-      - cache-bos4671-BOS
+      - cache-bos4670-BOS
       X-Timer:
-      - S1757605874.205909,VS0,VE2
+      - S1758207331.271586,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:28 GMT
+      - Thu, 18 Sep 2025 15:05:29 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_sat/test_clear_orbit_state.yaml
+++ b/tests/extensions/cassettes/test_sat/test_clear_orbit_state.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/sat/v1.0.0/schema.json
   response:
@@ -63,7 +63,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '345'
+      - '2'
       Cache-Control:
       - max-age=600
       Connection:
@@ -73,7 +73,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:14 GMT
+      - Thu, 18 Sep 2025 14:55:31 GMT
       ETag:
       - '"67627e9d-e82"'
       Last-Modified:
@@ -91,15 +91,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 70b3484addeed5b9f3852643005474b32625af8e
+      - f1e0abff9626c5afa09525df74674f3ac0c2a549
       X-GitHub-Request-Id:
-      - 621C:19FF07:BB2CFC:D6CBD0:68C2EE98
+      - 4F00:BAEAA:C82DD6:E297E0:68CC1D60
       X-Served-By:
-      - cache-bos4652-BOS
+      - cache-bos4660-BOS
       X-Timer:
-      - S1757605874.355622,VS0,VE2
+      - S1758207331.405161,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:28 GMT
+      - Thu, 18 Sep 2025 15:05:29 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_sat/test_clear_relative_orbit.yaml
+++ b/tests/extensions/cassettes/test_sat/test_clear_relative_orbit.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/sat/v1.0.0/schema.json
   response:
@@ -63,7 +63,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '345'
+      - '2'
       Cache-Control:
       - max-age=600
       Connection:
@@ -73,7 +73,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:14 GMT
+      - Thu, 18 Sep 2025 14:55:31 GMT
       ETag:
       - '"67627e9d-e82"'
       Last-Modified:
@@ -91,15 +91,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 00a896761f8fb6e88eed7f07d9d87961a915611a
+      - 6d1880b95b37c610b19b24acf097fe47e8afffab
       X-GitHub-Request-Id:
-      - 621C:19FF07:BB2CFC:D6CBD0:68C2EE98
+      - 4F00:BAEAA:C82DD6:E297E0:68CC1D60
       X-Served-By:
-      - cache-bos4658-BOS
+      - cache-bos4629-BOS
       X-Timer:
-      - S1757605874.432650,VS0,VE1
+      - S1758207331.473245,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:28 GMT
+      - Thu, 18 Sep 2025 15:05:29 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_sat/test_modify.yaml
+++ b/tests/extensions/cassettes/test_sat/test_modify.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/sat/v1.0.0/schema.json
   response:
@@ -63,7 +63,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '345'
+      - '2'
       Cache-Control:
       - max-age=600
       Connection:
@@ -73,7 +73,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:14 GMT
+      - Thu, 18 Sep 2025 14:55:31 GMT
       ETag:
       - '"67627e9d-e82"'
       Last-Modified:
@@ -91,15 +91,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 1feccaea5c785adf6c04e772bde93a418d8bf075
+      - eb8b7cbb4a40a68cbcef94fff9bc4f14156bd1e5
       X-GitHub-Request-Id:
-      - 621C:19FF07:BB2CFC:D6CBD0:68C2EE98
+      - 4F00:BAEAA:C82DD6:E297E0:68CC1D60
       X-Served-By:
-      - cache-bos4631-BOS
+      - cache-bos4686-BOS
       X-Timer:
-      - S1757605874.280042,VS0,VE1
+      - S1758207331.339930,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:28 GMT
+      - Thu, 18 Sep 2025 15:05:29 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_sat/test_no_args_fails.yaml
+++ b/tests/extensions/cassettes/test_sat/test_no_args_fails.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/sat/v1.0.0/schema.json
   response:
@@ -63,7 +63,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '345'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -73,7 +73,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:13 GMT
+      - Thu, 18 Sep 2025 14:55:30 GMT
       ETag:
       - '"67627e9d-e82"'
       Last-Modified:
@@ -91,15 +91,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 396b45781dfe01317ac4797b1e377572dd82f570
+      - e792c4b75ff98308849f514db5b5ca6b15666b04
       X-GitHub-Request-Id:
-      - 621C:19FF07:BB2CFC:D6CBD0:68C2EE98
+      - 4F00:BAEAA:C82DD6:E297E0:68CC1D60
       X-Served-By:
-      - cache-bos4633-BOS
+      - cache-bos4644-BOS
       X-Timer:
-      - S1757605874.679879,VS0,VE2
+      - S1758207331.699202,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:28 GMT
+      - Thu, 18 Sep 2025 15:05:29 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_sat/test_orbit_state.yaml
+++ b/tests/extensions/cassettes/test_sat/test_orbit_state.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/sat/v1.0.0/schema.json
   response:
@@ -63,7 +63,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '345'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -73,7 +73,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:13 GMT
+      - Thu, 18 Sep 2025 14:55:30 GMT
       ETag:
       - '"67627e9d-e82"'
       Last-Modified:
@@ -91,15 +91,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - ef5121a402bcc8949513e4801e5941d5a3649db7
+      - 7ddb1b793dcc42e950cee212ffe83891571857fe
       X-GitHub-Request-Id:
-      - 621C:19FF07:BB2CFC:D6CBD0:68C2EE98
+      - 4F00:BAEAA:C82DD6:E297E0:68CC1D60
       X-Served-By:
-      - cache-bos4675-BOS
+      - cache-bos4681-BOS
       X-Timer:
-      - S1757605874.769035,VS0,VE1
+      - S1758207331.816980,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:28 GMT
+      - Thu, 18 Sep 2025 15:05:29 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_sat/test_platform_international_designator.yaml
+++ b/tests/extensions/cassettes/test_sat/test_platform_international_designator.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/sat/v1.0.0/schema.json
   response:
@@ -63,7 +63,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '345'
+      - '2'
       Cache-Control:
       - max-age=600
       Connection:
@@ -73,7 +73,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:14 GMT
+      - Thu, 18 Sep 2025 14:55:31 GMT
       ETag:
       - '"67627e9d-e82"'
       Last-Modified:
@@ -89,17 +89,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 2d127e395a64ebe7b6d78e87b5b17bad7038a628
+      - 677e231e7fa996c8db138e4fba27739103ebc0ee
       X-GitHub-Request-Id:
-      - 621C:19FF07:BB2CFC:D6CBD0:68C2EE98
+      - 4F00:BAEAA:C82DD6:E297E0:68CC1D60
       X-Served-By:
-      - cache-bos4629-BOS
+      - cache-bos4620-BOS
       X-Timer:
-      - S1757605874.064292,VS0,VE0
+      - S1758207331.113184,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:28 GMT
+      - Thu, 18 Sep 2025 15:05:29 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_sat/test_relative_orbit.yaml
+++ b/tests/extensions/cassettes/test_sat/test_relative_orbit.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/sat/v1.0.0/schema.json
   response:
@@ -63,7 +63,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '345'
+      - '2'
       Cache-Control:
       - max-age=600
       Connection:
@@ -73,7 +73,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:13 GMT
+      - Thu, 18 Sep 2025 14:55:30 GMT
       ETag:
       - '"67627e9d-e82"'
       Last-Modified:
@@ -91,15 +91,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 0e568d3819a62b75f999b626d735b31667c945df
+      - 7566d9917dfdb683add12f7eafee1e0b6b8159d5
       X-GitHub-Request-Id:
-      - 621C:19FF07:BB2CFC:D6CBD0:68C2EE98
+      - 4F00:BAEAA:C82DD6:E297E0:68CC1D60
       X-Served-By:
-      - cache-bos4667-BOS
+      - cache-bos4669-BOS
       X-Timer:
-      - S1757605874.846544,VS0,VE2
+      - S1758207331.888953,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:28 GMT
+      - Thu, 18 Sep 2025 15:05:29 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_sat/test_relative_orbit_no_negative.yaml
+++ b/tests/extensions/cassettes/test_sat/test_relative_orbit_no_negative.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/sat/v1.0.0/schema.json
   response:
@@ -63,7 +63,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '345'
+      - '2'
       Cache-Control:
       - max-age=600
       Connection:
@@ -73,7 +73,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:14 GMT
+      - Thu, 18 Sep 2025 14:55:31 GMT
       ETag:
       - '"67627e9d-e82"'
       Last-Modified:
@@ -91,15 +91,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 917fc7cb3b8cd5bd378e73cf2d3c63deda946da0
+      - 4ae038967192a729e72d8b58d5e9b2942e2d2fce
       X-GitHub-Request-Id:
-      - 621C:19FF07:BB2CFC:D6CBD0:68C2EE98
+      - 4F00:BAEAA:C82DD6:E297E0:68CC1D60
       X-Served-By:
-      - cache-bos4634-BOS
+      - cache-bos4665-BOS
       X-Timer:
-      - S1757605874.141695,VS0,VE2
+      - S1758207331.199601,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:28 GMT
+      - Thu, 18 Sep 2025 15:05:29 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_scientific/test_citation.yaml
+++ b/tests/extensions/cassettes/test_scientific/test_citation.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/scientific/v1.0.0/schema.json
   response:
@@ -89,7 +89,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '356'
+      - '14'
       Cache-Control:
       - max-age=600
       Connection:
@@ -99,7 +99,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:14 GMT
+      - Thu, 18 Sep 2025 14:55:31 GMT
       ETag:
       - '"60febab7-15fa"'
       Last-Modified:
@@ -115,17 +115,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '0'
+      - '1'
       X-Fastly-Request-ID:
-      - 9d90a574d6656a6ab708c67712a3c685343f9058
+      - 07fbeeaa86197f3d155c3fbd5881e57bf772b23a
       X-GitHub-Request-Id:
-      - 3922:128B70:CB9EFB:E73AAF:68C2EE8E
+      - 5CF5:3D35AC:C4B412:DF1A74:68CC1D55
       X-Served-By:
-      - cache-bos4628-BOS
+      - cache-bos4647-BOS
       X-Timer:
-      - S1757605875.636892,VS0,VE1
+      - S1758207332.640243,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:18 GMT
+      - Thu, 18 Sep 2025 15:05:17 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_scientific/test_collection_citation.yaml
+++ b/tests/extensions/cassettes/test_scientific/test_collection_citation.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/scientific/v1.0.0/schema.json
   response:
@@ -89,7 +89,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '357'
+      - '15'
       Cache-Control:
       - max-age=600
       Connection:
@@ -99,7 +99,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:15 GMT
+      - Thu, 18 Sep 2025 14:55:32 GMT
       ETag:
       - '"60febab7-15fa"'
       Last-Modified:
@@ -117,15 +117,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - a455a5fd2f79bf50b41d081cbea801dd0fa64c1f
+      - 1f249938a5f236669f4a72485d578d11bf039190
       X-GitHub-Request-Id:
-      - 3922:128B70:CB9EFB:E73AAF:68C2EE8E
+      - 5CF5:3D35AC:C4B412:DF1A74:68CC1D55
       X-Served-By:
-      - cache-bos4645-BOS
+      - cache-bos4667-BOS
       X-Timer:
-      - S1757605876.508730,VS0,VE1
+      - S1758207333.529249,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:18 GMT
+      - Thu, 18 Sep 2025 15:05:17 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_scientific/test_collection_doi.yaml
+++ b/tests/extensions/cassettes/test_scientific/test_collection_doi.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/scientific/v1.0.0/schema.json
   response:
@@ -89,7 +89,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '357'
+      - '14'
       Cache-Control:
       - max-age=600
       Connection:
@@ -99,7 +99,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:15 GMT
+      - Thu, 18 Sep 2025 14:55:32 GMT
       ETag:
       - '"60febab7-15fa"'
       Last-Modified:
@@ -117,15 +117,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - ee7bf5eb718cfbea89231400e8a65d97eb7a9539
+      - e7797c92050cb3a7ca3a36fd3c9831aad85ff15b
       X-GitHub-Request-Id:
-      - 3922:128B70:CB9EFB:E73AAF:68C2EE8E
+      - 5CF5:3D35AC:C4B412:DF1A74:68CC1D55
       X-Served-By:
-      - cache-bos4661-BOS
+      - cache-bos4626-BOS
       X-Timer:
-      - S1757605875.407589,VS0,VE1
+      - S1758207332.440776,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:18 GMT
+      - Thu, 18 Sep 2025 15:05:17 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_scientific/test_collection_publications.yaml
+++ b/tests/extensions/cassettes/test_scientific/test_collection_publications.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/scientific/v1.0.0/schema.json
   response:
@@ -89,7 +89,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '357'
+      - '15'
       Cache-Control:
       - max-age=600
       Connection:
@@ -99,7 +99,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:15 GMT
+      - Thu, 18 Sep 2025 14:55:32 GMT
       ETag:
       - '"60febab7-15fa"'
       Last-Modified:
@@ -117,15 +117,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - a59534d8586232e8e3d0c9bd09b1f1ab408d3286
+      - 7f2737dd138334f21f6e48fecfedacdd6beb32e9
       X-GitHub-Request-Id:
-      - 3922:128B70:CB9EFB:E73AAF:68C2EE8E
+      - 5CF5:3D35AC:C4B412:DF1A74:68CC1D55
       X-Served-By:
-      - cache-bos4671-BOS
+      - cache-bos4653-BOS
       X-Timer:
-      - S1757605876.684771,VS0,VE44
+      - S1758207333.671315,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:18 GMT
+      - Thu, 18 Sep 2025 15:05:17 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_scientific/test_collection_publications_one.yaml
+++ b/tests/extensions/cassettes/test_scientific/test_collection_publications_one.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/scientific/v1.0.0/schema.json
   response:
@@ -89,7 +89,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '357'
+      - '15'
       Cache-Control:
       - max-age=600
       Connection:
@@ -99,7 +99,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:15 GMT
+      - Thu, 18 Sep 2025 14:55:32 GMT
       ETag:
       - '"60febab7-15fa"'
       Last-Modified:
@@ -115,17 +115,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '1'
       X-Fastly-Request-ID:
-      - f1a1184305272d0aa21d506d1310153d239cc474
+      - c347c16878ec2fcc6a64fb4928c48e9dd1f40346
       X-GitHub-Request-Id:
-      - 3922:128B70:CB9EFB:E73AAF:68C2EE8E
+      - 5CF5:3D35AC:C4B412:DF1A74:68CC1D55
       X-Served-By:
-      - cache-bos4641-BOS
+      - cache-bos4659-BOS
       X-Timer:
-      - S1757605876.602576,VS0,VE1
+      - S1758207333.600884,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:18 GMT
+      - Thu, 18 Sep 2025 15:05:17 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_scientific/test_collection_remove_all_publications_one.yaml
+++ b/tests/extensions/cassettes/test_scientific/test_collection_remove_all_publications_one.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/scientific/v1.0.0/schema.json
   response:
@@ -89,7 +89,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '358'
+      - '15'
       Cache-Control:
       - max-age=600
       Connection:
@@ -99,7 +99,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:15 GMT
+      - Thu, 18 Sep 2025 14:55:32 GMT
       ETag:
       - '"60febab7-15fa"'
       Last-Modified:
@@ -117,15 +117,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 674bd584e104ee858762b56202babbf2f888fd8a
+      - 8d4b7a94a2431a7ebd3163d932a2507c4627f4a2
       X-GitHub-Request-Id:
-      - 3922:128B70:CB9EFB:E73AAF:68C2EE8E
+      - 5CF5:3D35AC:C4B412:DF1A74:68CC1D55
       X-Served-By:
-      - cache-bos4669-BOS
+      - cache-bos4628-BOS
       X-Timer:
-      - S1757605876.878690,VS0,VE1
+      - S1758207333.816892,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:18 GMT
+      - Thu, 18 Sep 2025 15:05:17 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_scientific/test_collection_remove_all_publications_with_none.yaml
+++ b/tests/extensions/cassettes/test_scientific/test_collection_remove_all_publications_with_none.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/scientific/v1.0.0/schema.json
   response:
@@ -89,7 +89,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '358'
+      - '15'
       Cache-Control:
       - max-age=600
       Connection:
@@ -99,7 +99,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:16 GMT
+      - Thu, 18 Sep 2025 14:55:33 GMT
       ETag:
       - '"60febab7-15fa"'
       Last-Modified:
@@ -117,15 +117,15 @@ interactions:
       X-Cache-Hits:
       - '2'
       X-Fastly-Request-ID:
-      - a415215da04498032af573ee7fb3cd4b025e586e
+      - 36eb27acfb426bc7d2378a0b7c9fe644227e5d17
       X-GitHub-Request-Id:
-      - 3922:128B70:CB9EFB:E73AAF:68C2EE8E
+      - 5CF5:3D35AC:C4B412:DF1A74:68CC1D55
       X-Served-By:
-      - cache-bos4629-BOS
+      - cache-bos4638-BOS
       X-Timer:
-      - S1757605876.228644,VS0,VE1
+      - S1758207333.167649,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:18 GMT
+      - Thu, 18 Sep 2025 15:05:17 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_scientific/test_collection_remove_all_publications_with_some.yaml
+++ b/tests/extensions/cassettes/test_scientific/test_collection_remove_all_publications_with_some.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/scientific/v1.0.0/schema.json
   response:
@@ -89,7 +89,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '358'
+      - '15'
       Cache-Control:
       - max-age=600
       Connection:
@@ -99,7 +99,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:16 GMT
+      - Thu, 18 Sep 2025 14:55:33 GMT
       ETag:
       - '"60febab7-15fa"'
       Last-Modified:
@@ -117,15 +117,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 235a7118993343169acaeda6761117e421852c39
+      - 08b22d0149a757d2156b7503f36734601f7783f6
       X-GitHub-Request-Id:
-      - 3922:128B70:CB9EFB:E73AAF:68C2EE8E
+      - 5CF5:3D35AC:C4B412:DF1A74:68CC1D55
       X-Served-By:
-      - cache-bos4629-BOS
+      - cache-bos4641-BOS
       X-Timer:
-      - S1757605876.144602,VS0,VE2
+      - S1758207333.089735,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:18 GMT
+      - Thu, 18 Sep 2025 15:05:17 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_scientific/test_collection_remove_publication_forward.yaml
+++ b/tests/extensions/cassettes/test_scientific/test_collection_remove_publication_forward.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/scientific/v1.0.0/schema.json
   response:
@@ -89,7 +89,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '358'
+      - '15'
       Cache-Control:
       - max-age=600
       Connection:
@@ -99,7 +99,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:15 GMT
+      - Thu, 18 Sep 2025 14:55:32 GMT
       ETag:
       - '"60febab7-15fa"'
       Last-Modified:
@@ -115,17 +115,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '1'
       X-Fastly-Request-ID:
-      - 60d84c6536087932ad163cc2c738275bc851eb53
+      - 8766196907bb504a3bc0a2b53206f94da8f1f46b
       X-GitHub-Request-Id:
-      - 3922:128B70:CB9EFB:E73AAF:68C2EE8E
+      - 5CF5:3D35AC:C4B412:DF1A74:68CC1D55
       X-Served-By:
-      - cache-bos4638-BOS
+      - cache-bos4651-BOS
       X-Timer:
-      - S1757605876.967481,VS0,VE0
+      - S1758207333.904971,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:18 GMT
+      - Thu, 18 Sep 2025 15:05:17 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_scientific/test_collection_remove_publication_one.yaml
+++ b/tests/extensions/cassettes/test_scientific/test_collection_remove_publication_one.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/scientific/v1.0.0/schema.json
   response:
@@ -89,7 +89,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '357'
+      - '15'
       Cache-Control:
       - max-age=600
       Connection:
@@ -99,7 +99,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:15 GMT
+      - Thu, 18 Sep 2025 14:55:32 GMT
       ETag:
       - '"60febab7-15fa"'
       Last-Modified:
@@ -115,17 +115,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - f53c85d8a17ca0ecaeda92cc8113316825200b5d
+      - a36566d1e820e252454fcaaff76314b29bd5f32b
       X-GitHub-Request-Id:
-      - 3922:128B70:CB9EFB:E73AAF:68C2EE8E
+      - 5CF5:3D35AC:C4B412:DF1A74:68CC1D55
       X-Served-By:
-      - cache-bos4666-BOS
+      - cache-bos4665-BOS
       X-Timer:
-      - S1757605876.805828,VS0,VE0
+      - S1758207333.745181,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:18 GMT
+      - Thu, 18 Sep 2025 15:05:17 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_scientific/test_collection_remove_publication_reverse.yaml
+++ b/tests/extensions/cassettes/test_scientific/test_collection_remove_publication_reverse.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/scientific/v1.0.0/schema.json
   response:
@@ -89,7 +89,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '358'
+      - '15'
       Cache-Control:
       - max-age=600
       Connection:
@@ -99,7 +99,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:16 GMT
+      - Thu, 18 Sep 2025 14:55:33 GMT
       ETag:
       - '"60febab7-15fa"'
       Last-Modified:
@@ -117,15 +117,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - a42e9ea6400ee14d61fe50b63bd81f7698d2713c
+      - bf4a8974b7b559cd2604c42182cab1f9cd2138ff
       X-GitHub-Request-Id:
-      - 3922:128B70:CB9EFB:E73AAF:68C2EE8E
+      - 5CF5:3D35AC:C4B412:DF1A74:68CC1D55
       X-Served-By:
-      - cache-bos4664-BOS
+      - cache-bos4629-BOS
       X-Timer:
-      - S1757605876.054606,VS0,VE2
+      - S1758207333.001393,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:18 GMT
+      - Thu, 18 Sep 2025 15:05:17 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_scientific/test_doi.yaml
+++ b/tests/extensions/cassettes/test_scientific/test_doi.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/scientific/v1.0.0/schema.json
   response:
@@ -89,7 +89,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '356'
+      - '14'
       Cache-Control:
       - max-age=600
       Connection:
@@ -99,7 +99,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:14 GMT
+      - Thu, 18 Sep 2025 14:55:31 GMT
       ETag:
       - '"60febab7-15fa"'
       Last-Modified:
@@ -115,17 +115,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '1'
       X-Fastly-Request-ID:
-      - 3fc4ea6b4fe185197fad9d86813b7511b0b919a6
+      - 3cf86c6b58c845cc46915ee020b47fa77a9ebd5c
       X-GitHub-Request-Id:
-      - 3922:128B70:CB9EFB:E73AAF:68C2EE8E
+      - 5CF5:3D35AC:C4B412:DF1A74:68CC1D55
       X-Served-By:
-      - cache-bos4691-BOS
+      - cache-bos4671-BOS
       X-Timer:
-      - S1757605875.533994,VS0,VE0
+      - S1758207332.558990,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:18 GMT
+      - Thu, 18 Sep 2025 15:05:17 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_scientific/test_publications.yaml
+++ b/tests/extensions/cassettes/test_scientific/test_publications.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/scientific/v1.0.0/schema.json
   response:
@@ -89,7 +89,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '357'
+      - '14'
       Cache-Control:
       - max-age=600
       Connection:
@@ -99,7 +99,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:14 GMT
+      - Thu, 18 Sep 2025 14:55:31 GMT
       ETag:
       - '"60febab7-15fa"'
       Last-Modified:
@@ -115,17 +115,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - a01d78ebde7bbd1863de6429898e4873e41369b0
+      - db6961b7421bf162403b91f39baf2be04b5d5f57
       X-GitHub-Request-Id:
-      - 3922:128B70:CB9EFB:E73AAF:68C2EE8E
+      - 5CF5:3D35AC:C4B412:DF1A74:68CC1D55
       X-Served-By:
-      - cache-bos4687-BOS
+      - cache-bos4690-BOS
       X-Timer:
-      - S1757605875.814452,VS0,VE0
+      - S1758207332.777419,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:18 GMT
+      - Thu, 18 Sep 2025 15:05:17 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_scientific/test_publications_one.yaml
+++ b/tests/extensions/cassettes/test_scientific/test_publications_one.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/scientific/v1.0.0/schema.json
   response:
@@ -89,7 +89,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '356'
+      - '14'
       Cache-Control:
       - max-age=600
       Connection:
@@ -99,7 +99,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:14 GMT
+      - Thu, 18 Sep 2025 14:55:31 GMT
       ETag:
       - '"60febab7-15fa"'
       Last-Modified:
@@ -117,15 +117,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - a1e0a5d6a609927000f7eb0a71c5e1c32d0e0508
+      - 81730cc292c5f9b882616ec8733860f83b333dbd
       X-GitHub-Request-Id:
-      - 3922:128B70:CB9EFB:E73AAF:68C2EE8E
+      - 5CF5:3D35AC:C4B412:DF1A74:68CC1D55
       X-Served-By:
-      - cache-bos4672-BOS
+      - cache-bos4660-BOS
       X-Timer:
-      - S1757605875.723205,VS0,VE1
+      - S1758207332.713393,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:18 GMT
+      - Thu, 18 Sep 2025 15:05:17 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_scientific/test_remove_all_publications_one.yaml
+++ b/tests/extensions/cassettes/test_scientific/test_remove_all_publications_one.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/scientific/v1.0.0/schema.json
   response:
@@ -89,7 +89,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '357'
+      - '14'
       Cache-Control:
       - max-age=600
       Connection:
@@ -99,7 +99,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:14 GMT
+      - Thu, 18 Sep 2025 14:55:31 GMT
       ETag:
       - '"60febab7-15fa"'
       Last-Modified:
@@ -115,17 +115,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - b62b9f9cc2b253cb2c4ded060ac0e457f6cfea7b
+      - 1e7a5f37368bc016993e4490810722dc3399f9d6
       X-GitHub-Request-Id:
-      - 3922:128B70:CB9EFB:E73AAF:68C2EE8E
+      - 5CF5:3D35AC:C4B412:DF1A74:68CC1D55
       X-Served-By:
-      - cache-bos4638-BOS
+      - cache-bos4681-BOS
       X-Timer:
-      - S1757605875.989326,VS0,VE0
+      - S1758207332.933302,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:18 GMT
+      - Thu, 18 Sep 2025 15:05:17 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_scientific/test_remove_all_publications_with_none.yaml
+++ b/tests/extensions/cassettes/test_scientific/test_remove_all_publications_with_none.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/scientific/v1.0.0/schema.json
   response:
@@ -89,7 +89,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '357'
+      - '14'
       Cache-Control:
       - max-age=600
       Connection:
@@ -99,7 +99,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:15 GMT
+      - Thu, 18 Sep 2025 14:55:32 GMT
       ETag:
       - '"60febab7-15fa"'
       Last-Modified:
@@ -117,15 +117,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 13f6bc2786d1887f11e6b914a67669e311e73ae1
+      - ee30393c2f4a3c1e718934da32fb688e11086e99
       X-GitHub-Request-Id:
-      - 3922:128B70:CB9EFB:E73AAF:68C2EE8E
+      - 5CF5:3D35AC:C4B412:DF1A74:68CC1D55
       X-Served-By:
-      - cache-bos4621-BOS
+      - cache-bos4679-BOS
       X-Timer:
-      - S1757605875.317859,VS0,VE1
+      - S1758207332.295020,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:18 GMT
+      - Thu, 18 Sep 2025 15:05:17 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_scientific/test_remove_all_publications_with_some.yaml
+++ b/tests/extensions/cassettes/test_scientific/test_remove_all_publications_with_some.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/scientific/v1.0.0/schema.json
   response:
@@ -89,7 +89,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '357'
+      - '14'
       Cache-Control:
       - max-age=600
       Connection:
@@ -99,7 +99,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:15 GMT
+      - Thu, 18 Sep 2025 14:55:32 GMT
       ETag:
       - '"60febab7-15fa"'
       Last-Modified:
@@ -115,17 +115,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '1'
       X-Fastly-Request-ID:
-      - 940ac51801a8a81a732b143e40ac560207c0c843
+      - 39931c12c1b2c0e5b9cbfb30ea0d8f18d4b76b5d
       X-GitHub-Request-Id:
-      - 3922:128B70:CB9EFB:E73AAF:68C2EE8E
+      - 5CF5:3D35AC:C4B412:DF1A74:68CC1D55
       X-Served-By:
-      - cache-bos4651-BOS
+      - cache-bos4655-BOS
       X-Timer:
-      - S1757605875.236999,VS0,VE0
+      - S1758207332.205477,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:18 GMT
+      - Thu, 18 Sep 2025 15:05:17 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_scientific/test_remove_publication_forward.yaml
+++ b/tests/extensions/cassettes/test_scientific/test_remove_publication_forward.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/scientific/v1.0.0/schema.json
   response:
@@ -89,7 +89,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '357'
+      - '14'
       Cache-Control:
       - max-age=600
       Connection:
@@ -99,7 +99,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:15 GMT
+      - Thu, 18 Sep 2025 14:55:32 GMT
       ETag:
       - '"60febab7-15fa"'
       Last-Modified:
@@ -115,17 +115,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - a475dea1213a4fd2abbec8f1e6b01dbd7138fa35
+      - e9619a4cb2b18c7ea6f11e387efcf7a86ddf5e9c
       X-GitHub-Request-Id:
-      - 3922:128B70:CB9EFB:E73AAF:68C2EE8E
+      - 5CF5:3D35AC:C4B412:DF1A74:68CC1D55
       X-Served-By:
-      - cache-bos4673-BOS
+      - cache-bos4638-BOS
       X-Timer:
-      - S1757605875.071664,VS0,VE0
+      - S1758207332.017379,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:18 GMT
+      - Thu, 18 Sep 2025 15:05:17 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_scientific/test_remove_publication_one.yaml
+++ b/tests/extensions/cassettes/test_scientific/test_remove_publication_one.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/scientific/v1.0.0/schema.json
   response:
@@ -89,7 +89,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '357'
+      - '14'
       Cache-Control:
       - max-age=600
       Connection:
@@ -99,7 +99,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:14 GMT
+      - Thu, 18 Sep 2025 14:55:31 GMT
       ETag:
       - '"60febab7-15fa"'
       Last-Modified:
@@ -117,15 +117,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 0092b0148622f344e8cff5c5e0022350c70eb589
+      - 546d68bf0901c9642c9da60be6af35d7e48a869f
       X-GitHub-Request-Id:
-      - 3922:128B70:CB9EFB:E73AAF:68C2EE8E
+      - 5CF5:3D35AC:C4B412:DF1A74:68CC1D55
       X-Served-By:
-      - cache-bos4624-BOS
+      - cache-bos4645-BOS
       X-Timer:
-      - S1757605875.895763,VS0,VE2
+      - S1758207332.861129,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:18 GMT
+      - Thu, 18 Sep 2025 15:05:17 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_scientific/test_remove_publication_reverse.yaml
+++ b/tests/extensions/cassettes/test_scientific/test_remove_publication_reverse.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/scientific/v1.0.0/schema.json
   response:
@@ -89,7 +89,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '357'
+      - '14'
       Cache-Control:
       - max-age=600
       Connection:
@@ -99,7 +99,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:15 GMT
+      - Thu, 18 Sep 2025 14:55:32 GMT
       ETag:
       - '"60febab7-15fa"'
       Last-Modified:
@@ -117,15 +117,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 837a95738c75a6641ef7944dbe551f4b12875889
+      - 59f0316167cab97e223c83dc634de2612d03f8e8
       X-GitHub-Request-Id:
-      - 3922:128B70:CB9EFB:E73AAF:68C2EE8E
+      - 5CF5:3D35AC:C4B412:DF1A74:68CC1D55
       X-Served-By:
-      - cache-bos4623-BOS
+      - cache-bos4650-BOS
       X-Timer:
-      - S1757605875.158302,VS0,VE2
+      - S1758207332.112455,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:18 GMT
+      - Thu, 18 Sep 2025 15:05:17 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_storage/test_asset_platform.yaml
+++ b/tests/extensions/cassettes/test_storage/test_asset_platform.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/storage/v1.0.0/schema.json
   response:
@@ -53,7 +53,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '343'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -63,7 +63,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:16 GMT
+      - Thu, 18 Sep 2025 14:55:33 GMT
       ETag:
       - '"6718ce4f-b93"'
       Last-Modified:
@@ -79,17 +79,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 92674dc3dfaefe5b3479061fdefa80bda6920c04
+      - 1ae6b4c625e9fa15141dce043fcf4955309b9ccd
       X-GitHub-Request-Id:
-      - EA28:14A395:C58F5E:E13700:68C2EE9C
+      - F43B:358B9B:CCD30F:E73A5D:68CC1D63
       X-Served-By:
-      - cache-bos4656-BOS
+      - cache-bos4677-BOS
       X-Timer:
-      - S1757605876.432360,VS0,VE0
+      - S1758207333.407569,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:32 GMT
+      - Thu, 18 Sep 2025 15:05:33 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_storage/test_asset_region.yaml
+++ b/tests/extensions/cassettes/test_storage/test_asset_region.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/storage/v1.0.0/schema.json
   response:
@@ -53,7 +53,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -63,7 +63,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:16 GMT
+      - Thu, 18 Sep 2025 14:55:33 GMT
       ETag:
       - '"6718ce4f-b93"'
       Last-Modified:
@@ -81,15 +81,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - e5ff930a35d9971257acf5bf329b54c55c4ae20f
+      - eef34cdf9248f063f646a0e63217d227d8b6b714
       X-GitHub-Request-Id:
-      - EA28:14A395:C58F5E:E13700:68C2EE9C
+      - F43B:358B9B:CCD30F:E73A5D:68CC1D63
       X-Served-By:
-      - cache-bos4651-BOS
+      - cache-bos4653-BOS
       X-Timer:
-      - S1757605877.524961,VS0,VE1
+      - S1758207333.496885,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:32 GMT
+      - Thu, 18 Sep 2025 15:05:33 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_storage/test_asset_requester_pays.yaml
+++ b/tests/extensions/cassettes/test_storage/test_asset_requester_pays.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/storage/v1.0.0/schema.json
   response:
@@ -53,7 +53,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -63,7 +63,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:16 GMT
+      - Thu, 18 Sep 2025 14:55:33 GMT
       ETag:
       - '"6718ce4f-b93"'
       Last-Modified:
@@ -81,15 +81,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 3a03e05e5620f03f0551af03f53d8630e6940446
+      - e30c722af5ab28057dc072530eb559ddfb72e053
       X-GitHub-Request-Id:
-      - EA28:14A395:C58F5E:E13700:68C2EE9C
+      - F43B:358B9B:CCD30F:E73A5D:68CC1D63
       X-Served-By:
-      - cache-bos4688-BOS
+      - cache-bos4641-BOS
       X-Timer:
-      - S1757605877.613861,VS0,VE1
+      - S1758207334.589641,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:32 GMT
+      - Thu, 18 Sep 2025 15:05:33 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_storage/test_asset_tier.yaml
+++ b/tests/extensions/cassettes/test_storage/test_asset_tier.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/storage/v1.0.0/schema.json
   response:
@@ -53,7 +53,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -63,7 +63,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:16 GMT
+      - Thu, 18 Sep 2025 14:55:33 GMT
       ETag:
       - '"6718ce4f-b93"'
       Last-Modified:
@@ -79,17 +79,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '1'
       X-Fastly-Request-ID:
-      - d0228bdff814b6e1338fd913e7452c142bceb5bd
+      - 03beab00205d71186fb17269bf123629d7e79818
       X-GitHub-Request-Id:
-      - EA28:14A395:C58F5E:E13700:68C2EE9C
+      - F43B:358B9B:CCD30F:E73A5D:68CC1D63
       X-Served-By:
-      - cache-bos4656-BOS
+      - cache-bos4643-BOS
       X-Timer:
-      - S1757605877.707950,VS0,VE0
+      - S1758207334.683524,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:32 GMT
+      - Thu, 18 Sep 2025 15:05:33 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_storage/test_validate_storage.yaml
+++ b/tests/extensions/cassettes/test_storage/test_validate_storage.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/storage/v1.0.0/schema.json
   response:
@@ -53,7 +53,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -63,7 +63,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:16 GMT
+      - Thu, 18 Sep 2025 14:55:33 GMT
       ETag:
       - '"6718ce4f-b93"'
       Last-Modified:
@@ -77,19 +77,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - ad6f364553f4de6791f2532325ce5528079d63c6
+      - fa1b7e0b0a082c62df3104a71affc1d1bdafc129
       X-GitHub-Request-Id:
-      - EA28:14A395:C58F5E:E13700:68C2EE9C
+      - F43B:358B9B:CCD30F:E73A5D:68CC1D63
       X-Served-By:
-      - cache-bos4657-BOS
+      - cache-bos4644-BOS
       X-Timer:
-      - S1757605876.328052,VS0,VE1
+      - S1758207333.267612,VS0,VE26
       expires:
-      - Thu, 11 Sep 2025 15:55:32 GMT
+      - Thu, 18 Sep 2025 15:05:33 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_table/test_validate.yaml
+++ b/tests/extensions/cassettes/test_table/test_validate.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/table/v1.2.0/schema.json
   response:
@@ -91,7 +91,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -101,7 +101,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:16 GMT
+      - Thu, 18 Sep 2025 14:55:33 GMT
       ETag:
       - '"612cf691-16c2"'
       Last-Modified:
@@ -115,19 +115,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 57bb53a070dda24684ba11d932b50ad36c76c180
+      - cfedb83060cba2739f5885fe0fda28a69ba74240
       X-GitHub-Request-Id:
-      - E2AA:1C0114:1BE7583:1F239CF:68C2EE9B
+      - 4E58:3AF598:D6E900:F14FE2:68CC1D65
       X-Served-By:
-      - cache-bos4648-BOS
+      - cache-bos4671-BOS
       X-Timer:
-      - S1757605877.790121,VS0,VE1
+      - S1758207334.770734,VS0,VE26
       expires:
-      - Thu, 11 Sep 2025 15:55:33 GMT
+      - Thu, 18 Sep 2025 15:05:33 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_timestamps/test_expires.yaml
+++ b/tests/extensions/cassettes/test_timestamps/test_expires.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/timestamps/v1.1.0/schema.json
   response:
@@ -59,7 +59,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -69,7 +69,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:16 GMT
+      - Thu, 18 Sep 2025 14:55:34 GMT
       ETag:
       - '"63b6c089-d09"'
       Last-Modified:
@@ -87,15 +87,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 3bb8bdcc61f03279d8bc8a7f3988ef54275708da
+      - a601809aae13bc1e11a78148ca0403a9f9464ee8
       X-GitHub-Request-Id:
-      - 5D7C:128B70:CBAEF3:E74C93:68C2EE9D
+      - AECF:1D3617:CA21B7:E4923F:68CC1D65
       X-Served-By:
-      - cache-bos4627-BOS
+      - cache-bos4622-BOS
       X-Timer:
-      - S1757605877.980313,VS0,VE1
+      - S1758207334.041775,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:33 GMT
+      - Thu, 18 Sep 2025 15:05:33 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_timestamps/test_published.yaml
+++ b/tests/extensions/cassettes/test_timestamps/test_published.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/timestamps/v1.1.0/schema.json
   response:
@@ -59,7 +59,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -69,7 +69,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:17 GMT
+      - Thu, 18 Sep 2025 14:55:34 GMT
       ETag:
       - '"63b6c089-d09"'
       Last-Modified:
@@ -87,15 +87,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - c619794cfc5aa00f7109eebc5b1465c23ab9ebc4
+      - 2162171758d565876ed4f8b792737186b9a73c38
       X-GitHub-Request-Id:
-      - 5D7C:128B70:CBAEF3:E74C93:68C2EE9D
+      - AECF:1D3617:CA21B7:E4923F:68CC1D65
       X-Served-By:
-      - cache-bos4642-BOS
+      - cache-bos4643-BOS
       X-Timer:
-      - S1757605877.061845,VS0,VE1
+      - S1758207334.135245,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:33 GMT
+      - Thu, 18 Sep 2025 15:05:33 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_timestamps/test_unpublished.yaml
+++ b/tests/extensions/cassettes/test_timestamps/test_unpublished.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/timestamps/v1.1.0/schema.json
   response:
@@ -59,7 +59,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -69,7 +69,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:17 GMT
+      - Thu, 18 Sep 2025 14:55:34 GMT
       ETag:
       - '"63b6c089-d09"'
       Last-Modified:
@@ -87,15 +87,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 6443e152e55deeb32cf8ae077d0bf0ad60cedc6e
+      - 3bcddf4e47b62c174eb6128a5602bcf55db4e778
       X-GitHub-Request-Id:
-      - 5D7C:128B70:CBAEF3:E74C93:68C2EE9D
+      - AECF:1D3617:CA21B7:E4923F:68CC1D65
       X-Served-By:
-      - cache-bos4676-BOS
+      - cache-bos4653-BOS
       X-Timer:
-      - S1757605877.143592,VS0,VE19
+      - S1758207334.227487,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:33 GMT
+      - Thu, 18 Sep 2025 15:05:33 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_timestamps/test_validate_timestamps.yaml
+++ b/tests/extensions/cassettes/test_timestamps/test_validate_timestamps.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/timestamps/v1.1.0/schema.json
   response:
@@ -59,7 +59,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -69,7 +69,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:16 GMT
+      - Thu, 18 Sep 2025 14:55:33 GMT
       ETag:
       - '"63b6c089-d09"'
       Last-Modified:
@@ -83,19 +83,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - ea0b039508b3ba49effa555463b93285e44b25c9
+      - 4e87255fc26597a92ca63fff99d3ac7d7f1853ee
       X-GitHub-Request-Id:
-      - 5D7C:128B70:CBAEF3:E74C93:68C2EE9D
+      - AECF:1D3617:CA21B7:E4923F:68CC1D65
       X-Served-By:
-      - cache-bos4693-BOS
+      - cache-bos4648-BOS
       X-Timer:
-      - S1757605877.891833,VS0,VE1
+      - S1758207334.891344,VS0,VE61
       expires:
-      - Thu, 11 Sep 2025 15:55:33 GMT
+      - Thu, 18 Sep 2025 15:05:33 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_version/test_add_deprecated_version.yaml
+++ b/tests/extensions/cassettes/test_version/test_add_deprecated_version.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/version/v1.2.0/schema.json
   response:
@@ -61,7 +61,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -71,7 +71,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:17 GMT
+      - Thu, 18 Sep 2025 14:55:34 GMT
       ETag:
       - '"645249bd-d4d"'
       Last-Modified:
@@ -89,15 +89,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - e02308b9c9d43240b5d79d4755a3241f1cb44f37
+      - 64d7aa122b1f49962fc8cb1ea30dadbe1c35d82e
       X-GitHub-Request-Id:
-      - 7032:A4A55:2162D75:253434B:68C2EE9B
+      - 47C6:BCA08:C42B16:DE942D:68CC1D66
       X-Served-By:
-      - cache-bos4679-BOS
+      - cache-bos4656-BOS
       X-Timer:
-      - S1757605878.525758,VS0,VE1
+      - S1758207335.643175,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:33 GMT
+      - Thu, 18 Sep 2025 15:05:34 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_version/test_add_not_deprecated_version.yaml
+++ b/tests/extensions/cassettes/test_version/test_add_not_deprecated_version.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/version/v1.2.0/schema.json
   response:
@@ -61,7 +61,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -71,7 +71,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:17 GMT
+      - Thu, 18 Sep 2025 14:55:34 GMT
       ETag:
       - '"645249bd-d4d"'
       Last-Modified:
@@ -89,15 +89,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - d5fd921db094029cbd71022dca1f0dab033d6eb0
+      - fc1116955581ac876f298ef1753b583e7ca23372
       X-GitHub-Request-Id:
-      - 7032:A4A55:2162D75:253434B:68C2EE9B
+      - 47C6:BCA08:C42B16:DE942D:68CC1D66
       X-Served-By:
-      - cache-bos4673-BOS
+      - cache-bos4678-BOS
       X-Timer:
-      - S1757605877.432382,VS0,VE1
+      - S1758207335.555267,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:33 GMT
+      - Thu, 18 Sep 2025 15:05:34 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_version/test_add_version.yaml
+++ b/tests/extensions/cassettes/test_version/test_add_version.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/version/v1.2.0/schema.json
   response:
@@ -61,7 +61,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -71,7 +71,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:17 GMT
+      - Thu, 18 Sep 2025 14:55:34 GMT
       ETag:
       - '"645249bd-d4d"'
       Last-Modified:
@@ -85,19 +85,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 63c1886d816dd3f2fc8551d3835010ad83cbd308
+      - 34dc39dc44a070b5111033bdb6b976ce84da1535
       X-GitHub-Request-Id:
-      - 7032:A4A55:2162D75:253434B:68C2EE9B
+      - 47C6:BCA08:C42B16:DE942D:68CC1D66
       X-Served-By:
-      - cache-bos4636-BOS
+      - cache-bos4671-BOS
       X-Timer:
-      - S1757605877.259243,VS0,VE2
+      - S1758207334.327404,VS0,VE56
       expires:
-      - Thu, 11 Sep 2025 15:55:33 GMT
+      - Thu, 18 Sep 2025 15:05:34 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_version/test_all_links.yaml
+++ b/tests/extensions/cassettes/test_version/test_all_links.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/version/v1.2.0/schema.json
   response:
@@ -61,7 +61,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -71,7 +71,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:17 GMT
+      - Thu, 18 Sep 2025 14:55:34 GMT
       ETag:
       - '"645249bd-d4d"'
       Last-Modified:
@@ -87,17 +87,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 6cfaa26545b134de92d0dc45e90d43d1a0e3ea3a
+      - 1c89cf1d4350338ae317de26975f6b9e683aea3d
       X-GitHub-Request-Id:
-      - 7032:A4A55:2162D75:253434B:68C2EE9B
+      - 47C6:BCA08:C42B16:DE942D:68CC1D66
       X-Served-By:
-      - cache-bos4684-BOS
+      - cache-bos4622-BOS
       X-Timer:
-      - S1757605878.893950,VS0,VE0
+      - S1758207335.987904,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:33 GMT
+      - Thu, 18 Sep 2025 15:05:34 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_version/test_assets.yaml
+++ b/tests/extensions/cassettes/test_version/test_assets.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/version/v1.2.0/schema.json
   response:
@@ -61,7 +61,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '345'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -71,7 +71,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:18 GMT
+      - Thu, 18 Sep 2025 14:55:35 GMT
       ETag:
       - '"645249bd-d4d"'
       Last-Modified:
@@ -89,15 +89,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 7daeff350efc41cbc53e7e5feb6240817b47eb9b
+      - a85a368ded1957b288c6cfb2855f3dfd3ab6516e
       X-GitHub-Request-Id:
-      - 7032:A4A55:2162D75:253434B:68C2EE9B
+      - 47C6:BCA08:C42B16:DE942D:68CC1D66
       X-Served-By:
-      - cache-bos4622-BOS
+      - cache-bos4638-BOS
       X-Timer:
-      - S1757605878.419745,VS0,VE1
+      - S1758207336.527649,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:33 GMT
+      - Thu, 18 Sep 2025 15:05:34 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_version/test_catalog_add_version.yaml
+++ b/tests/extensions/cassettes/test_version/test_catalog_add_version.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/version/v1.2.0/schema.json
   response:
@@ -61,7 +61,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '345'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -71,7 +71,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:18 GMT
+      - Thu, 18 Sep 2025 14:55:35 GMT
       ETag:
       - '"645249bd-d4d"'
       Last-Modified:
@@ -87,17 +87,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - a26d241bc163be5ba317cccc527f665db42fa9a3
+      - c43ebd46b25106a01845b76f7df9f6b49d898632
       X-GitHub-Request-Id:
-      - 7032:A4A55:2162D75:253434B:68C2EE9B
+      - 47C6:BCA08:C42B16:DE942D:68CC1D66
       X-Served-By:
-      - cache-bos4673-BOS
+      - cache-bos4637-BOS
       X-Timer:
-      - S1757605878.159751,VS0,VE0
+      - S1758207335.257999,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:33 GMT
+      - Thu, 18 Sep 2025 15:05:34 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_version/test_catalog_validate_all.yaml
+++ b/tests/extensions/cassettes/test_version/test_catalog_validate_all.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/version/v1.2.0/schema.json
   response:
@@ -61,7 +61,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '345'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -71,7 +71,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:18 GMT
+      - Thu, 18 Sep 2025 14:55:35 GMT
       ETag:
       - '"645249bd-d4d"'
       Last-Modified:
@@ -87,17 +87,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Fastly-Request-ID:
-      - ea4978360fa53533bd08053539b00efc28cf6985
+      - e75971697f8c8f57488eea85f7c5190ea7d2fa07
       X-GitHub-Request-Id:
-      - 7032:A4A55:2162D75:253434B:68C2EE9B
+      - 47C6:BCA08:C42B16:DE942D:68CC1D66
       X-Served-By:
-      - cache-bos4665-BOS
+      - cache-bos4642-BOS
       X-Timer:
-      - S1757605878.239809,VS0,VE1
+      - S1758207335.342784,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:33 GMT
+      - Thu, 18 Sep 2025 15:05:34 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_version/test_collection_add_version.yaml
+++ b/tests/extensions/cassettes/test_version/test_collection_add_version.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/version/v1.2.0/schema.json
   response:
@@ -61,7 +61,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -71,7 +71,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:17 GMT
+      - Thu, 18 Sep 2025 14:55:35 GMT
       ETag:
       - '"645249bd-d4d"'
       Last-Modified:
@@ -89,15 +89,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 6476e3484316639fd3f2bebec0628d15a60558cc
+      - 00dd1a50e682385f0c28cd4b8d6503678680035b
       X-GitHub-Request-Id:
-      - 7032:A4A55:2162D75:253434B:68C2EE9B
+      - 47C6:BCA08:C42B16:DE942D:68CC1D66
       X-Served-By:
-      - cache-bos4654-BOS
+      - cache-bos4642-BOS
       X-Timer:
-      - S1757605878.997349,VS0,VE2
+      - S1758207335.087621,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:33 GMT
+      - Thu, 18 Sep 2025 15:05:34 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_version/test_collection_validate_all.yaml
+++ b/tests/extensions/cassettes/test_version/test_collection_validate_all.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/version/v1.2.0/schema.json
   response:
@@ -61,7 +61,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -71,7 +71,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:18 GMT
+      - Thu, 18 Sep 2025 14:55:35 GMT
       ETag:
       - '"645249bd-d4d"'
       Last-Modified:
@@ -89,15 +89,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 9d3011b53e4b80e9ecf15e118088ac32fca87a32
+      - c66bc93faef58c6c69c21202e421ea417523721e
       X-GitHub-Request-Id:
-      - 7032:A4A55:2162D75:253434B:68C2EE9B
+      - 47C6:BCA08:C42B16:DE942D:68CC1D66
       X-Served-By:
-      - cache-bos4641-BOS
+      - cache-bos4636-BOS
       X-Timer:
-      - S1757605878.081506,VS0,VE1
+      - S1758207335.172979,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:33 GMT
+      - Thu, 18 Sep 2025 15:05:34 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_version/test_latest.yaml
+++ b/tests/extensions/cassettes/test_version/test_latest.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/version/v1.2.0/schema.json
   response:
@@ -61,7 +61,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -71,7 +71,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:17 GMT
+      - Thu, 18 Sep 2025 14:55:34 GMT
       ETag:
       - '"645249bd-d4d"'
       Last-Modified:
@@ -89,15 +89,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 4bac1c9dfe3353e70f3fd6585967ae0341ba657d
+      - 7fdd41d80e82cff7a3fbc32378f19394509a1f50
       X-GitHub-Request-Id:
-      - 7032:A4A55:2162D75:253434B:68C2EE9B
+      - 47C6:BCA08:C42B16:DE942D:68CC1D66
       X-Served-By:
-      - cache-bos4689-BOS
+      - cache-bos4672-BOS
       X-Timer:
-      - S1757605878.613827,VS0,VE1
+      - S1758207335.727338,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:33 GMT
+      - Thu, 18 Sep 2025 15:05:34 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_version/test_optional_version.yaml
+++ b/tests/extensions/cassettes/test_version/test_optional_version.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/version/v1.2.0/schema.json
   response:
@@ -61,7 +61,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '345'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -71,7 +71,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:18 GMT
+      - Thu, 18 Sep 2025 14:55:35 GMT
       ETag:
       - '"645249bd-d4d"'
       Last-Modified:
@@ -89,15 +89,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 0f61ed8c107e61e296214629af8366336090e93c
+      - c6a130e3d89165f8477b307b3b822711e1ae3319
       X-GitHub-Request-Id:
-      - 7032:A4A55:2162D75:253434B:68C2EE9B
+      - 47C6:BCA08:C42B16:DE942D:68CC1D66
       X-Served-By:
-      - cache-bos4631-BOS
+      - cache-bos4627-BOS
       X-Timer:
-      - S1757605878.334062,VS0,VE1
+      - S1758207335.436537,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:33 GMT
+      - Thu, 18 Sep 2025 15:05:34 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_version/test_predecessor.yaml
+++ b/tests/extensions/cassettes/test_version/test_predecessor.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/version/v1.2.0/schema.json
   response:
@@ -61,7 +61,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -71,7 +71,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:17 GMT
+      - Thu, 18 Sep 2025 14:55:34 GMT
       ETag:
       - '"645249bd-d4d"'
       Last-Modified:
@@ -89,15 +89,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - ee179789cb698339bccfbf0ae10cd4931b10c636
+      - 0a42a9284992bc81790eb6824f4d3f0bf696dac1
       X-GitHub-Request-Id:
-      - 7032:A4A55:2162D75:253434B:68C2EE9B
+      - 47C6:BCA08:C42B16:DE942D:68CC1D66
       X-Served-By:
-      - cache-bos4686-BOS
+      - cache-bos4649-BOS
       X-Timer:
-      - S1757605878.700460,VS0,VE1
+      - S1758207335.809336,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:33 GMT
+      - Thu, 18 Sep 2025 15:05:34 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_version/test_successor.yaml
+++ b/tests/extensions/cassettes/test_version/test_successor.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/version/v1.2.0/schema.json
   response:
@@ -61,7 +61,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -71,7 +71,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:17 GMT
+      - Thu, 18 Sep 2025 14:55:34 GMT
       ETag:
       - '"645249bd-d4d"'
       Last-Modified:
@@ -89,15 +89,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 86cd0355c4f0ab9829557dc0c226cba84e6f5c49
+      - 70aa74ea2677d0e3ffaa23fe9968fa06492d8799
       X-GitHub-Request-Id:
-      - 7032:A4A55:2162D75:253434B:68C2EE9B
+      - 47C6:BCA08:C42B16:DE942D:68CC1D66
       X-Served-By:
-      - cache-bos4676-BOS
+      - cache-bos4625-BOS
       X-Timer:
-      - S1757605878.794081,VS0,VE1
+      - S1758207335.889370,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:33 GMT
+      - Thu, 18 Sep 2025 15:05:34 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_version/test_version_in_properties.yaml
+++ b/tests/extensions/cassettes/test_version/test_version_in_properties.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/version/v1.2.0/schema.json
   response:
@@ -61,7 +61,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -71,7 +71,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:17 GMT
+      - Thu, 18 Sep 2025 14:55:34 GMT
       ETag:
       - '"645249bd-d4d"'
       Last-Modified:
@@ -89,15 +89,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - f9795f155ecbc879d0c72d404e5b7af9e9dd1b46
+      - 0a51e83bc29b30a67d9651a95b8ab8cec17c7250
       X-GitHub-Request-Id:
-      - 7032:A4A55:2162D75:253434B:68C2EE9B
+      - 47C6:BCA08:C42B16:DE942D:68CC1D66
       X-Served-By:
-      - cache-bos4621-BOS
+      - cache-bos4635-BOS
       X-Timer:
-      - S1757605877.346270,VS0,VE1
+      - S1758207334.467228,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:33 GMT
+      - Thu, 18 Sep 2025 15:05:34 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_view/test_azimuth.yaml
+++ b/tests/extensions/cassettes/test_view/test_azimuth.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/view/v1.0.0/schema.json
   response:
@@ -61,7 +61,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '364'
+      - '152'
       Cache-Control:
       - max-age=600
       Connection:
@@ -71,7 +71,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:19 GMT
+      - Thu, 18 Sep 2025 14:55:36 GMT
       ETag:
       - '"689f5434-dff"'
       Last-Modified:
@@ -89,15 +89,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 93f1f03fa00865c90d9d0a2f3f2023ad6ebf2c7f
+      - 2ee31f1297d4166ecf5079bd91f3561e3d86f1bc
       X-GitHub-Request-Id:
-      - EACF:1C0114:1BE6594:1F22786:68C2EE8A
+      - 624D:BA176:74CE5:7ED3C:68CC1CD0
       X-Served-By:
-      - cache-bos4681-BOS
+      - cache-bos4679-BOS
       X-Timer:
-      - S1757605879.016357,VS0,VE1
+      - S1758207336.117486,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -107,7 +107,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/sat/v1.0.0/schema.json
   response:
@@ -167,7 +167,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '350'
+      - '7'
       Cache-Control:
       - max-age=600
       Connection:
@@ -177,7 +177,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:19 GMT
+      - Thu, 18 Sep 2025 14:55:36 GMT
       ETag:
       - '"67627e9d-e82"'
       Last-Modified:
@@ -195,15 +195,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 17c5d71e8b8109002c6fa39279edb202e4bfd632
+      - e3674c0bffa1674b76c5a556e6de246bc15e3f9a
       X-GitHub-Request-Id:
-      - 621C:19FF07:BB2CFC:D6CBD0:68C2EE98
+      - 4F00:BAEAA:C82DD6:E297E0:68CC1D60
       X-Served-By:
-      - cache-bos4690-BOS
+      - cache-bos4637-BOS
       X-Timer:
-      - S1757605879.090662,VS0,VE1
+      - S1758207336.185346,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:28 GMT
+      - Thu, 18 Sep 2025 15:05:29 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_view/test_incidence_angle.yaml
+++ b/tests/extensions/cassettes/test_view/test_incidence_angle.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/view/v1.0.0/schema.json
   response:
@@ -61,7 +61,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '364'
+      - '151'
       Cache-Control:
       - max-age=600
       Connection:
@@ -71,7 +71,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:18 GMT
+      - Thu, 18 Sep 2025 14:55:35 GMT
       ETag:
       - '"689f5434-dff"'
       Last-Modified:
@@ -89,15 +89,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - a966c945542031a87eb6e139b23b4fdeefcc1b32
+      - be2974da9c9a70c40212c272128f3a8b11f5c819
       X-GitHub-Request-Id:
-      - EACF:1C0114:1BE6594:1F22786:68C2EE8A
+      - 624D:BA176:74CE5:7ED3C:68CC1CD0
       X-Served-By:
-      - cache-bos4691-BOS
+      - cache-bos4634-BOS
       X-Timer:
-      - S1757605879.838876,VS0,VE1
+      - S1758207336.953185,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -107,7 +107,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/sat/v1.0.0/schema.json
   response:
@@ -167,7 +167,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '350'
+      - '7'
       Cache-Control:
       - max-age=600
       Connection:
@@ -177,7 +177,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:18 GMT
+      - Thu, 18 Sep 2025 14:55:36 GMT
       ETag:
       - '"67627e9d-e82"'
       Last-Modified:
@@ -195,15 +195,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 0344106e07d543980d51f1c428b6f5b11e7e87f1
+      - 7eb82cbdb832d0941cfaceeb76d67aac52051622
       X-GitHub-Request-Id:
-      - 621C:19FF07:BB2CFC:D6CBD0:68C2EE98
+      - 4F00:BAEAA:C82DD6:E297E0:68CC1D60
       X-Served-By:
-      - cache-bos4621-BOS
+      - cache-bos4646-BOS
       X-Timer:
-      - S1757605879.916157,VS0,VE1
+      - S1758207336.029251,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:28 GMT
+      - Thu, 18 Sep 2025 15:05:29 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_view/test_off_nadir.yaml
+++ b/tests/extensions/cassettes/test_view/test_off_nadir.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/view/v1.0.0/schema.json
   response:
@@ -61,7 +61,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '364'
+      - '151'
       Cache-Control:
       - max-age=600
       Connection:
@@ -71,7 +71,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:18 GMT
+      - Thu, 18 Sep 2025 14:55:35 GMT
       ETag:
       - '"689f5434-dff"'
       Last-Modified:
@@ -89,15 +89,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 9b2cbd7b60eb1d4ab8cbe887d06b9e0a9570ae61
+      - 0de63786deda00061c132713d9ecf01ebeb5a0c9
       X-GitHub-Request-Id:
-      - EACF:1C0114:1BE6594:1F22786:68C2EE8A
+      - 624D:BA176:74CE5:7ED3C:68CC1CD0
       X-Served-By:
-      - cache-bos4672-BOS
+      - cache-bos4644-BOS
       X-Timer:
-      - S1757605879.679590,VS0,VE1
+      - S1758207336.789100,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -107,7 +107,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/sat/v1.0.0/schema.json
   response:
@@ -167,7 +167,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '350'
+      - '7'
       Cache-Control:
       - max-age=600
       Connection:
@@ -177,7 +177,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:18 GMT
+      - Thu, 18 Sep 2025 14:55:35 GMT
       ETag:
       - '"67627e9d-e82"'
       Last-Modified:
@@ -195,15 +195,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - e6f8ffbb73ad0afe551b27e53133fd1dd14db1d3
+      - 3b52248afbe9c351aaa0b7a6dde30f828d98deb6
       X-GitHub-Request-Id:
-      - 621C:19FF07:BB2CFC:D6CBD0:68C2EE98
+      - 4F00:BAEAA:C82DD6:E297E0:68CC1D60
       X-Served-By:
-      - cache-bos4684-BOS
+      - cache-bos4692-BOS
       X-Timer:
-      - S1757605879.753677,VS0,VE1
+      - S1758207336.864921,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:28 GMT
+      - Thu, 18 Sep 2025 15:05:29 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_view/test_sun_azimuth.yaml
+++ b/tests/extensions/cassettes/test_view/test_sun_azimuth.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/view/v1.0.0/schema.json
   response:
@@ -61,7 +61,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '364'
+      - '152'
       Cache-Control:
       - max-age=600
       Connection:
@@ -71,7 +71,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:19 GMT
+      - Thu, 18 Sep 2025 14:55:36 GMT
       ETag:
       - '"689f5434-dff"'
       Last-Modified:
@@ -87,17 +87,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '1'
       X-Fastly-Request-ID:
-      - 92a30d073aca2b8d783ff7965c6607cc614146a4
+      - 40110b19ae78e04a00319575656ec5fa3cc672cb
       X-GitHub-Request-Id:
-      - EACF:1C0114:1BE6594:1F22786:68C2EE8A
+      - 624D:BA176:74CE5:7ED3C:68CC1CD0
       X-Served-By:
-      - cache-bos4642-BOS
+      - cache-bos4628-BOS
       X-Timer:
-      - S1757605879.174497,VS0,VE1
+      - S1758207336.273656,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -107,7 +107,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/sat/v1.0.0/schema.json
   response:
@@ -167,7 +167,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '350'
+      - '7'
       Cache-Control:
       - max-age=600
       Connection:
@@ -177,7 +177,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:19 GMT
+      - Thu, 18 Sep 2025 14:55:36 GMT
       ETag:
       - '"67627e9d-e82"'
       Last-Modified:
@@ -195,15 +195,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 1c9ccea2424ea316c4747fbbc94ddf0e16cbd287
+      - 655a898062b3fd044681540a47e2d684fa640bfb
       X-GitHub-Request-Id:
-      - 621C:19FF07:BB2CFC:D6CBD0:68C2EE98
+      - 4F00:BAEAA:C82DD6:E297E0:68CC1D60
       X-Served-By:
-      - cache-bos4637-BOS
+      - cache-bos4664-BOS
       X-Timer:
-      - S1757605879.252300,VS0,VE1
+      - S1758207336.343631,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:28 GMT
+      - Thu, 18 Sep 2025 15:05:29 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_view/test_sun_elevation.yaml
+++ b/tests/extensions/cassettes/test_view/test_sun_elevation.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/view/v1.0.0/schema.json
   response:
@@ -61,7 +61,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '365'
+      - '152'
       Cache-Control:
       - max-age=600
       Connection:
@@ -71,7 +71,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:19 GMT
+      - Thu, 18 Sep 2025 14:55:36 GMT
       ETag:
       - '"689f5434-dff"'
       Last-Modified:
@@ -89,15 +89,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 9c455742885a4586227aa974964836c72d1193e9
+      - fbaae66ad97fb714622f63641acafeb687750994
       X-GitHub-Request-Id:
-      - EACF:1C0114:1BE6594:1F22786:68C2EE8A
+      - 624D:BA176:74CE5:7ED3C:68CC1CD0
       X-Served-By:
-      - cache-bos4622-BOS
+      - cache-bos4650-BOS
       X-Timer:
-      - S1757605879.349683,VS0,VE2
+      - S1758207336.435290,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -107,7 +107,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/sat/v1.0.0/schema.json
   response:
@@ -167,7 +167,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '350'
+      - '7'
       Cache-Control:
       - max-age=600
       Connection:
@@ -177,7 +177,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:19 GMT
+      - Thu, 18 Sep 2025 14:55:36 GMT
       ETag:
       - '"67627e9d-e82"'
       Last-Modified:
@@ -195,15 +195,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - c3dbeeed12e3e1b96094bb47fe8a9f724193b5be
+      - 21b7bbfe5605c729378f2d761df2c245dc028114
       X-GitHub-Request-Id:
-      - 621C:19FF07:BB2CFC:D6CBD0:68C2EE98
+      - 4F00:BAEAA:C82DD6:E297E0:68CC1D60
       X-Served-By:
-      - cache-bos4653-BOS
+      - cache-bos4650-BOS
       X-Timer:
-      - S1757605879.423264,VS0,VE1
+      - S1758207337.505267,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:28 GMT
+      - Thu, 18 Sep 2025 15:05:29 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_view/test_validate_view.yaml
+++ b/tests/extensions/cassettes/test_view/test_validate_view.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/view/v1.0.0/schema.json
   response:
@@ -61,7 +61,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '364'
+      - '151'
       Cache-Control:
       - max-age=600
       Connection:
@@ -71,7 +71,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:18 GMT
+      - Thu, 18 Sep 2025 14:55:35 GMT
       ETag:
       - '"689f5434-dff"'
       Last-Modified:
@@ -87,17 +87,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - eb40b8c62a07fd12ea60cd3e0dc2fea322208d25
+      - fe07f71863d7402b0aeba44a602e865ad92457cb
       X-GitHub-Request-Id:
-      - EACF:1C0114:1BE6594:1F22786:68C2EE8A
+      - 624D:BA176:74CE5:7ED3C:68CC1CD0
       X-Served-By:
-      - cache-bos4675-BOS
+      - cache-bos4645-BOS
       X-Timer:
-      - S1757605879.513287,VS0,VE1
+      - S1758207336.629267,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -107,7 +107,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/sat/v1.0.0/schema.json
   response:
@@ -167,7 +167,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '350'
+      - '7'
       Cache-Control:
       - max-age=600
       Connection:
@@ -177,7 +177,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:18 GMT
+      - Thu, 18 Sep 2025 14:55:35 GMT
       ETag:
       - '"67627e9d-e82"'
       Last-Modified:
@@ -193,17 +193,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Fastly-Request-ID:
-      - 09de6858f38e155edb1d204cfd3ea2fff29fddef
+      - b7dab24c5361e661bde330c5b707e540ad925f1e
       X-GitHub-Request-Id:
-      - 621C:19FF07:BB2CFC:D6CBD0:68C2EE98
+      - 4F00:BAEAA:C82DD6:E297E0:68CC1D60
       X-Served-By:
-      - cache-bos4655-BOS
+      - cache-bos4690-BOS
       X-Timer:
-      - S1757605879.589720,VS0,VE1
+      - S1758207336.703564,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:28 GMT
+      - Thu, 18 Sep 2025 15:05:29 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_xarray_assets/test_collection_validate.yaml
+++ b/tests/extensions/cassettes/test_xarray_assets/test_collection_validate.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/xarray-assets/v1.0.0/schema.json
   response:
@@ -55,7 +55,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -65,7 +65,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:19 GMT
+      - Thu, 18 Sep 2025 14:55:36 GMT
       ETag:
       - '"60dcd7ae-bb0"'
       Last-Modified:
@@ -83,15 +83,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - e9dec127e4753155db0cdc527383d705822f94af
+      - e14d597ae9b811e8c02cfc4560e84e531e7fc825
       X-GitHub-Request-Id:
-      - 1500:E8E53:1F59330:2329BE7:68C2EE9E
+      - 39D7:358B9B:CCD787:E73F3A:68CC1D68
       X-Served-By:
-      - cache-bos4624-BOS
+      - cache-bos4632-BOS
       X-Timer:
-      - S1757605880.625969,VS0,VE1
+      - S1758207337.731171,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:35 GMT
+      - Thu, 18 Sep 2025 15:05:36 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_xarray_assets/test_item_validate.yaml
+++ b/tests/extensions/cassettes/test_xarray_assets/test_item_validate.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/xarray-assets/v1.0.0/schema.json
   response:
@@ -55,7 +55,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -65,7 +65,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:19 GMT
+      - Thu, 18 Sep 2025 14:55:36 GMT
       ETag:
       - '"60dcd7ae-bb0"'
       Last-Modified:
@@ -79,19 +79,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - f9a9dcd2b1fde5c0df4c8b89808aac99ca0eb450
+      - 50d222d2c614a22c0d9d5a506d60298263fc8d3b
       X-GitHub-Request-Id:
-      - 1500:E8E53:1F59330:2329BE7:68C2EE9E
+      - 39D7:358B9B:CCD787:E73F3A:68CC1D68
       X-Served-By:
-      - cache-bos4634-BOS
+      - cache-bos4645-BOS
       X-Timer:
-      - S1757605880.536473,VS0,VE1
+      - S1758207337.609915,VS0,VE53
       expires:
-      - Thu, 11 Sep 2025 15:55:35 GMT
+      - Thu, 18 Sep 2025 15:05:36 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_xarray_assets/test_set_field[open_kwargs-value1].yaml
+++ b/tests/extensions/cassettes/test_xarray_assets/test_set_field[open_kwargs-value1].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/xarray-assets/v1.0.0/schema.json
   response:
@@ -55,7 +55,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -65,7 +65,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:19 GMT
+      - Thu, 18 Sep 2025 14:55:36 GMT
       ETag:
       - '"60dcd7ae-bb0"'
       Last-Modified:
@@ -83,15 +83,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 01f52138d03a2d308b9b1f77a5d003aa9d50ddea
+      - d125dab6f878164b4fd4bb0eeb93856e913f64a6
       X-GitHub-Request-Id:
-      - 1500:E8E53:1F59330:2329BE7:68C2EE9E
+      - 39D7:358B9B:CCD787:E73F3A:68CC1D68
       X-Served-By:
-      - cache-bos4625-BOS
+      - cache-bos4682-BOS
       X-Timer:
-      - S1757605880.797007,VS0,VE1
+      - S1758207337.889300,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:35 GMT
+      - Thu, 18 Sep 2025 15:05:36 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/extensions/cassettes/test_xarray_assets/test_set_field[storage_options-value0].yaml
+++ b/tests/extensions/cassettes/test_xarray_assets/test_set_field[storage_options-value0].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/xarray-assets/v1.0.0/schema.json
   response:
@@ -55,7 +55,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -65,7 +65,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:51:19 GMT
+      - Thu, 18 Sep 2025 14:55:36 GMT
       ETag:
       - '"60dcd7ae-bb0"'
       Last-Modified:
@@ -83,15 +83,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - b43465fabc364e8e20077ed1c0f962a05a3442fe
+      - 3e4840e783e582fa1096e699503e32e8d311853f
       X-GitHub-Request-Id:
-      - 1500:E8E53:1F59330:2329BE7:68C2EE9E
+      - 39D7:358B9B:CCD787:E73F3A:68CC1D68
       X-Served-By:
-      - cache-bos4653-BOS
+      - cache-bos4655-BOS
       X-Timer:
-      - S1757605880.714020,VS0,VE2
+      - S1758207337.810998,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:35 GMT
+      - Thu, 18 Sep 2025 15:05:36 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_all.yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_all.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/label/v1.0.1/schema.json
   response:
@@ -106,7 +106,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '422'
+      - '84'
       Cache-Control:
       - max-age=600
       Connection:
@@ -116,7 +116,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:39 GMT
+      - Thu, 18 Sep 2025 14:57:03 GMT
       ETag:
       - '"61eb1dc9-1abf"'
       Last-Modified:
@@ -134,15 +134,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - ebacd30bc14dbb83789f73144910dcc0de2b0f65
+      - a78c8c2ac39fa41a5bbfa8cd04854bf3426ff49c
       X-GitHub-Request-Id:
-      - FE08:128B70:CBB40B:E7523E:68C2EEA2
+      - 600D:C1ED5:D907DA:F3637F:68CC1D6B
       X-Served-By:
-      - cache-bos4646-BOS
+      - cache-bos4628-BOS
       X-Timer:
-      - S1757605960.882614,VS0,VE1
+      - S1758207424.692727,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:38 GMT
+      - Thu, 18 Sep 2025 15:05:39 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_all_deprecated_dict_arg.yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_all_deprecated_dict_arg.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/label/v1.0.1/schema.json
   response:
@@ -106,7 +106,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '422'
+      - '84'
       Cache-Control:
       - max-age=600
       Connection:
@@ -116,7 +116,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:39 GMT
+      - Thu, 18 Sep 2025 14:57:03 GMT
       ETag:
       - '"61eb1dc9-1abf"'
       Last-Modified:
@@ -132,17 +132,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '0'
       X-Fastly-Request-ID:
-      - 86fa5a02b8ffe8141e1cab3967857ca13a6d4f02
+      - ff9fe2a2edf3876fc6199cd7c00debb606e92725
       X-GitHub-Request-Id:
-      - FE08:128B70:CBB40B:E7523E:68C2EEA2
+      - 600D:C1ED5:D907DA:F3637F:68CC1D6B
       X-Served-By:
-      - cache-bos4641-BOS
+      - cache-bos4637-BOS
       X-Timer:
-      - S1757605960.726986,VS0,VE1
+      - S1758207424.535319,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:38 GMT
+      - Thu, 18 Sep 2025 15:05:39 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_all_dict[test_case0].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_all_dict[test_case0].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/label/v1.0.1/schema.json
   response:
@@ -106,7 +106,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '422'
+      - '84'
       Cache-Control:
       - max-age=600
       Connection:
@@ -116,7 +116,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:40 GMT
+      - Thu, 18 Sep 2025 14:57:03 GMT
       ETag:
       - '"61eb1dc9-1abf"'
       Last-Modified:
@@ -134,15 +134,15 @@ interactions:
       X-Cache-Hits:
       - '2'
       X-Fastly-Request-ID:
-      - 26133ab205b0cc4ce2de2eff1443e3c9ef7bf657
+      - ba573f2cb222d5ea60466b7151a29205ac3b1181
       X-GitHub-Request-Id:
-      - FE08:128B70:CBB40B:E7523E:68C2EEA2
+      - 600D:C1ED5:D907DA:F3637F:68CC1D6B
       X-Served-By:
-      - cache-bos4642-BOS
+      - cache-bos4632-BOS
       X-Timer:
-      - S1757605960.046245,VS0,VE1
+      - S1758207424.847405,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:38 GMT
+      - Thu, 18 Sep 2025 15:05:39 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -152,7 +152,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/catalog-spec/json-schema/catalog.json
   response:
@@ -213,13 +213,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:40 GMT
+      - Thu, 18 Sep 2025 14:57:03 GMT
       ETag:
       - '"3b514933a3747f038125935624a13df108e30fe1cb8f9660a7f54ac6d4765ce9"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:40 GMT
+      - Thu, 18 Sep 2025 15:02:03 GMT
       Source-Age:
-      - '58'
+      - '63'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -229,19 +229,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 063a013b9f5b534a2dd44fa16204b3f3e47ab17e
+      - 565b93a29ed09a3a387d78db2d3f0181403279cc
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 4D53:1CB1E4:12EBE4:17599A:68C2EEB7
+      - BCE7:388807:C697B:F1BF7:68CC1D7C
       X-Served-By:
-      - cache-bos4686-BOS
+      - cache-bos4678-BOS
       X-Timer:
-      - S1757605960.185871,VS0,VE1
+      - S1758207424.974909,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -251,7 +251,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/collection-spec/json-schema/collection.json
   response:
@@ -333,13 +333,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:40 GMT
+      - Thu, 18 Sep 2025 14:57:04 GMT
       ETag:
       - '"031974beaaaf6f0b5c6877dc97088d9e2aff3bc8962df33ff291dddded353f09"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:40 GMT
+      - Thu, 18 Sep 2025 15:02:04 GMT
       Source-Age:
-      - '58'
+      - '63'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -349,19 +349,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '24'
+      - '1'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 8da8be92c62c779967d3727e1e4e59c9b9be4b06
+      - b75ec97edb22637ed48e8ad4c0643ce6603975cb
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 48D2:9DF63:14B8DC:192D3D:68C2EEB6
+      - EAA4:3C3312:A80AF:D3151:68CC1D7F
       X-Served-By:
-      - cache-bos4634-BOS
+      - cache-bos4653-BOS
       X-Timer:
-      - S1757605960.255840,VS0,VE0
+      - S1758207424.045057,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -371,7 +371,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/item.json
   response:
@@ -475,7 +475,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '338'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -485,7 +485,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:40 GMT
+      - Thu, 18 Sep 2025 14:57:04 GMT
       ETag:
       - '"66e1651c-1b3a"'
       Last-Modified:
@@ -497,19 +497,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - da9ee7e3c89eb60d85d24f68a59a9753a3396818
+      - f438378983c09746ca26a7b409a648792279b22d
       X-GitHub-Request-Id:
-      - BF31:3B188F:1EF9FB5:2255ED5:68C2EEF6
+      - 9945:BA176:8226E:8D5D0:68CC1DC0
       X-Served-By:
-      - cache-bos4638-BOS
+      - cache-bos4652-BOS
       X-Timer:
-      - S1757605960.346992,VS0,VE1
+      - S1758207424.129093,VS0,VE61
       expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -519,7 +519,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/basics.json
   response:
@@ -538,7 +538,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '338'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -548,7 +548,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:40 GMT
+      - Thu, 18 Sep 2025 14:57:04 GMT
       ETag:
       - '"66e1651c-21a"'
       Last-Modified:
@@ -560,19 +560,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
-      - '2'
+      - '0'
       X-Fastly-Request-ID:
-      - ebdc696c2be9a1b3364389dba6ec0309b7e352dc
+      - 209d2c3095f1c9cc2af3a23f06e0494fe3a8401a
       X-GitHub-Request-Id:
-      - C9D0:1561A9:1E3A377:21988BC:68C2EEF4
+      - 5B3B:239986:1C42F0:1DF164:68CC1DBF
       X-Served-By:
-      - cache-bos4620-BOS
+      - cache-bos4683-BOS
       X-Timer:
-      - S1757605960.443257,VS0,VE1
+      - S1758207424.275027,VS0,VE67
       expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -582,7 +582,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/datetime.json
   response:
@@ -614,7 +614,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '338'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -624,7 +624,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:40 GMT
+      - Thu, 18 Sep 2025 14:57:04 GMT
       ETag:
       - '"66e1651c-5c5"'
       Last-Modified:
@@ -636,19 +636,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
-      - '2'
+      - '0'
       X-Fastly-Request-ID:
-      - 761e814062cfbc2b6d215ab0232b60015b600169
+      - 178b4127442068aa721bae99e39c752ffd374538
       X-GitHub-Request-Id:
-      - B8DE:2B753C:1FB3308:2311128:68C2EEF6
+      - 5B44:174E5:1A4E3E:1BFD2E:68CC1DBE
       X-Served-By:
       - cache-bos4690-BOS
       X-Timer:
-      - S1757605961.521880,VS0,VE0
+      - S1758207424.421522,VS0,VE21
       expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -658,7 +660,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/instrument.json
   response:
@@ -679,7 +681,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '338'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -689,7 +691,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:40 GMT
+      - Thu, 18 Sep 2025 14:57:04 GMT
       ETag:
       - '"66e1651c-2bd"'
       Last-Modified:
@@ -701,19 +703,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 9b30d6200d526026e432199febe7d43ff14ae28c
+      - a3a8698b3f99311980b2c267b9317a2c35cd2338
       X-GitHub-Request-Id:
-      - 448A:38B0E6:1FA06BD:22FBE14:68C2EEF6
+      - B1E0:32B3EB:1A35D3:1BE3DB:68CC1DC0
       X-Served-By:
-      - cache-bos4673-BOS
+      - cache-bos4626-BOS
       X-Timer:
-      - S1757605961.612080,VS0,VE1
+      - S1758207425.521696,VS0,VE48
       expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -723,7 +725,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/licensing.json
   response:
@@ -739,7 +741,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '338'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -749,7 +751,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:40 GMT
+      - Thu, 18 Sep 2025 14:57:04 GMT
       ETag:
       - '"66e1651c-133"'
       Last-Modified:
@@ -761,19 +763,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - f6068d9370798eb046ee12d2b148741461392793
+      - 330362debaefefabd9c94f00596ca8007ee00d2f
       X-GitHub-Request-Id:
-      - 13EA:108A1F:1F46494:22A2D65:68C2EEF6
+      - 763C:1EB76C:1E950A:20443C:68CC1DC0
       X-Served-By:
-      - cache-bos4652-BOS
+      - cache-bos4670-BOS
       X-Timer:
-      - S1757605961.699635,VS0,VE1
+      - S1758207425.637430,VS0,VE36
       expires:
-      - Thu, 11 Sep 2025 15:57:03 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -785,7 +787,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/provider.json
   response:
@@ -812,7 +814,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '338'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -822,7 +824,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:40 GMT
+      - Thu, 18 Sep 2025 14:57:04 GMT
       ETag:
       - '"66e1651c-474"'
       Last-Modified:
@@ -834,19 +836,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 5707954c6f61ca6e5a8a00639478b8580df2def5
+      - e58e7986df6bbf06c76ab3f79f45e7bab3d4867a
       X-GitHub-Request-Id:
-      - 60B8:99D9B:1ED51A9:2232520:68C2EEF6
+      - 689D:239986:1C4373:1DF1F8:68CC1DBF
       X-Served-By:
-      - cache-bos4687-BOS
+      - cache-bos4623-BOS
       X-Timer:
-      - S1757605961.782036,VS0,VE1
+      - S1758207425.747500,VS0,VE34
       expires:
-      - Thu, 11 Sep 2025 15:57:03 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -858,7 +860,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/extensions/asset/json-schema/schema.json
   response:
@@ -895,13 +897,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:41 GMT
+      - Thu, 18 Sep 2025 14:57:05 GMT
       ETag:
       - '"cffbb0036f526b016f24477e0ad674e75b6fefb89708ca796686de9d2e2a67ed"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:41 GMT
+      - Thu, 18 Sep 2025 15:02:05 GMT
       Source-Age:
-      - '58'
+      - '63'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -915,15 +917,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 35e2ab66a41a3eb1d440b49bc811a646de523ee9
+      - 9e03a4ef38cf288c884924b1b995735e74a71eae
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 635E:2ACBC:149CBC:1913A5:68C2EEB7
+      - 6FDB:372AF9:AF9FC:DABC2:68CC1D80
       X-Served-By:
-      - cache-bos4652-BOS
+      - cache-bos4629-BOS
       X-Timer:
-      - S1757605961.400085,VS0,VE1
+      - S1758207425.424903,VS0,VE3
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_all_dict[test_case1].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_all_dict[test_case1].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/label/v1.0.1/schema.json
   response:
@@ -106,7 +106,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '423'
+      - '86'
       Cache-Control:
       - max-age=600
       Connection:
@@ -116,7 +116,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:41 GMT
+      - Thu, 18 Sep 2025 14:57:05 GMT
       ETag:
       - '"61eb1dc9-1abf"'
       Last-Modified:
@@ -134,15 +134,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 424caf1161e537a0afe4f26715a52a15c8b00a82
+      - 327d1898ed1411237bbbc463667fa9d8944094fa
       X-GitHub-Request-Id:
-      - FE08:128B70:CBB40B:E7523E:68C2EEA2
+      - 600D:C1ED5:D907DA:F3637F:68CC1D6B
       X-Served-By:
-      - cache-bos4627-BOS
+      - cache-bos4678-BOS
       X-Timer:
-      - S1757605961.496075,VS0,VE1
+      - S1758207426.542084,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:38 GMT
+      - Thu, 18 Sep 2025 15:05:39 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -152,7 +152,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/catalog-spec/json-schema/catalog.json
   response:
@@ -213,13 +213,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:41 GMT
+      - Thu, 18 Sep 2025 14:57:05 GMT
       ETag:
       - '"3b514933a3747f038125935624a13df108e30fe1cb8f9660a7f54ac6d4765ce9"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:41 GMT
+      - Thu, 18 Sep 2025 15:02:05 GMT
       Source-Age:
-      - '59'
+      - '65'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -229,19 +229,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 9a46b6e59f4430d3146a3a418bee415708776896
+      - 20a4e55ed2567c4aebefaa216515b6a0774378ad
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 4D53:1CB1E4:12EBE4:17599A:68C2EEB7
+      - BCE7:388807:C697B:F1BF7:68CC1D7C
       X-Served-By:
-      - cache-bos4626-BOS
+      - cache-bos4625-BOS
       X-Timer:
-      - S1757605962.592067,VS0,VE1
+      - S1758207426.637085,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -251,7 +251,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/collection-spec/json-schema/collection.json
   response:
@@ -333,13 +333,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:41 GMT
+      - Thu, 18 Sep 2025 14:57:05 GMT
       ETag:
       - '"031974beaaaf6f0b5c6877dc97088d9e2aff3bc8962df33ff291dddded353f09"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:41 GMT
+      - Thu, 18 Sep 2025 15:02:05 GMT
       Source-Age:
-      - '59'
+      - '64'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -349,19 +349,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '10'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - c02b46d86fd9a63dbbe5692b2681c0b9ff45b596
+      - 3c9200ab54646f38c8e11c8593c6c7ab6814a4c9
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 48D2:9DF63:14B8DC:192D3D:68C2EEB6
+      - EAA4:3C3312:A80AF:D3151:68CC1D7F
       X-Served-By:
-      - cache-bos4659-BOS
+      - cache-bos4634-BOS
       X-Timer:
-      - S1757605962.660078,VS0,VE1
+      - S1758207426.707466,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -371,7 +371,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/item.json
   response:
@@ -475,7 +475,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '339'
+      - '2'
       Cache-Control:
       - max-age=600
       Connection:
@@ -485,7 +485,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:41 GMT
+      - Thu, 18 Sep 2025 14:57:05 GMT
       ETag:
       - '"66e1651c-1b3a"'
       Last-Modified:
@@ -501,15 +501,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 33f0a525026988388f5b84ec2626e7f9ade6a693
+      - 49343b606dec5da2c3b65de1cdc7a6adb3328ffc
       X-GitHub-Request-Id:
-      - BF31:3B188F:1EF9FB5:2255ED5:68C2EEF6
+      - 9945:BA176:8226E:8D5D0:68CC1DC0
       X-Served-By:
-      - cache-bos4657-BOS
+      - cache-bos4620-BOS
       X-Timer:
-      - S1757605962.732267,VS0,VE1
+      - S1758207426.785045,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -519,7 +519,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/basics.json
   response:
@@ -538,7 +538,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '339'
+      - '2'
       Cache-Control:
       - max-age=600
       Connection:
@@ -548,7 +548,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:41 GMT
+      - Thu, 18 Sep 2025 14:57:05 GMT
       ETag:
       - '"66e1651c-21a"'
       Last-Modified:
@@ -562,17 +562,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '0'
+      - '1'
       X-Fastly-Request-ID:
-      - f42264c0fe1599f757bb4490d6bfb5f0dd26370d
+      - 1a7fdbc60893afb79a42e3de6d52305b096533fe
       X-GitHub-Request-Id:
-      - C9D0:1561A9:1E3A377:21988BC:68C2EEF4
+      - 5B3B:239986:1C42F0:1DF164:68CC1DBF
       X-Served-By:
-      - cache-bos4655-BOS
+      - cache-bos4647-BOS
       X-Timer:
-      - S1757605962.814186,VS0,VE2
+      - S1758207426.882922,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -582,7 +582,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/datetime.json
   response:
@@ -614,7 +614,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '339'
+      - '2'
       Cache-Control:
       - max-age=600
       Connection:
@@ -624,7 +624,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:41 GMT
+      - Thu, 18 Sep 2025 14:57:05 GMT
       ETag:
       - '"66e1651c-5c5"'
       Last-Modified:
@@ -638,17 +638,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '0'
+      - '1'
       X-Fastly-Request-ID:
-      - 64ff36a83919154fd7d81ade85796dbc0b0f66c2
+      - 4f96c6983b9e362874d0bc81643a7d444b8972c5
       X-GitHub-Request-Id:
-      - B8DE:2B753C:1FB3308:2311128:68C2EEF6
+      - 5B44:174E5:1A4E3E:1BFD2E:68CC1DBE
       X-Served-By:
-      - cache-bos4626-BOS
+      - cache-bos4687-BOS
       X-Timer:
-      - S1757605962.883974,VS0,VE1
+      - S1758207426.971179,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -658,7 +660,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/instrument.json
   response:
@@ -679,7 +681,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '339'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -689,7 +691,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:41 GMT
+      - Thu, 18 Sep 2025 14:57:06 GMT
       ETag:
       - '"66e1651c-2bd"'
       Last-Modified:
@@ -705,15 +707,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 57a6c26b687cea4196f9aeb3a6580f8b9e995492
+      - 83d8adbd8c6b41a483d80f2c39025112793e62d4
       X-GitHub-Request-Id:
-      - 448A:38B0E6:1FA06BD:22FBE14:68C2EEF6
+      - B1E0:32B3EB:1A35D3:1BE3DB:68CC1DC0
       X-Served-By:
-      - cache-bos4661-BOS
+      - cache-bos4663-BOS
       X-Timer:
-      - S1757605962.949449,VS0,VE2
+      - S1758207426.053295,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -723,7 +725,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/licensing.json
   response:
@@ -739,7 +741,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '339'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -749,7 +751,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:42 GMT
+      - Thu, 18 Sep 2025 14:57:06 GMT
       ETag:
       - '"66e1651c-133"'
       Last-Modified:
@@ -765,15 +767,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - e2ce81b2f7819dd0969655c190b2daee12476f5e
+      - 31ec938177413a5c17cca0071a1e41f24df47cf4
       X-GitHub-Request-Id:
-      - 13EA:108A1F:1F46494:22A2D65:68C2EEF6
+      - 763C:1EB76C:1E950A:20443C:68CC1DC0
       X-Served-By:
-      - cache-bos4630-BOS
+      - cache-bos4657-BOS
       X-Timer:
-      - S1757605962.019707,VS0,VE2
+      - S1758207426.138855,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:57:03 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -785,7 +787,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/provider.json
   response:
@@ -812,7 +814,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '339'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -822,7 +824,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:42 GMT
+      - Thu, 18 Sep 2025 14:57:06 GMT
       ETag:
       - '"66e1651c-474"'
       Last-Modified:
@@ -838,15 +840,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 989da648aa6b096be12b1c28aad48556652476e1
+      - 808b603b9d28be4bd7b38cc560bc8d010a3ef144
       X-GitHub-Request-Id:
-      - 60B8:99D9B:1ED51A9:2232520:68C2EEF6
+      - 689D:239986:1C4373:1DF1F8:68CC1DBF
       X-Served-By:
-      - cache-bos4664-BOS
+      - cache-bos4626-BOS
       X-Timer:
-      - S1757605962.096166,VS0,VE2
+      - S1758207426.225386,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:57:03 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -858,7 +860,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/extensions/asset/json-schema/schema.json
   response:
@@ -895,13 +897,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:42 GMT
+      - Thu, 18 Sep 2025 14:57:06 GMT
       ETag:
       - '"cffbb0036f526b016f24477e0ad674e75b6fefb89708ca796686de9d2e2a67ed"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:42 GMT
+      - Thu, 18 Sep 2025 15:02:06 GMT
       Source-Age:
-      - '60'
+      - '65'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -915,15 +917,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 5a0d0c422b2b0ba412948359f7bc8cfa8c8fe149
+      - 4d1824d0f31d2e8f4b5f01ddb4ed51992dc94b2b
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 635E:2ACBC:149CBC:1913A5:68C2EEB7
+      - 6FDB:372AF9:AF9FC:DABC2:68CC1D80
       X-Served-By:
-      - cache-bos4666-BOS
+      - cache-bos4642-BOS
       X-Timer:
-      - S1757605963.725679,VS0,VE1
+      - S1758207427.944033,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_all_dict[test_case2].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_all_dict[test_case2].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/catalog-spec/json-schema/catalog.json
   response:
@@ -64,13 +64,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:42 GMT
+      - Thu, 18 Sep 2025 14:57:07 GMT
       ETag:
       - '"3b514933a3747f038125935624a13df108e30fe1cb8f9660a7f54ac6d4765ce9"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:42 GMT
+      - Thu, 18 Sep 2025 15:02:07 GMT
       Source-Age:
-      - '61'
+      - '66'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -84,15 +84,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 7cf9efbe563201bf0a888e358650a707e2d08811
+      - d7a2e4b030d59e5df3f6aab8fdd1661d901a76a3
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 4D53:1CB1E4:12EBE4:17599A:68C2EEB7
+      - BCE7:388807:C697B:F1BF7:68CC1D7C
       X-Served-By:
-      - cache-bos4676-BOS
+      - cache-bos4672-BOS
       X-Timer:
-      - S1757605963.805878,VS0,VE1
+      - S1758207427.012502,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -102,7 +102,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/collection-spec/json-schema/collection.json
   response:
@@ -184,13 +184,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:42 GMT
+      - Thu, 18 Sep 2025 14:57:07 GMT
       ETag:
       - '"031974beaaaf6f0b5c6877dc97088d9e2aff3bc8962df33ff291dddded353f09"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:42 GMT
+      - Thu, 18 Sep 2025 15:02:07 GMT
       Source-Age:
-      - '60'
+      - '66'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -200,19 +200,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 306d0d0dfd7bd1551948ba5ce21f91b045a01155
+      - 7d110f7119017ce92566c7c03f136ff947ab82f0
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 48D2:9DF63:14B8DC:192D3D:68C2EEB6
+      - EAA4:3C3312:A80AF:D3151:68CC1D7F
       X-Served-By:
       - cache-bos4659-BOS
       X-Timer:
-      - S1757605963.878023,VS0,VE0
+      - S1758207427.075151,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -222,7 +222,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/item.json
   response:
@@ -326,7 +326,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '340'
+      - '3'
       Cache-Control:
       - max-age=600
       Connection:
@@ -336,7 +336,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:42 GMT
+      - Thu, 18 Sep 2025 14:57:07 GMT
       ETag:
       - '"66e1651c-1b3a"'
       Last-Modified:
@@ -350,17 +350,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '1'
       X-Fastly-Request-ID:
-      - c67bcffce65a6707c232c8b21efed2cc2fda34e5
+      - 3c31d04b999e13057cfa58c43cab7bf08fef3823
       X-GitHub-Request-Id:
-      - BF31:3B188F:1EF9FB5:2255ED5:68C2EEF6
+      - 9945:BA176:8226E:8D5D0:68CC1DC0
       X-Served-By:
-      - cache-bos4691-BOS
+      - cache-bos4681-BOS
       X-Timer:
-      - S1757605963.964163,VS0,VE0
+      - S1758207427.151386,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -370,7 +370,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/basics.json
   response:
@@ -389,7 +389,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '340'
+      - '3'
       Cache-Control:
       - max-age=600
       Connection:
@@ -399,7 +399,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:43 GMT
+      - Thu, 18 Sep 2025 14:57:07 GMT
       ETag:
       - '"66e1651c-21a"'
       Last-Modified:
@@ -415,15 +415,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - a1742fc4050f8dfd1f37952ac87074f2ebbe625e
+      - e3c800056b9da690833e08b7ec3b7b38399b60d0
       X-GitHub-Request-Id:
-      - C9D0:1561A9:1E3A377:21988BC:68C2EEF4
+      - 5B3B:239986:1C42F0:1DF164:68CC1DBF
       X-Served-By:
-      - cache-bos4656-BOS
+      - cache-bos4661-BOS
       X-Timer:
-      - S1757605963.066020,VS0,VE2
+      - S1758207427.253152,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -433,7 +433,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/datetime.json
   response:
@@ -465,7 +465,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '341'
+      - '3'
       Cache-Control:
       - max-age=600
       Connection:
@@ -475,7 +475,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:43 GMT
+      - Thu, 18 Sep 2025 14:57:07 GMT
       ETag:
       - '"66e1651c-5c5"'
       Last-Modified:
@@ -489,17 +489,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 9557fcf87053f5d0eb63a247e61e5b6a9a93a9bd
+      - 4f8b4d03326c5324c386769406c3bf1253ec91a8
       X-GitHub-Request-Id:
-      - B8DE:2B753C:1FB3308:2311128:68C2EEF6
+      - 5B44:174E5:1A4E3E:1BFD2E:68CC1DBE
       X-Served-By:
-      - cache-bos4654-BOS
+      - cache-bos4689-BOS
       X-Timer:
-      - S1757605963.155215,VS0,VE1
+      - S1758207427.336720,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -509,7 +511,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/instrument.json
   response:
@@ -530,7 +532,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '340'
+      - '3'
       Cache-Control:
       - max-age=600
       Connection:
@@ -540,7 +542,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:43 GMT
+      - Thu, 18 Sep 2025 14:57:07 GMT
       ETag:
       - '"66e1651c-2bd"'
       Last-Modified:
@@ -556,15 +558,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 7fdd72be3eea0352208973ff36e0ce6915f3080b
+      - 61e3da5298deff4bfdb1d2b8956e621267a4dcbc
       X-GitHub-Request-Id:
-      - 448A:38B0E6:1FA06BD:22FBE14:68C2EEF6
+      - B1E0:32B3EB:1A35D3:1BE3DB:68CC1DC0
       X-Served-By:
-      - cache-bos4631-BOS
+      - cache-bos4668-BOS
       X-Timer:
-      - S1757605963.225671,VS0,VE1
+      - S1758207427.415853,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -574,7 +576,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/licensing.json
   response:
@@ -590,7 +592,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '340'
+      - '3'
       Cache-Control:
       - max-age=600
       Connection:
@@ -600,7 +602,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:43 GMT
+      - Thu, 18 Sep 2025 14:57:07 GMT
       ETag:
       - '"66e1651c-133"'
       Last-Modified:
@@ -616,15 +618,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 15bda26604f4fc180180e2557373385247e3531c
+      - df7c9fc2cbbfe292b2b77aa6b972c091b88b78cc
       X-GitHub-Request-Id:
-      - 13EA:108A1F:1F46494:22A2D65:68C2EEF6
+      - 763C:1EB76C:1E950A:20443C:68CC1DC0
       X-Served-By:
-      - cache-bos4684-BOS
+      - cache-bos4622-BOS
       X-Timer:
-      - S1757605963.316206,VS0,VE1
+      - S1758207427.491897,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:57:03 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -636,7 +638,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/provider.json
   response:
@@ -663,7 +665,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '340'
+      - '3'
       Cache-Control:
       - max-age=600
       Connection:
@@ -673,7 +675,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:43 GMT
+      - Thu, 18 Sep 2025 14:57:07 GMT
       ETag:
       - '"66e1651c-474"'
       Last-Modified:
@@ -689,15 +691,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 6fa72e6ae85dcc4213be33e5d9d78a2ca9072777
+      - ef40e254d9cb6f7882aaa57946c3665ff10c4cd7
       X-GitHub-Request-Id:
-      - 60B8:99D9B:1ED51A9:2232520:68C2EEF6
+      - 689D:239986:1C4373:1DF1F8:68CC1DBF
       X-Served-By:
-      - cache-bos4679-BOS
+      - cache-bos4682-BOS
       X-Timer:
-      - S1757605963.402932,VS0,VE1
+      - S1758207428.569125,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:57:03 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -709,7 +711,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/label/v1.0.1/schema.json
   response:
@@ -812,7 +814,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '425'
+      - '89'
       Cache-Control:
       - max-age=600
       Connection:
@@ -822,7 +824,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:43 GMT
+      - Thu, 18 Sep 2025 14:57:07 GMT
       ETag:
       - '"61eb1dc9-1abf"'
       Last-Modified:
@@ -838,17 +840,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Fastly-Request-ID:
-      - 39ef2419148e2a71c522936053d820efe61ddbc8
+      - 4052dba34bfd105d27d8b9d85866f6585e692ee4
       X-GitHub-Request-Id:
-      - FE08:128B70:CBB40B:E7523E:68C2EEA2
+      - 600D:C1ED5:D907DA:F3637F:68CC1D6B
       X-Served-By:
-      - cache-bos4624-BOS
+      - cache-bos4630-BOS
       X-Timer:
-      - S1757605963.491957,VS0,VE1
+      - S1758207428.653196,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:38 GMT
+      - Thu, 18 Sep 2025 15:05:39 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -858,7 +860,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/extensions/asset/json-schema/schema.json
   response:
@@ -895,13 +897,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:44 GMT
+      - Thu, 18 Sep 2025 14:57:08 GMT
       ETag:
       - '"cffbb0036f526b016f24477e0ad674e75b6fefb89708ca796686de9d2e2a67ed"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:44 GMT
+      - Thu, 18 Sep 2025 15:02:08 GMT
       Source-Age:
-      - '61'
+      - '66'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -915,15 +917,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - d362d6960f257885859f07f7df5c6185167cb382
+      - 00fd240a006c655895f4a06d81c29360e7d515d6
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 635E:2ACBC:149CBC:1913A5:68C2EEB7
+      - 6FDB:372AF9:AF9FC:DABC2:68CC1D80
       X-Served-By:
-      - cache-bos4693-BOS
+      - cache-bos4653-BOS
       X-Timer:
-      - S1757605964.114032,VS0,VE1
+      - S1758207428.428806,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_all_dict[test_case3].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_all_dict[test_case3].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/label/v1.0.1/schema.json
   response:
@@ -106,7 +106,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '426'
+      - '89'
       Cache-Control:
       - max-age=600
       Connection:
@@ -116,7 +116,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:44 GMT
+      - Thu, 18 Sep 2025 14:57:08 GMT
       ETag:
       - '"61eb1dc9-1abf"'
       Last-Modified:
@@ -134,15 +134,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - df892dec9b4482b8dd6f69f9ea267f17dd767427
+      - 44e07bdd400b0f7f1987e6f04f2e974c8b18385f
       X-GitHub-Request-Id:
-      - FE08:128B70:CBB40B:E7523E:68C2EEA2
+      - 600D:C1ED5:D907DA:F3637F:68CC1D6B
       X-Served-By:
-      - cache-bos4643-BOS
+      - cache-bos4685-BOS
       X-Timer:
-      - S1757605964.212121,VS0,VE1
+      - S1758207429.541091,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:38 GMT
+      - Thu, 18 Sep 2025 15:05:39 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -152,7 +152,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/catalog-spec/json-schema/catalog.json
   response:
@@ -213,13 +213,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:44 GMT
+      - Thu, 18 Sep 2025 14:57:09 GMT
       ETag:
       - '"3b514933a3747f038125935624a13df108e30fe1cb8f9660a7f54ac6d4765ce9"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:44 GMT
+      - Thu, 18 Sep 2025 15:02:09 GMT
       Source-Age:
-      - '63'
+      - '68'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -229,19 +229,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '3'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - cc651262759972d899470f58d77f75ef8b20a808
+      - 0ce1e6b29da6ac8c7d70689c8c9259d0f6475d48
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 4D53:1CB1E4:12EBE4:17599A:68C2EEB7
+      - BCE7:388807:C697B:F1BF7:68CC1D7C
       X-Served-By:
-      - cache-bos4660-BOS
+      - cache-bos4687-BOS
       X-Timer:
-      - S1757605965.909498,VS0,VE1
+      - S1758207429.271066,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -251,7 +251,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/collection-spec/json-schema/collection.json
   response:
@@ -333,13 +333,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:44 GMT
+      - Thu, 18 Sep 2025 14:57:09 GMT
       ETag:
       - '"031974beaaaf6f0b5c6877dc97088d9e2aff3bc8962df33ff291dddded353f09"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:44 GMT
+      - Thu, 18 Sep 2025 15:02:09 GMT
       Source-Age:
-      - '62'
+      - '68'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -349,19 +349,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '1'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 41760543072a5169be90804c4ddf7e6011727bfe
+      - 35c42bae49a511b8876e0470793ca6cd0c6e8f1f
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 48D2:9DF63:14B8DC:192D3D:68C2EEB6
+      - EAA4:3C3312:A80AF:D3151:68CC1D7F
       X-Served-By:
-      - cache-bos4659-BOS
+      - cache-bos4686-BOS
       X-Timer:
-      - S1757605965.972498,VS0,VE0
+      - S1758207429.333212,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -371,7 +371,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/item.json
   response:
@@ -475,7 +475,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '342'
+      - '5'
       Cache-Control:
       - max-age=600
       Connection:
@@ -485,7 +485,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:45 GMT
+      - Thu, 18 Sep 2025 14:57:09 GMT
       ETag:
       - '"66e1651c-1b3a"'
       Last-Modified:
@@ -501,15 +501,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 5974cb448f6e04b47ebf994afc728dee19596583
+      - 74256b18875d701c538daa7d5a75b9139716d9ac
       X-GitHub-Request-Id:
-      - BF31:3B188F:1EF9FB5:2255ED5:68C2EEF6
+      - 9945:BA176:8226E:8D5D0:68CC1DC0
       X-Served-By:
-      - cache-bos4653-BOS
+      - cache-bos4672-BOS
       X-Timer:
-      - S1757605965.037328,VS0,VE18
+      - S1758207429.401107,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -519,7 +519,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/basics.json
   response:
@@ -538,7 +538,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '342'
+      - '5'
       Cache-Control:
       - max-age=600
       Connection:
@@ -548,7 +548,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:45 GMT
+      - Thu, 18 Sep 2025 14:57:09 GMT
       ETag:
       - '"66e1651c-21a"'
       Last-Modified:
@@ -564,15 +564,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 0ea997bd5af9e57b6e615c16ac8771a68ecdb7f2
+      - 37fe572f70010e42b6d9a443fb818be92360eaf4
       X-GitHub-Request-Id:
-      - C9D0:1561A9:1E3A377:21988BC:68C2EEF4
+      - 5B3B:239986:1C42F0:1DF164:68CC1DBF
       X-Served-By:
-      - cache-bos4675-BOS
+      - cache-bos4643-BOS
       X-Timer:
-      - S1757605965.140707,VS0,VE2
+      - S1758207429.483475,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -582,7 +582,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/datetime.json
   response:
@@ -614,7 +614,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '342'
+      - '5'
       Cache-Control:
       - max-age=600
       Connection:
@@ -624,7 +624,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:45 GMT
+      - Thu, 18 Sep 2025 14:57:09 GMT
       ETag:
       - '"66e1651c-5c5"'
       Last-Modified:
@@ -640,15 +640,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 6035d75b518194f2227be153ff52f4add383627b
+      - 1a3cfe8dd40aed6424aaa437db7c6805415cf2b0
       X-GitHub-Request-Id:
-      - B8DE:2B753C:1FB3308:2311128:68C2EEF6
+      - 5B44:174E5:1A4E3E:1BFD2E:68CC1DBE
       X-Served-By:
-      - cache-bos4633-BOS
+      - cache-bos4635-BOS
       X-Timer:
-      - S1757605965.210606,VS0,VE2
+      - S1758207430.563247,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -658,7 +660,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/instrument.json
   response:
@@ -679,7 +681,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '342'
+      - '5'
       Cache-Control:
       - max-age=600
       Connection:
@@ -689,7 +691,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:45 GMT
+      - Thu, 18 Sep 2025 14:57:09 GMT
       ETag:
       - '"66e1651c-2bd"'
       Last-Modified:
@@ -705,15 +707,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 4878b25cbf60f2f43a9ef54964f847c228b4e185
+      - bff6112541068a029ec0331d488fb2d7afa77463
       X-GitHub-Request-Id:
-      - 448A:38B0E6:1FA06BD:22FBE14:68C2EEF6
+      - B1E0:32B3EB:1A35D3:1BE3DB:68CC1DC0
       X-Served-By:
-      - cache-bos4684-BOS
+      - cache-bos4686-BOS
       X-Timer:
-      - S1757605965.279714,VS0,VE4
+      - S1758207430.633675,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -723,7 +725,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/licensing.json
   response:
@@ -739,7 +741,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '342'
+      - '5'
       Cache-Control:
       - max-age=600
       Connection:
@@ -749,7 +751,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:45 GMT
+      - Thu, 18 Sep 2025 14:57:09 GMT
       ETag:
       - '"66e1651c-133"'
       Last-Modified:
@@ -765,15 +767,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 2cd47569b5deeacb23c0daab939dbf69507a1a12
+      - ec0cf0217311d868c1bc342f4d82adde1ab773b3
       X-GitHub-Request-Id:
-      - 13EA:108A1F:1F46494:22A2D65:68C2EEF6
+      - 763C:1EB76C:1E950A:20443C:68CC1DC0
       X-Served-By:
-      - cache-bos4663-BOS
+      - cache-bos4644-BOS
       X-Timer:
-      - S1757605965.358112,VS0,VE2
+      - S1758207430.700955,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:57:03 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -785,7 +787,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/provider.json
   response:
@@ -812,7 +814,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '343'
+      - '5'
       Cache-Control:
       - max-age=600
       Connection:
@@ -822,7 +824,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:45 GMT
+      - Thu, 18 Sep 2025 14:57:09 GMT
       ETag:
       - '"66e1651c-474"'
       Last-Modified:
@@ -836,17 +838,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - e58ec716faf57677b5d87ad8dd7fadeddc03a23d
+      - 6580f3b243b34bbf429393245c7989159d4f976e
       X-GitHub-Request-Id:
-      - 60B8:99D9B:1ED51A9:2232520:68C2EEF6
+      - 689D:239986:1C4373:1DF1F8:68CC1DBF
       X-Served-By:
-      - cache-bos4668-BOS
+      - cache-bos4630-BOS
       X-Timer:
-      - S1757605965.439659,VS0,VE1
+      - S1758207430.771079,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:57:03 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -858,7 +860,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/extensions/asset/json-schema/schema.json
   response:
@@ -895,13 +897,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:46 GMT
+      - Thu, 18 Sep 2025 14:57:10 GMT
       ETag:
       - '"cffbb0036f526b016f24477e0ad674e75b6fefb89708ca796686de9d2e2a67ed"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:46 GMT
+      - Thu, 18 Sep 2025 15:02:10 GMT
       Source-Age:
-      - '63'
+      - '69'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -915,15 +917,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 76d4b0c5b3d8b29997c8e8475c9a51f1039c119a
+      - 57888e7bc4ba7b4855625e0214dd34b6114508d1
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 635E:2ACBC:149CBC:1913A5:68C2EEB7
+      - 6FDB:372AF9:AF9FC:DABC2:68CC1D80
       X-Served-By:
-      - cache-bos4671-BOS
+      - cache-bos4641-BOS
       X-Timer:
-      - S1757605966.078430,VS0,VE1
+      - S1758207431.599177,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_all_dict[test_case4].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_all_dict[test_case4].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/eo/v1.1.0/schema.json
   response:
@@ -81,7 +81,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '452'
+      - '246'
       Cache-Control:
       - max-age=600
       Connection:
@@ -91,7 +91,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:46 GMT
+      - Thu, 18 Sep 2025 14:57:10 GMT
       ETag:
       - '"66df1c53-13bc"'
       Last-Modified:
@@ -107,17 +107,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 0f1a7248719e3dcb0afb65239430ad362caa9227
+      - 20431b40bca0908b744a6f752a00f31135e5a2df
       X-GitHub-Request-Id:
-      - BE8A:14434E:B836A2:D3D600:68C2EE8A
+      - 98DE:39A2ED:1DBAAC:1F56C3:68CC1CD0
       X-Served-By:
-      - cache-bos4625-BOS
+      - cache-bos4643-BOS
       X-Timer:
-      - S1757605966.182378,VS0,VE0
+      - S1758207431.699377,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -127,7 +127,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/projection/v2.0.0/schema.json
   response:
@@ -195,7 +195,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '451'
+      - '246'
       Cache-Control:
       - max-age=600
       Connection:
@@ -205,7 +205,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:46 GMT
+      - Thu, 18 Sep 2025 14:57:10 GMT
       ETag:
       - '"669e563b-1116"'
       Last-Modified:
@@ -221,17 +221,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '0'
+      - '2'
       X-Fastly-Request-ID:
-      - d801a6566a8d5f706697eb3c22c5c05b046b1bf5
+      - 601669ef8b8eaf74c533ce19ef1ef0e28b3cc9f5
       X-GitHub-Request-Id:
-      - 21B3:2B753C:1E14E8F:2148802:68C2D6FB
+      - 224F:32B3EB:191F90:1ABAB3:68CC1CCF
       X-Served-By:
-      - cache-bos4651-BOS
+      - cache-bos4622-BOS
       X-Timer:
-      - S1757605966.259115,VS0,VE1
+      - S1758207431.766154,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 14:14:44 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -241,7 +241,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/view/v1.0.0/schema.json
   response:
@@ -299,7 +299,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '451'
+      - '246'
       Cache-Control:
       - max-age=600
       Connection:
@@ -309,7 +309,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:46 GMT
+      - Thu, 18 Sep 2025 14:57:10 GMT
       ETag:
       - '"689f5434-dff"'
       Last-Modified:
@@ -325,17 +325,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 5ad8f21b738fb21ad14c14b6b79bc96865ae0aec
+      - 0431fd6a3344e8a362f15a70a93d2c77ca42a347
       X-GitHub-Request-Id:
-      - EACF:1C0114:1BE6594:1F22786:68C2EE8A
+      - 624D:BA176:74CE5:7ED3C:68CC1CD0
       X-Served-By:
-      - cache-bos4682-BOS
+      - cache-bos4626-BOS
       X-Timer:
-      - S1757605966.335257,VS0,VE0
+      - S1758207431.823400,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -345,7 +345,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/catalog-spec/json-schema/catalog.json
   response:
@@ -406,13 +406,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:46 GMT
+      - Thu, 18 Sep 2025 14:57:10 GMT
       ETag:
       - '"3b514933a3747f038125935624a13df108e30fe1cb8f9660a7f54ac6d4765ce9"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:46 GMT
+      - Thu, 18 Sep 2025 15:02:10 GMT
       Source-Age:
-      - '64'
+      - '70'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -426,15 +426,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 5fa2067de2b68c0ad00b3ca7c16568cbaef855d5
+      - 5a53c1a6ccbb1f2ba9d0e00d99c7b0a436c470f9
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 4D53:1CB1E4:12EBE4:17599A:68C2EEB7
+      - BCE7:388807:C697B:F1BF7:68CC1D7C
       X-Served-By:
-      - cache-bos4655-BOS
+      - cache-bos4677-BOS
       X-Timer:
-      - S1757605966.410170,VS0,VE1
+      - S1758207431.897638,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -444,7 +444,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/collection-spec/json-schema/collection.json
   response:
@@ -526,13 +526,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:46 GMT
+      - Thu, 18 Sep 2025 14:57:10 GMT
       ETag:
       - '"031974beaaaf6f0b5c6877dc97088d9e2aff3bc8962df33ff291dddded353f09"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:46 GMT
+      - Thu, 18 Sep 2025 15:02:10 GMT
       Source-Age:
-      - '64'
+      - '70'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -546,15 +546,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - db970263f35e11ca690432c35ca4f452ef57d20a
+      - 6b89ab10521059b67596888a256cd6a4a5ef4732
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 48D2:9DF63:14B8DC:192D3D:68C2EEB6
+      - EAA4:3C3312:A80AF:D3151:68CC1D7F
       X-Served-By:
-      - cache-bos4665-BOS
+      - cache-bos4655-BOS
       X-Timer:
-      - S1757605966.488000,VS0,VE1
+      - S1758207431.969129,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -564,7 +564,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/item.json
   response:
@@ -668,7 +668,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '7'
       Cache-Control:
       - max-age=600
       Connection:
@@ -678,7 +678,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:46 GMT
+      - Thu, 18 Sep 2025 14:57:11 GMT
       ETag:
       - '"66e1651c-1b3a"'
       Last-Modified:
@@ -694,15 +694,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - f1c982a40191af3c54f778b088259a0c6421b7c8
+      - dde0a096df1c2e2907e90389dd31a0b423d81708
       X-GitHub-Request-Id:
-      - BF31:3B188F:1EF9FB5:2255ED5:68C2EEF6
+      - 9945:BA176:8226E:8D5D0:68CC1DC0
       X-Served-By:
-      - cache-bos4688-BOS
+      - cache-bos4631-BOS
       X-Timer:
-      - S1757605967.579878,VS0,VE1
+      - S1758207431.058638,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -712,7 +712,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/basics.json
   response:
@@ -731,7 +731,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '7'
       Cache-Control:
       - max-age=600
       Connection:
@@ -741,7 +741,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:46 GMT
+      - Thu, 18 Sep 2025 14:57:11 GMT
       ETag:
       - '"66e1651c-21a"'
       Last-Modified:
@@ -757,15 +757,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 9e60b68762ed8caba40d572140ab5da5e031e079
+      - 431484c0e3bc3c6070901a0272a963172935d7d7
       X-GitHub-Request-Id:
-      - C9D0:1561A9:1E3A377:21988BC:68C2EEF4
+      - 5B3B:239986:1C42F0:1DF164:68CC1DBF
       X-Served-By:
-      - cache-bos4690-BOS
+      - cache-bos4665-BOS
       X-Timer:
-      - S1757605967.670152,VS0,VE1
+      - S1758207431.157085,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -775,7 +775,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/datetime.json
   response:
@@ -807,7 +807,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '7'
       Cache-Control:
       - max-age=600
       Connection:
@@ -817,7 +817,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:46 GMT
+      - Thu, 18 Sep 2025 14:57:11 GMT
       ETag:
       - '"66e1651c-5c5"'
       Last-Modified:
@@ -833,15 +833,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - ef367bb2a4e9bf7137eb39cd883901e48f756f0b
+      - 5301b6ea7ce1a3c13f21dba4c68c91e21ef27c9e
       X-GitHub-Request-Id:
-      - B8DE:2B753C:1FB3308:2311128:68C2EEF6
+      - 5B44:174E5:1A4E3E:1BFD2E:68CC1DBE
       X-Served-By:
-      - cache-bos4692-BOS
+      - cache-bos4680-BOS
       X-Timer:
-      - S1757605967.755940,VS0,VE1
+      - S1758207431.231659,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -851,7 +853,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/instrument.json
   response:
@@ -872,7 +874,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '7'
       Cache-Control:
       - max-age=600
       Connection:
@@ -882,7 +884,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:46 GMT
+      - Thu, 18 Sep 2025 14:57:11 GMT
       ETag:
       - '"66e1651c-2bd"'
       Last-Modified:
@@ -896,17 +898,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - a73e7f260fb6acebe20d7fcb1493078c6f445104
+      - 1e92d047c9cd93ea67f598ef834b42f3364087e4
       X-GitHub-Request-Id:
-      - 448A:38B0E6:1FA06BD:22FBE14:68C2EEF6
+      - B1E0:32B3EB:1A35D3:1BE3DB:68CC1DC0
       X-Served-By:
-      - cache-bos4640-BOS
+      - cache-bos4646-BOS
       X-Timer:
-      - S1757605967.848994,VS0,VE0
+      - S1758207431.307899,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -916,7 +918,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/licensing.json
   response:
@@ -932,7 +934,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '343'
+      - '7'
       Cache-Control:
       - max-age=600
       Connection:
@@ -942,7 +944,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:46 GMT
+      - Thu, 18 Sep 2025 14:57:11 GMT
       ETag:
       - '"66e1651c-133"'
       Last-Modified:
@@ -956,17 +958,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - c3f071f5c8560687e2664c373fbd3f9bb49edfd8
+      - b11c5879cbf86bbad4ec6c3e0fd8ec4097a788e4
       X-GitHub-Request-Id:
-      - 13EA:108A1F:1F46494:22A2D65:68C2EEF6
+      - 763C:1EB76C:1E950A:20443C:68CC1DC0
       X-Served-By:
-      - cache-bos4621-BOS
+      - cache-bos4636-BOS
       X-Timer:
-      - S1757605967.937992,VS0,VE0
+      - S1758207431.381561,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:57:03 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -978,7 +980,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/provider.json
   response:
@@ -1005,7 +1007,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '7'
       Cache-Control:
       - max-age=600
       Connection:
@@ -1015,7 +1017,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:47 GMT
+      - Thu, 18 Sep 2025 14:57:11 GMT
       ETag:
       - '"66e1651c-474"'
       Last-Modified:
@@ -1031,15 +1033,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 18f4dd27b351d0bdbc1ce1a353c494a7f51966e3
+      - 765565c8f37b4c82142e3b27db4d89704c387f09
       X-GitHub-Request-Id:
-      - 60B8:99D9B:1ED51A9:2232520:68C2EEF6
+      - 689D:239986:1C4373:1DF1F8:68CC1DBF
       X-Served-By:
-      - cache-bos4660-BOS
+      - cache-bos4637-BOS
       X-Timer:
-      - S1757605967.028195,VS0,VE1
+      - S1758207431.459518,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:57:03 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -1051,7 +1053,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/label/v1.0.1/schema.json
   response:
@@ -1154,7 +1156,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '429'
+      - '92'
       Cache-Control:
       - max-age=600
       Connection:
@@ -1164,7 +1166,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:47 GMT
+      - Thu, 18 Sep 2025 14:57:11 GMT
       ETag:
       - '"61eb1dc9-1abf"'
       Last-Modified:
@@ -1180,17 +1182,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - f9c18dd0c6e9cc23a4eaf776c28c4d250218fb68
+      - 11a97819ac77ff0ef75fa4a6bfe7ca207d7192fc
       X-GitHub-Request-Id:
-      - FE08:128B70:CBB40B:E7523E:68C2EEA2
+      - 600D:C1ED5:D907DA:F3637F:68CC1D6B
       X-Served-By:
-      - cache-bos4627-BOS
+      - cache-bos4646-BOS
       X-Timer:
-      - S1757605967.122202,VS0,VE0
+      - S1758207432.539336,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:38 GMT
+      - Thu, 18 Sep 2025 15:05:39 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -1200,7 +1202,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/extensions/asset/json-schema/schema.json
   response:
@@ -1237,13 +1239,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:47 GMT
+      - Thu, 18 Sep 2025 14:57:12 GMT
       ETag:
       - '"cffbb0036f526b016f24477e0ad674e75b6fefb89708ca796686de9d2e2a67ed"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:47 GMT
+      - Thu, 18 Sep 2025 15:02:12 GMT
       Source-Age:
-      - '65'
+      - '70'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -1257,15 +1259,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - c0f6b2f6efbe068c77dbd4f4e9bf532a20ca3e86
+      - 062f42b092ae85b7da9808bc085fd054ac33ebaf
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 635E:2ACBC:149CBC:1913A5:68C2EEB7
+      - 6FDB:372AF9:AF9FC:DABC2:68CC1D80
       X-Served-By:
-      - cache-bos4660-BOS
+      - cache-bos4688-BOS
       X-Timer:
-      - S1757605968.751937,VS0,VE1
+      - S1758207432.179254,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_all_dict[test_case5].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_all_dict[test_case5].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/catalog-spec/json-schema/catalog.json
   response:
@@ -64,13 +64,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:47 GMT
+      - Thu, 18 Sep 2025 14:57:12 GMT
       ETag:
       - '"3b514933a3747f038125935624a13df108e30fe1cb8f9660a7f54ac6d4765ce9"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:47 GMT
+      - Thu, 18 Sep 2025 15:02:12 GMT
       Source-Age:
-      - '66'
+      - '71'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -80,19 +80,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 3d9b99f4228b9208105778f52fd8bb204423f3a0
+      - c75d35a7dc0bde34e76996db2781356fe79e907a
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 4D53:1CB1E4:12EBE4:17599A:68C2EEB7
+      - BCE7:388807:C697B:F1BF7:68CC1D7C
       X-Served-By:
-      - cache-bos4636-BOS
+      - cache-bos4656-BOS
       X-Timer:
-      - S1757605968.841893,VS0,VE0
+      - S1758207432.259151,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -102,7 +102,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/collection-spec/json-schema/collection.json
   response:
@@ -184,13 +184,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:47 GMT
+      - Thu, 18 Sep 2025 14:57:12 GMT
       ETag:
       - '"031974beaaaf6f0b5c6877dc97088d9e2aff3bc8962df33ff291dddded353f09"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:47 GMT
+      - Thu, 18 Sep 2025 15:02:12 GMT
       Source-Age:
-      - '66'
+      - '72'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -200,19 +200,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 86ffa44647d9235840e8d42ab109eb342c057dff
+      - 2471e33bc1e1cc07a9697b321efd47fd822d135c
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 48D2:9DF63:14B8DC:192D3D:68C2EEB6
+      - EAA4:3C3312:A80AF:D3151:68CC1D7F
       X-Served-By:
-      - cache-bos4681-BOS
+      - cache-bos4641-BOS
       X-Timer:
-      - S1757605968.917921,VS0,VE1
+      - S1758207432.311346,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -222,7 +222,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/item.json
   response:
@@ -326,7 +326,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '345'
+      - '8'
       Cache-Control:
       - max-age=600
       Connection:
@@ -336,7 +336,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:48 GMT
+      - Thu, 18 Sep 2025 14:57:12 GMT
       ETag:
       - '"66e1651c-1b3a"'
       Last-Modified:
@@ -350,17 +350,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 6fe7f3450adddd47b9e98b093a7b230921b32771
+      - 4a6163fc97e80452eea6b86bc12a495f92ad0a78
       X-GitHub-Request-Id:
-      - BF31:3B188F:1EF9FB5:2255ED5:68C2EEF6
+      - 9945:BA176:8226E:8D5D0:68CC1DC0
       X-Served-By:
-      - cache-bos4653-BOS
+      - cache-bos4630-BOS
       X-Timer:
-      - S1757605968.001405,VS0,VE0
+      - S1758207432.384924,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -370,7 +370,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/basics.json
   response:
@@ -389,7 +389,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '345'
+      - '9'
       Cache-Control:
       - max-age=600
       Connection:
@@ -399,7 +399,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:48 GMT
+      - Thu, 18 Sep 2025 14:57:12 GMT
       ETag:
       - '"66e1651c-21a"'
       Last-Modified:
@@ -413,17 +413,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Fastly-Request-ID:
-      - 97ec3cd5d6ef65edf808f6177491880a69caffd6
+      - 4d83d32dc57751877df7a5281b182e6149f66847
       X-GitHub-Request-Id:
-      - C9D0:1561A9:1E3A377:21988BC:68C2EEF4
+      - 5B3B:239986:1C42F0:1DF164:68CC1DBF
       X-Served-By:
-      - cache-bos4636-BOS
+      - cache-bos4647-BOS
       X-Timer:
-      - S1757605968.096623,VS0,VE1
+      - S1758207432.475428,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -433,7 +433,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/datetime.json
   response:
@@ -465,7 +465,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '345'
+      - '8'
       Cache-Control:
       - max-age=600
       Connection:
@@ -475,7 +475,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:48 GMT
+      - Thu, 18 Sep 2025 14:57:12 GMT
       ETag:
       - '"66e1651c-5c5"'
       Last-Modified:
@@ -491,15 +491,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 12a1d0f3ef44dc8498f3619a98956531aec06376
+      - dc6214eba4481e9a1a09199c04e68e7ed08ff3e6
       X-GitHub-Request-Id:
-      - B8DE:2B753C:1FB3308:2311128:68C2EEF6
+      - 5B44:174E5:1A4E3E:1BFD2E:68CC1DBE
       X-Served-By:
-      - cache-bos4651-BOS
+      - cache-bos4660-BOS
       X-Timer:
-      - S1757605968.189115,VS0,VE1
+      - S1758207433.550177,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -509,7 +511,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/instrument.json
   response:
@@ -530,7 +532,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '345'
+      - '8'
       Cache-Control:
       - max-age=600
       Connection:
@@ -540,7 +542,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:48 GMT
+      - Thu, 18 Sep 2025 14:57:12 GMT
       ETag:
       - '"66e1651c-2bd"'
       Last-Modified:
@@ -556,15 +558,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - b7ac9a3ed697326a17ff79070f526ee417bde2fb
+      - 143e8ca74c7efae71cf2f592ad23572c33834e65
       X-GitHub-Request-Id:
-      - 448A:38B0E6:1FA06BD:22FBE14:68C2EEF6
+      - B1E0:32B3EB:1A35D3:1BE3DB:68CC1DC0
       X-Served-By:
-      - cache-bos4675-BOS
+      - cache-bos4640-BOS
       X-Timer:
-      - S1757605968.277044,VS0,VE1
+      - S1758207433.619339,VS0,VE50
       expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -574,7 +576,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/licensing.json
   response:
@@ -590,7 +592,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '345'
+      - '8'
       Cache-Control:
       - max-age=600
       Connection:
@@ -600,7 +602,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:48 GMT
+      - Thu, 18 Sep 2025 14:57:12 GMT
       ETag:
       - '"66e1651c-133"'
       Last-Modified:
@@ -616,15 +618,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 0909ed2377eb68e34818c9bb2fc491920e012d5d
+      - 19d9860283a62386c95a44c4cd286d5e07dc87fd
       X-GitHub-Request-Id:
-      - 13EA:108A1F:1F46494:22A2D65:68C2EEF6
+      - 763C:1EB76C:1E950A:20443C:68CC1DC0
       X-Served-By:
-      - cache-bos4671-BOS
+      - cache-bos4670-BOS
       X-Timer:
-      - S1757605968.364654,VS0,VE1
+      - S1758207433.747325,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:57:03 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -636,7 +638,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/provider.json
   response:
@@ -663,7 +665,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '345'
+      - '8'
       Cache-Control:
       - max-age=600
       Connection:
@@ -673,7 +675,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:48 GMT
+      - Thu, 18 Sep 2025 14:57:12 GMT
       ETag:
       - '"66e1651c-474"'
       Last-Modified:
@@ -689,15 +691,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 6a578fda3d14d1d247beead2289945e705e14c77
+      - ce223bd18d76e8ee26170e3a98d4420528b31273
       X-GitHub-Request-Id:
-      - 60B8:99D9B:1ED51A9:2232520:68C2EEF6
+      - 689D:239986:1C4373:1DF1F8:68CC1DBF
       X-Served-By:
-      - cache-bos4665-BOS
+      - cache-bos4622-BOS
       X-Timer:
-      - S1757605968.453752,VS0,VE2
+      - S1758207433.817304,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:57:03 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -709,7 +711,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/label/v1.0.1/schema.json
   response:
@@ -812,7 +814,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '430'
+      - '93'
       Cache-Control:
       - max-age=600
       Connection:
@@ -822,7 +824,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:48 GMT
+      - Thu, 18 Sep 2025 14:57:12 GMT
       ETag:
       - '"61eb1dc9-1abf"'
       Last-Modified:
@@ -838,17 +840,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '3'
       X-Fastly-Request-ID:
-      - 44e6166e99108128a3042f79f8e4b6ae7dcea26c
+      - 429fa915f56cb010394339a8aed06f7c481d0233
       X-GitHub-Request-Id:
-      - FE08:128B70:CBB40B:E7523E:68C2EEA2
+      - 600D:C1ED5:D907DA:F3637F:68CC1D6B
       X-Served-By:
-      - cache-bos4660-BOS
+      - cache-bos4648-BOS
       X-Timer:
-      - S1757605969.541725,VS0,VE0
+      - S1758207433.891194,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:38 GMT
+      - Thu, 18 Sep 2025 15:05:39 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -858,7 +860,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/extensions/asset/json-schema/schema.json
   response:
@@ -895,13 +897,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:49 GMT
+      - Thu, 18 Sep 2025 14:57:14 GMT
       ETag:
       - '"cffbb0036f526b016f24477e0ad674e75b6fefb89708ca796686de9d2e2a67ed"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:49 GMT
+      - Thu, 18 Sep 2025 15:02:14 GMT
       Source-Age:
-      - '67'
+      - '72'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -911,19 +913,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '6'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 741105dd91a9c40443250a00ed90a32f81b7e443
+      - 1e5f22e3d96a4622e5c86fe10fe7994e154f01cf
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 635E:2ACBC:149CBC:1913A5:68C2EEB7
+      - 6FDB:372AF9:AF9FC:DABC2:68CC1D80
       X-Served-By:
-      - cache-bos4648-BOS
+      - cache-bos4620-BOS
       X-Timer:
-      - S1757605970.731969,VS0,VE2
+      - S1758207434.168959,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_all_dict[test_case6].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_all_dict[test_case6].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/collection-spec/json-schema/collection.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '381'
+      - '44'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:49 GMT
+      - Thu, 18 Sep 2025 14:57:14 GMT
       ETag:
       - '"66e1651c-14e2"'
       Last-Modified:
@@ -109,17 +109,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Fastly-Request-ID:
-      - f669cbf79b11cf21de465719d4a9dd11ffac30aa
+      - 31c7b8bec46c31ed5e9d2d0eb1ea862d2d75c897
       X-GitHub-Request-Id:
-      - 3C0F:3556F2:2104189:236964E:68C2EED2
+      - DF8C:3D7940:20E828F:24A0D28:68CC1D9D
       X-Served-By:
-      - cache-bos4689-BOS
+      - cache-bos4668-BOS
       X-Timer:
-      - S1757605970.833831,VS0,VE1
+      - S1758207434.259993,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:56:28 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/catalog-spec/json-schema/catalog.json
   response:
@@ -171,7 +171,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '382'
+      - '45'
       Cache-Control:
       - max-age=600
       Connection:
@@ -181,7 +181,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:49 GMT
+      - Thu, 18 Sep 2025 14:57:14 GMT
       ETag:
       - '"66e1651c-84e"'
       Last-Modified:
@@ -195,17 +195,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 892c057fe89b523961cbd08f4e93d659bcb521ce
+      - 95dd27f39249df97f07c24f36d2767898b60b359
       X-GitHub-Request-Id:
-      - 6A55:180028:223E696:24A38DD:68C2EED2
+      - 3695:91567:105B1F4:125794D:68CC1D9D
       X-Served-By:
-      - cache-bos4675-BOS
+      - cache-bos4620-BOS
       X-Timer:
-      - S1757605970.924314,VS0,VE0
+      - S1758207434.342737,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:27 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -215,7 +215,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/item.json
   response:
@@ -319,7 +319,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '347'
+      - '10'
       Cache-Control:
       - max-age=600
       Connection:
@@ -329,7 +329,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:50 GMT
+      - Thu, 18 Sep 2025 14:57:14 GMT
       ETag:
       - '"66e1651c-1b3a"'
       Last-Modified:
@@ -345,15 +345,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 42057d282d376f2f783c2420e27d144ddd7015e6
+      - e64847fabfb5d187c2674134c732a4fab1c5bc93
       X-GitHub-Request-Id:
-      - BF31:3B188F:1EF9FB5:2255ED5:68C2EEF6
+      - 9945:BA176:8226E:8D5D0:68CC1DC0
       X-Served-By:
-      - cache-bos4647-BOS
+      - cache-bos4691-BOS
       X-Timer:
-      - S1757605970.009895,VS0,VE1
+      - S1758207434.434895,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -363,7 +363,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/basics.json
   response:
@@ -382,7 +382,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '347'
+      - '10'
       Cache-Control:
       - max-age=600
       Connection:
@@ -392,7 +392,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:50 GMT
+      - Thu, 18 Sep 2025 14:57:14 GMT
       ETag:
       - '"66e1651c-21a"'
       Last-Modified:
@@ -408,15 +408,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - bf1dfee7608dc4f63b07b96a994bd02baebe6bfd
+      - 073f785e721b2ec4d7d62f621f0574e2226e72c9
       X-GitHub-Request-Id:
-      - C9D0:1561A9:1E3A377:21988BC:68C2EEF4
+      - 5B3B:239986:1C42F0:1DF164:68CC1DBF
       X-Served-By:
-      - cache-bos4669-BOS
+      - cache-bos4681-BOS
       X-Timer:
-      - S1757605970.105762,VS0,VE1
+      - S1758207435.523103,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -426,7 +426,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/datetime.json
   response:
@@ -458,7 +458,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '347'
+      - '10'
       Cache-Control:
       - max-age=600
       Connection:
@@ -468,7 +468,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:50 GMT
+      - Thu, 18 Sep 2025 14:57:14 GMT
       ETag:
       - '"66e1651c-5c5"'
       Last-Modified:
@@ -484,15 +484,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - e135e78f21592a23200f001e73d9c0446dd6c5bf
+      - ada7c82194e56aee577e92e3a2c2f81ee53ca3e4
       X-GitHub-Request-Id:
-      - B8DE:2B753C:1FB3308:2311128:68C2EEF6
+      - 5B44:174E5:1A4E3E:1BFD2E:68CC1DBE
       X-Served-By:
-      - cache-bos4644-BOS
+      - cache-bos4657-BOS
       X-Timer:
-      - S1757605970.196132,VS0,VE1
+      - S1758207435.613318,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -502,7 +504,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/instrument.json
   response:
@@ -523,7 +525,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '347'
+      - '10'
       Cache-Control:
       - max-age=600
       Connection:
@@ -533,7 +535,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:50 GMT
+      - Thu, 18 Sep 2025 14:57:14 GMT
       ETag:
       - '"66e1651c-2bd"'
       Last-Modified:
@@ -549,15 +551,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 2ab378bb45abf40e164a98daa826fb21a93d15b1
+      - 1d78f378fad9000ad07429d055b6edb6b05bcb08
       X-GitHub-Request-Id:
-      - 448A:38B0E6:1FA06BD:22FBE14:68C2EEF6
+      - B1E0:32B3EB:1A35D3:1BE3DB:68CC1DC0
       X-Served-By:
-      - cache-bos4626-BOS
+      - cache-bos4659-BOS
       X-Timer:
-      - S1757605970.287300,VS0,VE1
+      - S1758207435.704853,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -567,7 +569,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/licensing.json
   response:
@@ -583,7 +585,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '347'
+      - '10'
       Cache-Control:
       - max-age=600
       Connection:
@@ -593,7 +595,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:50 GMT
+      - Thu, 18 Sep 2025 14:57:14 GMT
       ETag:
       - '"66e1651c-133"'
       Last-Modified:
@@ -609,15 +611,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 81bb7f48c512808a170a8efa9c90757128453d6d
+      - ef36885ee32138bf7aed0df7143507657fdb7e84
       X-GitHub-Request-Id:
-      - 13EA:108A1F:1F46494:22A2D65:68C2EEF6
+      - 763C:1EB76C:1E950A:20443C:68CC1DC0
       X-Served-By:
-      - cache-bos4634-BOS
+      - cache-bos4639-BOS
       X-Timer:
-      - S1757605970.375815,VS0,VE1
+      - S1758207435.789027,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:57:03 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -629,7 +631,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.3/item-spec/json-schema/provider.json
   response:
@@ -656,7 +658,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '347'
+      - '10'
       Cache-Control:
       - max-age=600
       Connection:
@@ -666,7 +668,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:50 GMT
+      - Thu, 18 Sep 2025 14:57:14 GMT
       ETag:
       - '"66e1651c-474"'
       Last-Modified:
@@ -680,17 +682,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - b0da0d76b5b2f0604de0ab0e95182c4f79e87ea6
+      - 6fddbb45223c07e173a6903eb6ec8c1ab53e23c7
       X-GitHub-Request-Id:
-      - 60B8:99D9B:1ED51A9:2232520:68C2EEF6
+      - 689D:239986:1C4373:1DF1F8:68CC1DBF
       X-Served-By:
-      - cache-bos4665-BOS
+      - cache-bos4686-BOS
       X-Timer:
-      - S1757605970.464222,VS0,VE0
+      - S1758207435.869247,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:57:03 GMT
+      - Thu, 18 Sep 2025 15:07:04 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -702,7 +704,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/eo/v1.1.0/schema.json
   response:
@@ -780,7 +782,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '456'
+      - '251'
       Cache-Control:
       - max-age=600
       Connection:
@@ -790,7 +792,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:50 GMT
+      - Thu, 18 Sep 2025 14:57:14 GMT
       ETag:
       - '"66df1c53-13bc"'
       Last-Modified:
@@ -808,15 +810,15 @@ interactions:
       X-Cache-Hits:
       - '2'
       X-Fastly-Request-ID:
-      - 0bcf7f6679eb9c4abd501225c4e82ec3fd35eb14
+      - 71f01a37334f7516d45d980181f12431710725e6
       X-GitHub-Request-Id:
-      - BE8A:14434E:B836A2:D3D600:68C2EE8A
+      - 98DE:39A2ED:1DBAAC:1F56C3:68CC1CD0
       X-Served-By:
-      - cache-bos4680-BOS
+      - cache-bos4659-BOS
       X-Timer:
-      - S1757605971.583982,VS0,VE0
+      - S1758207435.977355,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -826,7 +828,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/view/v1.0.0/schema.json
   response:
@@ -884,7 +886,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '456'
+      - '251'
       Cache-Control:
       - max-age=600
       Connection:
@@ -894,7 +896,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:50 GMT
+      - Thu, 18 Sep 2025 14:57:15 GMT
       ETag:
       - '"689f5434-dff"'
       Last-Modified:
@@ -910,17 +912,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '3'
       X-Fastly-Request-ID:
-      - e037cc02833ee806bfe5a4e6892defde27002f86
+      - 9a35387f28b2a03845ccf3db9a7f10aa68e204cd
       X-GitHub-Request-Id:
-      - EACF:1C0114:1BE6594:1F22786:68C2EE8A
+      - 624D:BA176:74CE5:7ED3C:68CC1CD0
       X-Served-By:
-      - cache-bos4647-BOS
+      - cache-bos4650-BOS
       X-Timer:
-      - S1757605971.656015,VS0,VE0
+      - S1758207435.043332,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -930,7 +932,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/projection/v2.0.0/schema.json
   response:
@@ -998,7 +1000,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '456'
+      - '250'
       Cache-Control:
       - max-age=600
       Connection:
@@ -1008,7 +1010,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:50 GMT
+      - Thu, 18 Sep 2025 14:57:15 GMT
       ETag:
       - '"669e563b-1116"'
       Last-Modified:
@@ -1024,17 +1026,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '0'
       X-Fastly-Request-ID:
-      - 59282e8f6c23920d44cd67656469de29c49c96cc
+      - 622cefac4d55c4f9a9f81fe821df44bd3efa930c
       X-GitHub-Request-Id:
-      - 21B3:2B753C:1E14E8F:2148802:68C2D6FB
+      - 224F:32B3EB:191F90:1ABAB3:68CC1CCF
       X-Served-By:
-      - cache-bos4671-BOS
+      - cache-bos4661-BOS
       X-Timer:
-      - S1757605971.730083,VS0,VE0
+      - S1758207435.117367,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 14:14:44 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -1044,7 +1046,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/catalog-spec/json-schema/catalog.json
   response:
@@ -1105,13 +1107,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:50 GMT
+      - Thu, 18 Sep 2025 14:57:15 GMT
       ETag:
       - '"3b514933a3747f038125935624a13df108e30fe1cb8f9660a7f54ac6d4765ce9"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:50 GMT
+      - Thu, 18 Sep 2025 15:02:15 GMT
       Source-Age:
-      - '69'
+      - '74'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -1125,15 +1127,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 86fa450db24e330b0f65614309c938fe58e95c98
+      - 49cfa4051d54ea8a60d39ffa2af2e6f4e0832a52
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 4D53:1CB1E4:12EBE4:17599A:68C2EEB7
+      - BCE7:388807:C697B:F1BF7:68CC1D7C
       X-Served-By:
-      - cache-bos4651-BOS
+      - cache-bos4675-BOS
       X-Timer:
-      - S1757605971.844842,VS0,VE1
+      - S1758207435.233365,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -1143,7 +1145,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/collection-spec/json-schema/collection.json
   response:
@@ -1225,13 +1227,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:50 GMT
+      - Thu, 18 Sep 2025 14:57:15 GMT
       ETag:
       - '"031974beaaaf6f0b5c6877dc97088d9e2aff3bc8962df33ff291dddded353f09"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:50 GMT
+      - Thu, 18 Sep 2025 15:02:15 GMT
       Source-Age:
-      - '69'
+      - '74'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -1241,19 +1243,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - a462cec71265f898abef975e39bd4e88f201a91a
+      - 0f4f945ccd28ccf3b0d4ae57c676b3898b80bf96
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 48D2:9DF63:14B8DC:192D3D:68C2EEB6
+      - EAA4:3C3312:A80AF:D3151:68CC1D7F
       X-Served-By:
-      - cache-bos4678-BOS
+      - cache-bos4666-BOS
       X-Timer:
-      - S1757605971.918003,VS0,VE0
+      - S1758207435.309551,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -1263,7 +1265,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/label/v1.0.1/schema.json
   response:
@@ -1366,7 +1368,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '433'
+      - '96'
       Cache-Control:
       - max-age=600
       Connection:
@@ -1376,7 +1378,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:51 GMT
+      - Thu, 18 Sep 2025 14:57:15 GMT
       ETag:
       - '"61eb1dc9-1abf"'
       Last-Modified:
@@ -1392,17 +1394,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 3ce9ef7d811d599a2825ccf3deccaccb5fbe78e9
+      - 0d30442eb62997afbb7f01047740e2bb6ce36d53
       X-GitHub-Request-Id:
-      - FE08:128B70:CBB40B:E7523E:68C2EEA2
+      - 600D:C1ED5:D907DA:F3637F:68CC1D6B
       X-Served-By:
-      - cache-bos4628-BOS
+      - cache-bos4688-BOS
       X-Timer:
-      - S1757605971.007664,VS0,VE1
+      - S1758207435.395313,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:38 GMT
+      - Thu, 18 Sep 2025 15:05:39 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -1412,7 +1414,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/extensions/asset/json-schema/schema.json
   response:
@@ -1449,13 +1451,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:51 GMT
+      - Thu, 18 Sep 2025 14:57:16 GMT
       ETag:
       - '"cffbb0036f526b016f24477e0ad674e75b6fefb89708ca796686de9d2e2a67ed"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:51 GMT
+      - Thu, 18 Sep 2025 15:02:16 GMT
       Source-Age:
-      - '69'
+      - '74'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -1469,15 +1471,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 129f5966dd78766e0aa1af415fc4ec089f748bdc
+      - fe81d501678e26ebb535e4c81d76e68974679430
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 635E:2ACBC:149CBC:1913A5:68C2EEB7
+      - 6FDB:372AF9:AF9FC:DABC2:68CC1D80
       X-Served-By:
-      - cache-bos4688-BOS
+      - cache-bos4672-BOS
       X-Timer:
-      - S1757605972.721771,VS0,VE1
+      - S1758207436.053197,VS0,VE4
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_custom_validator.yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_custom_validator.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/custom-extension/v1.0.0/schema.json
   response:
@@ -54,7 +54,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '336'
+      - '0'
       Connection:
       - keep-alive
       Content-Length:
@@ -65,9 +65,9 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:51 GMT
+      - Thu, 18 Sep 2025 14:57:16 GMT
       ETag:
-      - '"64d39a40-24a3"'
+      - '"64d248ca-24a3"'
       Server:
       - GitHub.com
       Strict-Transport-Security:
@@ -77,17 +77,17 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - b96d8ff0fa27c9981a95595ca9c6fcf166a3eb6e
+      - 177bd79ca7730e04f4d2145eda89af6a0180b992
       X-GitHub-Request-Id:
-      - 5CA9:FA1FD:1EE767D:22450FC:68C2EF03
+      - 1E9F:3E33CC:1F8523:213561:68CC1DCB
       X-Served-By:
-      - cache-bos4664-BOS
+      - cache-bos4688-BOS
       X-Timer:
-      - S1757605972.802315,VS0,VE1
+      - S1758207436.153125,VS0,VE52
       x-proxy-cache:
       - MISS
     status:
@@ -97,7 +97,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/custom-extension/v1.0.0/schema.json
   response:
@@ -148,7 +148,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '336'
+      - '0'
       Connection:
       - keep-alive
       Content-Length:
@@ -159,9 +159,9 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:51 GMT
+      - Thu, 18 Sep 2025 14:57:16 GMT
       ETag:
-      - '"64d39a40-24a3"'
+      - '"64d248ca-24a3"'
       Server:
       - GitHub.com
       Strict-Transport-Security:
@@ -175,13 +175,13 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 5d0f5a8400c75769e6b3d09a041d222a14a7228b
+      - 262dfd413adf1af18ad78e3807f7ac6742152b98
       X-GitHub-Request-Id:
-      - 5CA9:FA1FD:1EE767D:22450FC:68C2EF03
+      - 1E9F:3E33CC:1F8523:213561:68CC1DCB
       X-Served-By:
-      - cache-bos4633-BOS
+      - cache-bos4684-BOS
       X-Timer:
-      - S1757605972.892075,VS0,VE2
+      - S1758207436.293029,VS0,VE1
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example0].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example0].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/catalog-spec/json-schema/catalog.json
   response:
@@ -64,11 +64,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:42 GMT
+      - Thu, 18 Sep 2025 14:56:01 GMT
       ETag:
       - '"3b514933a3747f038125935624a13df108e30fe1cb8f9660a7f54ac6d4765ce9"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:42 GMT
+      - Thu, 18 Sep 2025 15:01:01 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -78,21 +78,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 849dd36f3f4f71abdd3c6e680782118eb9d3704f
+      - 2902f62ebc10d55ca6b97ac74c83a03749535030
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 4D53:1CB1E4:12EBE4:17599A:68C2EEB7
+      - BCE7:388807:C697B:F1BF7:68CC1D7C
       X-Served-By:
-      - cache-bos4658-BOS
+      - cache-bos4622-BOS
       X-Timer:
-      - S1757605902.108222,VS0,VE54
+      - S1758207361.945598,VS0,VE73
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example100].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example100].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/item.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '403'
+      - '64'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:24 GMT
+      - Thu, 18 Sep 2025 14:56:46 GMT
       ETag:
       - '"66e1651c-147c"'
       Last-Modified:
@@ -109,17 +109,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '1'
       X-Fastly-Request-ID:
-      - 87bdda37c4dbc75ac165ef9b11471e1e00efec59
+      - 42de6611bcae04ab2ce5de4946f96342e6fc2c42
       X-GitHub-Request-Id:
-      - 9540:197FBB:BCDCFE:D8897B:68C2EEA5
+      - A3C0:BAEAA:C84169:E2AD23:68CC1D6E
       X-Served-By:
-      - cache-bos4686-BOS
+      - cache-bos4672-BOS
       X-Timer:
-      - S1757605945.911748,VS0,VE0
+      - S1758207407.833280,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/basics.json
   response:
@@ -148,7 +148,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '403'
+      - '64'
       Cache-Control:
       - max-age=600
       Connection:
@@ -158,7 +158,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:25 GMT
+      - Thu, 18 Sep 2025 14:56:46 GMT
       ETag:
       - '"66e1651c-21c"'
       Last-Modified:
@@ -174,15 +174,15 @@ interactions:
       X-Cache-Hits:
       - '3'
       X-Fastly-Request-ID:
-      - 9d040cdb5002a62779c46fdb3f12647c6c551481
+      - 1e577e14aa061ef267d81ff740155432178f9329
       X-GitHub-Request-Id:
-      - E1F2:14AA27:C232A6:DDCD4A:68C2EEA4
+      - 2F53:A07A9:C8C99E:E32E77:68CC1D6E
       X-Served-By:
-      - cache-bos4651-BOS
+      - cache-bos4624-BOS
       X-Timer:
-      - S1757605945.004447,VS0,VE0
+      - S1758207407.911178,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -192,7 +192,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/datetime.json
   response:
@@ -241,7 +241,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '403'
+      - '63'
       Cache-Control:
       - max-age=600
       Connection:
@@ -251,7 +251,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:25 GMT
+      - Thu, 18 Sep 2025 14:56:47 GMT
       ETag:
       - '"66e1651c-a82"'
       Last-Modified:
@@ -267,15 +267,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 0d73ebf0c8c447e83171c2c5fd3a121875cdfc38
+      - 8f48be99bda7d759de710ce13d31c2349d09ea18
       X-GitHub-Request-Id:
-      - 1865:153265:C4294F:DFCE98:68C2EEA5
+      - 3E81:0D6F:C30426:DD705D:68CC1D6F
       X-Served-By:
-      - cache-bos4665-BOS
+      - cache-bos4649-BOS
       X-Timer:
-      - S1757605945.081902,VS0,VE7
+      - S1758207407.008008,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -285,7 +287,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/instrument.json
   response:
@@ -306,7 +308,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '403'
+      - '63'
       Cache-Control:
       - max-age=600
       Connection:
@@ -316,7 +318,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:25 GMT
+      - Thu, 18 Sep 2025 14:56:47 GMT
       ETag:
       - '"66e1651c-2a2"'
       Last-Modified:
@@ -330,17 +332,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 0e391b5dd08d433c70e2d76f7a0f5fa7918f0ce4
+      - 34af6d5fb94f2dcdb17d459f59125dacd842c521
       X-GitHub-Request-Id:
-      - 4500:CA757:1EF5208:22C6B31:68C2EEA5
+      - 7C03:3CD2C3:DA5DDA:F4BC38:68CC1D6F
       X-Served-By:
-      - cache-bos4659-BOS
+      - cache-bos4663-BOS
       X-Timer:
-      - S1757605945.175360,VS0,VE0
+      - S1758207407.101135,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -350,7 +354,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/licensing.json
   response:
@@ -366,7 +370,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '403'
+      - '63'
       Cache-Control:
       - max-age=600
       Connection:
@@ -376,7 +380,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:25 GMT
+      - Thu, 18 Sep 2025 14:56:47 GMT
       ETag:
       - '"66e1651c-135"'
       Last-Modified:
@@ -390,17 +394,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Fastly-Request-ID:
-      - e36405b71558684acd9910623613e941846a0e21
+      - 9d008c60af4b0e2cafd9e32508e703d95e893f97
       X-GitHub-Request-Id:
-      - ED10:15FE94:C5AB5F:E14C22:68C2EEA5
+      - C4E5:1D3617:CA3033:E4A206:68CC1D6F
       X-Served-By:
-      - cache-bos4629-BOS
+      - cache-bos4647-BOS
       X-Timer:
-      - S1757605945.262274,VS0,VE2
+      - S1758207407.187426,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -412,7 +416,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/provider.json
   response:
@@ -438,7 +442,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '403'
+      - '63'
       Cache-Control:
       - max-age=600
       Connection:
@@ -448,7 +452,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:25 GMT
+      - Thu, 18 Sep 2025 14:56:47 GMT
       ETag:
       - '"66e1651c-40e"'
       Last-Modified:
@@ -464,15 +468,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - ca600abb448ea6a0673e740ed5705100e4dcc13b
+      - c51d684fbbec55be98e907c2712bed1dc83f3ec7
       X-GitHub-Request-Id:
-      - F8AD:14A94E:C2C9FE:DE6C58:68C2EEA4
+      - 5805:B21BA:AD266F:C78835:68CC1D6F
       X-Served-By:
-      - cache-bos4661-BOS
+      - cache-bos4626-BOS
       X-Timer:
-      - S1757605945.348039,VS0,VE2
+      - S1758207407.273435,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:44 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -484,7 +488,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/timestamps/json-schema/schema.json
   response:
@@ -517,7 +521,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '339'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -527,7 +531,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:25 GMT
+      - Thu, 18 Sep 2025 14:56:47 GMT
       ETag:
       - '"66e1651c-675"'
       Last-Modified:
@@ -539,19 +543,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 97af914cd6777aff3c1bffe054ac827037660e0c
+      - 95e474a5e435f63d498729273e52586df68df68f
       X-GitHub-Request-Id:
-      - 33F9:38E837:1EE1EA6:223FBEE:68C2EEE6
+      - 1ACF:202A94:209177B:244B514:68CC1DAE
       X-Served-By:
-      - cache-bos4658-BOS
+      - cache-bos4678-BOS
       X-Timer:
-      - S1757605945.430043,VS0,VE2
+      - S1758207407.350996,VS0,VE63
       expires:
-      - Thu, 11 Sep 2025 15:56:46 GMT
+      - Thu, 18 Sep 2025 15:06:47 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example101].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example101].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/collection-spec/json-schema/collection.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '357'
+      - '18'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:25 GMT
+      - Thu, 18 Sep 2025 14:56:47 GMT
       ETag:
       - '"66e1651c-14e2"'
       Last-Modified:
@@ -111,15 +111,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 5b5026722f0360e58819cf5907e8a14bda53b2a0
+      - a7ac775c2707f378e7a03058d066cbb4afdcd8f0
       X-GitHub-Request-Id:
-      - 3C0F:3556F2:2104189:236964E:68C2EED2
+      - DF8C:3D7940:20E828F:24A0D28:68CC1D9D
       X-Served-By:
-      - cache-bos4636-BOS
+      - cache-bos4678-BOS
       X-Timer:
-      - S1757605946.522451,VS0,VE1
+      - S1758207408.505069,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:28 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/catalog-spec/json-schema/catalog.json
   response:
@@ -171,7 +171,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '358'
+      - '18'
       Cache-Control:
       - max-age=600
       Connection:
@@ -181,7 +181,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:25 GMT
+      - Thu, 18 Sep 2025 14:56:47 GMT
       ETag:
       - '"66e1651c-84e"'
       Last-Modified:
@@ -195,17 +195,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 44910438d71d10a30fa2affd6a98aca2d008ebec
+      - acf9c2de3ff4d25a2e60a46141775d867ec8c8f9
       X-GitHub-Request-Id:
-      - 6A55:180028:223E696:24A38DD:68C2EED2
+      - 3695:91567:105B1F4:125794D:68CC1D9D
       X-Served-By:
-      - cache-bos4652-BOS
+      - cache-bos4640-BOS
       X-Timer:
-      - S1757605946.700055,VS0,VE0
+      - S1758207408.597138,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:56:27 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -215,7 +215,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/version/json-schema/schema.json
   response:
@@ -250,7 +250,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '353'
+      - '14'
       Cache-Control:
       - max-age=600
       Connection:
@@ -260,7 +260,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:25 GMT
+      - Thu, 18 Sep 2025 14:56:47 GMT
       ETag:
       - '"66e1651c-70b"'
       Last-Modified:
@@ -276,17 +276,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 98a4fb845838722d82d8a874f0d9c6f351ffaba7
+      - f22a0a9eb92e9accd398b7300183e0bba2b0c781
       X-GitHub-Request-Id:
-      - 3270:18947A:1F21620:227ED15:68C2EED8
+      - A42A:91567:105B703:1257EE0:68CC1DA0
       X-Served-By:
-      - cache-bos4643-BOS
+      - cache-bos4676-BOS
       X-Timer:
-      - S1757605946.783725,VS0,VE1
+      - S1758207408.683220,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:33 GMT
-      x-origin-cache:
-      - HIT
+      - Thu, 18 Sep 2025 15:06:34 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -296,7 +294,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/item.json
   response:
@@ -378,7 +376,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '404'
+      - '65'
       Cache-Control:
       - max-age=600
       Connection:
@@ -388,7 +386,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:25 GMT
+      - Thu, 18 Sep 2025 14:56:47 GMT
       ETag:
       - '"66e1651c-147c"'
       Last-Modified:
@@ -402,17 +400,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 339ddc8108ad50a9e577d7b840ad5e0d3679df6e
+      - 8cd4fc3d1ee0413b54d6890e56808a778adbb39e
       X-GitHub-Request-Id:
-      - 9540:197FBB:BCDCFE:D8897B:68C2EEA5
+      - A3C0:BAEAA:C84169:E2AD23:68CC1D6E
       X-Served-By:
-      - cache-bos4690-BOS
+      - cache-bos4637-BOS
       X-Timer:
-      - S1757605946.873606,VS0,VE0
+      - S1758207408.772934,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example102].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example102].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/item.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '404'
+      - '65'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:25 GMT
+      - Thu, 18 Sep 2025 14:56:47 GMT
       ETag:
       - '"66e1651c-147c"'
       Last-Modified:
@@ -111,15 +111,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 5a6fc718f3d1f901dc6c4255b7d5ec66bd6f7ef5
+      - d2bef36f0f5c40b892925786c2ca3bcd94c6834a
       X-GitHub-Request-Id:
-      - 9540:197FBB:BCDCFE:D8897B:68C2EEA5
+      - A3C0:BAEAA:C84169:E2AD23:68CC1D6E
       X-Served-By:
-      - cache-bos4693-BOS
+      - cache-bos4627-BOS
       X-Timer:
-      - S1757605946.965712,VS0,VE1
+      - S1758207408.870960,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/basics.json
   response:
@@ -148,7 +148,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '405'
+      - '65'
       Cache-Control:
       - max-age=600
       Connection:
@@ -158,7 +158,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:26 GMT
+      - Thu, 18 Sep 2025 14:56:47 GMT
       ETag:
       - '"66e1651c-21c"'
       Last-Modified:
@@ -172,17 +172,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '1'
       X-Fastly-Request-ID:
-      - 21174c9c56a508df44e1288fd16b6ed1eb8e9abe
+      - 2608b95a6f681284d995357a069e006d3e6ce887
       X-GitHub-Request-Id:
-      - E1F2:14AA27:C232A6:DDCD4A:68C2EEA4
+      - 2F53:A07A9:C8C99E:E32E77:68CC1D6E
       X-Served-By:
-      - cache-bos4621-BOS
+      - cache-bos4655-BOS
       X-Timer:
-      - S1757605946.050062,VS0,VE1
+      - S1758207408.957162,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -192,7 +192,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/datetime.json
   response:
@@ -241,7 +241,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '404'
+      - '65'
       Cache-Control:
       - max-age=600
       Connection:
@@ -251,7 +251,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:26 GMT
+      - Thu, 18 Sep 2025 14:56:48 GMT
       ETag:
       - '"66e1651c-a82"'
       Last-Modified:
@@ -267,15 +267,17 @@ interactions:
       X-Cache-Hits:
       - '2'
       X-Fastly-Request-ID:
-      - 197c7855faa48fa9a8c3b074c9f61c4639a78612
+      - db41ba5d4fb393506e9dd3268c0d92a5507610eb
       X-GitHub-Request-Id:
-      - 1865:153265:C4294F:DFCE98:68C2EEA5
+      - 3E81:0D6F:C30426:DD705D:68CC1D6F
       X-Served-By:
-      - cache-bos4625-BOS
+      - cache-bos4645-BOS
       X-Timer:
-      - S1757605946.124126,VS0,VE0
+      - S1758207408.031107,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -285,7 +287,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/instrument.json
   response:
@@ -306,7 +308,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '404'
+      - '65'
       Cache-Control:
       - max-age=600
       Connection:
@@ -316,7 +318,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:26 GMT
+      - Thu, 18 Sep 2025 14:56:48 GMT
       ETag:
       - '"66e1651c-2a2"'
       Last-Modified:
@@ -330,17 +332,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '3'
       X-Fastly-Request-ID:
-      - 133b9de08aa2dafd09b532cab65f55fbf9aa0a7a
+      - 23dc1e5f59bc4e85906ee05663d1b860b3690fa5
       X-GitHub-Request-Id:
-      - 4500:CA757:1EF5208:22C6B31:68C2EEA5
+      - 7C03:3CD2C3:DA5DDA:F4BC38:68CC1D6F
       X-Served-By:
-      - cache-bos4623-BOS
+      - cache-bos4671-BOS
       X-Timer:
-      - S1757605946.200252,VS0,VE1
+      - S1758207408.125385,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -350,7 +354,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/licensing.json
   response:
@@ -366,7 +370,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '404'
+      - '64'
       Cache-Control:
       - max-age=600
       Connection:
@@ -376,7 +380,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:26 GMT
+      - Thu, 18 Sep 2025 14:56:48 GMT
       ETag:
       - '"66e1651c-135"'
       Last-Modified:
@@ -392,15 +396,15 @@ interactions:
       X-Cache-Hits:
       - '2'
       X-Fastly-Request-ID:
-      - 1c95e383d123d18957f7a0ea8174b6de30225f62
+      - bb452eb72eab5425a5db421349c26727fb90bb6f
       X-GitHub-Request-Id:
-      - ED10:15FE94:C5AB5F:E14C22:68C2EEA5
+      - C4E5:1D3617:CA3033:E4A206:68CC1D6F
       X-Served-By:
-      - cache-bos4693-BOS
+      - cache-bos4688-BOS
       X-Timer:
-      - S1757605946.286001,VS0,VE0
+      - S1758207408.204037,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -412,7 +416,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/provider.json
   response:
@@ -438,7 +442,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '404'
+      - '64'
       Cache-Control:
       - max-age=600
       Connection:
@@ -448,7 +452,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:26 GMT
+      - Thu, 18 Sep 2025 14:56:48 GMT
       ETag:
       - '"66e1651c-40e"'
       Last-Modified:
@@ -464,15 +468,15 @@ interactions:
       X-Cache-Hits:
       - '2'
       X-Fastly-Request-ID:
-      - 0b8da94d1ad7e53cc987d6ec4a75aa1ed1b099a0
+      - 22cbb2f06c440a38bee0d9f69427df724200a628
       X-GitHub-Request-Id:
-      - F8AD:14A94E:C2C9FE:DE6C58:68C2EEA4
+      - 5805:B21BA:AD266F:C78835:68CC1D6F
       X-Served-By:
-      - cache-bos4632-BOS
+      - cache-bos4666-BOS
       X-Timer:
-      - S1757605946.359989,VS0,VE0
+      - S1758207408.287317,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:44 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -484,7 +488,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/version/json-schema/schema.json
   response:
@@ -519,7 +523,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '353'
+      - '14'
       Cache-Control:
       - max-age=600
       Connection:
@@ -529,7 +533,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:26 GMT
+      - Thu, 18 Sep 2025 14:56:48 GMT
       ETag:
       - '"66e1651c-70b"'
       Last-Modified:
@@ -545,17 +549,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - cf7cdf60a37c578a49f841467b70f40bb96bc924
+      - f0f72909501d3e1ff240f321c1930c47598d7373
       X-GitHub-Request-Id:
-      - 3270:18947A:1F21620:227ED15:68C2EED8
+      - A42A:91567:105B703:1257EE0:68CC1DA0
       X-Served-By:
-      - cache-bos4684-BOS
+      - cache-bos4635-BOS
       X-Timer:
-      - S1757605946.437107,VS0,VE1
+      - S1758207408.361074,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:33 GMT
-      x-origin-cache:
-      - HIT
+      - Thu, 18 Sep 2025 15:06:34 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -565,7 +567,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/collection-spec/json-schema/collection.json
   response:
@@ -647,7 +649,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '358'
+      - '19'
       Cache-Control:
       - max-age=600
       Connection:
@@ -657,7 +659,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:26 GMT
+      - Thu, 18 Sep 2025 14:56:48 GMT
       ETag:
       - '"66e1651c-14e2"'
       Last-Modified:
@@ -671,17 +673,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 2e4957139c3db121fb3ba0ceee0ddff6977d4e8d
+      - eecf60dfe39912d2a5386f02b0c4444b20b49c2e
       X-GitHub-Request-Id:
-      - 3C0F:3556F2:2104189:236964E:68C2EED2
+      - DF8C:3D7940:20E828F:24A0D28:68CC1D9D
       X-Served-By:
-      - cache-bos4655-BOS
+      - cache-bos4692-BOS
       X-Timer:
-      - S1757605947.518435,VS0,VE0
+      - S1758207408.429226,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:28 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -691,7 +693,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/catalog-spec/json-schema/catalog.json
   response:
@@ -733,7 +735,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '359'
+      - '19'
       Cache-Control:
       - max-age=600
       Connection:
@@ -743,7 +745,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:26 GMT
+      - Thu, 18 Sep 2025 14:56:48 GMT
       ETag:
       - '"66e1651c-84e"'
       Last-Modified:
@@ -759,15 +761,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 44b515c4f683c3455f826703314d84a3593991cd
+      - f7e93b9597a7d502e4e518785dcf47ab4bbef617
       X-GitHub-Request-Id:
-      - 6A55:180028:223E696:24A38DD:68C2EED2
+      - 3695:91567:105B1F4:125794D:68CC1D9D
       X-Served-By:
-      - cache-bos4638-BOS
+      - cache-bos4634-BOS
       X-Timer:
-      - S1757605947.595240,VS0,VE1
+      - S1758207408.499269,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:27 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example103].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example103].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/item.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '405'
+      - '66'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:26 GMT
+      - Thu, 18 Sep 2025 14:56:48 GMT
       ETag:
       - '"66e1651c-147c"'
       Last-Modified:
@@ -111,15 +111,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 2a6718c67f28790c428278eee33737703fd9f8a7
+      - 8f53611bdf529542ae702645040ddbf364eba8ac
       X-GitHub-Request-Id:
-      - 9540:197FBB:BCDCFE:D8897B:68C2EEA5
+      - A3C0:BAEAA:C84169:E2AD23:68CC1D6E
       X-Served-By:
-      - cache-bos4689-BOS
+      - cache-bos4659-BOS
       X-Timer:
-      - S1757605947.675554,VS0,VE1
+      - S1758207409.585400,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/basics.json
   response:
@@ -148,7 +148,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '405'
+      - '66'
       Cache-Control:
       - max-age=600
       Connection:
@@ -158,7 +158,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:26 GMT
+      - Thu, 18 Sep 2025 14:56:48 GMT
       ETag:
       - '"66e1651c-21c"'
       Last-Modified:
@@ -174,15 +174,15 @@ interactions:
       X-Cache-Hits:
       - '2'
       X-Fastly-Request-ID:
-      - 997bc0422ff5f2f3d8dd1fa78ed174ebc73bf5fb
+      - eed3846f108078c7e8ab3cc450e6d7027b6d1318
       X-GitHub-Request-Id:
-      - E1F2:14AA27:C232A6:DDCD4A:68C2EEA4
+      - 2F53:A07A9:C8C99E:E32E77:68CC1D6E
       X-Served-By:
-      - cache-bos4633-BOS
+      - cache-bos4656-BOS
       X-Timer:
-      - S1757605947.757901,VS0,VE1
+      - S1758207409.673139,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -192,7 +192,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/datetime.json
   response:
@@ -241,7 +241,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '405'
+      - '65'
       Cache-Control:
       - max-age=600
       Connection:
@@ -251,7 +251,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:26 GMT
+      - Thu, 18 Sep 2025 14:56:48 GMT
       ETag:
       - '"66e1651c-a82"'
       Last-Modified:
@@ -265,17 +265,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 9a0d745bbce5544faece0c1641e84e0d390715d8
+      - 8f2d1f0c38889ddca721bb541139546ed273fa5e
       X-GitHub-Request-Id:
-      - 1865:153265:C4294F:DFCE98:68C2EEA5
+      - 3E81:0D6F:C30426:DD705D:68CC1D6F
       X-Served-By:
-      - cache-bos4668-BOS
+      - cache-bos4682-BOS
       X-Timer:
-      - S1757605947.838060,VS0,VE1
+      - S1758207409.747222,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -285,7 +287,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/instrument.json
   response:
@@ -306,7 +308,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '405'
+      - '65'
       Cache-Control:
       - max-age=600
       Connection:
@@ -316,7 +318,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:26 GMT
+      - Thu, 18 Sep 2025 14:56:48 GMT
       ETag:
       - '"66e1651c-2a2"'
       Last-Modified:
@@ -330,17 +332,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Fastly-Request-ID:
-      - ae3545f039c9c64bb617127eb186b851a6b8328f
+      - 3c1726fd00ca6113f2e80ad68938fc6449cba49b
       X-GitHub-Request-Id:
-      - 4500:CA757:1EF5208:22C6B31:68C2EEA5
+      - 7C03:3CD2C3:DA5DDA:F4BC38:68CC1D6F
       X-Served-By:
-      - cache-bos4679-BOS
+      - cache-bos4641-BOS
       X-Timer:
-      - S1757605947.926177,VS0,VE1
+      - S1758207409.823244,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -350,7 +354,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/licensing.json
   response:
@@ -366,7 +370,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '405'
+      - '65'
       Cache-Control:
       - max-age=600
       Connection:
@@ -376,7 +380,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:27 GMT
+      - Thu, 18 Sep 2025 14:56:48 GMT
       ETag:
       - '"66e1651c-135"'
       Last-Modified:
@@ -390,17 +394,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Fastly-Request-ID:
-      - b4938c9038bccbf6813016fb8da2ffc771cfa79b
+      - 76ea1257de7ba63c321b9f2f91a6a39f1759fbe2
       X-GitHub-Request-Id:
-      - ED10:15FE94:C5AB5F:E14C22:68C2EEA5
+      - C4E5:1D3617:CA3033:E4A206:68CC1D6F
       X-Served-By:
-      - cache-bos4682-BOS
+      - cache-bos4690-BOS
       X-Timer:
-      - S1757605947.003860,VS0,VE3
+      - S1758207409.897062,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -412,7 +416,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/provider.json
   response:
@@ -438,7 +442,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '405'
+      - '65'
       Cache-Control:
       - max-age=600
       Connection:
@@ -448,7 +452,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:27 GMT
+      - Thu, 18 Sep 2025 14:56:48 GMT
       ETag:
       - '"66e1651c-40e"'
       Last-Modified:
@@ -464,15 +468,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - d5b6d03de398f98113fa95c6b8e70dc180b08abc
+      - 280a2c8a4abb22e047e540220e4eca920745cbdb
       X-GitHub-Request-Id:
-      - F8AD:14A94E:C2C9FE:DE6C58:68C2EEA4
+      - 5805:B21BA:AD266F:C78835:68CC1D6F
       X-Served-By:
-      - cache-bos4648-BOS
+      - cache-bos4683-BOS
       X-Timer:
-      - S1757605947.083619,VS0,VE2
+      - S1758207409.973000,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:44 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -484,7 +488,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/sat/json-schema/schema.json
   response:
@@ -514,7 +518,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '346'
+      - '7'
       Cache-Control:
       - max-age=600
       Connection:
@@ -524,7 +528,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:27 GMT
+      - Thu, 18 Sep 2025 14:56:49 GMT
       ETag:
       - '"66e1651c-5bb"'
       Last-Modified:
@@ -540,15 +544,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - eb23ae336e30853c9cf7779a9f4da3e2ccbdc9a1
+      - 7935e241777820cef5fff1341d396f134c885029
       X-GitHub-Request-Id:
-      - 2BE1:2BF852:1E93090:21F0E03:68C2EEE0
+      - DF43:1629B2:212BCBC:24E37AE:68CC1DA9
       X-Served-By:
-      - cache-bos4626-BOS
+      - cache-bos4649-BOS
       X-Timer:
-      - S1757605947.160284,VS0,VE2
+      - S1758207409.054933,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:41 GMT
+      - Thu, 18 Sep 2025 15:06:42 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -560,7 +564,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/view/json-schema/schema.json
   response:
@@ -599,7 +603,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '355'
+      - '16'
       Cache-Control:
       - max-age=600
       Connection:
@@ -609,7 +613,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:27 GMT
+      - Thu, 18 Sep 2025 14:56:49 GMT
       ETag:
       - '"66e1651c-829"'
       Last-Modified:
@@ -625,15 +629,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - e8cbe1e82645d7e5f2e394f83172397b225f58f7
+      - dcd5090b059dcb62551faf2741c1e36b769cf998
       X-GitHub-Request-Id:
-      - 8BE4:15BCE:1E9511B:21F04EB:68C2EED7
+      - 2A0E:3A039E:FF2E25:11EE6ED:68CC1D9F
       X-Served-By:
-      - cache-bos4635-BOS
+      - cache-bos4658-BOS
       X-Timer:
-      - S1757605947.238527,VS0,VE1
+      - S1758207409.145438,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:56:31 GMT
+      - Thu, 18 Sep 2025 15:06:32 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example104].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example104].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/item.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '406'
+      - '66'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:27 GMT
+      - Thu, 18 Sep 2025 14:56:49 GMT
       ETag:
       - '"66e1651c-147c"'
       Last-Modified:
@@ -111,15 +111,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - e98c056574dc64443ef27b1eb361e4651625de42
+      - 60b001e9fc812b94cba42027caa1a4204c5c628b
       X-GitHub-Request-Id:
-      - 9540:197FBB:BCDCFE:D8897B:68C2EEA5
+      - A3C0:BAEAA:C84169:E2AD23:68CC1D6E
       X-Served-By:
-      - cache-bos4641-BOS
+      - cache-bos4661-BOS
       X-Timer:
-      - S1757605947.308071,VS0,VE1
+      - S1758207409.239040,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/basics.json
   response:
@@ -148,7 +148,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '406'
+      - '66'
       Cache-Control:
       - max-age=600
       Connection:
@@ -158,7 +158,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:27 GMT
+      - Thu, 18 Sep 2025 14:56:49 GMT
       ETag:
       - '"66e1651c-21c"'
       Last-Modified:
@@ -174,15 +174,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - ad0b919c6924b4d52051e730095f8b11276b8eb3
+      - ded3c8f02d0c142222d59e9d2ce8c9248f1bfc2a
       X-GitHub-Request-Id:
-      - E1F2:14AA27:C232A6:DDCD4A:68C2EEA4
+      - 2F53:A07A9:C8C99E:E32E77:68CC1D6E
       X-Served-By:
-      - cache-bos4630-BOS
+      - cache-bos4646-BOS
       X-Timer:
-      - S1757605947.387731,VS0,VE1
+      - S1758207409.311162,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -192,7 +192,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/datetime.json
   response:
@@ -241,7 +241,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '405'
+      - '66'
       Cache-Control:
       - max-age=600
       Connection:
@@ -251,7 +251,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:27 GMT
+      - Thu, 18 Sep 2025 14:56:49 GMT
       ETag:
       - '"66e1651c-a82"'
       Last-Modified:
@@ -267,15 +267,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 95ab0182b050dc9d41e2971f887a67b256601f9d
+      - de034eab841732a575562eb70e5bd8d2aa666194
       X-GitHub-Request-Id:
-      - 1865:153265:C4294F:DFCE98:68C2EEA5
+      - 3E81:0D6F:C30426:DD705D:68CC1D6F
       X-Served-By:
-      - cache-bos4652-BOS
+      - cache-bos4643-BOS
       X-Timer:
-      - S1757605947.467708,VS0,VE2
+      - S1758207409.383064,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -285,7 +287,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/instrument.json
   response:
@@ -306,7 +308,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '405'
+      - '66'
       Cache-Control:
       - max-age=600
       Connection:
@@ -316,7 +318,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:27 GMT
+      - Thu, 18 Sep 2025 14:56:49 GMT
       ETag:
       - '"66e1651c-2a2"'
       Last-Modified:
@@ -332,15 +334,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 3163fdd9dd26b02fa1c1a88f855ab85c7c46c6e0
+      - 9cf7d0e5362f6154282abf5c1483eb329ade8ac9
       X-GitHub-Request-Id:
-      - 4500:CA757:1EF5208:22C6B31:68C2EEA5
+      - 7C03:3CD2C3:DA5DDA:F4BC38:68CC1D6F
       X-Served-By:
-      - cache-bos4682-BOS
+      - cache-bos4693-BOS
       X-Timer:
-      - S1757605948.545348,VS0,VE1
+      - S1758207409.460249,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -350,7 +354,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/licensing.json
   response:
@@ -366,7 +370,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '405'
+      - '66'
       Cache-Control:
       - max-age=600
       Connection:
@@ -376,7 +380,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:27 GMT
+      - Thu, 18 Sep 2025 14:56:49 GMT
       ETag:
       - '"66e1651c-135"'
       Last-Modified:
@@ -390,17 +394,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '1'
       X-Fastly-Request-ID:
-      - 6b216e08e509413e893038e4f527f2b5a8dd420b
+      - ceb227220434644918d00799e6df1737dfe75823
       X-GitHub-Request-Id:
-      - ED10:15FE94:C5AB5F:E14C22:68C2EEA5
+      - C4E5:1D3617:CA3033:E4A206:68CC1D6F
       X-Served-By:
-      - cache-bos4656-BOS
+      - cache-bos4687-BOS
       X-Timer:
-      - S1757605948.622005,VS0,VE1
+      - S1758207410.531379,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -412,7 +416,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/provider.json
   response:
@@ -438,7 +442,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '405'
+      - '66'
       Cache-Control:
       - max-age=600
       Connection:
@@ -448,7 +452,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:27 GMT
+      - Thu, 18 Sep 2025 14:56:49 GMT
       ETag:
       - '"66e1651c-40e"'
       Last-Modified:
@@ -462,17 +466,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Fastly-Request-ID:
-      - c2aee3f7d8b1cd128a7d2e5362f6be919b3e44f3
+      - ac92932b5d439af56080e1e21f278fd102971574
       X-GitHub-Request-Id:
-      - F8AD:14A94E:C2C9FE:DE6C58:68C2EEA4
+      - 5805:B21BA:AD266F:C78835:68CC1D6F
       X-Served-By:
-      - cache-bos4684-BOS
+      - cache-bos4683-BOS
       X-Timer:
-      - S1757605948.705669,VS0,VE1
+      - S1758207410.611134,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:44 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -484,7 +488,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/projection/json-schema/schema.json
   response:
@@ -538,7 +542,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '348'
+      - '9'
       Cache-Control:
       - max-age=600
       Connection:
@@ -548,7 +552,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:27 GMT
+      - Thu, 18 Sep 2025 14:56:49 GMT
       ETag:
       - '"66e1651c-dc7"'
       Last-Modified:
@@ -564,15 +568,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - a2a5259237ee999a6ce92ba021980778bd230512
+      - e811f03c093b041ce6774079b1838e3401f25433
       X-GitHub-Request-Id:
-      - A35A:108A1F:1F448D6:22A0F0C:68C2EEDF
+      - C94B:21FE6A:2283F11:263C621:68CC1DA8
       X-Served-By:
-      - cache-bos4631-BOS
+      - cache-bos4685-BOS
       X-Timer:
-      - S1757605948.781804,VS0,VE1
+      - S1758207410.690048,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:39 GMT
+      - Thu, 18 Sep 2025 15:06:40 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -582,7 +588,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/view/json-schema/schema.json
   response:
@@ -621,7 +627,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '356'
+      - '17'
       Cache-Control:
       - max-age=600
       Connection:
@@ -631,7 +637,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:27 GMT
+      - Thu, 18 Sep 2025 14:56:49 GMT
       ETag:
       - '"66e1651c-829"'
       Last-Modified:
@@ -647,15 +653,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 99b22368780308b0ffaa2c1866ea5de120dbfdd3
+      - 507cc309bb038f9f0eb952340c8c7e5dfbf0f9b9
       X-GitHub-Request-Id:
-      - 8BE4:15BCE:1E9511B:21F04EB:68C2EED7
+      - 2A0E:3A039E:FF2E25:11EE6ED:68CC1D9F
       X-Served-By:
-      - cache-bos4678-BOS
+      - cache-bos4651-BOS
       X-Timer:
-      - S1757605948.867815,VS0,VE2
+      - S1758207410.775662,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:31 GMT
+      - Thu, 18 Sep 2025 15:06:32 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example105].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example105].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/item.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '406'
+      - '67'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:27 GMT
+      - Thu, 18 Sep 2025 14:56:49 GMT
       ETag:
       - '"66e1651c-147c"'
       Last-Modified:
@@ -111,15 +111,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 355189a4a6a84c813ef15a3b71255a3743e7018a
+      - 8643b4e9454a3dca05c485bb4160330c30c22f6a
       X-GitHub-Request-Id:
-      - 9540:197FBB:BCDCFE:D8897B:68C2EEA5
+      - A3C0:BAEAA:C84169:E2AD23:68CC1D6E
       X-Served-By:
-      - cache-bos4626-BOS
+      - cache-bos4631-BOS
       X-Timer:
-      - S1757605948.975264,VS0,VE1
+      - S1758207410.867881,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/basics.json
   response:
@@ -148,7 +148,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '406'
+      - '67'
       Cache-Control:
       - max-age=600
       Connection:
@@ -158,7 +158,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:28 GMT
+      - Thu, 18 Sep 2025 14:56:49 GMT
       ETag:
       - '"66e1651c-21c"'
       Last-Modified:
@@ -174,15 +174,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - c013735485d60977040804fcf1773de470a928d8
+      - 73bc4786efdb6282e8f936f649689bd557cb5f3b
       X-GitHub-Request-Id:
-      - E1F2:14AA27:C232A6:DDCD4A:68C2EEA4
+      - 2F53:A07A9:C8C99E:E32E77:68CC1D6E
       X-Served-By:
-      - cache-bos4665-BOS
+      - cache-bos4629-BOS
       X-Timer:
-      - S1757605948.062353,VS0,VE2
+      - S1758207410.973889,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -192,7 +192,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/datetime.json
   response:
@@ -241,7 +241,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '406'
+      - '66'
       Cache-Control:
       - max-age=600
       Connection:
@@ -251,7 +251,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:28 GMT
+      - Thu, 18 Sep 2025 14:56:50 GMT
       ETag:
       - '"66e1651c-a82"'
       Last-Modified:
@@ -265,17 +265,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 08e9208746ec15c70595597a80df9fb4887babb3
+      - 2b0140a70cdaca5ce68a97d6cb8d31c851df54f5
       X-GitHub-Request-Id:
-      - 1865:153265:C4294F:DFCE98:68C2EEA5
+      - 3E81:0D6F:C30426:DD705D:68CC1D6F
       X-Served-By:
-      - cache-bos4645-BOS
+      - cache-bos4686-BOS
       X-Timer:
-      - S1757605948.156182,VS0,VE0
+      - S1758207410.050004,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -285,7 +287,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/instrument.json
   response:
@@ -306,7 +308,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '406'
+      - '66'
       Cache-Control:
       - max-age=600
       Connection:
@@ -316,7 +318,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:28 GMT
+      - Thu, 18 Sep 2025 14:56:50 GMT
       ETag:
       - '"66e1651c-2a2"'
       Last-Modified:
@@ -330,17 +332,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - e3ba978ec5a12957b408171eb19af3e83a50381a
+      - 4bfd3f889f78a8ae157e26b1452914fe0116750e
       X-GitHub-Request-Id:
-      - 4500:CA757:1EF5208:22C6B31:68C2EEA5
+      - 7C03:3CD2C3:DA5DDA:F4BC38:68CC1D6F
       X-Served-By:
-      - cache-bos4671-BOS
+      - cache-bos4672-BOS
       X-Timer:
-      - S1757605948.242879,VS0,VE0
+      - S1758207410.145644,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -350,7 +354,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/licensing.json
   response:
@@ -366,7 +370,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '406'
+      - '66'
       Cache-Control:
       - max-age=600
       Connection:
@@ -376,7 +380,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:28 GMT
+      - Thu, 18 Sep 2025 14:56:50 GMT
       ETag:
       - '"66e1651c-135"'
       Last-Modified:
@@ -390,17 +394,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '1'
       X-Fastly-Request-ID:
-      - d63a5c4be091288a5444d1cc1ba07aa9ac1d0426
+      - fb09f1fbc81763f76ec34a73942eafb926293975
       X-GitHub-Request-Id:
-      - ED10:15FE94:C5AB5F:E14C22:68C2EEA5
+      - C4E5:1D3617:CA3033:E4A206:68CC1D6F
       X-Served-By:
-      - cache-bos4669-BOS
+      - cache-bos4671-BOS
       X-Timer:
-      - S1757605948.329810,VS0,VE1
+      - S1758207410.249565,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -412,7 +416,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/provider.json
   response:
@@ -438,7 +442,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '406'
+      - '66'
       Cache-Control:
       - max-age=600
       Connection:
@@ -448,7 +452,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:28 GMT
+      - Thu, 18 Sep 2025 14:56:50 GMT
       ETag:
       - '"66e1651c-40e"'
       Last-Modified:
@@ -462,17 +466,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '1'
       X-Fastly-Request-ID:
-      - 39c3f1dfa4579e56e1e757b699e26c8d94f1fbf5
+      - 837416b12bcc692ef124c7357ce819109e3fc869
       X-GitHub-Request-Id:
-      - F8AD:14A94E:C2C9FE:DE6C58:68C2EEA4
+      - 5805:B21BA:AD266F:C78835:68CC1D6F
       X-Served-By:
-      - cache-bos4643-BOS
+      - cache-bos4645-BOS
       X-Timer:
-      - S1757605948.420120,VS0,VE1
+      - S1758207410.344177,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:44 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example106].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example106].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/item.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '406'
+      - '67'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:28 GMT
+      - Thu, 18 Sep 2025 14:56:50 GMT
       ETag:
       - '"66e1651c-147c"'
       Last-Modified:
@@ -109,17 +109,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - fce0e9924a9d3ec0ae224abfdc4b619160970452
+      - aa3ccca7bb3da58348e15d8c42497b4e37192283
       X-GitHub-Request-Id:
-      - 9540:197FBB:BCDCFE:D8897B:68C2EEA5
+      - A3C0:BAEAA:C84169:E2AD23:68CC1D6E
       X-Served-By:
-      - cache-bos4635-BOS
+      - cache-bos4663-BOS
       X-Timer:
-      - S1757605949.508763,VS0,VE0
+      - S1758207410.429993,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/basics.json
   response:
@@ -148,7 +148,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '407'
+      - '67'
       Cache-Control:
       - max-age=600
       Connection:
@@ -158,7 +158,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:28 GMT
+      - Thu, 18 Sep 2025 14:56:50 GMT
       ETag:
       - '"66e1651c-21c"'
       Last-Modified:
@@ -174,15 +174,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - bf6086f97bf392a781705a13b97aeaf218279905
+      - a674434b6268036d88a9fb995346b6a99d67cd09
       X-GitHub-Request-Id:
-      - E1F2:14AA27:C232A6:DDCD4A:68C2EEA4
+      - 2F53:A07A9:C8C99E:E32E77:68CC1D6E
       X-Served-By:
-      - cache-bos4681-BOS
+      - cache-bos4641-BOS
       X-Timer:
-      - S1757605949.622248,VS0,VE1
+      - S1758207411.527366,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -192,7 +192,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/datetime.json
   response:
@@ -241,7 +241,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '407'
+      - '67'
       Cache-Control:
       - max-age=600
       Connection:
@@ -251,7 +251,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:28 GMT
+      - Thu, 18 Sep 2025 14:56:50 GMT
       ETag:
       - '"66e1651c-a82"'
       Last-Modified:
@@ -265,17 +265,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Fastly-Request-ID:
-      - 3af9c37e06896b538365d60a27638e6e76f9d180
+      - 8b74e33a8944c96cb163cf8caed470ce5eb34d18
       X-GitHub-Request-Id:
-      - 1865:153265:C4294F:DFCE98:68C2EEA5
+      - 3E81:0D6F:C30426:DD705D:68CC1D6F
       X-Served-By:
-      - cache-bos4655-BOS
+      - cache-bos4620-BOS
       X-Timer:
-      - S1757605949.710049,VS0,VE1
+      - S1758207411.626932,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -285,7 +287,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/instrument.json
   response:
@@ -306,7 +308,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '406'
+      - '67'
       Cache-Control:
       - max-age=600
       Connection:
@@ -316,7 +318,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:28 GMT
+      - Thu, 18 Sep 2025 14:56:50 GMT
       ETag:
       - '"66e1651c-2a2"'
       Last-Modified:
@@ -330,17 +332,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '20'
       X-Fastly-Request-ID:
-      - def75fe74252fb0466ea0fea3bbc8112e11da16f
+      - a9310edf36528f75db408d14d95c7799f371e8e8
       X-GitHub-Request-Id:
-      - 4500:CA757:1EF5208:22C6B31:68C2EEA5
+      - 7C03:3CD2C3:DA5DDA:F4BC38:68CC1D6F
       X-Served-By:
-      - cache-bos4650-BOS
+      - cache-bos4668-BOS
       X-Timer:
-      - S1757605949.801128,VS0,VE0
+      - S1758207411.717597,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -350,7 +354,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/licensing.json
   response:
@@ -366,7 +370,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '407'
+      - '67'
       Cache-Control:
       - max-age=600
       Connection:
@@ -376,7 +380,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:28 GMT
+      - Thu, 18 Sep 2025 14:56:50 GMT
       ETag:
       - '"66e1651c-135"'
       Last-Modified:
@@ -392,15 +396,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - b81ab832d6bb9506acd18ed6d22f577cae303019
+      - c08064c0dc665f0280342bf7c1b5b2bfe92e129b
       X-GitHub-Request-Id:
-      - ED10:15FE94:C5AB5F:E14C22:68C2EEA5
+      - C4E5:1D3617:CA3033:E4A206:68CC1D6F
       X-Served-By:
-      - cache-bos4686-BOS
+      - cache-bos4642-BOS
       X-Timer:
-      - S1757605949.877436,VS0,VE1
+      - S1758207411.806693,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -412,7 +416,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/provider.json
   response:
@@ -438,7 +442,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '406'
+      - '67'
       Cache-Control:
       - max-age=600
       Connection:
@@ -448,7 +452,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:28 GMT
+      - Thu, 18 Sep 2025 14:56:50 GMT
       ETag:
       - '"66e1651c-40e"'
       Last-Modified:
@@ -462,17 +466,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '1'
       X-Fastly-Request-ID:
-      - bd0bd120c5ea8a66fa7db1edce18a7c710336f05
+      - be960d588e5302ca7471c01bd1dd0781398dd079
       X-GitHub-Request-Id:
-      - F8AD:14A94E:C2C9FE:DE6C58:68C2EEA4
+      - 5805:B21BA:AD266F:C78835:68CC1D6F
       X-Served-By:
-      - cache-bos4677-BOS
+      - cache-bos4649-BOS
       X-Timer:
-      - S1757605949.950001,VS0,VE0
+      - S1758207411.897111,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:44 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -484,7 +488,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/eo/json-schema/schema.json
   response:
@@ -522,7 +526,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '357'
+      - '18'
       Cache-Control:
       - max-age=600
       Connection:
@@ -532,7 +536,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:29 GMT
+      - Thu, 18 Sep 2025 14:56:50 GMT
       ETag:
       - '"66e1651c-805"'
       Last-Modified:
@@ -548,15 +552,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - ab4145baf9977caf7ad683bfc027b88eea683c3d
+      - 28f15ec14716a8c00df1f2f425b23a6e0c95b844
       X-GitHub-Request-Id:
-      - 61E0:85CEC:1F72DF5:22CFA7F:68C2EED7
+      - 2976:1A3C1:217E151:25362CA:68CC1DA0
       X-Served-By:
-      - cache-bos4651-BOS
+      - cache-bos4658-BOS
       X-Timer:
-      - S1757605949.022982,VS0,VE1
+      - S1758207411.978044,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:56:31 GMT
+      - Thu, 18 Sep 2025 15:06:32 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -566,7 +572,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/projection/json-schema/schema.json
   response:
@@ -620,7 +626,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '349'
+      - '10'
       Cache-Control:
       - max-age=600
       Connection:
@@ -630,7 +636,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:29 GMT
+      - Thu, 18 Sep 2025 14:56:51 GMT
       ETag:
       - '"66e1651c-dc7"'
       Last-Modified:
@@ -646,15 +652,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 127c20dc849f6a0d4dd1f24b988df8c317524436
+      - 722e1e5a55122a26820c78139d64a4dd51822d15
       X-GitHub-Request-Id:
-      - A35A:108A1F:1F448D6:22A0F0C:68C2EEDF
+      - C94B:21FE6A:2283F11:263C621:68CC1DA8
       X-Served-By:
-      - cache-bos4625-BOS
+      - cache-bos4626-BOS
       X-Timer:
-      - S1757605949.100084,VS0,VE1
+      - S1758207411.077358,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:39 GMT
+      - Thu, 18 Sep 2025 15:06:40 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -664,7 +672,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/view/json-schema/schema.json
   response:
@@ -703,7 +711,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '357'
+      - '18'
       Cache-Control:
       - max-age=600
       Connection:
@@ -713,7 +721,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:29 GMT
+      - Thu, 18 Sep 2025 14:56:51 GMT
       ETag:
       - '"66e1651c-829"'
       Last-Modified:
@@ -729,15 +737,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - b0304e691e2167e310b6e318f0cf9fbc2c136c68
+      - 8ea77985ea380e3e574087b4f4aa69f0ba5f6160
       X-GitHub-Request-Id:
-      - 8BE4:15BCE:1E9511B:21F04EB:68C2EED7
+      - 2A0E:3A039E:FF2E25:11EE6ED:68CC1D9F
       X-Served-By:
-      - cache-bos4634-BOS
+      - cache-bos4624-BOS
       X-Timer:
-      - S1757605949.175713,VS0,VE1
+      - S1758207411.163396,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:56:31 GMT
+      - Thu, 18 Sep 2025 15:06:32 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example107].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example107].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/item.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '408'
+      - '68'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:29 GMT
+      - Thu, 18 Sep 2025 14:56:51 GMT
       ETag:
       - '"66e1651c-147c"'
       Last-Modified:
@@ -111,15 +111,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 6681f2822911163caa8d4cff0e4d62d961b27af7
+      - c7fe47b482691526712a9f04242065a27e51e05b
       X-GitHub-Request-Id:
-      - 9540:197FBB:BCDCFE:D8897B:68C2EEA5
+      - A3C0:BAEAA:C84169:E2AD23:68CC1D6E
       X-Served-By:
-      - cache-bos4651-BOS
+      - cache-bos4691-BOS
       X-Timer:
-      - S1757605949.262453,VS0,VE1
+      - S1758207411.270797,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/basics.json
   response:
@@ -148,7 +148,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '407'
+      - '68'
       Cache-Control:
       - max-age=600
       Connection:
@@ -158,7 +158,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:29 GMT
+      - Thu, 18 Sep 2025 14:56:51 GMT
       ETag:
       - '"66e1651c-21c"'
       Last-Modified:
@@ -172,17 +172,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 18501b04fd84738377fe8d56affdb17e021085ba
+      - 888de3afe49989f8439ff953f6483ea9a99aa453
       X-GitHub-Request-Id:
-      - E1F2:14AA27:C232A6:DDCD4A:68C2EEA4
+      - 2F53:A07A9:C8C99E:E32E77:68CC1D6E
       X-Served-By:
-      - cache-bos4686-BOS
+      - cache-bos4620-BOS
       X-Timer:
-      - S1757605949.337520,VS0,VE0
+      - S1758207411.375860,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -192,7 +192,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/datetime.json
   response:
@@ -241,7 +241,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '407'
+      - '68'
       Cache-Control:
       - max-age=600
       Connection:
@@ -251,7 +251,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:29 GMT
+      - Thu, 18 Sep 2025 14:56:51 GMT
       ETag:
       - '"66e1651c-a82"'
       Last-Modified:
@@ -267,15 +267,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 5b59f2d46c894c0dabe869676876a366fe38a6c2
+      - a06d5ec352374a17b64931ce2e73107787aed831
       X-GitHub-Request-Id:
-      - 1865:153265:C4294F:DFCE98:68C2EEA5
+      - 3E81:0D6F:C30426:DD705D:68CC1D6F
       X-Served-By:
-      - cache-bos4642-BOS
+      - cache-bos4623-BOS
       X-Timer:
-      - S1757605949.420442,VS0,VE1
+      - S1758207411.452362,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -285,7 +287,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/instrument.json
   response:
@@ -306,7 +308,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '407'
+      - '68'
       Cache-Control:
       - max-age=600
       Connection:
@@ -316,7 +318,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:29 GMT
+      - Thu, 18 Sep 2025 14:56:51 GMT
       ETag:
       - '"66e1651c-2a2"'
       Last-Modified:
@@ -332,15 +334,17 @@ interactions:
       X-Cache-Hits:
       - '2'
       X-Fastly-Request-ID:
-      - 93b384a9fa9ab46c07a78ba498a1be29978b95c7
+      - ba43b11b022e3e663582376ab8d7392c09c44864
       X-GitHub-Request-Id:
-      - 4500:CA757:1EF5208:22C6B31:68C2EEA5
+      - 7C03:3CD2C3:DA5DDA:F4BC38:68CC1D6F
       X-Served-By:
-      - cache-bos4676-BOS
+      - cache-bos4669-BOS
       X-Timer:
-      - S1757605950.505976,VS0,VE1
+      - S1758207412.537387,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -350,7 +354,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/licensing.json
   response:
@@ -366,7 +370,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '407'
+      - '68'
       Cache-Control:
       - max-age=600
       Connection:
@@ -376,7 +380,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:29 GMT
+      - Thu, 18 Sep 2025 14:56:51 GMT
       ETag:
       - '"66e1651c-135"'
       Last-Modified:
@@ -390,17 +394,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Fastly-Request-ID:
-      - 9c7fa5e2501eee65381cc068b15ca68d1fb88040
+      - 7e8546c02503f86385473db5a131ee3c66c23a09
       X-GitHub-Request-Id:
-      - ED10:15FE94:C5AB5F:E14C22:68C2EEA5
+      - C4E5:1D3617:CA3033:E4A206:68CC1D6F
       X-Served-By:
-      - cache-bos4671-BOS
+      - cache-bos4641-BOS
       X-Timer:
-      - S1757605950.590217,VS0,VE1
+      - S1758207412.613650,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -412,7 +416,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/provider.json
   response:
@@ -438,7 +442,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '407'
+      - '68'
       Cache-Control:
       - max-age=600
       Connection:
@@ -448,7 +452,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:29 GMT
+      - Thu, 18 Sep 2025 14:56:51 GMT
       ETag:
       - '"66e1651c-40e"'
       Last-Modified:
@@ -464,15 +468,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 23e80a25195ac3524a8a58f260ddfbcc4d4009bd
+      - 306832c30cbc2803f86ec9ad5a758a619e063a58
       X-GitHub-Request-Id:
-      - F8AD:14A94E:C2C9FE:DE6C58:68C2EEA4
+      - 5805:B21BA:AD266F:C78835:68CC1D6F
       X-Served-By:
-      - cache-bos4658-BOS
+      - cache-bos4691-BOS
       X-Timer:
-      - S1757605950.676292,VS0,VE2
+      - S1758207412.690694,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:44 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -484,7 +488,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/eo/json-schema/schema.json
   response:
@@ -522,7 +526,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '358'
+      - '19'
       Cache-Control:
       - max-age=600
       Connection:
@@ -532,7 +536,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:29 GMT
+      - Thu, 18 Sep 2025 14:56:51 GMT
       ETag:
       - '"66e1651c-805"'
       Last-Modified:
@@ -548,15 +552,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 019894edfdc9a52708c831919f6526d5d2ec5986
+      - 7c40228cf1fa2aad6e59fea68693c204567fee2e
       X-GitHub-Request-Id:
-      - 61E0:85CEC:1F72DF5:22CFA7F:68C2EED7
+      - 2976:1A3C1:217E151:25362CA:68CC1DA0
       X-Served-By:
-      - cache-bos4633-BOS
+      - cache-bos4678-BOS
       X-Timer:
-      - S1757605950.752215,VS0,VE1
+      - S1758207412.771848,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:56:31 GMT
+      - Thu, 18 Sep 2025 15:06:32 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -566,7 +572,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/view/json-schema/schema.json
   response:
@@ -605,7 +611,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '358'
+      - '19'
       Cache-Control:
       - max-age=600
       Connection:
@@ -615,7 +621,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:29 GMT
+      - Thu, 18 Sep 2025 14:56:51 GMT
       ETag:
       - '"66e1651c-829"'
       Last-Modified:
@@ -629,17 +635,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - e4fa477020d0de733e77456a5f475629aa9340e8
+      - 1aa8d3d8e60d9e1de0849f4c2383b75ce0d64353
       X-GitHub-Request-Id:
-      - 8BE4:15BCE:1E9511B:21F04EB:68C2EED7
+      - 2A0E:3A039E:FF2E25:11EE6ED:68CC1D9F
       X-Served-By:
-      - cache-bos4652-BOS
+      - cache-bos4684-BOS
       X-Timer:
-      - S1757605950.834061,VS0,VE1
+      - S1758207412.852830,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:31 GMT
+      - Thu, 18 Sep 2025 15:06:32 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example108].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example108].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/item.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '408'
+      - '69'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:29 GMT
+      - Thu, 18 Sep 2025 14:56:51 GMT
       ETag:
       - '"66e1651c-147c"'
       Last-Modified:
@@ -111,15 +111,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 94907cf448c32dc5f7b354cc72071d3603f732b7
+      - 394ce0ecb0d69e665efae9fc1a923917d094e83a
       X-GitHub-Request-Id:
-      - 9540:197FBB:BCDCFE:D8897B:68C2EEA5
+      - A3C0:BAEAA:C84169:E2AD23:68CC1D6E
       X-Served-By:
-      - cache-bos4658-BOS
+      - cache-bos4647-BOS
       X-Timer:
-      - S1757605950.919893,VS0,VE1
+      - S1758207412.989883,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/basics.json
   response:
@@ -148,7 +148,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '408'
+      - '69'
       Cache-Control:
       - max-age=600
       Connection:
@@ -158,7 +158,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:30 GMT
+      - Thu, 18 Sep 2025 14:56:52 GMT
       ETag:
       - '"66e1651c-21c"'
       Last-Modified:
@@ -174,15 +174,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 13125d5a49585e9d52c04f079865b41ed7142f30
+      - 545653a590049c72ed7649dda90f66ca71b5cd87
       X-GitHub-Request-Id:
-      - E1F2:14AA27:C232A6:DDCD4A:68C2EEA4
+      - 2F53:A07A9:C8C99E:E32E77:68CC1D6E
       X-Served-By:
-      - cache-bos4654-BOS
+      - cache-bos4663-BOS
       X-Timer:
-      - S1757605950.999549,VS0,VE1
+      - S1758207412.074081,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -192,7 +192,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/datetime.json
   response:
@@ -241,7 +241,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '408'
+      - '69'
       Cache-Control:
       - max-age=600
       Connection:
@@ -251,7 +251,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:30 GMT
+      - Thu, 18 Sep 2025 14:56:52 GMT
       ETag:
       - '"66e1651c-a82"'
       Last-Modified:
@@ -267,15 +267,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 84c73b268e0328a8eb34164e8aebbd1034a3802b
+      - e7b2aee411f13e92bcfdee4ebd8e9daeffc15e03
       X-GitHub-Request-Id:
-      - 1865:153265:C4294F:DFCE98:68C2EEA5
+      - 3E81:0D6F:C30426:DD705D:68CC1D6F
       X-Served-By:
-      - cache-bos4660-BOS
+      - cache-bos4661-BOS
       X-Timer:
-      - S1757605950.071595,VS0,VE1
+      - S1758207412.167113,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -285,7 +287,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/instrument.json
   response:
@@ -306,7 +308,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '408'
+      - '68'
       Cache-Control:
       - max-age=600
       Connection:
@@ -316,7 +318,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:30 GMT
+      - Thu, 18 Sep 2025 14:56:52 GMT
       ETag:
       - '"66e1651c-2a2"'
       Last-Modified:
@@ -330,17 +332,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '1'
       X-Fastly-Request-ID:
-      - 31200c653754e332300ed0813e6085b4757bf85b
+      - c2a94ecdb14ea657c49739db8120fa999b94c56e
       X-GitHub-Request-Id:
-      - 4500:CA757:1EF5208:22C6B31:68C2EEA5
+      - 7C03:3CD2C3:DA5DDA:F4BC38:68CC1D6F
       X-Served-By:
-      - cache-bos4676-BOS
+      - cache-bos4655-BOS
       X-Timer:
-      - S1757605950.143593,VS0,VE0
+      - S1758207412.243023,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -350,7 +354,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/licensing.json
   response:
@@ -366,7 +370,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '408'
+      - '69'
       Cache-Control:
       - max-age=600
       Connection:
@@ -376,7 +380,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:30 GMT
+      - Thu, 18 Sep 2025 14:56:52 GMT
       ETag:
       - '"66e1651c-135"'
       Last-Modified:
@@ -390,17 +394,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Fastly-Request-ID:
-      - b5326f62859a06e49b08b1180c60e4f68ff45ec8
+      - dfbc5d95fb9d8965b878a7567314de679cd0d94e
       X-GitHub-Request-Id:
-      - ED10:15FE94:C5AB5F:E14C22:68C2EEA5
+      - C4E5:1D3617:CA3033:E4A206:68CC1D6F
       X-Served-By:
-      - cache-bos4647-BOS
+      - cache-bos4631-BOS
       X-Timer:
-      - S1757605950.218395,VS0,VE2
+      - S1758207412.313256,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -412,7 +416,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/provider.json
   response:
@@ -438,7 +442,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '408'
+      - '68'
       Cache-Control:
       - max-age=600
       Connection:
@@ -448,7 +452,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:30 GMT
+      - Thu, 18 Sep 2025 14:56:52 GMT
       ETag:
       - '"66e1651c-40e"'
       Last-Modified:
@@ -464,15 +468,15 @@ interactions:
       X-Cache-Hits:
       - '2'
       X-Fastly-Request-ID:
-      - f3b5ade8bed4e893ff8ec77f517d7c21e6c32ef3
+      - 535a9239a53b8bf57d72895a1561d1936f6c2d9d
       X-GitHub-Request-Id:
-      - F8AD:14A94E:C2C9FE:DE6C58:68C2EEA4
+      - 5805:B21BA:AD266F:C78835:68CC1D6F
       X-Served-By:
-      - cache-bos4693-BOS
+      - cache-bos4640-BOS
       X-Timer:
-      - S1757605950.299682,VS0,VE0
+      - S1758207412.391926,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:44 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -484,7 +488,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/eo/json-schema/schema.json
   response:
@@ -522,7 +526,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '358'
+      - '20'
       Cache-Control:
       - max-age=600
       Connection:
@@ -532,7 +536,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:30 GMT
+      - Thu, 18 Sep 2025 14:56:52 GMT
       ETag:
       - '"66e1651c-805"'
       Last-Modified:
@@ -546,17 +550,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - a4232e9fd7937e55792863d8a3aa2dcf11c5f0c2
+      - 7181e74189bc8fe77a107d3b5349e5c6f50d1a71
       X-GitHub-Request-Id:
-      - 61E0:85CEC:1F72DF5:22CFA7F:68C2EED7
+      - 2976:1A3C1:217E151:25362CA:68CC1DA0
       X-Served-By:
-      - cache-bos4691-BOS
+      - cache-bos4682-BOS
       X-Timer:
-      - S1757605950.376054,VS0,VE0
+      - S1758207412.467222,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:56:31 GMT
+      - Thu, 18 Sep 2025 15:06:32 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -566,7 +572,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/view/json-schema/schema.json
   response:
@@ -605,7 +611,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '358'
+      - '20'
       Cache-Control:
       - max-age=600
       Connection:
@@ -615,7 +621,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:30 GMT
+      - Thu, 18 Sep 2025 14:56:52 GMT
       ETag:
       - '"66e1651c-829"'
       Last-Modified:
@@ -629,17 +635,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '1'
       X-Fastly-Request-ID:
-      - 7c2efde449c1ba63bbc24757fdad98909ddef9ff
+      - 3abb28c3319dc58e46848225865f8326c6f741cf
       X-GitHub-Request-Id:
-      - 8BE4:15BCE:1E9511B:21F04EB:68C2EED7
+      - 2A0E:3A039E:FF2E25:11EE6ED:68CC1D9F
       X-Served-By:
-      - cache-bos4690-BOS
+      - cache-bos4672-BOS
       X-Timer:
-      - S1757605950.457544,VS0,VE0
+      - S1758207413.549382,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:31 GMT
+      - Thu, 18 Sep 2025 15:06:32 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example109].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example109].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/item.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '409'
+      - '70'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:30 GMT
+      - Thu, 18 Sep 2025 14:56:52 GMT
       ETag:
       - '"66e1651c-147c"'
       Last-Modified:
@@ -109,17 +109,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 6a3b2f74a01377aca557a4b575bf78f10b27e0ca
+      - c67090db9e9874c1244d1f87f4c6d59b382a853c
       X-GitHub-Request-Id:
-      - 9540:197FBB:BCDCFE:D8897B:68C2EEA5
+      - A3C0:BAEAA:C84169:E2AD23:68CC1D6E
       X-Served-By:
-      - cache-bos4667-BOS
+      - cache-bos4693-BOS
       X-Timer:
-      - S1757605951.644669,VS0,VE0
+      - S1758207413.639545,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/basics.json
   response:
@@ -148,7 +148,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '409'
+      - '70'
       Cache-Control:
       - max-age=600
       Connection:
@@ -158,7 +158,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:30 GMT
+      - Thu, 18 Sep 2025 14:56:52 GMT
       ETag:
       - '"66e1651c-21c"'
       Last-Modified:
@@ -174,15 +174,15 @@ interactions:
       X-Cache-Hits:
       - '2'
       X-Fastly-Request-ID:
-      - d4811f3892883acabcd75bbe661e280c6bfdcbeb
+      - 8683e755c15a38a2173e7d17e7a3a5071a329129
       X-GitHub-Request-Id:
-      - E1F2:14AA27:C232A6:DDCD4A:68C2EEA4
+      - 2F53:A07A9:C8C99E:E32E77:68CC1D6E
       X-Served-By:
-      - cache-bos4664-BOS
+      - cache-bos4629-BOS
       X-Timer:
-      - S1757605951.739986,VS0,VE0
+      - S1758207413.720898,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -192,7 +192,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/datetime.json
   response:
@@ -241,7 +241,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '409'
+      - '69'
       Cache-Control:
       - max-age=600
       Connection:
@@ -251,7 +251,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:30 GMT
+      - Thu, 18 Sep 2025 14:56:52 GMT
       ETag:
       - '"66e1651c-a82"'
       Last-Modified:
@@ -267,15 +267,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 708be04dbecd283013a717ac49f4b0bda34551b4
+      - 20df40e2f3e3d8d0ee79b56d9f7b70e31e25f2d7
       X-GitHub-Request-Id:
-      - 1865:153265:C4294F:DFCE98:68C2EEA5
+      - 3E81:0D6F:C30426:DD705D:68CC1D6F
       X-Served-By:
-      - cache-bos4621-BOS
+      - cache-bos4666-BOS
       X-Timer:
-      - S1757605951.820118,VS0,VE2
+      - S1758207413.793354,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -285,7 +287,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/instrument.json
   response:
@@ -306,7 +308,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '409'
+      - '69'
       Cache-Control:
       - max-age=600
       Connection:
@@ -316,7 +318,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:30 GMT
+      - Thu, 18 Sep 2025 14:56:52 GMT
       ETag:
       - '"66e1651c-2a2"'
       Last-Modified:
@@ -332,15 +334,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 7cce86766d5ca326c0938d50d4ed0134bb4c4009
+      - fca9ef0ec9ed0b27bfb431834fc5b25a668e6f31
       X-GitHub-Request-Id:
-      - 4500:CA757:1EF5208:22C6B31:68C2EEA5
+      - 7C03:3CD2C3:DA5DDA:F4BC38:68CC1D6F
       X-Served-By:
-      - cache-bos4620-BOS
+      - cache-bos4644-BOS
       X-Timer:
-      - S1757605951.909396,VS0,VE1
+      - S1758207413.867581,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -350,7 +354,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/licensing.json
   response:
@@ -366,7 +370,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '409'
+      - '69'
       Cache-Control:
       - max-age=600
       Connection:
@@ -376,7 +380,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:30 GMT
+      - Thu, 18 Sep 2025 14:56:52 GMT
       ETag:
       - '"66e1651c-135"'
       Last-Modified:
@@ -392,15 +396,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 65c78480b5305ecd0aaea0d76feee0c298556507
+      - bd27ee6b95c45fe444934fe180efaa508727c56b
       X-GitHub-Request-Id:
-      - ED10:15FE94:C5AB5F:E14C22:68C2EEA5
+      - C4E5:1D3617:CA3033:E4A206:68CC1D6F
       X-Served-By:
-      - cache-bos4633-BOS
+      - cache-bos4628-BOS
       X-Timer:
-      - S1757605951.994735,VS0,VE2
+      - S1758207413.941461,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -412,7 +416,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/provider.json
   response:
@@ -438,7 +442,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '409'
+      - '69'
       Cache-Control:
       - max-age=600
       Connection:
@@ -448,7 +452,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:31 GMT
+      - Thu, 18 Sep 2025 14:56:53 GMT
       ETag:
       - '"66e1651c-40e"'
       Last-Modified:
@@ -464,15 +468,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 2735155b3448e73228771bc0ebe3081806383db1
+      - 37b82251be6b34d9bdf3e1c3ddb0fdb78692455f
       X-GitHub-Request-Id:
-      - F8AD:14A94E:C2C9FE:DE6C58:68C2EEA4
+      - 5805:B21BA:AD266F:C78835:68CC1D6F
       X-Served-By:
-      - cache-bos4679-BOS
+      - cache-bos4681-BOS
       X-Timer:
-      - S1757605951.067931,VS0,VE2
+      - S1758207413.017028,VS0,VE3
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:44 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -484,7 +488,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/eo/json-schema/schema.json
   response:
@@ -522,7 +526,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '359'
+      - '20'
       Cache-Control:
       - max-age=600
       Connection:
@@ -532,7 +536,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:31 GMT
+      - Thu, 18 Sep 2025 14:56:53 GMT
       ETag:
       - '"66e1651c-805"'
       Last-Modified:
@@ -548,15 +552,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 858ecd4986e6a093d47a98a2fab9642337232cf7
+      - 845cf70d2d7fe33a0756f8e90067cd524fea10ec
       X-GitHub-Request-Id:
-      - 61E0:85CEC:1F72DF5:22CFA7F:68C2EED7
+      - 2976:1A3C1:217E151:25362CA:68CC1DA0
       X-Served-By:
-      - cache-bos4677-BOS
+      - cache-bos4657-BOS
       X-Timer:
-      - S1757605951.145546,VS0,VE1
+      - S1758207413.093222,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:56:31 GMT
+      - Thu, 18 Sep 2025 15:06:32 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -566,7 +572,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/view/json-schema/schema.json
   response:
@@ -605,7 +611,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '359'
+      - '20'
       Cache-Control:
       - max-age=600
       Connection:
@@ -615,7 +621,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:31 GMT
+      - Thu, 18 Sep 2025 14:56:53 GMT
       ETag:
       - '"66e1651c-829"'
       Last-Modified:
@@ -629,17 +635,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 1adfbd820aaee2d193a08801c669df82fb6217fe
+      - e108dfea0cec3ccc4789cfa1dd2df53ebeca5731
       X-GitHub-Request-Id:
-      - 8BE4:15BCE:1E9511B:21F04EB:68C2EED7
+      - 2A0E:3A039E:FF2E25:11EE6ED:68CC1D9F
       X-Served-By:
-      - cache-bos4678-BOS
+      - cache-bos4677-BOS
       X-Timer:
-      - S1757605951.236009,VS0,VE0
+      - S1758207413.180831,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:31 GMT
+      - Thu, 18 Sep 2025 15:06:32 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example10].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example10].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/catalog-spec/json-schema/catalog.json
   response:
@@ -64,13 +64,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:43 GMT
+      - Thu, 18 Sep 2025 14:56:02 GMT
       ETag:
       - '"3b514933a3747f038125935624a13df108e30fe1cb8f9660a7f54ac6d4765ce9"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:43 GMT
+      - Thu, 18 Sep 2025 15:01:02 GMT
       Source-Age:
-      - '1'
+      - '2'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -80,19 +80,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 36e48d90253f4f0aa564077b2cbce3e828d74362
+      - 11c1552da1c6b994868bdd55ba1def4d6d917b4a
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 4D53:1CB1E4:12EBE4:17599A:68C2EEB7
+      - BCE7:388807:C697B:F1BF7:68CC1D7C
       X-Served-By:
-      - cache-bos4622-BOS
+      - cache-bos4670-BOS
       X-Timer:
-      - S1757605904.655598,VS0,VE0
+      - S1758207363.755565,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example110].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example110].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/item.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '410'
+      - '70'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:31 GMT
+      - Thu, 18 Sep 2025 14:56:53 GMT
       ETag:
       - '"66e1651c-147c"'
       Last-Modified:
@@ -109,17 +109,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 9848f3f4e9bea3793a7278b3b04fc9c50fd722d2
+      - 8efacee4fda6c2a2680a949aae917b178bd03ae5
       X-GitHub-Request-Id:
-      - 9540:197FBB:BCDCFE:D8897B:68C2EEA5
+      - A3C0:BAEAA:C84169:E2AD23:68CC1D6E
       X-Served-By:
-      - cache-bos4663-BOS
+      - cache-bos4685-BOS
       X-Timer:
-      - S1757605951.336429,VS0,VE1
+      - S1758207413.286545,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/basics.json
   response:
@@ -148,7 +148,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '410'
+      - '70'
       Cache-Control:
       - max-age=600
       Connection:
@@ -158,7 +158,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:31 GMT
+      - Thu, 18 Sep 2025 14:56:53 GMT
       ETag:
       - '"66e1651c-21c"'
       Last-Modified:
@@ -174,15 +174,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - a5eeb2aa8a33fa49e123787c2edd6925446c7ce9
+      - befc77b85f6030e6e93104651d0799a6b1fbbf3b
       X-GitHub-Request-Id:
-      - E1F2:14AA27:C232A6:DDCD4A:68C2EEA4
+      - 2F53:A07A9:C8C99E:E32E77:68CC1D6E
       X-Served-By:
-      - cache-bos4643-BOS
+      - cache-bos4631-BOS
       X-Timer:
-      - S1757605951.425923,VS0,VE1
+      - S1758207413.379787,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -192,7 +192,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/datetime.json
   response:
@@ -241,7 +241,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '409'
+      - '70'
       Cache-Control:
       - max-age=600
       Connection:
@@ -251,7 +251,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:31 GMT
+      - Thu, 18 Sep 2025 14:56:53 GMT
       ETag:
       - '"66e1651c-a82"'
       Last-Modified:
@@ -265,17 +265,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Fastly-Request-ID:
-      - d4f013493362abcc57dba5e7b1b820dee2864a1d
+      - fda916b163a538e2265a6754d04a93b1000a2d79
       X-GitHub-Request-Id:
-      - 1865:153265:C4294F:DFCE98:68C2EEA5
+      - 3E81:0D6F:C30426:DD705D:68CC1D6F
       X-Served-By:
-      - cache-bos4629-BOS
+      - cache-bos4661-BOS
       X-Timer:
-      - S1757605952.508063,VS0,VE2
+      - S1758207413.473145,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -285,7 +287,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/instrument.json
   response:
@@ -306,7 +308,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '409'
+      - '70'
       Cache-Control:
       - max-age=600
       Connection:
@@ -316,7 +318,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:31 GMT
+      - Thu, 18 Sep 2025 14:56:53 GMT
       ETag:
       - '"66e1651c-2a2"'
       Last-Modified:
@@ -330,17 +332,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '39'
+      - '1'
       X-Fastly-Request-ID:
-      - 02439ad4bf82067715de1b9db508f1d35a2e6486
+      - 9a3290083a7d689f36c04b4dafefdfaf8991be63
       X-GitHub-Request-Id:
-      - 4500:CA757:1EF5208:22C6B31:68C2EEA5
+      - 7C03:3CD2C3:DA5DDA:F4BC38:68CC1D6F
       X-Served-By:
-      - cache-bos4668-BOS
+      - cache-bos4656-BOS
       X-Timer:
-      - S1757605952.592418,VS0,VE1
+      - S1758207414.573146,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -350,7 +354,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/licensing.json
   response:
@@ -366,7 +370,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '409'
+      - '70'
       Cache-Control:
       - max-age=600
       Connection:
@@ -376,7 +380,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:31 GMT
+      - Thu, 18 Sep 2025 14:56:53 GMT
       ETag:
       - '"66e1651c-135"'
       Last-Modified:
@@ -392,15 +396,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - e8febbda33370bca37d67ae4069ae3dc3ad8f2f6
+      - 2943269ea916b0a0867342426f9668065bc4c136
       X-GitHub-Request-Id:
-      - ED10:15FE94:C5AB5F:E14C22:68C2EEA5
+      - C4E5:1D3617:CA3033:E4A206:68CC1D6F
       X-Served-By:
-      - cache-bos4679-BOS
+      - cache-bos4626-BOS
       X-Timer:
-      - S1757605952.678900,VS0,VE1
+      - S1758207414.664446,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -412,7 +416,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/provider.json
   response:
@@ -438,7 +442,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '409'
+      - '70'
       Cache-Control:
       - max-age=600
       Connection:
@@ -448,7 +452,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:31 GMT
+      - Thu, 18 Sep 2025 14:56:53 GMT
       ETag:
       - '"66e1651c-40e"'
       Last-Modified:
@@ -464,15 +468,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - ace3251e87db8e7874d214878a90b1c8c8aef360
+      - a37086869150db956efd736b87b8f8bd70e157e6
       X-GitHub-Request-Id:
-      - F8AD:14A94E:C2C9FE:DE6C58:68C2EEA4
+      - 5805:B21BA:AD266F:C78835:68CC1D6F
       X-Served-By:
-      - cache-bos4645-BOS
+      - cache-bos4659-BOS
       X-Timer:
-      - S1757605952.766637,VS0,VE1
+      - S1758207414.751555,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:44 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example111].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example111].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/item.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '410'
+      - '71'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:31 GMT
+      - Thu, 18 Sep 2025 14:56:53 GMT
       ETag:
       - '"66e1651c-147c"'
       Last-Modified:
@@ -109,17 +109,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '1'
       X-Fastly-Request-ID:
-      - 6dfc81eb76f103cfaaf65d5b8111f2c3e7eae2a6
+      - f5027fb572f08506f5a1c3cd7f9cb1a81aea63b1
       X-GitHub-Request-Id:
-      - 9540:197FBB:BCDCFE:D8897B:68C2EEA5
+      - A3C0:BAEAA:C84169:E2AD23:68CC1D6E
       X-Served-By:
-      - cache-bos4631-BOS
+      - cache-bos4671-BOS
       X-Timer:
-      - S1757605952.851683,VS0,VE0
+      - S1758207414.857512,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/basics.json
   response:
@@ -148,7 +148,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '410'
+      - '71'
       Cache-Control:
       - max-age=600
       Connection:
@@ -158,7 +158,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:31 GMT
+      - Thu, 18 Sep 2025 14:56:53 GMT
       ETag:
       - '"66e1651c-21c"'
       Last-Modified:
@@ -174,15 +174,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 5484983581de1d86bd918d3db7184f6b58b23556
+      - 991574ee1d28c90a7d577290d5baeff730ea9671
       X-GitHub-Request-Id:
-      - E1F2:14AA27:C232A6:DDCD4A:68C2EEA4
+      - 2F53:A07A9:C8C99E:E32E77:68CC1D6E
       X-Served-By:
-      - cache-bos4684-BOS
+      - cache-bos4667-BOS
       X-Timer:
-      - S1757605952.927996,VS0,VE1
+      - S1758207414.959527,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -192,7 +192,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/datetime.json
   response:
@@ -241,7 +241,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '410'
+      - '71'
       Cache-Control:
       - max-age=600
       Connection:
@@ -251,7 +251,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:32 GMT
+      - Thu, 18 Sep 2025 14:56:54 GMT
       ETag:
       - '"66e1651c-a82"'
       Last-Modified:
@@ -267,15 +267,17 @@ interactions:
       X-Cache-Hits:
       - '2'
       X-Fastly-Request-ID:
-      - a0ff3bc82d6e1b6ae274348d3ed3c6e51b07cba3
+      - 86daf49d731247e1a4b4f4cbca643e72697378a1
       X-GitHub-Request-Id:
-      - 1865:153265:C4294F:DFCE98:68C2EEA5
+      - 3E81:0D6F:C30426:DD705D:68CC1D6F
       X-Served-By:
-      - cache-bos4684-BOS
+      - cache-bos4692-BOS
       X-Timer:
-      - S1757605952.999941,VS0,VE0
+      - S1758207414.037393,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -285,7 +287,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/instrument.json
   response:
@@ -306,7 +308,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '410'
+      - '70'
       Cache-Control:
       - max-age=600
       Connection:
@@ -316,7 +318,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:32 GMT
+      - Thu, 18 Sep 2025 14:56:54 GMT
       ETag:
       - '"66e1651c-2a2"'
       Last-Modified:
@@ -332,15 +334,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 3e373a36d5ba1c91c68940d072ed490a104e44f3
+      - 70e4658cf3b380ca0a522743aec6077aa963fd1d
       X-GitHub-Request-Id:
-      - 4500:CA757:1EF5208:22C6B31:68C2EEA5
+      - 7C03:3CD2C3:DA5DDA:F4BC38:68CC1D6F
       X-Served-By:
-      - cache-bos4654-BOS
+      - cache-bos4689-BOS
       X-Timer:
-      - S1757605952.075499,VS0,VE1
+      - S1758207414.128764,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -350,7 +354,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/licensing.json
   response:
@@ -366,7 +370,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '410'
+      - '70'
       Cache-Control:
       - max-age=600
       Connection:
@@ -376,7 +380,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:32 GMT
+      - Thu, 18 Sep 2025 14:56:54 GMT
       ETag:
       - '"66e1651c-135"'
       Last-Modified:
@@ -390,17 +394,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '4'
+      - '1'
       X-Fastly-Request-ID:
-      - e46728d84faecb8cb925719b359013df871a3147
+      - 06c7e23f0f36a186515e7b1a4d730077f94a7a3e
       X-GitHub-Request-Id:
-      - ED10:15FE94:C5AB5F:E14C22:68C2EEA5
+      - C4E5:1D3617:CA3033:E4A206:68CC1D6F
       X-Served-By:
-      - cache-bos4656-BOS
+      - cache-bos4655-BOS
       X-Timer:
-      - S1757605952.150430,VS0,VE0
+      - S1758207414.219501,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -412,7 +416,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/provider.json
   response:
@@ -438,7 +442,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '410'
+      - '70'
       Cache-Control:
       - max-age=600
       Connection:
@@ -448,7 +452,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:32 GMT
+      - Thu, 18 Sep 2025 14:56:54 GMT
       ETag:
       - '"66e1651c-40e"'
       Last-Modified:
@@ -464,15 +468,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 8b476a0f461dc5ce276e724dca82a401ff2bf5d5
+      - f5b26b5f58cc46b310ecd214033c1707c53522e7
       X-GitHub-Request-Id:
-      - F8AD:14A94E:C2C9FE:DE6C58:68C2EEA4
+      - 5805:B21BA:AD266F:C78835:68CC1D6F
       X-Served-By:
-      - cache-bos4628-BOS
+      - cache-bos4660-BOS
       X-Timer:
-      - S1757605952.226497,VS0,VE2
+      - S1758207414.313130,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:44 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -484,7 +488,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/view/json-schema/schema.json
   response:
@@ -523,7 +527,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '360'
+      - '21'
       Cache-Control:
       - max-age=600
       Connection:
@@ -533,7 +537,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:32 GMT
+      - Thu, 18 Sep 2025 14:56:54 GMT
       ETag:
       - '"66e1651c-829"'
       Last-Modified:
@@ -547,17 +551,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 6a6d5212008056186d06f75d402edeaf5408ea88
+      - 0c211f9da2c4f306f85315fefb73a177d25c477f
       X-GitHub-Request-Id:
-      - 8BE4:15BCE:1E9511B:21F04EB:68C2EED7
+      - 2A0E:3A039E:FF2E25:11EE6ED:68CC1D9F
       X-Served-By:
-      - cache-bos4624-BOS
+      - cache-bos4681-BOS
       X-Timer:
-      - S1757605952.302199,VS0,VE1
+      - S1758207414.397700,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:31 GMT
+      - Thu, 18 Sep 2025 15:06:32 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -567,7 +573,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/projection/json-schema/schema.json
   response:
@@ -621,7 +627,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '353'
+      - '14'
       Cache-Control:
       - max-age=600
       Connection:
@@ -631,7 +637,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:32 GMT
+      - Thu, 18 Sep 2025 14:56:54 GMT
       ETag:
       - '"66e1651c-dc7"'
       Last-Modified:
@@ -647,15 +653,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - a75f7dbc43ade8b550d45a7e068b86746943b18e
+      - 27ba71252a4df2add8435b486d52e1bab604d24a
       X-GitHub-Request-Id:
-      - A35A:108A1F:1F448D6:22A0F0C:68C2EEDF
+      - C94B:21FE6A:2283F11:263C621:68CC1DA8
       X-Served-By:
-      - cache-bos4677-BOS
+      - cache-bos4686-BOS
       X-Timer:
-      - S1757605952.384324,VS0,VE1
+      - S1758207414.490660,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:39 GMT
+      - Thu, 18 Sep 2025 15:06:40 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example112].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example112].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/collection-spec/json-schema/collection.json
   response:
@@ -96,13 +96,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:32 GMT
+      - Thu, 18 Sep 2025 14:56:54 GMT
       ETag:
       - '"efa6309742b904ab7b06bab4c30c3ea2e1ce78163892365a7f4ee461716396b3"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:32 GMT
+      - Thu, 18 Sep 2025 15:01:54 GMT
       Source-Age:
-      - '42'
+      - '44'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -116,15 +116,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 4d2cc9de35afc318436b72ea7106eac18687c032
+      - beeaa2e6bef489e79c0d74e5929cb5a19a9ed28e
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - ED3E:151D18:158C55:1A0484:68C2EEC0
+      - E19D:388807:C6F9A:F2341:68CC1D89
       X-Served-By:
-      - cache-bos4682-BOS
+      - cache-bos4656-BOS
       X-Timer:
-      - S1757605952.457814,VS0,VE0
+      - S1758207415.577961,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -134,7 +134,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/catalog-spec/json-schema/catalog.json
   response:
@@ -183,13 +183,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:32 GMT
+      - Thu, 18 Sep 2025 14:56:54 GMT
       ETag:
       - '"c76fd44b22619705d40fb03a5b1d875e2e786f9ac7a85244758d15cc7cc947a9"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:32 GMT
+      - Thu, 18 Sep 2025 15:01:54 GMT
       Source-Age:
-      - '42'
+      - '45'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -203,15 +203,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 5e64a1893faabe01508fbf3d11b3ae58c0290e44
+      - a9d6188027fa99b0dc173d59e62bd23e62bdb9df
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F35F:176261:68C2EEC0
+      - DF64:33F2BE:BEF40:EA092:68CC1D88
       X-Served-By:
       - cache-bos4669-BOS
       X-Timer:
-      - S1757605953.525547,VS0,VE1
+      - S1758207415.665693,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example113].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example113].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/collection-spec/json-schema/collection.json
   response:
@@ -85,13 +85,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:32 GMT
+      - Thu, 18 Sep 2025 14:56:54 GMT
       ETag:
       - '"031974beaaaf6f0b5c6877dc97088d9e2aff3bc8962df33ff291dddded353f09"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:32 GMT
+      - Thu, 18 Sep 2025 15:01:54 GMT
       Source-Age:
-      - '50'
+      - '54'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -105,15 +105,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - a0034b757b75e9131b312574bccee313a34eda7c
+      - 988b22c6a1690f829df707536e2c9e26dc3a3833
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 48D2:9DF63:14B8DC:192D3D:68C2EEB6
+      - EAA4:3C3312:A80AF:D3151:68CC1D7F
       X-Served-By:
-      - cache-bos4658-BOS
+      - cache-bos4641-BOS
       X-Timer:
-      - S1757605953.596048,VS0,VE3
+      - S1758207415.751466,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -123,7 +123,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/catalog-spec/json-schema/catalog.json
   response:
@@ -184,13 +184,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:32 GMT
+      - Thu, 18 Sep 2025 14:56:54 GMT
       ETag:
       - '"3b514933a3747f038125935624a13df108e30fe1cb8f9660a7f54ac6d4765ce9"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:32 GMT
+      - Thu, 18 Sep 2025 15:01:54 GMT
       Source-Age:
-      - '51'
+      - '54'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -200,19 +200,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 622d3c54e882792492e020400b488d56e72ce7ff
+      - 60ff5d149a06d126a5f7332034666e66728f985f
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 4D53:1CB1E4:12EBE4:17599A:68C2EEB7
+      - BCE7:388807:C697B:F1BF7:68CC1D7C
       X-Served-By:
-      - cache-bos4679-BOS
+      - cache-bos4687-BOS
       X-Timer:
-      - S1757605953.677512,VS0,VE1
+      - S1758207415.829765,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example114].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example114].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.1/item-spec/json-schema/item.json
   response:
@@ -96,7 +96,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '339'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -106,7 +106,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:32 GMT
+      - Thu, 18 Sep 2025 14:56:54 GMT
       ETag:
       - '"66e1651c-17f9"'
       Last-Modified:
@@ -118,19 +118,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 34cc6d7218d977b8a0e9bf46550d67788919d084
+      - 348289f327ef3795e345371e197283f65877e4e4
       X-GitHub-Request-Id:
-      - 118F:D080E:1FEF938:234C243:68C2EEED
+      - 2276:28543:1B7C58:1D2AAD:68CC1DB6
       X-Served-By:
-      - cache-bos4657-BOS
+      - cache-bos4631-BOS
       X-Timer:
-      - S1757605953.762213,VS0,VE1
+      - S1758207415.919392,VS0,VE51
       expires:
-      - Thu, 11 Sep 2025 15:56:53 GMT
+      - Thu, 18 Sep 2025 15:06:54 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -140,7 +140,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.1/item-spec/json-schema/basics.json
   response:
@@ -159,7 +159,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '339'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -169,7 +169,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:32 GMT
+      - Thu, 18 Sep 2025 14:56:55 GMT
       ETag:
       - '"66e1651c-21a"'
       Last-Modified:
@@ -181,19 +181,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - fcadf7a1776276c0ec1151f18f3c45e195885d70
+      - 30eb66400d9b27d87bca7e5debfcd0579aca2276
       X-GitHub-Request-Id:
-      - 2BDC:3A03AF:1DFA092:2158367:68C2EEED
+      - C6D7:334B2B:1C1020:1DBE44:68CC1DB7
       X-Served-By:
-      - cache-bos4649-BOS
+      - cache-bos4679-BOS
       X-Timer:
-      - S1757605953.853921,VS0,VE1
+      - S1758207415.071746,VS0,VE66
       expires:
-      - Thu, 11 Sep 2025 15:56:53 GMT
+      - Thu, 18 Sep 2025 15:06:55 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -205,7 +205,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.1/item-spec/json-schema/datetime.json
   response:
@@ -235,7 +235,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '339'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -245,7 +245,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:32 GMT
+      - Thu, 18 Sep 2025 14:56:55 GMT
       ETag:
       - '"66e1651c-51b"'
       Last-Modified:
@@ -257,19 +257,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - e9fa007b38f36756c5b5e7cb31924e7db26dc7c4
+      - 5a20670a4d4f8db20ae6bff89de2f745a0f06982
       X-GitHub-Request-Id:
-      - B5AD:2BF852:1E9432D:21F2211:68C2EEED
+      - 7949:3E33CC:1F6957:2117F0:68CC1DB7
       X-Served-By:
-      - cache-bos4692-BOS
+      - cache-bos4676-BOS
       X-Timer:
-      - S1757605953.927761,VS0,VE1
+      - S1758207415.225851,VS0,VE91
       expires:
-      - Thu, 11 Sep 2025 15:56:54 GMT
+      - Thu, 18 Sep 2025 15:06:55 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -279,7 +279,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.1/item-spec/json-schema/instrument.json
   response:
@@ -300,7 +300,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '339'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -310,7 +310,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:33 GMT
+      - Thu, 18 Sep 2025 14:56:55 GMT
       ETag:
       - '"66e1651c-2a0"'
       Last-Modified:
@@ -322,19 +322,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 0cdb3216871e94f8f56128603d6ba429b6c293a6
+      - f8c64a11898557aafb3421699c18a54885fd959d
       X-GitHub-Request-Id:
-      - 227C:3CD789:1F91BDD:22ED59D:68C2EEED
+      - 2AF2:3F3ECC:1E0097:1FAE57:68CC1DB6
       X-Served-By:
-      - cache-bos4689-BOS
+      - cache-bos4691-BOS
       X-Timer:
-      - S1757605953.001586,VS0,VE1
+      - S1758207415.407429,VS0,VE40
       expires:
-      - Thu, 11 Sep 2025 15:56:54 GMT
+      - Thu, 18 Sep 2025 15:06:55 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -344,7 +344,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.1/item-spec/json-schema/licensing.json
   response:
@@ -360,7 +360,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '339'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -370,7 +370,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:33 GMT
+      - Thu, 18 Sep 2025 14:56:55 GMT
       ETag:
       - '"66e1651c-133"'
       Last-Modified:
@@ -382,19 +382,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 6801e97d617745b0df206696ff590f4093e75873
+      - bcd40679867cf4f7d4ed5d19a7f3732e5778d82b
       X-GitHub-Request-Id:
-      - E1FB:3FCF91:1F7612F:22D2144:68C2EEED
+      - 34A2:37295B:1E2B1D:1FDA76:68CC1DB7
       X-Served-By:
-      - cache-bos4643-BOS
+      - cache-bos4651-BOS
       X-Timer:
-      - S1757605953.074156,VS0,VE2
+      - S1758207416.537694,VS0,VE119
       expires:
-      - Thu, 11 Sep 2025 15:56:54 GMT
+      - Thu, 18 Sep 2025 15:06:55 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -406,7 +406,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.1/item-spec/json-schema/provider.json
   response:
@@ -433,7 +433,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '339'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -443,7 +443,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:33 GMT
+      - Thu, 18 Sep 2025 14:56:55 GMT
       ETag:
       - '"66e1651c-458"'
       Last-Modified:
@@ -455,19 +455,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - dd23b93473f8f8445ad3b8a02607d968a96c2de3
+      - d2bee74e83748e094f3e160b5187f748c9219a0c
       X-GitHub-Request-Id:
-      - D639:11E81:1FAF471:230C531:68C2EEED
+      - FF90:1EB76C:1E8994:203810:68CC1DB7
       X-Served-By:
-      - cache-bos4645-BOS
+      - cache-bos4665-BOS
       X-Timer:
-      - S1757605953.152881,VS0,VE1
+      - S1758207416.733570,VS0,VE42
       expires:
-      - Thu, 11 Sep 2025 15:56:54 GMT
+      - Thu, 18 Sep 2025 15:06:55 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -479,7 +479,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.1/extensions/eo/json-schema/schema.json
   response:
@@ -545,7 +545,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '339'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -555,7 +555,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:33 GMT
+      - Thu, 18 Sep 2025 14:56:55 GMT
       ETag:
       - '"66e1651c-1039"'
       Last-Modified:
@@ -567,19 +567,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 670c647c08c1824ed430a37fd839f07e473d19af
+      - 9a68dc64c29d1fffcf60b8ae0dbf2f436b7d2e31
       X-GitHub-Request-Id:
-      - 2482:D080E:1FEF9F8:234C31C:68C2EEED
+      - 61DA:35199E:207586A:242D608:68CC1DB7
       X-Served-By:
-      - cache-bos4693-BOS
+      - cache-bos4670-BOS
       X-Timer:
-      - S1757605953.269872,VS0,VE1
+      - S1758207416.891877,VS0,VE52
       expires:
-      - Thu, 11 Sep 2025 15:56:54 GMT
+      - Thu, 18 Sep 2025 15:06:55 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -589,7 +589,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.1/extensions/projection/json-schema/schema.json
   response:
@@ -662,7 +662,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '339'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -672,7 +672,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:33 GMT
+      - Thu, 18 Sep 2025 14:56:56 GMT
       ETag:
       - '"66e1651c-1247"'
       Last-Modified:
@@ -684,19 +684,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 63b283c025500ea8d14f4b2a3abe10927a2234ff
+      - a8af9f81aa8556c33a0f8fc28081b4b5b8a5419b
       X-GitHub-Request-Id:
-      - AB95:FB713:1DE0274:213E2AF:68C2EEEE
+      - F068:3C31CF:191069:1ABDA1:68CC1DB7
       X-Served-By:
-      - cache-bos4682-BOS
+      - cache-bos4640-BOS
       X-Timer:
-      - S1757605953.347912,VS0,VE2
+      - S1758207416.099705,VS0,VE24
       expires:
-      - Thu, 11 Sep 2025 15:56:54 GMT
+      - Thu, 18 Sep 2025 15:06:56 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -708,7 +708,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.1/extensions/scientific/json-schema/schema.json
   response:
@@ -769,7 +769,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '338'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -779,7 +779,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:33 GMT
+      - Thu, 18 Sep 2025 14:56:56 GMT
       ETag:
       - '"66e1651c-e6f"'
       Last-Modified:
@@ -791,19 +791,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 0756842bc8020be5269c25dd528c1419cf8775b6
+      - 77f4a50c6c913e23f78294948fb60ac7b05bcbef
       X-GitHub-Request-Id:
-      - DE8D:FA1FD:1EE5E80:22436AE:68C2EEEE
+      - 34FC:239986:1C3921:1DE6F7:68CC1DB7
       X-Served-By:
-      - cache-bos4692-BOS
+      - cache-bos4620-BOS
       X-Timer:
-      - S1757605953.419958,VS0,VE1
+      - S1758207416.223556,VS0,VE44
       expires:
-      - Thu, 11 Sep 2025 15:56:54 GMT
+      - Thu, 18 Sep 2025 15:06:56 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -815,7 +815,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.1/extensions/view/json-schema/schema.json
   response:
@@ -874,7 +874,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '338'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -884,7 +884,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:33 GMT
+      - Thu, 18 Sep 2025 14:56:56 GMT
       ETag:
       - '"66e1651c-def"'
       Last-Modified:
@@ -896,19 +896,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 68b6ad3fc177e60edbb83f17818d381b143497a1
+      - 18159b338e19033c57d98db768e7b42e51d999db
       X-GitHub-Request-Id:
-      - 448A:38B0E6:1F9FCEE:22FB363:68C2EEEE
+      - B1E0:32B3EB:1A2BD3:1BD92E:68CC1DB8
       X-Served-By:
-      - cache-bos4689-BOS
+      - cache-bos4640-BOS
       X-Timer:
-      - S1757605954.505946,VS0,VE1
+      - S1758207416.371749,VS0,VE43
       expires:
-      - Thu, 11 Sep 2025 15:56:55 GMT
+      - Thu, 18 Sep 2025 15:06:56 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example115].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example115].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.2/item-spec/json-schema/item.json
   response:
@@ -98,7 +98,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '338'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -108,7 +108,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:33 GMT
+      - Thu, 18 Sep 2025 14:56:56 GMT
       ETag:
       - '"66e1651c-1887"'
       Last-Modified:
@@ -120,19 +120,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 80b8a162a8f88a9f6319c5c0a4e3a04ac11dd262
+      - 319912a5b1d0e8d3f9804eded8601667a3518cbb
       X-GitHub-Request-Id:
-      - A479:38B0E6:1F9FD19:22FB390:68C2EEEE
+      - A228:32B3EB:1A2BFE:1BD963:68CC1DB7
       X-Served-By:
-      - cache-bos4649-BOS
+      - cache-bos4625-BOS
       X-Timer:
-      - S1757605954.604428,VS0,VE1
+      - S1758207417.506635,VS0,VE52
       expires:
-      - Thu, 11 Sep 2025 15:56:55 GMT
+      - Thu, 18 Sep 2025 15:06:56 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -142,7 +142,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.2/item-spec/json-schema/basics.json
   response:
@@ -161,7 +161,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '338'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -171,7 +171,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:33 GMT
+      - Thu, 18 Sep 2025 14:56:56 GMT
       ETag:
       - '"66e1651c-21a"'
       Last-Modified:
@@ -183,19 +183,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - dd4e9e4e0fdbe05a0f0c512d44c9f295577e943c
+      - 70287e37fad5988ee9be7e721be75338dd57fd8b
       X-GitHub-Request-Id:
-      - 4CF0:2A9F2B:1FA20B8:22FF1C7:68C2EEED
+      - 5153:32B3EB:1A2C3A:1BD99C:68CC1DB7
       X-Served-By:
-      - cache-bos4667-BOS
+      - cache-bos4658-BOS
       X-Timer:
-      - S1757605954.689726,VS0,VE1
+      - S1758207417.655993,VS0,VE52
       expires:
-      - Thu, 11 Sep 2025 15:56:55 GMT
+      - Thu, 18 Sep 2025 15:06:56 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -205,7 +205,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.2/item-spec/json-schema/datetime.json
   response:
@@ -235,7 +235,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '338'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -245,7 +245,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:33 GMT
+      - Thu, 18 Sep 2025 14:56:56 GMT
       ETag:
       - '"66e1651c-51b"'
       Last-Modified:
@@ -257,19 +257,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 001bc4a7624e640fa00d300a90b342f9c902b89c
+      - 34b657048d9f3c347bb07e10520c956a98fe9b0c
       X-GitHub-Request-Id:
-      - B7EE:3CD789:1F91D5E:22ED73E:68C2EEED
+      - ACC0:4837E:1C6011:1E0F4A:68CC1DB8
       X-Served-By:
-      - cache-bos4686-BOS
+      - cache-bos4661-BOS
       X-Timer:
-      - S1757605954.777498,VS0,VE1
+      - S1758207417.797674,VS0,VE29
       expires:
-      - Thu, 11 Sep 2025 15:56:55 GMT
+      - Thu, 18 Sep 2025 15:06:56 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -281,7 +281,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.2/item-spec/json-schema/instrument.json
   response:
@@ -302,7 +302,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '338'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -312,7 +312,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:33 GMT
+      - Thu, 18 Sep 2025 14:56:56 GMT
       ETag:
       - '"66e1651c-2bd"'
       Last-Modified:
@@ -324,19 +324,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 54239936271fcc35ffb22009b7d9d5d02c019417
+      - a66cbb4d7f04653d2b7d5242efa49445d1976903
       X-GitHub-Request-Id:
-      - 0E4B:FA1FD:1EE5F3B:224377B:68C2EEEE
+      - E59A:2EDCE9:1DD0E8:1F7E34:68CC1DB7
       X-Served-By:
-      - cache-bos4651-BOS
+      - cache-bos4636-BOS
       X-Timer:
-      - S1757605954.856652,VS0,VE1
+      - S1758207417.915914,VS0,VE24
       expires:
-      - Thu, 11 Sep 2025 15:56:55 GMT
+      - Thu, 18 Sep 2025 15:06:56 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -348,7 +348,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.2/item-spec/json-schema/licensing.json
   response:
@@ -364,7 +364,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '338'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -374,7 +374,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:33 GMT
+      - Thu, 18 Sep 2025 14:56:57 GMT
       ETag:
       - '"66e1651c-133"'
       Last-Modified:
@@ -386,19 +386,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 29a6ee60dfe4be024711e52ecf8212878410bdd8
+      - 0912f464af9d7cfe4148c4a9d6f5b06d6d6e6cf9
       X-GitHub-Request-Id:
-      - A1A4:20D39C:1FB17CA:230D717:68C2EEEF
+      - 1F3A:34271B:1DA320:1F50CF:68CC1DB8
       X-Served-By:
-      - cache-bos4690-BOS
+      - cache-bos4650-BOS
       X-Timer:
-      - S1757605954.943262,VS0,VE1
+      - S1758207417.028274,VS0,VE52
       expires:
-      - Thu, 11 Sep 2025 15:56:55 GMT
+      - Thu, 18 Sep 2025 15:06:57 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -410,7 +410,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-rc.2/item-spec/json-schema/provider.json
   response:
@@ -437,7 +437,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '338'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -447,7 +447,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:34 GMT
+      - Thu, 18 Sep 2025 14:56:57 GMT
       ETag:
       - '"66e1651c-474"'
       Last-Modified:
@@ -459,19 +459,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 023c396533e8682df55acbe832b13eddc4a8bf12
+      - 5733c41a209c5da0126258a72c7db86b83a40991
       X-GitHub-Request-Id:
-      - 227C:3CD789:1F91DC7:22ED7B1:68C2EEEF
+      - 2AF2:3F3ECC:1E0355:1FB140:68CC1DB8
       X-Served-By:
-      - cache-bos4666-BOS
+      - cache-bos4665-BOS
       X-Timer:
-      - S1757605954.029777,VS0,VE2
+      - S1758207417.163630,VS0,VE34
       expires:
-      - Thu, 11 Sep 2025 15:56:55 GMT
+      - Thu, 18 Sep 2025 15:06:57 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -483,7 +483,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/eo/v1.1.0/schema.json
   response:
@@ -561,7 +561,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '439'
+      - '233'
       Cache-Control:
       - max-age=600
       Connection:
@@ -571,7 +571,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:34 GMT
+      - Thu, 18 Sep 2025 14:56:57 GMT
       ETag:
       - '"66df1c53-13bc"'
       Last-Modified:
@@ -587,17 +587,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 7c22bf90af86ce9c611229903022cd7da72f160f
+      - 6f8a7004ef607bb7fbb921edbd6defa5193eeaac
       X-GitHub-Request-Id:
-      - BE8A:14434E:B836A2:D3D600:68C2EE8A
+      - 98DE:39A2ED:1DBAAC:1F56C3:68CC1CD0
       X-Served-By:
-      - cache-bos4686-BOS
+      - cache-bos4687-BOS
       X-Timer:
-      - S1757605954.138228,VS0,VE0
+      - S1758207417.307511,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -607,7 +607,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/projection/v1.0.0/schema.json
   response:
@@ -679,7 +679,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '338'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -689,7 +689,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:34 GMT
+      - Thu, 18 Sep 2025 14:56:57 GMT
       ETag:
       - '"669e563b-1226"'
       Last-Modified:
@@ -703,19 +703,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - e951bc4e7d712ee27e83c89d13e6b42c744ca82a
+      - 6425a92ed590f5966bd49b16afb50294c241d0a3
       X-GitHub-Request-Id:
-      - 495E:15BCE:1E96F66:21F25DD:68C2EEEF
+      - 3CEC:2EDCE9:1DD175:1F7EC7:68CC1DB8
       X-Served-By:
-      - cache-bos4685-BOS
+      - cache-bos4635-BOS
       X-Timer:
-      - S1757605954.209776,VS0,VE1
+      - S1758207417.375849,VS0,VE35
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:57 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -725,7 +727,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/scientific/v1.0.0/schema.json
   response:
@@ -811,7 +813,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '436'
+      - '100'
       Cache-Control:
       - max-age=600
       Connection:
@@ -821,7 +823,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:34 GMT
+      - Thu, 18 Sep 2025 14:56:57 GMT
       ETag:
       - '"60febab7-15fa"'
       Last-Modified:
@@ -839,15 +841,15 @@ interactions:
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - c0942ceaf0c4a54f12cc11508be42c18f7e3510a
+      - 9f1954df41a9b70858c189440bb8f09993b130ae
       X-GitHub-Request-Id:
-      - 3922:128B70:CB9EFB:E73AAF:68C2EE8E
+      - 5CF5:3D35AC:C4B412:DF1A74:68CC1D55
       X-Served-By:
-      - cache-bos4681-BOS
+      - cache-bos4636-BOS
       X-Timer:
-      - S1757605954.279753,VS0,VE1
+      - S1758207417.478885,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:18 GMT
+      - Thu, 18 Sep 2025 15:05:17 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -857,7 +859,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/view/v1.0.0/schema.json
   response:
@@ -915,7 +917,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '440'
+      - '233'
       Cache-Control:
       - max-age=600
       Connection:
@@ -925,7 +927,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:34 GMT
+      - Thu, 18 Sep 2025 14:56:57 GMT
       ETag:
       - '"689f5434-dff"'
       Last-Modified:
@@ -941,17 +943,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 75bb7ab40b1646dc886f71605c27fc68c125e1e1
+      - 5a9b5371d4d9ca69132e92772c915750173c777c
       X-GitHub-Request-Id:
-      - EACF:1C0114:1BE6594:1F22786:68C2EE8A
+      - 624D:BA176:74CE5:7ED3C:68CC1CD0
       X-Served-By:
-      - cache-bos4659-BOS
+      - cache-bos4632-BOS
       X-Timer:
-      - S1757605954.357949,VS0,VE1
+      - S1758207418.553929,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -961,7 +963,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/remote-data/v1.0.0/schema.json
   response:
@@ -1026,7 +1028,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '338'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -1036,7 +1038,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:34 GMT
+      - Thu, 18 Sep 2025 14:56:57 GMT
       ETag:
       - '"6046b731-f97"'
       Last-Modified:
@@ -1050,19 +1052,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 67078c67cf1f3b526948efd77931be0c31dec140
+      - b67fc3f8ae33e470d2137998c8eec479a536901d
       X-GitHub-Request-Id:
-      - B45E:3B188F:1EF9852:22556BA:68C2EEEF
+      - 28D8:39A2ED:1EEE14:209C7E:68CC1DB9
       X-Served-By:
-      - cache-bos4673-BOS
+      - cache-bos4625-BOS
       X-Timer:
-      - S1757605954.431878,VS0,VE1
+      - S1758207418.621420,VS0,VE69
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:57 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example116].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example116].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/catalog-spec/json-schema/catalog.json
   response:
@@ -45,7 +45,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '338'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -55,7 +55,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:34 GMT
+      - Thu, 18 Sep 2025 14:56:57 GMT
       ETag:
       - '"66e1651c-879"'
       Last-Modified:
@@ -67,19 +67,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 86ecaeba3a7f3d59e2c57e3ec042fd1d36c3809b
+      - 6c6c15458ddf3fb302ce0591996cc62829fd55ca
       X-GitHub-Request-Id:
-      - 920C:15BCE:1E96FCE:21F264B:68C2EEEF
+      - 994B:3886BD:228FB0:243E6F:68CC1DB9
       X-Served-By:
-      - cache-bos4630-BOS
+      - cache-bos4656-BOS
       X-Timer:
-      - S1757605955.527823,VS0,VE1
+      - S1758207418.784220,VS0,VE39
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:57 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example117].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example117].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/collection-spec/json-schema/collection.json
   response:
@@ -110,7 +110,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '338'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -120,7 +120,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:34 GMT
+      - Thu, 18 Sep 2025 14:56:57 GMT
       ETag:
       - '"66e1651c-1c29"'
       Last-Modified:
@@ -132,19 +132,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 372e4d9c329b4ae36410f9f7f9a0443c66ff073e
+      - c154a108ea6a811b93e98f57f4db01c31017d96f
       X-GitHub-Request-Id:
-      - A4D3:13E3A5:1E98041:21F570A:68C2EEF0
+      - A7D1:3FED61:1CD3D5:1E813E:68CC1DB9
       X-Served-By:
-      - cache-bos4681-BOS
+      - cache-bos4659-BOS
       X-Timer:
-      - S1757605955.631513,VS0,VE1
+      - S1758207418.898133,VS0,VE34
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:57 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -154,7 +154,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json
   response:
@@ -255,7 +255,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '338'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -265,7 +265,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:34 GMT
+      - Thu, 18 Sep 2025 14:56:58 GMT
       ETag:
       - '"66e1651c-1a43"'
       Last-Modified:
@@ -277,19 +277,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
-      - '2'
+      - '0'
       X-Fastly-Request-ID:
-      - e426d025099082da87f3081c29aa3d2217498a82
+      - d28807da0ef186c92939c833e05992b1a63f4c16
       X-GitHub-Request-Id:
-      - 6830:FB713:1DE043F:213E4A8:68C2EEEE
+      - B0CD:E2749:22797A:2427D7:68CC1DB8
       X-Served-By:
-      - cache-bos4638-BOS
+      - cache-bos4623-BOS
       X-Timer:
-      - S1757605955.718812,VS0,VE1
+      - S1758207418.999544,VS0,VE31
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:58 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -301,7 +301,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/basics.json
   response:
@@ -320,7 +320,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '338'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -330,7 +330,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:34 GMT
+      - Thu, 18 Sep 2025 14:56:58 GMT
       ETag:
       - '"66e1651c-215"'
       Last-Modified:
@@ -342,19 +342,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 5b1c705adddb2000c540b443c772096c448806f6
+      - b71616902c12fef21401ac20883ed1323549ada2
       X-GitHub-Request-Id:
-      - 8BC5:2391:1FBEC5E:231AD43:68C2EEF0
+      - 99F8:39AA35:1CC8B1:1E77A0:68CC1DBA
       X-Served-By:
-      - cache-bos4633-BOS
+      - cache-bos4641-BOS
       X-Timer:
-      - S1757605955.794213,VS0,VE2
+      - S1758207418.102709,VS0,VE112
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:58 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -366,7 +366,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/datetime.json
   response:
@@ -398,7 +398,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '338'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -408,7 +408,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:34 GMT
+      - Thu, 18 Sep 2025 14:56:58 GMT
       ETag:
       - '"66e1651c-5c0"'
       Last-Modified:
@@ -420,19 +420,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - a53501f56f51c40cf08d609724c6f90cb1d1d1b5
+      - 79c6a9d8bfe4de00530d56f118c5cc42f6d22ac1
       X-GitHub-Request-Id:
-      - 280E:FA1FD:1EE60B6:2243920:68C2EEF0
+      - AA6A:16B07D:1DD504:1F82A5:68CC1DB8
       X-Served-By:
-      - cache-bos4642-BOS
+      - cache-bos4691-BOS
       X-Timer:
-      - S1757605955.884320,VS0,VE2
+      - S1758207418.291550,VS0,VE34
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:58 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -444,7 +444,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/instrument.json
   response:
@@ -465,7 +465,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '338'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -475,7 +475,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:34 GMT
+      - Thu, 18 Sep 2025 14:56:58 GMT
       ETag:
       - '"66e1651c-2b8"'
       Last-Modified:
@@ -487,19 +487,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 5b86d893ec38e23bbee84200f134a268cd0ffe43
+      - f391b4792f3ae04edde8379adb0494d7f4885e3e
       X-GitHub-Request-Id:
-      - C268:C8585:1E15137:2173E2A:68C2EEF0
+      - B511:14943E:1DCDB1:1F7CB5:68CC1DB9
       X-Served-By:
-      - cache-bos4674-BOS
+      - cache-bos4643-BOS
       X-Timer:
-      - S1757605955.959970,VS0,VE1
+      - S1758207418.403978,VS0,VE46
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:58 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -509,7 +511,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/licensing.json
   response:
@@ -525,7 +527,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '338'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -535,7 +537,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:35 GMT
+      - Thu, 18 Sep 2025 14:56:58 GMT
       ETag:
       - '"66e1651c-12e"'
       Last-Modified:
@@ -547,19 +549,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
-      - '2'
+      - '0'
       X-Fastly-Request-ID:
-      - d9f399d73b431221600aa1e22df9b851539f7bb3
+      - 2b29c85fc5ab47546a383db52c9191563166bb26
       X-GitHub-Request-Id:
-      - 9288:FB713:1DE04AB:213E52A:68C2EEF0
+      - BE90:3E33CC:1F6E08:211CE4:68CC1DBA
       X-Served-By:
-      - cache-bos4630-BOS
+      - cache-bos4670-BOS
       X-Timer:
-      - S1757605955.035746,VS0,VE1
+      - S1758207419.526711,VS0,VE34
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:58 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -569,7 +573,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/provider.json
   response:
@@ -596,7 +600,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '338'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -606,7 +610,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:35 GMT
+      - Thu, 18 Sep 2025 14:56:58 GMT
       ETag:
       - '"66e1651c-46f"'
       Last-Modified:
@@ -618,19 +622,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - fb49a563fafd6e970d71a408b0869b44d34cfc47
+      - 4ac0375df1293d16cb22c0ee38763e191c8b7b79
       X-GitHub-Request-Id:
-      - B5B2:C72BD:20215CF:237DE00:68C2EEF0
+      - 7949:3E33CC:1F6E30:211D0C:68CC1DBA
       X-Served-By:
-      - cache-bos4670-BOS
+      - cache-bos4620-BOS
       X-Timer:
-      - S1757605955.110080,VS0,VE1
+      - S1758207419.640416,VS0,VE20
       expires:
-      - Thu, 11 Sep 2025 15:56:57 GMT
+      - Thu, 18 Sep 2025 15:06:58 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -642,7 +646,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/eo/v1.1.0/schema.json
   response:
@@ -720,7 +724,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '441'
+      - '234'
       Cache-Control:
       - max-age=600
       Connection:
@@ -730,7 +734,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:35 GMT
+      - Thu, 18 Sep 2025 14:56:58 GMT
       ETag:
       - '"66df1c53-13bc"'
       Last-Modified:
@@ -746,17 +750,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '1'
       X-Fastly-Request-ID:
-      - 6c4a9b13aed6a133e03376b1844ec612309708ae
+      - ee1770a6753a6e3a466fe9f02839352c94087714
       X-GitHub-Request-Id:
-      - BE8A:14434E:B836A2:D3D600:68C2EE8A
+      - 98DE:39A2ED:1DBAAC:1F56C3:68CC1CD0
       X-Served-By:
-      - cache-bos4656-BOS
+      - cache-bos4671-BOS
       X-Timer:
-      - S1757605955.175936,VS0,VE1
+      - S1758207419.753647,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -766,7 +770,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/projection/v1.0.0/schema.json
   response:
@@ -838,7 +842,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '339'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -848,7 +852,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:35 GMT
+      - Thu, 18 Sep 2025 14:56:58 GMT
       ETag:
       - '"669e563b-1226"'
       Last-Modified:
@@ -866,15 +870,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 5da162a2d37547b31a6d75a456060cbc0e8eec2f
+      - a4153c138fa9d15e46b85b7aee5669caa40b7113
       X-GitHub-Request-Id:
-      - 495E:15BCE:1E96F66:21F25DD:68C2EEEF
+      - 3CEC:2EDCE9:1DD175:1F7EC7:68CC1DB8
       X-Served-By:
-      - cache-bos4634-BOS
+      - cache-bos4658-BOS
       X-Timer:
-      - S1757605955.240260,VS0,VE1
+      - S1758207419.820308,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:57 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -884,7 +890,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/view/v1.0.0/schema.json
   response:
@@ -942,7 +948,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '440'
+      - '234'
       Cache-Control:
       - max-age=600
       Connection:
@@ -952,7 +958,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:35 GMT
+      - Thu, 18 Sep 2025 14:56:58 GMT
       ETag:
       - '"689f5434-dff"'
       Last-Modified:
@@ -970,15 +976,15 @@ interactions:
       X-Cache-Hits:
       - '2'
       X-Fastly-Request-ID:
-      - 2b02b1b57791e1325b8f5499e5c8372ac4915525
+      - 07f2cf4c5589bb093bfa355d4cabfe0a634e5b37
       X-GitHub-Request-Id:
-      - EACF:1C0114:1BE6594:1F22786:68C2EE8A
+      - 624D:BA176:74CE5:7ED3C:68CC1CD0
       X-Served-By:
-      - cache-bos4678-BOS
+      - cache-bos4690-BOS
       X-Timer:
-      - S1757605955.301866,VS0,VE1
+      - S1758207419.891675,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example118].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example118].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/collection-spec/json-schema/collection.json
   response:
@@ -110,7 +110,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '339'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -120,7 +120,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:35 GMT
+      - Thu, 18 Sep 2025 14:56:58 GMT
       ETag:
       - '"66e1651c-1c29"'
       Last-Modified:
@@ -136,15 +136,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - eca94a018eeaa94be240eef5cbe30987820daaf2
+      - 0cd1794992b8735e0791eb053f18604720910d8b
       X-GitHub-Request-Id:
-      - A4D3:13E3A5:1E98041:21F570A:68C2EEF0
+      - A7D1:3FED61:1CD3D5:1E813E:68CC1DB9
       X-Served-By:
-      - cache-bos4691-BOS
+      - cache-bos4683-BOS
       X-Timer:
-      - S1757605955.386227,VS0,VE1
+      - S1758207419.996193,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:57 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -154,7 +154,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/eo/v1.1.0/schema.json
   response:
@@ -232,7 +232,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '441'
+      - '235'
       Cache-Control:
       - max-age=600
       Connection:
@@ -242,7 +242,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:35 GMT
+      - Thu, 18 Sep 2025 14:56:59 GMT
       ETag:
       - '"66df1c53-13bc"'
       Last-Modified:
@@ -258,17 +258,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 5e66575afc0434cdb565c960922cfa4cd0506d0a
+      - 4867c4df58513640b64f80c38f22b3ace1e8ec76
       X-GitHub-Request-Id:
-      - BE8A:14434E:B836A2:D3D600:68C2EE8A
+      - 98DE:39A2ED:1DBAAC:1F56C3:68CC1CD0
       X-Served-By:
-      - cache-bos4672-BOS
+      - cache-bos4660-BOS
       X-Timer:
-      - S1757605955.454618,VS0,VE0
+      - S1758207419.068251,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -278,7 +278,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/view/v1.0.0/schema.json
   response:
@@ -336,7 +336,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '441'
+      - '235'
       Cache-Control:
       - max-age=600
       Connection:
@@ -346,7 +346,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:35 GMT
+      - Thu, 18 Sep 2025 14:56:59 GMT
       ETag:
       - '"689f5434-dff"'
       Last-Modified:
@@ -362,17 +362,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 87392513c314e8f607682a360d34ae1bcdfc7685
+      - 94918a7525c4e66af490d6e68866b536adcf5d72
       X-GitHub-Request-Id:
-      - EACF:1C0114:1BE6594:1F22786:68C2EE8A
+      - 624D:BA176:74CE5:7ED3C:68CC1CD0
       X-Served-By:
-      - cache-bos4672-BOS
+      - cache-bos4636-BOS
       X-Timer:
-      - S1757605956.523730,VS0,VE0
+      - S1758207419.151710,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example119].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example119].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json
   response:
@@ -104,7 +104,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '339'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -114,7 +114,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:35 GMT
+      - Thu, 18 Sep 2025 14:56:59 GMT
       ETag:
       - '"66e1651c-1a43"'
       Last-Modified:
@@ -128,17 +128,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '0'
+      - '1'
       X-Fastly-Request-ID:
-      - 8057e616355766c8f7d4b4f387e28f787a407058
+      - 6543cfe627dccc9e5a8312ed87d0b2ce24bf358e
       X-GitHub-Request-Id:
-      - 6830:FB713:1DE043F:213E4A8:68C2EEEE
+      - B0CD:E2749:22797A:2427D7:68CC1DB8
       X-Served-By:
-      - cache-bos4676-BOS
+      - cache-bos4631-BOS
       X-Timer:
-      - S1757605956.605790,VS0,VE1
+      - S1758207419.245994,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:58 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -150,7 +150,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/basics.json
   response:
@@ -169,7 +169,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '339'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -179,7 +179,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:35 GMT
+      - Thu, 18 Sep 2025 14:56:59 GMT
       ETag:
       - '"66e1651c-215"'
       Last-Modified:
@@ -195,15 +195,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - deb11a5dade95c6ee68e63fa53ea356c61f46939
+      - d968fc608f9b945c209d1a30b48ddfdf5f653326
       X-GitHub-Request-Id:
-      - 8BC5:2391:1FBEC5E:231AD43:68C2EEF0
+      - 99F8:39AA35:1CC8B1:1E77A0:68CC1DBA
       X-Served-By:
-      - cache-bos4624-BOS
+      - cache-bos4679-BOS
       X-Timer:
-      - S1757605956.681905,VS0,VE1
+      - S1758207419.343411,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:58 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -215,7 +215,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/datetime.json
   response:
@@ -247,7 +247,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '339'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -257,7 +257,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:35 GMT
+      - Thu, 18 Sep 2025 14:56:59 GMT
       ETag:
       - '"66e1651c-5c0"'
       Last-Modified:
@@ -273,15 +273,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 3e79219835d8231e7446f513a82094d77d76c39d
+      - 83ab9fcec44031feb3c15248690161694adbc44e
       X-GitHub-Request-Id:
-      - 280E:FA1FD:1EE60B6:2243920:68C2EEF0
+      - AA6A:16B07D:1DD504:1F82A5:68CC1DB8
       X-Served-By:
-      - cache-bos4674-BOS
+      - cache-bos4627-BOS
       X-Timer:
-      - S1757605956.759599,VS0,VE1
+      - S1758207419.414779,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:58 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -293,7 +293,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/instrument.json
   response:
@@ -314,7 +314,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '339'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -324,7 +324,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:35 GMT
+      - Thu, 18 Sep 2025 14:56:59 GMT
       ETag:
       - '"66e1651c-2b8"'
       Last-Modified:
@@ -340,15 +340,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 71c3fb2c27f14cfcdf6b72f38dc389837bac5560
+      - ccf4c35b35d8de5e2e81151567170eeb89435ecd
       X-GitHub-Request-Id:
-      - C268:C8585:1E15137:2173E2A:68C2EEF0
+      - B511:14943E:1DCDB1:1F7CB5:68CC1DB9
       X-Served-By:
-      - cache-bos4645-BOS
+      - cache-bos4676-BOS
       X-Timer:
-      - S1757605956.840545,VS0,VE1
+      - S1758207419.491116,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:58 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -358,7 +360,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/licensing.json
   response:
@@ -374,7 +376,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '339'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -384,7 +386,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:35 GMT
+      - Thu, 18 Sep 2025 14:56:59 GMT
       ETag:
       - '"66e1651c-12e"'
       Last-Modified:
@@ -398,17 +400,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '0'
+      - '1'
       X-Fastly-Request-ID:
-      - f3b76023bd640d1e92a1da701448686525817c73
+      - 109afb5e88f5f30e1d9acc4ee25c1dd9bba825ea
       X-GitHub-Request-Id:
-      - 9288:FB713:1DE04AB:213E52A:68C2EEF0
+      - BE90:3E33CC:1F6E08:211CE4:68CC1DBA
       X-Served-By:
-      - cache-bos4690-BOS
+      - cache-bos4684-BOS
       X-Timer:
-      - S1757605956.911497,VS0,VE1
+      - S1758207420.567021,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:58 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -418,7 +422,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/provider.json
   response:
@@ -445,7 +449,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '339'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -455,7 +459,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:35 GMT
+      - Thu, 18 Sep 2025 14:56:59 GMT
       ETag:
       - '"66e1651c-46f"'
       Last-Modified:
@@ -471,15 +475,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - d5320722df992fc1cbb84624dd945a640c626838
+      - 51743e014214ce50adf284eb2a451136bdee839f
       X-GitHub-Request-Id:
-      - B5B2:C72BD:20215CF:237DE00:68C2EEF0
+      - 7949:3E33CC:1F6E30:211D0C:68CC1DBA
       X-Served-By:
-      - cache-bos4620-BOS
+      - cache-bos4634-BOS
       X-Timer:
-      - S1757605956.984214,VS0,VE2
+      - S1758207420.651469,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:57 GMT
+      - Thu, 18 Sep 2025 15:06:58 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -491,7 +495,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/eo/v1.1.0/schema.json
   response:
@@ -569,7 +573,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '441'
+      - '235'
       Cache-Control:
       - max-age=600
       Connection:
@@ -579,7 +583,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:36 GMT
+      - Thu, 18 Sep 2025 14:56:59 GMT
       ETag:
       - '"66df1c53-13bc"'
       Last-Modified:
@@ -595,17 +599,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '5'
+      - '1'
       X-Fastly-Request-ID:
-      - 52981c9e59681122ab7e8b4c9b3c1c956362205b
+      - 02931252aabf4eba397117ea74a4d5177530c998
       X-GitHub-Request-Id:
-      - BE8A:14434E:B836A2:D3D600:68C2EE8A
+      - 98DE:39A2ED:1DBAAC:1F56C3:68CC1CD0
       X-Served-By:
-      - cache-bos4643-BOS
+      - cache-bos4632-BOS
       X-Timer:
-      - S1757605956.080466,VS0,VE0
+      - S1758207420.757788,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -615,7 +619,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/view/v1.0.0/schema.json
   response:
@@ -673,7 +677,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '441'
+      - '235'
       Cache-Control:
       - max-age=600
       Connection:
@@ -683,7 +687,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:36 GMT
+      - Thu, 18 Sep 2025 14:56:59 GMT
       ETag:
       - '"689f5434-dff"'
       Last-Modified:
@@ -701,15 +705,15 @@ interactions:
       X-Cache-Hits:
       - '2'
       X-Fastly-Request-ID:
-      - 0aa504d8d16249b980130512e1f668e7594531a4
+      - ce113f67ec3345ed998beaf26cc4e3ac9fb478bf
       X-GitHub-Request-Id:
-      - EACF:1C0114:1BE6594:1F22786:68C2EE8A
+      - 624D:BA176:74CE5:7ED3C:68CC1CD0
       X-Served-By:
-      - cache-bos4691-BOS
+      - cache-bos4672-BOS
       X-Timer:
-      - S1757605956.144057,VS0,VE0
+      - S1758207420.839029,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example11].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example11].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/item-spec/json-schema/item.json
   response:
@@ -108,11 +108,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:43 GMT
+      - Thu, 18 Sep 2025 14:56:02 GMT
       ETag:
       - '"4e24763d74f0d463b0cb6c63fc099e0b59447c7a049b93ffda4c6eb9eb54ae95"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:43 GMT
+      - Thu, 18 Sep 2025 15:01:02 GMT
       Source-Age:
       - '1'
       Strict-Transport-Security:
@@ -128,15 +128,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 74ec3bd777796f59fc015e902a405c563666abfd
+      - 4327652c8a49afd1cdd8ec29ba7b4038102a397f
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 688A:1E0DA2:13B02E:181CCC:68C2EEB5
+      - DDD5:286E0:D0F1D:FC0CF:68CC1D7C
       X-Served-By:
-      - cache-bos4644-BOS
+      - cache-bos4692-BOS
       X-Timer:
-      - S1757605904.737948,VS0,VE1
+      - S1758207363.827162,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -146,7 +146,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/extensions/label/schema.json
   response:
@@ -215,11 +215,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:43 GMT
+      - Thu, 18 Sep 2025 14:56:02 GMT
       ETag:
       - '"46c09f290da4303780880924f1569b2cb0b979a2d363a4446e2b8b7cc494844b"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:43 GMT
+      - Thu, 18 Sep 2025 15:01:02 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -229,21 +229,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 6b51d54b043dcb988d96da61809e926f0e3fbe5f
+      - 984dd32d8a91de000a6540db4a51bce511354ad3
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 6167:2ACBC:149D59:191454:68C2EEB6
+      - 84D7:1EB8B2:B9B89:E4D7F:68CC1D82
       X-Served-By:
-      - cache-bos4648-BOS
+      - cache-bos4678-BOS
       X-Timer:
-      - S1757605904.860317,VS0,VE51
+      - S1758207363.913098,VS0,VE73
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example120].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example120].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json
   response:
@@ -104,7 +104,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '340'
+      - '2'
       Cache-Control:
       - max-age=600
       Connection:
@@ -114,7 +114,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:36 GMT
+      - Thu, 18 Sep 2025 14:56:59 GMT
       ETag:
       - '"66e1651c-1a43"'
       Last-Modified:
@@ -130,15 +130,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 7884d8f2e2d683c995798101a2cb317081fdd425
+      - 27d457396b9c8411316d9d5cc0f35001f8bf7294
       X-GitHub-Request-Id:
-      - 6830:FB713:1DE043F:213E4A8:68C2EEEE
+      - B0CD:E2749:22797A:2427D7:68CC1DB8
       X-Served-By:
-      - cache-bos4655-BOS
+      - cache-bos4647-BOS
       X-Timer:
-      - S1757605956.222050,VS0,VE1
+      - S1758207420.935020,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:58 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -150,7 +150,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/basics.json
   response:
@@ -169,7 +169,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '340'
+      - '2'
       Cache-Control:
       - max-age=600
       Connection:
@@ -179,7 +179,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:36 GMT
+      - Thu, 18 Sep 2025 14:57:00 GMT
       ETag:
       - '"66e1651c-215"'
       Last-Modified:
@@ -195,15 +195,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 589a2599f1fbb3f5eaede41d352a06ac74982461
+      - 8937d1fa0c7fd9fe55bf04dc4d74a15849d0e8ed
       X-GitHub-Request-Id:
-      - 8BC5:2391:1FBEC5E:231AD43:68C2EEF0
+      - 99F8:39AA35:1CC8B1:1E77A0:68CC1DBA
       X-Served-By:
-      - cache-bos4686-BOS
+      - cache-bos4643-BOS
       X-Timer:
-      - S1757605956.289419,VS0,VE1
+      - S1758207420.029389,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:58 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -215,7 +215,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/datetime.json
   response:
@@ -247,7 +247,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '340'
+      - '2'
       Cache-Control:
       - max-age=600
       Connection:
@@ -257,7 +257,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:36 GMT
+      - Thu, 18 Sep 2025 14:57:00 GMT
       ETag:
       - '"66e1651c-5c0"'
       Last-Modified:
@@ -273,15 +273,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - ccfbcaff5ad3b930e4fe68a7c46858091a4cb3e4
+      - e80824df7ec03fed4a4a7698e6c9a5ea0dc39f6f
       X-GitHub-Request-Id:
-      - 280E:FA1FD:1EE60B6:2243920:68C2EEF0
+      - AA6A:16B07D:1DD504:1F82A5:68CC1DB8
       X-Served-By:
-      - cache-bos4649-BOS
+      - cache-bos4629-BOS
       X-Timer:
-      - S1757605956.366602,VS0,VE1
+      - S1758207420.111247,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:58 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -293,7 +293,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/instrument.json
   response:
@@ -314,7 +314,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '340'
+      - '2'
       Cache-Control:
       - max-age=600
       Connection:
@@ -324,7 +324,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:36 GMT
+      - Thu, 18 Sep 2025 14:57:00 GMT
       ETag:
       - '"66e1651c-2b8"'
       Last-Modified:
@@ -340,15 +340,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 22c62385e720cf31eb312eb0b3f9795617879d56
+      - 935a6900395c8fa2f18dca20f86465fa8bc200f2
       X-GitHub-Request-Id:
-      - C268:C8585:1E15137:2173E2A:68C2EEF0
+      - B511:14943E:1DCDB1:1F7CB5:68CC1DB9
       X-Served-By:
-      - cache-bos4633-BOS
+      - cache-bos4640-BOS
       X-Timer:
-      - S1757605956.438415,VS0,VE1
+      - S1758207420.197285,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:58 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -358,7 +360,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/licensing.json
   response:
@@ -374,7 +376,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '339'
+      - '2'
       Cache-Control:
       - max-age=600
       Connection:
@@ -384,7 +386,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:36 GMT
+      - Thu, 18 Sep 2025 14:57:00 GMT
       ETag:
       - '"66e1651c-12e"'
       Last-Modified:
@@ -400,15 +402,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - ff73cf76c5f15181ca5cbe5b93ccd9323002609a
+      - 89cf13f9f91821c524d312a8f5a5c9ad4488c033
       X-GitHub-Request-Id:
-      - 9288:FB713:1DE04AB:213E52A:68C2EEF0
+      - BE90:3E33CC:1F6E08:211CE4:68CC1DBA
       X-Served-By:
-      - cache-bos4683-BOS
+      - cache-bos4642-BOS
       X-Timer:
-      - S1757605957.512214,VS0,VE1
+      - S1758207420.271058,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:58 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -418,7 +422,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/provider.json
   response:
@@ -445,7 +449,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '339'
+      - '2'
       Cache-Control:
       - max-age=600
       Connection:
@@ -455,7 +459,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:36 GMT
+      - Thu, 18 Sep 2025 14:57:00 GMT
       ETag:
       - '"66e1651c-46f"'
       Last-Modified:
@@ -471,15 +475,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - ddfe72b8f502fea2079f7c70329232181f4cedaa
+      - c91340761b49dd98278ee5d07bf48a49ff8330b9
       X-GitHub-Request-Id:
-      - B5B2:C72BD:20215CF:237DE00:68C2EEF0
+      - 7949:3E33CC:1F6E30:211D0C:68CC1DBA
       X-Served-By:
-      - cache-bos4676-BOS
+      - cache-bos4648-BOS
       X-Timer:
-      - S1757605957.593425,VS0,VE1
+      - S1758207420.347171,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:57 GMT
+      - Thu, 18 Sep 2025 15:06:58 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example121].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example121].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json
   response:
@@ -104,7 +104,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '340'
+      - '2'
       Cache-Control:
       - max-age=600
       Connection:
@@ -114,7 +114,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:36 GMT
+      - Thu, 18 Sep 2025 14:57:00 GMT
       ETag:
       - '"66e1651c-1a43"'
       Last-Modified:
@@ -128,17 +128,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - dd4af5a4cee6a77e13dc7a7824c6ab3976dc99b8
+      - 1bca95048c2740e302c466230659334622c98529
       X-GitHub-Request-Id:
-      - 6830:FB713:1DE043F:213E4A8:68C2EEEE
+      - B0CD:E2749:22797A:2427D7:68CC1DB8
       X-Served-By:
-      - cache-bos4657-BOS
+      - cache-bos4685-BOS
       X-Timer:
-      - S1757605957.727909,VS0,VE0
+      - S1758207420.461137,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:58 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -150,7 +150,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/basics.json
   response:
@@ -169,7 +169,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '340'
+      - '2'
       Cache-Control:
       - max-age=600
       Connection:
@@ -179,7 +179,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:36 GMT
+      - Thu, 18 Sep 2025 14:57:00 GMT
       ETag:
       - '"66e1651c-215"'
       Last-Modified:
@@ -195,15 +195,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - a936b7257daba11d702588381df55ddb19843776
+      - a57807379fa3709e1b07e01bf3fe3c561c3c346d
       X-GitHub-Request-Id:
-      - 8BC5:2391:1FBEC5E:231AD43:68C2EEF0
+      - 99F8:39AA35:1CC8B1:1E77A0:68CC1DBA
       X-Served-By:
-      - cache-bos4682-BOS
+      - cache-bos4678-BOS
       X-Timer:
-      - S1757605957.819605,VS0,VE1
+      - S1758207421.543104,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:58 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -215,7 +215,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/datetime.json
   response:
@@ -247,7 +247,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '340'
+      - '2'
       Cache-Control:
       - max-age=600
       Connection:
@@ -257,7 +257,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:36 GMT
+      - Thu, 18 Sep 2025 14:57:00 GMT
       ETag:
       - '"66e1651c-5c0"'
       Last-Modified:
@@ -273,15 +273,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 0b6375fc3e685620d826ff9af81f2f45380770e9
+      - 1651353259430447cf17d6fb8d0c01b311aa792e
       X-GitHub-Request-Id:
-      - 280E:FA1FD:1EE60B6:2243920:68C2EEF0
+      - AA6A:16B07D:1DD504:1F82A5:68CC1DB8
       X-Served-By:
-      - cache-bos4663-BOS
+      - cache-bos4690-BOS
       X-Timer:
-      - S1757605957.906219,VS0,VE2
+      - S1758207421.617504,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:58 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -293,7 +293,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/instrument.json
   response:
@@ -314,7 +314,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '340'
+      - '2'
       Cache-Control:
       - max-age=600
       Connection:
@@ -324,7 +324,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:36 GMT
+      - Thu, 18 Sep 2025 14:57:00 GMT
       ETag:
       - '"66e1651c-2b8"'
       Last-Modified:
@@ -340,15 +340,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 5c33a6f97006b452e109b50ab59d7c508e946dc3
+      - 2a69c49503da74342d45cc96b185cd6a9d0ae9f4
       X-GitHub-Request-Id:
-      - C268:C8585:1E15137:2173E2A:68C2EEF0
+      - B511:14943E:1DCDB1:1F7CB5:68CC1DB9
       X-Served-By:
-      - cache-bos4691-BOS
+      - cache-bos4628-BOS
       X-Timer:
-      - S1757605957.992946,VS0,VE1
+      - S1758207421.690971,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:58 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -358,7 +360,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/licensing.json
   response:
@@ -374,7 +376,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '340'
+      - '2'
       Cache-Control:
       - max-age=600
       Connection:
@@ -384,7 +386,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:37 GMT
+      - Thu, 18 Sep 2025 14:57:00 GMT
       ETag:
       - '"66e1651c-12e"'
       Last-Modified:
@@ -400,15 +402,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 622c0ab01359508d00d7bd2b0bc6d97199f3848c
+      - 98cc7d88d3137ae8d5429249660c8f745dfd5204
       X-GitHub-Request-Id:
-      - 9288:FB713:1DE04AB:213E52A:68C2EEF0
+      - BE90:3E33CC:1F6E08:211CE4:68CC1DBA
       X-Served-By:
-      - cache-bos4687-BOS
+      - cache-bos4660-BOS
       X-Timer:
-      - S1757605957.079940,VS0,VE1
+      - S1758207421.767399,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:58 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -418,7 +422,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/provider.json
   response:
@@ -445,7 +449,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '340'
+      - '2'
       Cache-Control:
       - max-age=600
       Connection:
@@ -455,7 +459,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:37 GMT
+      - Thu, 18 Sep 2025 14:57:00 GMT
       ETag:
       - '"66e1651c-46f"'
       Last-Modified:
@@ -471,15 +475,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 3d50d0878c3742e33a048a44f9c3500af3ee3315
+      - 3b2b03afba3afbfbbbfb2dd5163694aa98460aa2
       X-GitHub-Request-Id:
-      - B5B2:C72BD:20215CF:237DE00:68C2EEF0
+      - 7949:3E33CC:1F6E30:211D0C:68CC1DBA
       X-Served-By:
-      - cache-bos4670-BOS
+      - cache-bos4625-BOS
       X-Timer:
-      - S1757605957.165911,VS0,VE2
+      - S1758207421.843109,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:56:57 GMT
+      - Thu, 18 Sep 2025 15:06:58 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -491,7 +495,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/eo/v1.1.0/schema.json
   response:
@@ -569,7 +573,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '443'
+      - '237'
       Cache-Control:
       - max-age=600
       Connection:
@@ -579,7 +583,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:37 GMT
+      - Thu, 18 Sep 2025 14:57:01 GMT
       ETag:
       - '"66df1c53-13bc"'
       Last-Modified:
@@ -595,17 +599,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - fb5401c6429b276562954969ba782afe9b276e12
+      - 7fec0d725709e6f30f7c70039055172fbd3f76c5
       X-GitHub-Request-Id:
-      - BE8A:14434E:B836A2:D3D600:68C2EE8A
+      - 98DE:39A2ED:1DBAAC:1F56C3:68CC1CD0
       X-Served-By:
-      - cache-bos4671-BOS
+      - cache-bos4670-BOS
       X-Timer:
-      - S1757605957.370403,VS0,VE0
+      - S1758207421.037109,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -615,7 +619,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/sat/v1.0.0/schema.json
   response:
@@ -675,7 +679,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '428'
+      - '92'
       Cache-Control:
       - max-age=600
       Connection:
@@ -685,7 +689,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:37 GMT
+      - Thu, 18 Sep 2025 14:57:01 GMT
       ETag:
       - '"67627e9d-e82"'
       Last-Modified:
@@ -701,17 +705,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '0'
       X-Fastly-Request-ID:
-      - 9eea0553e95fcae9016f4c8a98668fec2a80ab50
+      - 7bfe7b188026272df3ce083a3a2c1dae2fa4d8de
       X-GitHub-Request-Id:
-      - 621C:19FF07:BB2CFC:D6CBD0:68C2EE98
+      - 4F00:BAEAA:C82DD6:E297E0:68CC1D60
       X-Served-By:
-      - cache-bos4682-BOS
+      - cache-bos4624-BOS
       X-Timer:
-      - S1757605957.447575,VS0,VE0
+      - S1758207421.115134,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:28 GMT
+      - Thu, 18 Sep 2025 15:05:29 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -721,7 +725,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/projection/v1.0.0/schema.json
   response:
@@ -793,7 +797,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '341'
+      - '4'
       Cache-Control:
       - max-age=600
       Connection:
@@ -803,7 +807,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:37 GMT
+      - Thu, 18 Sep 2025 14:57:01 GMT
       ETag:
       - '"669e563b-1226"'
       Last-Modified:
@@ -821,15 +825,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - cc9a93d99939adca00082f5f44d7185e0051b289
+      - 5d31dd2354874ced6b8040d631aebaf05b823c0a
       X-GitHub-Request-Id:
-      - 495E:15BCE:1E96F66:21F25DD:68C2EEEF
+      - 3CEC:2EDCE9:1DD175:1F7EC7:68CC1DB8
       X-Served-By:
-      - cache-bos4631-BOS
+      - cache-bos4661-BOS
       X-Timer:
-      - S1757605958.519876,VS0,VE1
+      - S1758207421.193183,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:57 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -839,7 +845,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/mgrs/v1.0.0/schema.json
   response:
@@ -889,7 +895,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '435'
+      - '99'
       Cache-Control:
       - max-age=600
       Connection:
@@ -899,7 +905,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:37 GMT
+      - Thu, 18 Sep 2025 14:57:01 GMT
       ETag:
       - '"60c20ce1-b49"'
       Last-Modified:
@@ -915,17 +921,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '0'
+      - '4'
       X-Fastly-Request-ID:
-      - 4c0ee8c128659ece94b3df948f484f5536a5de9f
+      - 904467c5eebdc3352f77038a903a810c9d738b44
       X-GitHub-Request-Id:
-      - 8146:41371:C197CC:DD3EA9:68C2EE91
+      - 4494:C5EEF:CC4460:E69E65:68CC1D5A
       X-Served-By:
-      - cache-bos4654-BOS
+      - cache-bos4627-BOS
       X-Timer:
-      - S1757605958.601976,VS0,VE2
+      - S1758207421.263469,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:22 GMT
+      - Thu, 18 Sep 2025 15:05:22 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -935,7 +941,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/grid/v1.0.0/schema.json
   response:
@@ -969,7 +975,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '338'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -979,7 +985,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:37 GMT
+      - Thu, 18 Sep 2025 14:57:01 GMT
       ETag:
       - '"638a24f0-6d5"'
       Last-Modified:
@@ -993,19 +999,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 9fd510118f628f1ed09802ff88635ec5152b3e70
+      - bf77314df924ae7ce3cc88933758ad9554ef0398
       X-GitHub-Request-Id:
-      - 8BC5:2391:1FBEFF4:231B128:68C2EEF3
+      - 5854:5C5F9:1F3035:20DE22:68CC1DBD
       X-Served-By:
-      - cache-bos4673-BOS
+      - cache-bos4641-BOS
       X-Timer:
-      - S1757605958.676046,VS0,VE1
+      - S1758207421.329438,VS0,VE40
       expires:
-      - Thu, 11 Sep 2025 15:56:59 GMT
+      - Thu, 18 Sep 2025 15:07:01 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -1015,7 +1021,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/view/v1.0.0/schema.json
   response:
@@ -1073,7 +1079,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '443'
+      - '237'
       Cache-Control:
       - max-age=600
       Connection:
@@ -1083,7 +1089,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:37 GMT
+      - Thu, 18 Sep 2025 14:57:01 GMT
       ETag:
       - '"689f5434-dff"'
       Last-Modified:
@@ -1101,15 +1107,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 87bf6afb38c8fc92dbb75af496f6ebb6c0b1d7d4
+      - a0271ab03ac022ed06fa06f3871b410074dd1e16
       X-GitHub-Request-Id:
-      - EACF:1C0114:1BE6594:1F22786:68C2EE8A
+      - 624D:BA176:74CE5:7ED3C:68CC1CD0
       X-Served-By:
-      - cache-bos4647-BOS
+      - cache-bos4651-BOS
       X-Timer:
-      - S1757605958.754089,VS0,VE2
+      - S1758207421.427244,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example122].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example122].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json
   response:
@@ -104,7 +104,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '341'
+      - '3'
       Cache-Control:
       - max-age=600
       Connection:
@@ -114,7 +114,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:37 GMT
+      - Thu, 18 Sep 2025 14:57:01 GMT
       ETag:
       - '"66e1651c-1a43"'
       Last-Modified:
@@ -130,15 +130,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 5eec05a22c43a02dc4929f26238d12a8363c890f
+      - fabe25d81b8e91ea0ab8b7d332218b67e61be4b7
       X-GitHub-Request-Id:
-      - 6830:FB713:1DE043F:213E4A8:68C2EEEE
+      - B0CD:E2749:22797A:2427D7:68CC1DB8
       X-Served-By:
-      - cache-bos4621-BOS
+      - cache-bos4680-BOS
       X-Timer:
-      - S1757605958.867990,VS0,VE2
+      - S1758207422.514421,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:58 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -150,7 +150,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/basics.json
   response:
@@ -169,7 +169,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '341'
+      - '3'
       Cache-Control:
       - max-age=600
       Connection:
@@ -179,7 +179,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:37 GMT
+      - Thu, 18 Sep 2025 14:57:01 GMT
       ETag:
       - '"66e1651c-215"'
       Last-Modified:
@@ -193,17 +193,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - a58966784834010f4df8e8b2838b253e5223403b
+      - b4c2e340d53c3f4a0854813f42c22d86880222d3
       X-GitHub-Request-Id:
-      - 8BC5:2391:1FBEC5E:231AD43:68C2EEF0
+      - 99F8:39AA35:1CC8B1:1E77A0:68CC1DBA
       X-Served-By:
-      - cache-bos4690-BOS
+      - cache-bos4625-BOS
       X-Timer:
-      - S1757605958.965792,VS0,VE0
+      - S1758207422.596888,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:58 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -215,7 +215,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/datetime.json
   response:
@@ -247,7 +247,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '341'
+      - '3'
       Cache-Control:
       - max-age=600
       Connection:
@@ -257,7 +257,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:38 GMT
+      - Thu, 18 Sep 2025 14:57:01 GMT
       ETag:
       - '"66e1651c-5c0"'
       Last-Modified:
@@ -273,15 +273,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 6a1f055fa8ca8b08e28fb55cbe5ac1c2e442018c
+      - 676c09c42b5118c5e702fc45cf13549ec7e64ff8
       X-GitHub-Request-Id:
-      - 280E:FA1FD:1EE60B6:2243920:68C2EEF0
+      - AA6A:16B07D:1DD504:1F82A5:68CC1DB8
       X-Served-By:
-      - cache-bos4648-BOS
+      - cache-bos4655-BOS
       X-Timer:
-      - S1757605958.052705,VS0,VE1
+      - S1758207422.673024,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:58 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -293,7 +293,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/instrument.json
   response:
@@ -314,7 +314,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '341'
+      - '3'
       Cache-Control:
       - max-age=600
       Connection:
@@ -324,7 +324,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:38 GMT
+      - Thu, 18 Sep 2025 14:57:01 GMT
       ETag:
       - '"66e1651c-2b8"'
       Last-Modified:
@@ -338,17 +338,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '10'
+      - '1'
       X-Fastly-Request-ID:
-      - 476e7fdd7029695fb9086d27ff7e5ac73ea64b6c
+      - a3b84dd50fd19b811edfc716dd5ef53da1994094
       X-GitHub-Request-Id:
-      - C268:C8585:1E15137:2173E2A:68C2EEF0
+      - B511:14943E:1DCDB1:1F7CB5:68CC1DB9
       X-Served-By:
-      - cache-bos4672-BOS
+      - cache-bos4678-BOS
       X-Timer:
-      - S1757605958.129202,VS0,VE0
+      - S1758207422.748858,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:58 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -358,7 +360,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/licensing.json
   response:
@@ -374,7 +376,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '341'
+      - '3'
       Cache-Control:
       - max-age=600
       Connection:
@@ -384,7 +386,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:38 GMT
+      - Thu, 18 Sep 2025 14:57:01 GMT
       ETag:
       - '"66e1651c-12e"'
       Last-Modified:
@@ -400,15 +402,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 8ebd16bed43a9e13cfba83abb4d2b1bbe1d0fba3
+      - 43f21adcdd234ee63d9c3324fce414d70329878f
       X-GitHub-Request-Id:
-      - 9288:FB713:1DE04AB:213E52A:68C2EEF0
+      - BE90:3E33CC:1F6E08:211CE4:68CC1DBA
       X-Served-By:
-      - cache-bos4677-BOS
+      - cache-bos4686-BOS
       X-Timer:
-      - S1757605958.201783,VS0,VE1
+      - S1758207422.827070,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:58 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -418,7 +422,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/provider.json
   response:
@@ -445,7 +449,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '341'
+      - '3'
       Cache-Control:
       - max-age=600
       Connection:
@@ -455,7 +459,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:38 GMT
+      - Thu, 18 Sep 2025 14:57:01 GMT
       ETag:
       - '"66e1651c-46f"'
       Last-Modified:
@@ -471,15 +475,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 72097387f8cc168ca39f8c091d3a5524538aaf41
+      - d6910bd333ec83045842f765433ee0ec62a9e1ff
       X-GitHub-Request-Id:
-      - B5B2:C72BD:20215CF:237DE00:68C2EEF0
+      - 7949:3E33CC:1F6E30:211D0C:68CC1DBA
       X-Served-By:
-      - cache-bos4666-BOS
+      - cache-bos4690-BOS
       X-Timer:
-      - S1757605958.277886,VS0,VE2
+      - S1758207422.903836,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:57 GMT
+      - Thu, 18 Sep 2025 15:06:58 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -491,7 +495,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/eo/v1.1.0/schema.json
   response:
@@ -569,7 +573,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '444'
+      - '238'
       Cache-Control:
       - max-age=600
       Connection:
@@ -579,7 +583,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:38 GMT
+      - Thu, 18 Sep 2025 14:57:02 GMT
       ETag:
       - '"66df1c53-13bc"'
       Last-Modified:
@@ -597,15 +601,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 9645bc55f9945046fa067316e78ea8cfa6e1eba4
+      - c4fc22913fc56ee33726900e2fe82afaa9f87e5f
       X-GitHub-Request-Id:
-      - BE8A:14434E:B836A2:D3D600:68C2EE8A
+      - 98DE:39A2ED:1DBAAC:1F56C3:68CC1CD0
       X-Served-By:
-      - cache-bos4670-BOS
+      - cache-bos4659-BOS
       X-Timer:
-      - S1757605958.378158,VS0,VE1
+      - S1758207422.012944,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -615,7 +619,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/projection/v1.0.0/schema.json
   response:
@@ -687,7 +691,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '342'
+      - '5'
       Cache-Control:
       - max-age=600
       Connection:
@@ -697,7 +701,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:38 GMT
+      - Thu, 18 Sep 2025 14:57:02 GMT
       ETag:
       - '"669e563b-1226"'
       Last-Modified:
@@ -715,15 +719,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 758ea6dbdb99934cef6427d6830f035a4058f7fe
+      - 9cbb2b17fcc080f3eb53ab4d89915d770996b0fb
       X-GitHub-Request-Id:
-      - 495E:15BCE:1E96F66:21F25DD:68C2EEEF
+      - 3CEC:2EDCE9:1DD175:1F7EC7:68CC1DB8
       X-Served-By:
-      - cache-bos4655-BOS
+      - cache-bos4643-BOS
       X-Timer:
-      - S1757605958.447539,VS0,VE1
+      - S1758207422.075968,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:57 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -733,7 +739,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/scientific/v1.0.0/schema.json
   response:
@@ -819,7 +825,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '440'
+      - '104'
       Cache-Control:
       - max-age=600
       Connection:
@@ -829,7 +835,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:38 GMT
+      - Thu, 18 Sep 2025 14:57:02 GMT
       ETag:
       - '"60febab7-15fa"'
       Last-Modified:
@@ -847,15 +853,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 307ad4a1a88a1a0fc4a673df12cdb8ecc58b9e8a
+      - 18674409f5677e9327dbde2698d35c5e35ef28ee
       X-GitHub-Request-Id:
-      - 3922:128B70:CB9EFB:E73AAF:68C2EE8E
+      - 5CF5:3D35AC:C4B412:DF1A74:68CC1D55
       X-Served-By:
-      - cache-bos4643-BOS
+      - cache-bos4656-BOS
       X-Timer:
-      - S1757605959.513950,VS0,VE2
+      - S1758207422.149779,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:18 GMT
+      - Thu, 18 Sep 2025 15:05:17 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -865,7 +871,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/view/v1.0.0/schema.json
   response:
@@ -923,7 +929,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '444'
+      - '238'
       Cache-Control:
       - max-age=600
       Connection:
@@ -933,7 +939,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:38 GMT
+      - Thu, 18 Sep 2025 14:57:02 GMT
       ETag:
       - '"689f5434-dff"'
       Last-Modified:
@@ -949,17 +955,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '1'
       X-Fastly-Request-ID:
-      - 45cfabd0b5f4a1084bd7acefd9235bf4a2abd29e
+      - cd020685c61b53e3bee8e76ff090424635404b5e
       X-GitHub-Request-Id:
-      - EACF:1C0114:1BE6594:1F22786:68C2EE8A
+      - 624D:BA176:74CE5:7ED3C:68CC1CD0
       X-Served-By:
-      - cache-bos4634-BOS
+      - cache-bos4680-BOS
       X-Timer:
-      - S1757605959.578210,VS0,VE1
+      - S1758207422.223624,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -969,7 +975,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/remote-data/v1.0.0/schema.json
   response:
@@ -1034,7 +1040,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '342'
+      - '5'
       Cache-Control:
       - max-age=600
       Connection:
@@ -1044,7 +1050,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:38 GMT
+      - Thu, 18 Sep 2025 14:57:02 GMT
       ETag:
       - '"6046b731-f97"'
       Last-Modified:
@@ -1062,15 +1068,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 6f3fa94be5affb8e3c0455de531a218b523f1474
+      - 6a061c25e18ea23aec33804eb7eb35fea97e4df3
       X-GitHub-Request-Id:
-      - B45E:3B188F:1EF9852:22556BA:68C2EEEF
+      - 28D8:39A2ED:1EEE14:209C7E:68CC1DB9
       X-Served-By:
-      - cache-bos4627-BOS
+      - cache-bos4655-BOS
       X-Timer:
-      - S1757605959.642263,VS0,VE1
+      - S1758207422.293164,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:57 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example123].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example123].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/collection-spec/json-schema/collection.json
   response:
@@ -110,7 +110,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '342'
+      - '4'
       Cache-Control:
       - max-age=600
       Connection:
@@ -120,7 +120,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:38 GMT
+      - Thu, 18 Sep 2025 14:57:02 GMT
       ETag:
       - '"66e1651c-1c29"'
       Last-Modified:
@@ -134,17 +134,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '5'
+      - '1'
       X-Fastly-Request-ID:
-      - d67277b21a9d44cfea290194fb387dfbe7b34fa5
+      - 78839c4f6322209c03fd56405e7252e395b228c8
       X-GitHub-Request-Id:
-      - A4D3:13E3A5:1E98041:21F570A:68C2EEF0
+      - A7D1:3FED61:1CD3D5:1E813E:68CC1DB9
       X-Served-By:
-      - cache-bos4674-BOS
+      - cache-bos4663-BOS
       X-Timer:
-      - S1757605959.735935,VS0,VE0
+      - S1758207422.391119,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:57 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example124].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example124].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json
   response:
@@ -104,7 +104,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '342'
+      - '4'
       Cache-Control:
       - max-age=600
       Connection:
@@ -114,7 +114,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:38 GMT
+      - Thu, 18 Sep 2025 14:57:02 GMT
       ETag:
       - '"66e1651c-1a43"'
       Last-Modified:
@@ -130,15 +130,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - e53afd2d9452749faed4b284b51d07f2ebc807a1
+      - 0d5f680d83cd125dcd43899fea183e357ae7e906
       X-GitHub-Request-Id:
-      - 6830:FB713:1DE043F:213E4A8:68C2EEEE
+      - B0CD:E2749:22797A:2427D7:68CC1DB8
       X-Served-By:
-      - cache-bos4637-BOS
+      - cache-bos4625-BOS
       X-Timer:
-      - S1757605959.834358,VS0,VE2
+      - S1758207422.477031,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:58 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -150,7 +150,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/basics.json
   response:
@@ -169,7 +169,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '342'
+      - '4'
       Cache-Control:
       - max-age=600
       Connection:
@@ -179,7 +179,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:38 GMT
+      - Thu, 18 Sep 2025 14:57:02 GMT
       ETag:
       - '"66e1651c-215"'
       Last-Modified:
@@ -195,15 +195,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 7dfba9a69c5373c25bac7667f3cf6e9fb9f5c87d
+      - 78435da8387e874d8e40fe253bf50c2076e2ccb0
       X-GitHub-Request-Id:
-      - 8BC5:2391:1FBEC5E:231AD43:68C2EEF0
+      - 99F8:39AA35:1CC8B1:1E77A0:68CC1DBA
       X-Served-By:
-      - cache-bos4683-BOS
+      - cache-bos4624-BOS
       X-Timer:
-      - S1757605959.919821,VS0,VE2
+      - S1758207423.575364,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:58 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -215,7 +215,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/datetime.json
   response:
@@ -247,7 +247,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '342'
+      - '4'
       Cache-Control:
       - max-age=600
       Connection:
@@ -257,7 +257,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:38 GMT
+      - Thu, 18 Sep 2025 14:57:02 GMT
       ETag:
       - '"66e1651c-5c0"'
       Last-Modified:
@@ -273,15 +273,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 718371df34876919cfa95cf010fb1952a185ad8b
+      - c71bdd9ea4dfb8e2f85c13af029815a19e8636e0
       X-GitHub-Request-Id:
-      - 280E:FA1FD:1EE60B6:2243920:68C2EEF0
+      - AA6A:16B07D:1DD504:1F82A5:68CC1DB8
       X-Served-By:
-      - cache-bos4658-BOS
+      - cache-bos4651-BOS
       X-Timer:
-      - S1757605959.992272,VS0,VE1
+      - S1758207423.659247,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:58 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -293,7 +293,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/instrument.json
   response:
@@ -314,7 +314,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '342'
+      - '4'
       Cache-Control:
       - max-age=600
       Connection:
@@ -324,7 +324,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:39 GMT
+      - Thu, 18 Sep 2025 14:57:02 GMT
       ETag:
       - '"66e1651c-2b8"'
       Last-Modified:
@@ -340,15 +340,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 1091a84b388552a5a562dff663adb1381c9591b0
+      - dd2a00d093b3a46b8965ebb1125de680b1019e95
       X-GitHub-Request-Id:
-      - C268:C8585:1E15137:2173E2A:68C2EEF0
+      - B511:14943E:1DCDB1:1F7CB5:68CC1DB9
       X-Served-By:
-      - cache-bos4688-BOS
+      - cache-bos4670-BOS
       X-Timer:
-      - S1757605959.066121,VS0,VE1
+      - S1758207423.749466,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:58 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -358,7 +360,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/licensing.json
   response:
@@ -374,7 +376,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '342'
+      - '4'
       Cache-Control:
       - max-age=600
       Connection:
@@ -384,7 +386,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:39 GMT
+      - Thu, 18 Sep 2025 14:57:02 GMT
       ETag:
       - '"66e1651c-12e"'
       Last-Modified:
@@ -398,17 +400,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '1'
       X-Fastly-Request-ID:
-      - b1c843f1b88fc2695fddde1b2acb9b8af81a23fd
+      - 6394f17bbc49679a728286939858df4a7eff8b0c
       X-GitHub-Request-Id:
-      - 9288:FB713:1DE04AB:213E52A:68C2EEF0
+      - BE90:3E33CC:1F6E08:211CE4:68CC1DBA
       X-Served-By:
-      - cache-bos4630-BOS
+      - cache-bos4651-BOS
       X-Timer:
-      - S1757605959.141900,VS0,VE0
+      - S1758207423.839393,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:58 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -418,7 +422,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/provider.json
   response:
@@ -445,7 +449,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '342'
+      - '4'
       Cache-Control:
       - max-age=600
       Connection:
@@ -455,7 +459,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:39 GMT
+      - Thu, 18 Sep 2025 14:57:02 GMT
       ETag:
       - '"66e1651c-46f"'
       Last-Modified:
@@ -471,15 +475,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 6cf81255ebb5aee87a450aeb35c64f82ca4ee663
+      - 8d9ab802a9f881930b8281a273c6d0456fed77f7
       X-GitHub-Request-Id:
-      - B5B2:C72BD:20215CF:237DE00:68C2EEF0
+      - 7949:3E33CC:1F6E30:211D0C:68CC1DBA
       X-Served-By:
-      - cache-bos4674-BOS
+      - cache-bos4656-BOS
       X-Timer:
-      - S1757605959.215943,VS0,VE1
+      - S1758207423.919413,VS0,VE3
       expires:
-      - Thu, 11 Sep 2025 15:56:57 GMT
+      - Thu, 18 Sep 2025 15:06:58 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -491,7 +495,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/eo/v1.1.0/schema.json
   response:
@@ -569,7 +573,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '444'
+      - '238'
       Cache-Control:
       - max-age=600
       Connection:
@@ -579,7 +583,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:39 GMT
+      - Thu, 18 Sep 2025 14:57:03 GMT
       ETag:
       - '"66df1c53-13bc"'
       Last-Modified:
@@ -595,17 +599,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '2'
       X-Fastly-Request-ID:
-      - fef1661b740efa14bd1c95513bb11936b128660c
+      - d1d6845086cbe3d405942272664a4f9270b429fb
       X-GitHub-Request-Id:
-      - BE8A:14434E:B836A2:D3D600:68C2EE8A
+      - 98DE:39A2ED:1DBAAC:1F56C3:68CC1CD0
       X-Served-By:
-      - cache-bos4653-BOS
+      - cache-bos4632-BOS
       X-Timer:
-      - S1757605959.287436,VS0,VE0
+      - S1758207423.013607,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:14 GMT
+      - Thu, 18 Sep 2025 15:03:04 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -615,7 +619,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://stac-extensions.github.io/projection/v1.0.0/schema.json
   response:
@@ -687,7 +691,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '343'
+      - '6'
       Cache-Control:
       - max-age=600
       Connection:
@@ -697,7 +701,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:39 GMT
+      - Thu, 18 Sep 2025 14:57:03 GMT
       ETag:
       - '"669e563b-1226"'
       Last-Modified:
@@ -715,15 +719,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - c538af6780c045021f2984914ac2d09b496a3b6e
+      - 3c756d3f9aa6bd5d13c10ed5bd72e334a35b7fc8
       X-GitHub-Request-Id:
-      - 495E:15BCE:1E96F66:21F25DD:68C2EEEF
+      - 3CEC:2EDCE9:1DD175:1F7EC7:68CC1DB8
       X-Served-By:
-      - cache-bos4624-BOS
+      - cache-bos4684-BOS
       X-Timer:
-      - S1757605959.350202,VS0,VE2
+      - S1758207423.085091,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:06:57 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -733,7 +739,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://proj.org/schemas/v0.2/projjson.schema.json
   response:
@@ -743,11 +749,11 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '1200'
+      - '23'
       CF-Cache-Status:
       - HIT
       CF-Ray:
-      - 97d8555e7aa9778a-IAD
+      - 9811b18afaa3e6f2-IAD
       Cache-Control:
       - max-age=1200
       Connection:
@@ -759,16 +765,16 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:39 GMT
+      - Thu, 18 Sep 2025 14:57:03 GMT
       Location:
       - https://proj.org/en/latest/schemas/v0.2/projjson.schema.json
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=HwFVx5oCNI5sICvYUG7w8r60vxPS2_bNYh_.upIwjlk-1757605959-1.0.1.1-XrnVJ.9lVjW6B79xJoJlegnctVNuYbaB_yt.s7AKQSlUvyD.mv.QTgcspvNmBw3fOflqOIZx_ZoZER8pd4h3fn5iHeTxiVSK96U4reZ_Ykw;
-        path=/; expires=Thu, 11-Sep-25 16:22:39 GMT; domain=.proj.org; HttpOnly; Secure;
+      - __cf_bm=DRRi0yxzufwbzYEvp0nBCvnFbORWtkqkNM40RPQom3E-1758207423-1.0.1.1-Pnk5e739Iyrooh91WAHd2EgZb9QrGdP0Cx5B27IWKPj5PPjjleAAFDLVEOT4_qm2YFJpO4KE25c82b.LlOpAdFll3fI69ppp3EUAidPJ22c;
+        path=/; expires=Thu, 18-Sep-25 15:27:03 GMT; domain=.proj.org; HttpOnly; Secure;
         SameSite=None
-      - _cfuvid=K6vW.i2O_YkpG7J0ZgOWQQra3SnBXjRCUTWpEJDb5lA-1757605959473-0.0.1.1-604800000;
+      - _cfuvid=gKlQawBDH439.SQBQXI.XTnEOVwChcozkb36v4jzmmg-1758207423244-0.0.1.1-604800000;
         path=/; domain=.proj.org; HttpOnly; Secure; SameSite=None
       Vary:
       - Accept-Language, Accept-Encoding
@@ -783,7 +789,7 @@ interactions:
       referrer-policy:
       - no-referrer-when-downgrade
       x-backend:
-      - web-i-08cdc39b7f37b37d5
+      - web-i-088faff751a7543b1
       x-content-type-options:
       - nosniff
       x-rtd-domain:
@@ -807,7 +813,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://proj.org/en/latest/schemas/v0.2/projjson.schema.json
   response:
@@ -1255,11 +1261,11 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '4764'
+      - '4747'
       CF-Cache-Status:
       - HIT
       CF-Ray:
-      - 97d8555f4ed2f28b-IAD
+      - 9811b18bd8c8c970-IAD
       Cache-Control:
       - max-age=1200
       Connection:
@@ -1267,7 +1273,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 11 Sep 2025 15:52:39 GMT
+      - Thu, 18 Sep 2025 14:57:03 GMT
       ETag:
       - W/"54be42a997d748d338984583b3f2c900"
       Last-Modified:
@@ -1275,10 +1281,10 @@ interactions:
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=.4blPwK2KU4IpAlVfJJ3IdCy6AqsVqfaPdbtpmuEFHQ-1757605959-1.0.1.1-YBHLhmg4Y3mFpYX5toy4GhqsfCGVOzFoTt67vmCk1vfJc9xfR52NwM8D7S0M00W.0kx7XR3dPwPynHaNPJWRw5YM9TtPRoWgARlKKt3QrUc;
-        path=/; expires=Thu, 11-Sep-25 16:22:39 GMT; domain=.proj.org; HttpOnly; Secure;
+      - __cf_bm=NPzQqjCcwLpzOpqD.o6tcNnUeOtGVLQYIdABQGK9CnI-1758207423-1.0.1.1-tB5v2d8H1cDIAstiolskvNyH1.ak2NElnZA1Mwks7o36aQkO2MZ0q1.UW0ahKKKTijRfH.IywWfo1xKPL5w445f0ZchM4zf59L49L7bYXL4;
+        path=/; expires=Thu, 18-Sep-25 15:27:03 GMT; domain=.proj.org; HttpOnly; Secure;
         SameSite=None
-      - _cfuvid=sHJN_K4.uSYap99f8bFwceXhkdsm___J4utTdq0AttI-1757605959593-0.0.1.1-604800000;
+      - _cfuvid=pYHTSK15UJq75wcCI9lHg1yYiK1OZb_Zgjgzd8hBoss-1758207423413-0.0.1.1-604800000;
         path=/; domain=.proj.org; HttpOnly; Secure; SameSite=None
       Transfer-Encoding:
       - chunked
@@ -1293,15 +1299,15 @@ interactions:
       referrer-policy:
       - no-referrer-when-downgrade
       x-amz-id-2:
-      - u7n7KSoYu8w9cyLO4XLwBwTwYdQ3Wyml7J+C6woLMpHwu3whoWqiNnD9hKVSLIN5ghQElMaJ3Fo=
+      - AOYvBP/LpvTJOKVw+9O+zVM1dIoIgJlzOhPZaGe8UT/+DK52CrocE7/yPv9E1BQZHrqmD4BMboo=
       x-amz-meta-mtime:
       - '1714074779.458591481'
       x-amz-request-id:
-      - 8ARFMN6T2PBWDEG6
+      - VNA6573JK8SCMD2V
       x-amz-server-side-encryption:
       - AES256
       x-backend:
-      - web-i-0ff35b8ab69d931fc
+      - web-i-046a40256d6a3b46c
       x-content-type-options:
       - nosniff
       x-rtd-domain:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example12].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example12].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/item-spec/json-schema/item.json
   response:
@@ -108,13 +108,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:43 GMT
+      - Thu, 18 Sep 2025 14:56:03 GMT
       ETag:
       - '"4e24763d74f0d463b0cb6c63fc099e0b59447c7a049b93ffda4c6eb9eb54ae95"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:43 GMT
+      - Thu, 18 Sep 2025 15:01:03 GMT
       Source-Age:
-      - '1'
+      - '2'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -128,15 +128,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 631e83ab9d960d4bd3168fcaa179b225b9d72f0d
+      - fe8009098396f77c62e624c45230b4115ca4686f
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 688A:1E0DA2:13B02E:181CCC:68C2EEB5
+      - DDD5:286E0:D0F1D:FC0CF:68CC1D7C
       X-Served-By:
-      - cache-bos4633-BOS
+      - cache-bos4625-BOS
       X-Timer:
-      - S1757605904.976088,VS0,VE1
+      - S1758207363.069196,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -146,7 +146,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/extensions/label/schema.json
   response:
@@ -215,11 +215,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:44 GMT
+      - Thu, 18 Sep 2025 14:56:03 GMT
       ETag:
       - '"46c09f290da4303780880924f1569b2cb0b979a2d363a4446e2b8b7cc494844b"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:44 GMT
+      - Thu, 18 Sep 2025 15:01:03 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -235,15 +235,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - a916b8dbd4d13e60d91706e503406eaeb8888bee
+      - ba968f1f47182c47950cb20381963d0d1794f074
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 6167:2ACBC:149D59:191454:68C2EEB6
+      - 84D7:1EB8B2:B9B89:E4D7F:68CC1D82
       X-Served-By:
-      - cache-bos4639-BOS
+      - cache-bos4621-BOS
       X-Timer:
-      - S1757605904.054262,VS0,VE1
+      - S1758207363.161955,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example13].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example13].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/item-spec/json-schema/item.json
   response:
@@ -108,11 +108,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:44 GMT
+      - Thu, 18 Sep 2025 14:56:03 GMT
       ETag:
       - '"4e24763d74f0d463b0cb6c63fc099e0b59447c7a049b93ffda4c6eb9eb54ae95"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:44 GMT
+      - Thu, 18 Sep 2025 15:01:03 GMT
       Source-Age:
       - '2'
       Strict-Transport-Security:
@@ -124,19 +124,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 0298874401cc5acc62e8efc5af860aedf5718bb0
+      - 059f4f0fc0bd78033ea9d5722f2dd47690ec5fb7
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 688A:1E0DA2:13B02E:181CCC:68C2EEB5
+      - DDD5:286E0:D0F1D:FC0CF:68CC1D7C
       X-Served-By:
-      - cache-bos4689-BOS
+      - cache-bos4653-BOS
       X-Timer:
-      - S1757605904.115458,VS0,VE1
+      - S1758207363.231100,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -146,7 +146,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/extensions/label/schema.json
   response:
@@ -215,11 +215,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:44 GMT
+      - Thu, 18 Sep 2025 14:56:03 GMT
       ETag:
       - '"46c09f290da4303780880924f1569b2cb0b979a2d363a4446e2b8b7cc494844b"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:44 GMT
+      - Thu, 18 Sep 2025 15:01:03 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -235,15 +235,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - df2aaf0d9e3578b0e7a7e0842986ce539dd8e8a3
+      - 0fdea015a2f2ab7c55174c9756ad9f20711576f3
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 6167:2ACBC:149D59:191454:68C2EEB6
+      - 84D7:1EB8B2:B9B89:E4D7F:68CC1D82
       X-Served-By:
-      - cache-bos4629-BOS
+      - cache-bos4645-BOS
       X-Timer:
-      - S1757605904.184603,VS0,VE1
+      - S1758207363.299585,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example14].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example14].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/collection-spec/json-schema/collection.json
   response:
@@ -85,11 +85,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:44 GMT
+      - Thu, 18 Sep 2025 14:56:03 GMT
       ETag:
       - '"031974beaaaf6f0b5c6877dc97088d9e2aff3bc8962df33ff291dddded353f09"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:44 GMT
+      - Thu, 18 Sep 2025 15:01:03 GMT
       Source-Age:
       - '2'
       Strict-Transport-Security:
@@ -101,19 +101,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '18'
+      - '3'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 57ca208525a453112d908c48469cf16331537cbf
+      - c51d67818dbbf68615b37b90d8c4867fbc884629
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 48D2:9DF63:14B8DC:192D3D:68C2EEB6
+      - EAA4:3C3312:A80AF:D3151:68CC1D7F
       X-Served-By:
       - cache-bos4634-BOS
       X-Timer:
-      - S1757605904.247823,VS0,VE0
+      - S1758207363.369232,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -123,7 +123,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/catalog-spec/json-schema/catalog.json
   response:
@@ -184,11 +184,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:44 GMT
+      - Thu, 18 Sep 2025 14:56:03 GMT
       ETag:
       - '"3b514933a3747f038125935624a13df108e30fe1cb8f9660a7f54ac6d4765ce9"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:44 GMT
+      - Thu, 18 Sep 2025 15:01:03 GMT
       Source-Age:
       - '2'
       Strict-Transport-Security:
@@ -204,15 +204,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - ede77bf599298addc5a9d621a69895b788fa9d2e
+      - 2f316ce369749013bcad6614d977f07b5c7e09fe
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 4D53:1CB1E4:12EBE4:17599A:68C2EEB7
+      - BCE7:388807:C697B:F1BF7:68CC1D7C
       X-Served-By:
-      - cache-bos4634-BOS
+      - cache-bos4643-BOS
       X-Timer:
-      - S1757605904.310193,VS0,VE1
+      - S1758207363.431202,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example15].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example15].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/collection-spec/json-schema/collection.json
   response:
@@ -85,11 +85,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:44 GMT
+      - Thu, 18 Sep 2025 14:56:03 GMT
       ETag:
       - '"031974beaaaf6f0b5c6877dc97088d9e2aff3bc8962df33ff291dddded353f09"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:44 GMT
+      - Thu, 18 Sep 2025 15:01:03 GMT
       Source-Age:
       - '2'
       Strict-Transport-Security:
@@ -105,15 +105,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 3cdb2a7b1db26cf9fcf79c7384e444836c557a6c
+      - 01eae8f234a5961dfbf083b7810b532ccfa88e0f
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 48D2:9DF63:14B8DC:192D3D:68C2EEB6
+      - EAA4:3C3312:A80AF:D3151:68CC1D7F
       X-Served-By:
-      - cache-bos4646-BOS
+      - cache-bos4649-BOS
       X-Timer:
-      - S1757605904.380370,VS0,VE1
+      - S1758207363.495181,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -123,7 +123,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/catalog-spec/json-schema/catalog.json
   response:
@@ -184,11 +184,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:44 GMT
+      - Thu, 18 Sep 2025 14:56:03 GMT
       ETag:
       - '"3b514933a3747f038125935624a13df108e30fe1cb8f9660a7f54ac6d4765ce9"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:44 GMT
+      - Thu, 18 Sep 2025 15:01:03 GMT
       Source-Age:
       - '2'
       Strict-Transport-Security:
@@ -204,15 +204,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - a24c80bc66e5258e27de5cd3cfbe0626fd697f66
+      - 1ca8f8715738d443b99a5ad353f4b1c1cec00c09
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 4D53:1CB1E4:12EBE4:17599A:68C2EEB7
+      - BCE7:388807:C697B:F1BF7:68CC1D7C
       X-Served-By:
-      - cache-bos4634-BOS
+      - cache-bos4643-BOS
       X-Timer:
-      - S1757605904.444151,VS0,VE0
+      - S1758207364.559115,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example16].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example16].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/item-spec/json-schema/item.json
   response:
@@ -108,11 +108,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:44 GMT
+      - Thu, 18 Sep 2025 14:56:03 GMT
       ETag:
       - '"4e24763d74f0d463b0cb6c63fc099e0b59447c7a049b93ffda4c6eb9eb54ae95"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:44 GMT
+      - Thu, 18 Sep 2025 15:01:03 GMT
       Source-Age:
       - '2'
       Strict-Transport-Security:
@@ -128,15 +128,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - a12bef360e5c0fe1c35001c432ba32e0cb37adc3
+      - 318d294bd16abd7b1468fd629dbac2263df0c01a
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 688A:1E0DA2:13B02E:181CCC:68C2EEB5
+      - DDD5:286E0:D0F1D:FC0CF:68CC1D7C
       X-Served-By:
-      - cache-bos4659-BOS
+      - cache-bos4676-BOS
       X-Timer:
-      - S1757605905.677842,VS0,VE2
+      - S1758207364.771212,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -146,7 +146,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/extensions/label/schema.json
   response:
@@ -215,13 +215,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:47 GMT
+      - Thu, 18 Sep 2025 14:56:06 GMT
       ETag:
       - '"46c09f290da4303780880924f1569b2cb0b979a2d363a4446e2b8b7cc494844b"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:47 GMT
+      - Thu, 18 Sep 2025 15:01:06 GMT
       Source-Age:
-      - '3'
+      - '4'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -235,15 +235,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - ce26fae71327d69d54728ffd62d6d71dbb994bd4
+      - 767d46c4d0ca2daba04e4d7d91a2aaeedd7ae639
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 6167:2ACBC:149D59:191454:68C2EEB6
+      - 84D7:1EB8B2:B9B89:E4D7F:68CC1D82
       X-Served-By:
-      - cache-bos4660-BOS
+      - cache-bos4678-BOS
       X-Timer:
-      - S1757605907.305525,VS0,VE1
+      - S1758207367.661199,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example17].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example17].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/item-spec/json-schema/item.json
   response:
@@ -108,11 +108,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:47 GMT
+      - Thu, 18 Sep 2025 14:56:06 GMT
       ETag:
       - '"4e24763d74f0d463b0cb6c63fc099e0b59447c7a049b93ffda4c6eb9eb54ae95"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:47 GMT
+      - Thu, 18 Sep 2025 15:01:06 GMT
       Source-Age:
       - '5'
       Strict-Transport-Security:
@@ -128,15 +128,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 562321b8f117d9bccd0ba7d9f32a2fdd5ecc8406
+      - c2f5a3c7f6c4f2997217c5c3bda1ae2631a74eea
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 688A:1E0DA2:13B02E:181CCC:68C2EEB5
+      - DDD5:286E0:D0F1D:FC0CF:68CC1D7C
       X-Served-By:
-      - cache-bos4649-BOS
+      - cache-bos4668-BOS
       X-Timer:
-      - S1757605907.394018,VS0,VE1
+      - S1758207367.749668,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -146,7 +146,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/extensions/label/schema.json
   response:
@@ -215,13 +215,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:48 GMT
+      - Thu, 18 Sep 2025 14:56:07 GMT
       ETag:
       - '"46c09f290da4303780880924f1569b2cb0b979a2d363a4446e2b8b7cc494844b"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:48 GMT
+      - Thu, 18 Sep 2025 15:01:07 GMT
       Source-Age:
-      - '4'
+      - '5'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -235,15 +235,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 3fcb81749d29e68fac6156551bacf7acc564fc7c
+      - 8a4d4d507605ebaf67aeace423d01d16c1bf4a73
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 6167:2ACBC:149D59:191454:68C2EEB6
+      - 84D7:1EB8B2:B9B89:E4D7F:68CC1D82
       X-Served-By:
-      - cache-bos4644-BOS
+      - cache-bos4647-BOS
       X-Timer:
-      - S1757605908.058318,VS0,VE6
+      - S1758207368.560882,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example18].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example18].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/collection-spec/json-schema/collection.json
   response:
@@ -85,11 +85,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:48 GMT
+      - Thu, 18 Sep 2025 14:56:07 GMT
       ETag:
       - '"031974beaaaf6f0b5c6877dc97088d9e2aff3bc8962df33ff291dddded353f09"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:48 GMT
+      - Thu, 18 Sep 2025 15:01:07 GMT
       Source-Age:
       - '6'
       Strict-Transport-Security:
@@ -105,15 +105,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - aa85ed1c09cfdbabc3abe2dfb2c8563e4e4d4638
+      - 5d20bdea0e7fed08db894a61f1278177227fb099
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 48D2:9DF63:14B8DC:192D3D:68C2EEB6
+      - EAA4:3C3312:A80AF:D3151:68CC1D7F
       X-Served-By:
-      - cache-bos4673-BOS
+      - cache-bos4657-BOS
       X-Timer:
-      - S1757605908.124105,VS0,VE1
+      - S1758207368.640980,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -123,7 +123,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/catalog-spec/json-schema/catalog.json
   response:
@@ -184,13 +184,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:48 GMT
+      - Thu, 18 Sep 2025 14:56:07 GMT
       ETag:
       - '"3b514933a3747f038125935624a13df108e30fe1cb8f9660a7f54ac6d4765ce9"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:48 GMT
+      - Thu, 18 Sep 2025 15:01:07 GMT
       Source-Age:
-      - '6'
+      - '7'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -204,15 +204,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - c7c85a49f69d16ed61f9dab68eb7af65b358cd57
+      - bc5223cddf3c75586e9e467abd12bb83a2c82db4
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 4D53:1CB1E4:12EBE4:17599A:68C2EEB7
+      - BCE7:388807:C697B:F1BF7:68CC1D7C
       X-Served-By:
-      - cache-bos4636-BOS
+      - cache-bos4680-BOS
       X-Timer:
-      - S1757605908.190229,VS0,VE1
+      - S1758207368.708174,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example19].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example19].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/item-spec/json-schema/item.json
   response:
@@ -108,11 +108,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:48 GMT
+      - Thu, 18 Sep 2025 14:56:07 GMT
       ETag:
       - '"4e24763d74f0d463b0cb6c63fc099e0b59447c7a049b93ffda4c6eb9eb54ae95"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:48 GMT
+      - Thu, 18 Sep 2025 15:01:07 GMT
       Source-Age:
       - '6'
       Strict-Transport-Security:
@@ -124,19 +124,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 78df23c3fcdd4b851742863408a7be73d5a65493
+      - 906490f1d89ebb1934a059b8312a128d322ace03
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 688A:1E0DA2:13B02E:181CCC:68C2EEB5
+      - DDD5:286E0:D0F1D:FC0CF:68CC1D7C
       X-Served-By:
-      - cache-bos4671-BOS
+      - cache-bos4664-BOS
       X-Timer:
-      - S1757605908.254165,VS0,VE1
+      - S1758207368.777293,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -146,7 +146,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/extensions/label/schema.json
   response:
@@ -215,13 +215,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:48 GMT
+      - Thu, 18 Sep 2025 14:56:07 GMT
       ETag:
       - '"46c09f290da4303780880924f1569b2cb0b979a2d363a4446e2b8b7cc494844b"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:48 GMT
+      - Thu, 18 Sep 2025 15:01:07 GMT
       Source-Age:
-      - '4'
+      - '5'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -235,15 +235,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 57a3e4f0688635dd191ef39fa46754e707e00cf0
+      - eb1331804c8ce01ffc87071aa28f4a9b34928ca1
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 6167:2ACBC:149D59:191454:68C2EEB6
+      - 84D7:1EB8B2:B9B89:E4D7F:68CC1D82
       X-Served-By:
-      - cache-bos4693-BOS
+      - cache-bos4631-BOS
       X-Timer:
-      - S1757605908.320049,VS0,VE1
+      - S1758207368.838598,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example1].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example1].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/catalog-spec/json-schema/catalog.json
   response:
@@ -64,11 +64,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:42 GMT
+      - Thu, 18 Sep 2025 14:56:01 GMT
       ETag:
       - '"3b514933a3747f038125935624a13df108e30fe1cb8f9660a7f54ac6d4765ce9"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:42 GMT
+      - Thu, 18 Sep 2025 15:01:01 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -84,15 +84,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 0ded7616650fceb15f76870e8ffc860df8ae5924
+      - e3f041cc16eba854b1f8882c56d7d8191a0f091e
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 4D53:1CB1E4:12EBE4:17599A:68C2EEB7
+      - BCE7:388807:C697B:F1BF7:68CC1D7C
       X-Served-By:
-      - cache-bos4665-BOS
+      - cache-bos4687-BOS
       X-Timer:
-      - S1757605902.229676,VS0,VE1
+      - S1758207361.097121,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example20].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example20].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/item-spec/json-schema/item.json
   response:
@@ -108,11 +108,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:48 GMT
+      - Thu, 18 Sep 2025 14:56:07 GMT
       ETag:
       - '"4e24763d74f0d463b0cb6c63fc099e0b59447c7a049b93ffda4c6eb9eb54ae95"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:48 GMT
+      - Thu, 18 Sep 2025 15:01:07 GMT
       Source-Age:
       - '6'
       Strict-Transport-Security:
@@ -128,15 +128,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - e538982b4dbbc5f973f44567b4e403d97a4beebb
+      - 42e2dd06b7c9f842a34a7f09044056ff5edaac2d
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 688A:1E0DA2:13B02E:181CCC:68C2EEB5
+      - DDD5:286E0:D0F1D:FC0CF:68CC1D7C
       X-Served-By:
-      - cache-bos4652-BOS
+      - cache-bos4645-BOS
       X-Timer:
-      - S1757605908.383749,VS0,VE1
+      - S1758207368.909298,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example21].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example21].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/item-spec/json-schema/item.json
   response:
@@ -108,13 +108,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:48 GMT
+      - Thu, 18 Sep 2025 14:56:07 GMT
       ETag:
       - '"4e24763d74f0d463b0cb6c63fc099e0b59447c7a049b93ffda4c6eb9eb54ae95"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:48 GMT
+      - Thu, 18 Sep 2025 15:01:07 GMT
       Source-Age:
-      - '6'
+      - '7'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -128,15 +128,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - bad02a10912c68feb85926966b9734bb53799f64
+      - dd3eb0ab0a7d2773395882aea07d3c6a067d4fb8
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 688A:1E0DA2:13B02E:181CCC:68C2EEB5
+      - DDD5:286E0:D0F1D:FC0CF:68CC1D7C
       X-Served-By:
-      - cache-bos4693-BOS
+      - cache-bos4661-BOS
       X-Timer:
-      - S1757605908.448605,VS0,VE1
+      - S1758207368.987421,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example22].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example22].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/item-spec/json-schema/item.json
   response:
@@ -108,13 +108,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:48 GMT
+      - Thu, 18 Sep 2025 14:56:08 GMT
       ETag:
       - '"4e24763d74f0d463b0cb6c63fc099e0b59447c7a049b93ffda4c6eb9eb54ae95"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:48 GMT
+      - Thu, 18 Sep 2025 15:01:08 GMT
       Source-Age:
-      - '6'
+      - '7'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -124,19 +124,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 0911eede464f453fccc596ebddda499d3a82133f
+      - 13fdc62aa8c5e06036afe4ce3e4110179efd4aa6
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 688A:1E0DA2:13B02E:181CCC:68C2EEB5
+      - DDD5:286E0:D0F1D:FC0CF:68CC1D7C
       X-Served-By:
-      - cache-bos4689-BOS
+      - cache-bos4674-BOS
       X-Timer:
-      - S1757605909.518093,VS0,VE0
+      - S1758207368.071123,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -146,7 +146,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/extensions/sar/json-schema/schema.json
   response:
@@ -248,11 +248,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:48 GMT
+      - Thu, 18 Sep 2025 14:56:08 GMT
       ETag:
       - '"bd0d97e01404052bb35eda302935aea6ab05818f78d1970e785c7083dedc3bad"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:48 GMT
+      - Thu, 18 Sep 2025 15:01:08 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -262,21 +262,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 2293be264c5a5cd661f3e28609e8b3f5b429825c
+      - bbe20494fa9831753e56bae80e403c035a66d647
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3EB7:6F752:15D719:1A5C50:68C2EEBE
+      - D912:3C3312:A84E7:D3691:68CC1D7C
       X-Served-By:
-      - cache-bos4690-BOS
+      - cache-bos4670-BOS
       X-Timer:
-      - S1757605909.587583,VS0,VE73
+      - S1758207368.137652,VS0,VE99
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example23].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example23].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/item-spec/json-schema/item.json
   response:
@@ -108,13 +108,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:48 GMT
+      - Thu, 18 Sep 2025 14:56:08 GMT
       ETag:
       - '"4e24763d74f0d463b0cb6c63fc099e0b59447c7a049b93ffda4c6eb9eb54ae95"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:48 GMT
+      - Thu, 18 Sep 2025 15:01:08 GMT
       Source-Age:
-      - '6'
+      - '7'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -128,15 +128,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 68b98173fd76daa6e9e911150b26f3037fdeb106
+      - cdc4c2538fe22b26eb0a803e6c82cff7489e0470
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 688A:1E0DA2:13B02E:181CCC:68C2EEB5
+      - DDD5:286E0:D0F1D:FC0CF:68CC1D7C
       X-Served-By:
-      - cache-bos4663-BOS
+      - cache-bos4639-BOS
       X-Timer:
-      - S1757605909.732039,VS0,VE1
+      - S1758207368.323488,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -146,7 +146,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/extensions/checksum/json-schema/schema.json
   response:
@@ -190,11 +190,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:48 GMT
+      - Thu, 18 Sep 2025 14:56:08 GMT
       ETag:
       - '"ceed674cee48a43076989957b8a4f96d8acba3f52df1d52a3745e28225923aac"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:48 GMT
+      - Thu, 18 Sep 2025 15:01:08 GMT
       Source-Age:
       - '6'
       Strict-Transport-Security:
@@ -210,15 +210,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 46c09dad1dd3c4ad0aadb6b3085ccf78da61c081
+      - 12e75cc2cb592e18bd73c789675f7af7488a82f0
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3EB7:6F752:15D306:1A5757:68C2EEB5
+      - A80D:3428C5:C3D9C:EEEC9:68CC1D81
       X-Served-By:
-      - cache-bos4653-BOS
+      - cache-bos4693-BOS
       X-Timer:
-      - S1757605909.806868,VS0,VE1
+      - S1758207368.397622,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -228,7 +228,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/extensions/sar/json-schema/schema.json
   response:
@@ -330,11 +330,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:48 GMT
+      - Thu, 18 Sep 2025 14:56:08 GMT
       ETag:
       - '"bd0d97e01404052bb35eda302935aea6ab05818f78d1970e785c7083dedc3bad"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:48 GMT
+      - Thu, 18 Sep 2025 15:01:08 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -350,15 +350,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - b952ec2a860c64ff29c5d05fa3765d2836bde941
+      - 9bfaa0704545bb266c5e69ab3bc09420a53a3126
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3EB7:6F752:15D719:1A5C50:68C2EEBE
+      - D912:3C3312:A84E7:D3691:68CC1D7C
       X-Served-By:
-      - cache-bos4678-BOS
+      - cache-bos4669-BOS
       X-Timer:
-      - S1757605909.883952,VS0,VE1
+      - S1758207368.469255,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example24].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example24].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/collection-spec/json-schema/collection.json
   response:
@@ -85,11 +85,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:48 GMT
+      - Thu, 18 Sep 2025 14:56:08 GMT
       ETag:
       - '"031974beaaaf6f0b5c6877dc97088d9e2aff3bc8962df33ff291dddded353f09"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:48 GMT
+      - Thu, 18 Sep 2025 15:01:08 GMT
       Source-Age:
       - '7'
       Strict-Transport-Security:
@@ -105,15 +105,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - e6aca2b63024235b7b07cfb72695d3db7e84cea9
+      - fb62bdf99bf519de144708e35ddd12ab4a0ee021
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 48D2:9DF63:14B8DC:192D3D:68C2EEB6
+      - EAA4:3C3312:A80AF:D3151:68CC1D7F
       X-Served-By:
-      - cache-bos4629-BOS
+      - cache-bos4690-BOS
       X-Timer:
-      - S1757605909.968013,VS0,VE1
+      - S1758207369.554180,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -123,7 +123,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/catalog-spec/json-schema/catalog.json
   response:
@@ -184,13 +184,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:49 GMT
+      - Thu, 18 Sep 2025 14:56:08 GMT
       ETag:
       - '"3b514933a3747f038125935624a13df108e30fe1cb8f9660a7f54ac6d4765ce9"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:49 GMT
+      - Thu, 18 Sep 2025 15:01:08 GMT
       Source-Age:
-      - '7'
+      - '8'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -204,15 +204,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 45cb4008162f0241e7582e1e3cbcec0b3fe3998f
+      - 7c9ecb25ea815a213e3ca1a19e234b1a48cad9bc
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 4D53:1CB1E4:12EBE4:17599A:68C2EEB7
+      - BCE7:388807:C697B:F1BF7:68CC1D7C
       X-Served-By:
-      - cache-bos4648-BOS
+      - cache-bos4678-BOS
       X-Timer:
-      - S1757605909.044904,VS0,VE1
+      - S1758207369.623047,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -222,7 +222,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/extensions/scientific/json-schema/schema.json
   response:
@@ -268,11 +268,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:49 GMT
+      - Thu, 18 Sep 2025 14:56:08 GMT
       ETag:
       - '"13ff4323200a45e6acb12e649221282624758beb0a8f5b3a190160c2aa9d358a"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:49 GMT
+      - Thu, 18 Sep 2025 15:01:08 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -282,21 +282,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 70e2aae76b0fadeb521333bffcfc7b210a9ac308
+      - 113703579d9e90398d9fb7776f2f210451a8b111
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 2EC0:32AE5D:141C0A:188ED5:68C2EEBE
+      - 5D46:3CAE3B:BE640:E98CC:68CC1D88
       X-Served-By:
-      - cache-bos4629-BOS
+      - cache-bos4671-BOS
       X-Timer:
-      - S1757605909.115987,VS0,VE50
+      - S1758207369.683090,VS0,VE76
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -306,7 +306,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/item-spec/json-schema/item.json
   response:
@@ -411,11 +411,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:49 GMT
+      - Thu, 18 Sep 2025 14:56:08 GMT
       ETag:
       - '"4e24763d74f0d463b0cb6c63fc099e0b59447c7a049b93ffda4c6eb9eb54ae95"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:49 GMT
+      - Thu, 18 Sep 2025 15:01:08 GMT
       Source-Age:
       - '7'
       Strict-Transport-Security:
@@ -431,15 +431,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - f17aa497660361cf7b17100b45c3feb83b5d870f
+      - 17fb621d01e78128d65f9f11133b6902c77ddc87
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 688A:1E0DA2:13B02E:181CCC:68C2EEB5
+      - DDD5:286E0:D0F1D:FC0CF:68CC1D7C
       X-Served-By:
       - cache-bos4621-BOS
       X-Timer:
-      - S1757605909.240165,VS0,VE1
+      - S1758207369.816697,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example25].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example25].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/item-spec/json-schema/item.json
   response:
@@ -108,11 +108,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:49 GMT
+      - Thu, 18 Sep 2025 14:56:08 GMT
       ETag:
       - '"4e24763d74f0d463b0cb6c63fc099e0b59447c7a049b93ffda4c6eb9eb54ae95"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:49 GMT
+      - Thu, 18 Sep 2025 15:01:08 GMT
       Source-Age:
       - '7'
       Strict-Transport-Security:
@@ -124,19 +124,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 2f9d51b0f5184a734aba3c2fed3968bb37f71520
+      - d676f49d96f1b4ba70ccc61651d3cb0c37a6d4f9
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 688A:1E0DA2:13B02E:181CCC:68C2EEB5
+      - DDD5:286E0:D0F1D:FC0CF:68CC1D7C
       X-Served-By:
-      - cache-bos4648-BOS
+      - cache-bos4684-BOS
       X-Timer:
-      - S1757605909.320057,VS0,VE0
+      - S1758207369.881107,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -146,7 +146,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/extensions/scientific/json-schema/schema.json
   response:
@@ -192,11 +192,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:49 GMT
+      - Thu, 18 Sep 2025 14:56:08 GMT
       ETag:
       - '"13ff4323200a45e6acb12e649221282624758beb0a8f5b3a190160c2aa9d358a"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:49 GMT
+      - Thu, 18 Sep 2025 15:01:08 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -212,15 +212,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 7cb6c933b5ebd4559168cf396b1f50fad851b815
+      - 74d44f7db307640e997f0b620029600b215df6a0
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 2EC0:32AE5D:141C0A:188ED5:68C2EEBE
+      - 5D46:3CAE3B:BE640:E98CC:68CC1D88
       X-Served-By:
-      - cache-bos4630-BOS
+      - cache-bos4672-BOS
       X-Timer:
-      - S1757605909.395455,VS0,VE2
+      - S1758207369.943143,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -230,7 +230,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/collection-spec/json-schema/collection.json
   response:
@@ -312,13 +312,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:49 GMT
+      - Thu, 18 Sep 2025 14:56:09 GMT
       ETag:
       - '"031974beaaaf6f0b5c6877dc97088d9e2aff3bc8962df33ff291dddded353f09"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:49 GMT
+      - Thu, 18 Sep 2025 15:01:09 GMT
       Source-Age:
-      - '7'
+      - '8'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -332,15 +332,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 9c07be3af86d1c4689a0c53bde3d6ef020ae7ac8
+      - a519b1d84226e2a21b0cf1cede91301a0d4b29b4
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 48D2:9DF63:14B8DC:192D3D:68C2EEB6
+      - EAA4:3C3312:A80AF:D3151:68CC1D7F
       X-Served-By:
-      - cache-bos4639-BOS
+      - cache-bos4675-BOS
       X-Timer:
-      - S1757605909.477222,VS0,VE1
+      - S1758207369.010780,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -350,7 +350,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/catalog-spec/json-schema/catalog.json
   response:
@@ -411,13 +411,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:49 GMT
+      - Thu, 18 Sep 2025 14:56:09 GMT
       ETag:
       - '"3b514933a3747f038125935624a13df108e30fe1cb8f9660a7f54ac6d4765ce9"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:49 GMT
+      - Thu, 18 Sep 2025 15:01:09 GMT
       Source-Age:
-      - '7'
+      - '8'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -427,19 +427,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 5058e3e4c5f011533a5f7389e2829e22f9aed30a
+      - 259cd04b1efb98c0c2c298449a7eb1f573adeb75
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 4D53:1CB1E4:12EBE4:17599A:68C2EEB7
+      - BCE7:388807:C697B:F1BF7:68CC1D7C
       X-Served-By:
-      - cache-bos4658-BOS
+      - cache-bos4663-BOS
       X-Timer:
-      - S1757605910.542405,VS0,VE1
+      - S1758207369.073610,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -449,7 +449,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/extensions/checksum/json-schema/schema.json
   response:
@@ -493,13 +493,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:49 GMT
+      - Thu, 18 Sep 2025 14:56:09 GMT
       ETag:
       - '"ceed674cee48a43076989957b8a4f96d8acba3f52df1d52a3745e28225923aac"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:49 GMT
+      - Thu, 18 Sep 2025 15:01:09 GMT
       Source-Age:
-      - '6'
+      - '7'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -513,15 +513,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - b181e5050e18f0c8ac52cf1b8f51e1692d00f5dd
+      - 4c21141c3500fb4121b1547512ffb754aafa9cd6
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3EB7:6F752:15D306:1A5757:68C2EEB5
+      - A80D:3428C5:C3D9C:EEEC9:68CC1D81
       X-Served-By:
-      - cache-bos4626-BOS
+      - cache-bos4632-BOS
       X-Timer:
-      - S1757605910.617875,VS0,VE1
+      - S1758207369.131340,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example26].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example26].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/item-spec/json-schema/item.json
   response:
@@ -108,11 +108,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:49 GMT
+      - Thu, 18 Sep 2025 14:56:09 GMT
       ETag:
       - '"4e24763d74f0d463b0cb6c63fc099e0b59447c7a049b93ffda4c6eb9eb54ae95"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:49 GMT
+      - Thu, 18 Sep 2025 15:01:09 GMT
       Source-Age:
       - '8'
       Strict-Transport-Security:
@@ -124,19 +124,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '1'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 0f0315fbb3aa80fb4b194fb707b2a03c1858ad4b
+      - 38b22f041f4eff5a996eefcc433984cddf2181d5
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 688A:1E0DA2:13B02E:181CCC:68C2EEB5
+      - DDD5:286E0:D0F1D:FC0CF:68CC1D7C
       X-Served-By:
-      - cache-bos4648-BOS
+      - cache-bos4651-BOS
       X-Timer:
-      - S1757605910.702257,VS0,VE0
+      - S1758207369.201233,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -146,7 +146,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/extensions/eo/json-schema/schema.json
   response:
@@ -212,13 +212,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:49 GMT
+      - Thu, 18 Sep 2025 14:56:09 GMT
       ETag:
       - '"c8576d5ea3fcee4039dcddbdcf9e59fed3f3086419a33aa96f18f4617203b76d"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:49 GMT
+      - Thu, 18 Sep 2025 15:01:09 GMT
       Source-Age:
-      - '7'
+      - '8'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -232,15 +232,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 24db01765ebf6307b203c7c5c85d02aa4a92bc98
+      - 03c5062e437940ce09b7cdb6864e7c71960b42fc
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 10B8:1C3F94:144BD8:18BB04:68C2EEB7
+      - 46FA:175DD:C2790:ED92C:68CC1D80
       X-Served-By:
-      - cache-bos4641-BOS
+      - cache-bos4663-BOS
       X-Timer:
-      - S1757605910.778052,VS0,VE1
+      - S1758207369.267029,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example27].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example27].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/item-spec/json-schema/item.json
   response:
@@ -108,13 +108,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:49 GMT
+      - Thu, 18 Sep 2025 14:56:09 GMT
       ETag:
       - '"4e24763d74f0d463b0cb6c63fc099e0b59447c7a049b93ffda4c6eb9eb54ae95"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:49 GMT
+      - Thu, 18 Sep 2025 15:01:09 GMT
       Source-Age:
-      - '7'
+      - '8'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -124,19 +124,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - b578c47326fdf80bd0278802b65136c9d419075a
+      - ad4922dfbc68f7103bfe89302f666cb508dd21ae
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 688A:1E0DA2:13B02E:181CCC:68C2EEB5
+      - DDD5:286E0:D0F1D:FC0CF:68CC1D7C
       X-Served-By:
-      - cache-bos4693-BOS
+      - cache-bos4681-BOS
       X-Timer:
-      - S1757605910.841982,VS0,VE0
+      - S1758207369.335196,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -146,7 +146,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/extensions/eo/json-schema/schema.json
   response:
@@ -212,13 +212,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:49 GMT
+      - Thu, 18 Sep 2025 14:56:09 GMT
       ETag:
       - '"c8576d5ea3fcee4039dcddbdcf9e59fed3f3086419a33aa96f18f4617203b76d"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:49 GMT
+      - Thu, 18 Sep 2025 15:01:09 GMT
       Source-Age:
-      - '7'
+      - '8'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -228,19 +228,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 32f962b580e8cb63f62397cd889d13c8097bceaf
+      - c8eb532132a66ea44f58a5149fd971e3b96a020e
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 10B8:1C3F94:144BD8:18BB04:68C2EEB7
+      - 46FA:175DD:C2790:ED92C:68CC1D80
       X-Served-By:
-      - cache-bos4648-BOS
+      - cache-bos4674-BOS
       X-Timer:
-      - S1757605910.904515,VS0,VE41
+      - S1758207369.397268,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example28].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example28].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/item-spec/json-schema/item.json
   response:
@@ -108,11 +108,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:50 GMT
+      - Thu, 18 Sep 2025 14:56:09 GMT
       ETag:
       - '"4e24763d74f0d463b0cb6c63fc099e0b59447c7a049b93ffda4c6eb9eb54ae95"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:50 GMT
+      - Thu, 18 Sep 2025 15:01:09 GMT
       Source-Age:
       - '8'
       Strict-Transport-Security:
@@ -124,19 +124,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 8463ebb03271f2feba8d6ac2dfe500556a6df5d6
+      - afd84d3709dc05737cab3ff4ce18666d35e36833
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 688A:1E0DA2:13B02E:181CCC:68C2EEB5
+      - DDD5:286E0:D0F1D:FC0CF:68CC1D7C
       X-Served-By:
-      - cache-bos4622-BOS
+      - cache-bos4681-BOS
       X-Timer:
-      - S1757605910.004223,VS0,VE1
+      - S1758207369.470970,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -146,7 +146,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/extensions/eo/json-schema/schema.json
   response:
@@ -212,13 +212,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:50 GMT
+      - Thu, 18 Sep 2025 14:56:09 GMT
       ETag:
       - '"c8576d5ea3fcee4039dcddbdcf9e59fed3f3086419a33aa96f18f4617203b76d"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:50 GMT
+      - Thu, 18 Sep 2025 15:01:09 GMT
       Source-Age:
-      - '7'
+      - '8'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -232,15 +232,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - f4c6b88496f489958775cd48b3bb68a295bc5311
+      - 1df0b4a674fb4787109751923c973e003b1d056b
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 10B8:1C3F94:144BD8:18BB04:68C2EEB7
+      - 46FA:175DD:C2790:ED92C:68CC1D80
       X-Served-By:
-      - cache-bos4680-BOS
+      - cache-bos4685-BOS
       X-Timer:
-      - S1757605910.074112,VS0,VE1
+      - S1758207370.537207,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example29].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example29].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/item-spec/json-schema/item.json
   response:
@@ -108,11 +108,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:50 GMT
+      - Thu, 18 Sep 2025 14:56:09 GMT
       ETag:
       - '"4e24763d74f0d463b0cb6c63fc099e0b59447c7a049b93ffda4c6eb9eb54ae95"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:50 GMT
+      - Thu, 18 Sep 2025 15:01:09 GMT
       Source-Age:
       - '8'
       Strict-Transport-Security:
@@ -128,15 +128,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - d4defdab3883752fd0c009e4725e8e4200dc7830
+      - 9f3e5248ca237134b07390ffe4f79e39b66b8ac9
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 688A:1E0DA2:13B02E:181CCC:68C2EEB5
+      - DDD5:286E0:D0F1D:FC0CF:68CC1D7C
       X-Served-By:
-      - cache-bos4640-BOS
+      - cache-bos4655-BOS
       X-Timer:
-      - S1757605910.150898,VS0,VE1
+      - S1758207370.600949,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -146,7 +146,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/extensions/eo/json-schema/schema.json
   response:
@@ -212,11 +212,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:50 GMT
+      - Thu, 18 Sep 2025 14:56:09 GMT
       ETag:
       - '"c8576d5ea3fcee4039dcddbdcf9e59fed3f3086419a33aa96f18f4617203b76d"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:50 GMT
+      - Thu, 18 Sep 2025 15:01:09 GMT
       Source-Age:
       - '8'
       Strict-Transport-Security:
@@ -228,19 +228,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - a293da2f5cb6afa9c1e74cfab9920dea25380080
+      - fcbe86d60a602b3104f32de584f9684604ea5b4f
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 10B8:1C3F94:144BD8:18BB04:68C2EEB7
+      - 46FA:175DD:C2790:ED92C:68CC1D80
       X-Served-By:
-      - cache-bos4626-BOS
+      - cache-bos4679-BOS
       X-Timer:
-      - S1757605910.213898,VS0,VE0
+      - S1758207370.675098,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example2].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example2].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/collection-spec/json-schema/collection.json
   response:
@@ -85,11 +85,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:42 GMT
+      - Thu, 18 Sep 2025 14:56:01 GMT
       ETag:
       - '"031974beaaaf6f0b5c6877dc97088d9e2aff3bc8962df33ff291dddded353f09"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:42 GMT
+      - Thu, 18 Sep 2025 15:01:01 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -99,21 +99,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 92eb49fc2496cf48dd2710799363b45af9eda281
+      - 96c061be81f9fc59f8723fda96750d34ee2bebae
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 48D2:9DF63:14B8DC:192D3D:68C2EEB6
+      - EAA4:3C3312:A80AF:D3151:68CC1D7F
       X-Served-By:
-      - cache-bos4639-BOS
+      - cache-bos4640-BOS
       X-Timer:
-      - S1757605902.294011,VS0,VE37
+      - S1758207361.181811,VS0,VE68
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -123,7 +123,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/catalog-spec/json-schema/catalog.json
   response:
@@ -184,11 +184,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:42 GMT
+      - Thu, 18 Sep 2025 14:56:01 GMT
       ETag:
       - '"3b514933a3747f038125935624a13df108e30fe1cb8f9660a7f54ac6d4765ce9"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:42 GMT
+      - Thu, 18 Sep 2025 15:01:01 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -204,15 +204,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - cdc513c665e7d8e8d3ff888fdf567f4b8c8db676
+      - 9b81b3cb59324fe96532470bfbe8d629a41a493c
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 4D53:1CB1E4:12EBE4:17599A:68C2EEB7
+      - BCE7:388807:C697B:F1BF7:68CC1D7C
       X-Served-By:
-      - cache-bos4622-BOS
+      - cache-bos4653-BOS
       X-Timer:
-      - S1757605902.393938,VS0,VE1
+      - S1758207361.325057,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example30].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example30].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/item-spec/json-schema/item.json
   response:
@@ -108,11 +108,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:50 GMT
+      - Thu, 18 Sep 2025 14:56:09 GMT
       ETag:
       - '"4e24763d74f0d463b0cb6c63fc099e0b59447c7a049b93ffda4c6eb9eb54ae95"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:50 GMT
+      - Thu, 18 Sep 2025 15:01:09 GMT
       Source-Age:
       - '8'
       Strict-Transport-Security:
@@ -128,15 +128,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 52783269edc68625a0759eef5f4e5b07cb62e06a
+      - a627868cb6a568ab4ba1a8e0d3682a3543600823
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 688A:1E0DA2:13B02E:181CCC:68C2EEB5
+      - DDD5:286E0:D0F1D:FC0CF:68CC1D7C
       X-Served-By:
-      - cache-bos4666-BOS
+      - cache-bos4690-BOS
       X-Timer:
-      - S1757605910.283898,VS0,VE1
+      - S1758207370.759110,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example31].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example31].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/item-spec/json-schema/item.json
   response:
@@ -108,11 +108,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:50 GMT
+      - Thu, 18 Sep 2025 14:56:09 GMT
       ETag:
       - '"4e24763d74f0d463b0cb6c63fc099e0b59447c7a049b93ffda4c6eb9eb54ae95"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:50 GMT
+      - Thu, 18 Sep 2025 15:01:09 GMT
       Source-Age:
       - '8'
       Strict-Transport-Security:
@@ -128,15 +128,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - ffd96743b4c95c4219eb26734f2a789a001d4969
+      - 631ab1e717645cf5b79557112dd819518bf55636
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 688A:1E0DA2:13B02E:181CCC:68C2EEB5
+      - DDD5:286E0:D0F1D:FC0CF:68CC1D7C
       X-Served-By:
-      - cache-bos4656-BOS
+      - cache-bos4691-BOS
       X-Timer:
-      - S1757605910.347991,VS0,VE1
+      - S1758207370.845114,VS0,VE2
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -146,7 +146,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/extensions/eo/json-schema/schema.json
   response:
@@ -212,11 +212,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:50 GMT
+      - Thu, 18 Sep 2025 14:56:09 GMT
       ETag:
       - '"c8576d5ea3fcee4039dcddbdcf9e59fed3f3086419a33aa96f18f4617203b76d"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:50 GMT
+      - Thu, 18 Sep 2025 15:01:09 GMT
       Source-Age:
       - '8'
       Strict-Transport-Security:
@@ -228,19 +228,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 0e5efaf5f8fc06efad8267daca5fb61d88a476af
+      - 21bd326e848c410587a76a51cbf485dfefd111c1
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 10B8:1C3F94:144BD8:18BB04:68C2EEB7
+      - 46FA:175DD:C2790:ED92C:68CC1D80
       X-Served-By:
-      - cache-bos4675-BOS
+      - cache-bos4679-BOS
       X-Timer:
-      - S1757605910.412988,VS0,VE1
+      - S1758207370.929984,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example32].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example32].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/catalog-spec/json-schema/catalog.json
   response:
@@ -52,11 +52,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:50 GMT
+      - Thu, 18 Sep 2025 14:56:10 GMT
       ETag:
       - '"c76fd44b22619705d40fb03a5b1d875e2e786f9ac7a85244758d15cc7cc947a9"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:50 GMT
+      - Thu, 18 Sep 2025 15:01:10 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -66,21 +66,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 88740fa6b438f82f784e3a2b93ce9f2ca80662e4
+      - 74407291c783f1cd9e1c6a27fc83562588571b27
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F35F:176261:68C2EEC0
+      - DF64:33F2BE:BEF40:EA092:68CC1D88
       X-Served-By:
-      - cache-bos4655-BOS
+      - cache-bos4691-BOS
       X-Timer:
-      - S1757605910.488290,VS0,VE66
+      - S1758207370.014942,VS0,VE69
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example33].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example33].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/collection-spec/json-schema/collection.json
   response:
@@ -96,11 +96,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:50 GMT
+      - Thu, 18 Sep 2025 14:56:10 GMT
       ETag:
       - '"efa6309742b904ab7b06bab4c30c3ea2e1ce78163892365a7f4ee461716396b3"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:50 GMT
+      - Thu, 18 Sep 2025 15:01:10 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -110,21 +110,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 1e165404bca76090880154c14fceea532c200f6e
+      - d86a09f0ac565a7c2a6e034c4e3f5ccb89c08ec6
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - ED3E:151D18:158C55:1A0484:68C2EEC0
+      - E19D:388807:C6F9A:F2341:68CC1D89
       X-Served-By:
-      - cache-bos4651-BOS
+      - cache-bos4693-BOS
       X-Timer:
-      - S1757605911.630717,VS0,VE63
+      - S1758207370.163083,VS0,VE59
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -134,7 +134,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/catalog-spec/json-schema/catalog.json
   response:
@@ -183,11 +183,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:50 GMT
+      - Thu, 18 Sep 2025 14:56:10 GMT
       ETag:
       - '"c76fd44b22619705d40fb03a5b1d875e2e786f9ac7a85244758d15cc7cc947a9"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:50 GMT
+      - Thu, 18 Sep 2025 15:01:10 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -203,15 +203,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 09923e9ff39f7a19e1cef11db50f07d29fad212c
+      - e0d242c971cc90cffe3cd700ff1c7b03c54a6730
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F35F:176261:68C2EEC0
+      - DF64:33F2BE:BEF40:EA092:68CC1D88
       X-Served-By:
       - cache-bos4670-BOS
       X-Timer:
-      - S1757605911.755947,VS0,VE1
+      - S1758207370.301497,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example34].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example34].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/item.json
   response:
@@ -96,11 +96,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:50 GMT
+      - Thu, 18 Sep 2025 14:56:10 GMT
       ETag:
       - '"eb4ef35f5071c45c7b53e7fe6ef92a682455a0de207fcbe27507488c4bfcc9ca"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:50 GMT
+      - Thu, 18 Sep 2025 15:01:10 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -110,21 +110,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - aaf6d22cc476663e8f52cc78caf48a6a84ec5624
+      - 3e2d72b27b3b6bc97c68577ef08ec01b5b0f23f0
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F39D:1762AB:68C2EEC2
+      - DF64:33F2BE:BEF70:EA0D4:68CC1D8A
       X-Served-By:
-      - cache-bos4680-BOS
+      - cache-bos4666-BOS
       X-Timer:
-      - S1757605911.820346,VS0,VE54
+      - S1758207370.381367,VS0,VE60
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -134,7 +134,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/basics.json
   response:
@@ -164,11 +164,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:50 GMT
+      - Thu, 18 Sep 2025 14:56:10 GMT
       ETag:
       - '"2436fa8ce8356cb57ec6581098dc3ea04f5395558aaca6e4008e09eb43f0a9db"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:50 GMT
+      - Thu, 18 Sep 2025 15:01:10 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -178,21 +178,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 5af6816da91feb05aa785de6d3f32f8cd62557b3
+      - d38c77c8141c86d272a761f12e3f2abba66847ec
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F42A:3A83F:147263:18E1C9:68C2EEC1
+      - F7BE:14958F:C3456:EE728:68CC1D89
       X-Served-By:
-      - cache-bos4634-BOS
+      - cache-bos4687-BOS
       X-Timer:
-      - S1757605911.935913,VS0,VE33
+      - S1758207371.521096,VS0,VE89
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -202,7 +202,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/datetimerange.json
   response:
@@ -237,11 +237,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:51 GMT
+      - Thu, 18 Sep 2025 14:56:10 GMT
       ETag:
       - '"e1248a7fa9f6feeddb9c683a0fcfcab1b8ea66ae5db2d9a36f0602d44879a0f8"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:51 GMT
+      - Thu, 18 Sep 2025 15:01:10 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -251,21 +251,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - f35a0f04c22037bfbf100e3fb666de23c2d5dc51
+      - 4ee0961217e88906b6dbf6e29161ef44f6aabaab
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 7F51:114F63:12D433:1743BA:68C2EEBE
+      - 9DD1:E9BED:A09F7:CECE4:68CC1D8A
       X-Served-By:
-      - cache-bos4649-BOS
+      - cache-bos4623-BOS
       X-Timer:
-      - S1757605911.034199,VS0,VE38
+      - S1758207371.695437,VS0,VE153
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -275,7 +275,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/instrument.json
   response:
@@ -306,11 +306,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:51 GMT
+      - Thu, 18 Sep 2025 14:56:11 GMT
       ETag:
       - '"84c39a084fe100d85a10cdeef11399cb06ceed2c623ee37cfbdb03f85d39477c"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:51 GMT
+      - Thu, 18 Sep 2025 15:01:11 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -320,21 +320,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - dab22a1ebf0ddbc72cad2615e52003b1c3164789
+      - 4ca73047acb2a0978f57f78678da7591e6895c5d
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - DE22:5461F:13BA26:1824C1:68C2EEC2
+      - 1F1B:2036C0:A67D8:D4AEF:68CC1D8A
       X-Served-By:
-      - cache-bos4688-BOS
+      - cache-bos4659-BOS
       X-Timer:
-      - S1757605911.133809,VS0,VE52
+      - S1758207371.933437,VS0,VE155
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -344,7 +344,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/licensing.json
   response:
@@ -371,11 +371,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:51 GMT
+      - Thu, 18 Sep 2025 14:56:11 GMT
       ETag:
       - '"d2cd4998f5154410f2dc79b42af5baaf118454186cee8d12066a5f42d3e821fc"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:51 GMT
+      - Thu, 18 Sep 2025 15:01:11 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -385,21 +385,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - bfcd9414681b1bc78c3a77e2f7399e69a0ae44d9
+      - 7687ba271a1b78e1a332b57c50ce4d185513e677
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 2635:21E1E:F47BCB:132FF57:68C2EEC1
+      - 5403:383255:115583:14CF3E:68CC1D8B
       X-Served-By:
       - cache-bos4674-BOS
       X-Timer:
-      - S1757605911.249857,VS0,VE41
+      - S1758207371.245393,VS0,VE170
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -409,7 +409,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/metadata.json
   response:
@@ -438,11 +438,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:51 GMT
+      - Thu, 18 Sep 2025 14:56:11 GMT
       ETag:
       - '"a99228769e5d0400f7b006fa153262053fb7a6ffdb3b8bbf51c4df37a82098f6"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:51 GMT
+      - Thu, 18 Sep 2025 15:01:11 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -452,21 +452,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 3e7f372f600a7f131ef6284c9497a9b824e2236f
+      - a5c1579f2973ae4458500386d715d04648dac109
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F45D:12459A:14DF05:195A37:68C2EEC2
+      - F21B:2AFB8F:119511:151B54:68CC1D8B
       X-Served-By:
-      - cache-bos4692-BOS
+      - cache-bos4623-BOS
       X-Timer:
-      - S1757605911.351984,VS0,VE54
+      - S1758207372.551399,VS0,VE98
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -476,7 +476,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/provider.json
   response:
@@ -513,11 +513,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:51 GMT
+      - Thu, 18 Sep 2025 14:56:11 GMT
       ETag:
       - '"a92eac8e15643dce5b9165724ce350d2ee5edad5f8baca7140c79ce8ce0da8c6"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:51 GMT
+      - Thu, 18 Sep 2025 15:01:11 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -527,21 +527,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 7f43c9b3b646628f8223a27dfbf1701efd883b52
+      - b3f883fabd852cc836510c23bafdbf093f5826a0
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 13D9:87AC7:1335CB:17A9EB:68C2EEC3
+      - B078:1485D6:12232B:15A44A:68CC1D8B
       X-Served-By:
-      - cache-bos4677-BOS
+      - cache-bos4623-BOS
       X-Timer:
-      - S1757605911.482174,VS0,VE49
+      - S1758207372.717248,VS0,VE156
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -551,7 +551,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/extensions/eo/json-schema/schema.json
   response:
@@ -604,11 +604,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:51 GMT
+      - Thu, 18 Sep 2025 14:56:12 GMT
       ETag:
       - '"4ce0628a6b4d2c8e80ff67d116b60196c8f9d0a017a63b3557ebd6b46f42dfef"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:51 GMT
+      - Thu, 18 Sep 2025 15:01:12 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -618,21 +618,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 02af66b774612ec1bbb04e4cadb27f94a14a8413
+      - 71eceac5bee968d5c4f61d0313bd4283c0cbfbf9
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 5020:6F752:15D8B0:1A5E45:68C2EEC3
+      - 7FC8:E9BED:A0AA0:CEDB6:68CC1D8B
       X-Served-By:
-      - cache-bos4631-BOS
+      - cache-bos4690-BOS
       X-Timer:
-      - S1757605912.600080,VS0,VE52
+      - S1758207372.957280,VS0,VE102
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example35].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example35].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/collection-spec/json-schema/collection.json
   response:
@@ -96,13 +96,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:51 GMT
+      - Thu, 18 Sep 2025 14:56:12 GMT
       ETag:
       - '"efa6309742b904ab7b06bab4c30c3ea2e1ce78163892365a7f4ee461716396b3"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:51 GMT
+      - Thu, 18 Sep 2025 15:01:12 GMT
       Source-Age:
-      - '1'
+      - '2'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -116,15 +116,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - a9c8beef5bcb8e3ab67e743b6c2ad16dfde1470c
+      - 7877406ea3ce2d1bc884f0656eb6fb9f9cc9d797
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - ED3E:151D18:158C55:1A0484:68C2EEC0
+      - E19D:388807:C6F9A:F2341:68CC1D89
       X-Served-By:
-      - cache-bos4660-BOS
+      - cache-bos4641-BOS
       X-Timer:
-      - S1757605912.725615,VS0,VE1
+      - S1758207372.145508,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -134,7 +134,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/catalog-spec/json-schema/catalog.json
   response:
@@ -183,13 +183,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:51 GMT
+      - Thu, 18 Sep 2025 14:56:12 GMT
       ETag:
       - '"c76fd44b22619705d40fb03a5b1d875e2e786f9ac7a85244758d15cc7cc947a9"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:51 GMT
+      - Thu, 18 Sep 2025 15:01:12 GMT
       Source-Age:
-      - '1'
+      - '2'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -203,15 +203,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - f4f0e5632eb99460ec16593572c92a018aae277d
+      - 20e4ef6716eaf02b41707cf1768b9a48cf0a75b5
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F35F:176261:68C2EEC0
+      - DF64:33F2BE:BEF40:EA092:68CC1D88
       X-Served-By:
-      - cache-bos4642-BOS
+      - cache-bos4665-BOS
       X-Timer:
-      - S1757605912.806155,VS0,VE1
+      - S1758207372.224713,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example36].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example36].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/collection-spec/json-schema/collection.json
   response:
@@ -96,13 +96,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:51 GMT
+      - Thu, 18 Sep 2025 14:56:12 GMT
       ETag:
       - '"efa6309742b904ab7b06bab4c30c3ea2e1ce78163892365a7f4ee461716396b3"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:51 GMT
+      - Thu, 18 Sep 2025 15:01:12 GMT
       Source-Age:
-      - '1'
+      - '2'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -116,15 +116,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 58945c526b2e69150a9fe5c6a3f677f8924d73ba
+      - d32b240704b5449058db2481c743b56d68ace0f5
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - ED3E:151D18:158C55:1A0484:68C2EEC0
+      - E19D:388807:C6F9A:F2341:68CC1D89
       X-Served-By:
-      - cache-bos4653-BOS
+      - cache-bos4672-BOS
       X-Timer:
-      - S1757605912.891094,VS0,VE1
+      - S1758207372.293634,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -134,7 +134,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/catalog-spec/json-schema/catalog.json
   response:
@@ -183,13 +183,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:51 GMT
+      - Thu, 18 Sep 2025 14:56:12 GMT
       ETag:
       - '"c76fd44b22619705d40fb03a5b1d875e2e786f9ac7a85244758d15cc7cc947a9"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:51 GMT
+      - Thu, 18 Sep 2025 15:01:12 GMT
       Source-Age:
-      - '1'
+      - '2'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -203,15 +203,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 895b47d278c438c0be5be69ba061f54e28d9f4b7
+      - e7eaec71ef237aded8187c9961c3e80b5239d594
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F35F:176261:68C2EEC0
+      - DF64:33F2BE:BEF40:EA092:68CC1D88
       X-Served-By:
-      - cache-bos4631-BOS
+      - cache-bos4644-BOS
       X-Timer:
-      - S1757605912.968425,VS0,VE1
+      - S1758207372.359189,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -221,7 +221,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/extensions/asset/json-schema/schema.json
   response:
@@ -262,11 +262,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:52 GMT
+      - Thu, 18 Sep 2025 14:56:12 GMT
       ETag:
       - '"6ae857b8e1e2f74d6b996d5f7111e822099d2620956150db4b96325f59fccc52"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:52 GMT
+      - Thu, 18 Sep 2025 15:01:12 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -276,21 +276,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 2d1e60bd1b131a6b50f13d1631f105679db89f21
+      - ae6c69a73207cc1fa74b0e8eca8d80c37a8a7f72
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - AE36:35E91B:14981C:191054:68C2EEC3
+      - 97B0:2036C0:A6896:D4BDE:68CC1D8C
       X-Served-By:
-      - cache-bos4621-BOS
+      - cache-bos4682-BOS
       X-Timer:
-      - S1757605912.040093,VS0,VE52
+      - S1758207372.423752,VS0,VE193
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example37].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example37].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/item.json
   response:
@@ -96,13 +96,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:52 GMT
+      - Thu, 18 Sep 2025 14:56:12 GMT
       ETag:
       - '"eb4ef35f5071c45c7b53e7fe6ef92a682455a0de207fcbe27507488c4bfcc9ca"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:52 GMT
+      - Thu, 18 Sep 2025 15:01:12 GMT
       Source-Age:
-      - '1'
+      - '2'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -116,15 +116,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 5c76e996f4de17efa1ef3de9fa38190041da295a
+      - 4ed44ee6f99f9859b8919b0b548f2d3a6603f399
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F39D:1762AB:68C2EEC2
+      - DF64:33F2BE:BEF70:EA0D4:68CC1D8A
       X-Served-By:
-      - cache-bos4693-BOS
+      - cache-bos4686-BOS
       X-Timer:
-      - S1757605912.172042,VS0,VE1
+      - S1758207373.773126,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -134,7 +134,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/basics.json
   response:
@@ -164,13 +164,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:52 GMT
+      - Thu, 18 Sep 2025 14:56:12 GMT
       ETag:
       - '"2436fa8ce8356cb57ec6581098dc3ea04f5395558aaca6e4008e09eb43f0a9db"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:52 GMT
+      - Thu, 18 Sep 2025 15:01:12 GMT
       Source-Age:
-      - '1'
+      - '2'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -184,15 +184,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 809535b4034ebb3722a4d5f6c8988397adc523c9
+      - 68daf4fe31a08e171e8f26a041ea0b9e00fdb3da
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F42A:3A83F:147263:18E1C9:68C2EEC1
+      - F7BE:14958F:C3456:EE728:68CC1D89
       X-Served-By:
-      - cache-bos4638-BOS
+      - cache-bos4664-BOS
       X-Timer:
-      - S1757605912.248916,VS0,VE1
+      - S1758207373.835585,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -202,7 +202,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/datetimerange.json
   response:
@@ -237,13 +237,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:52 GMT
+      - Thu, 18 Sep 2025 14:56:12 GMT
       ETag:
       - '"e1248a7fa9f6feeddb9c683a0fcfcab1b8ea66ae5db2d9a36f0602d44879a0f8"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:52 GMT
+      - Thu, 18 Sep 2025 15:01:12 GMT
       Source-Age:
-      - '1'
+      - '2'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -257,15 +257,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 58861c0fd8a8a658e4c8742b7c0d56054aa1233b
+      - f5570a5bb2c394330f2ebcd4dfa495ed7734090a
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 7F51:114F63:12D433:1743BA:68C2EEBE
+      - 9DD1:E9BED:A09F7:CECE4:68CC1D8A
       X-Served-By:
-      - cache-bos4628-BOS
+      - cache-bos4645-BOS
       X-Timer:
-      - S1757605912.316014,VS0,VE1
+      - S1758207373.899224,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -275,7 +275,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/instrument.json
   response:
@@ -306,13 +306,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:52 GMT
+      - Thu, 18 Sep 2025 14:56:12 GMT
       ETag:
       - '"84c39a084fe100d85a10cdeef11399cb06ceed2c623ee37cfbdb03f85d39477c"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:52 GMT
+      - Thu, 18 Sep 2025 15:01:12 GMT
       Source-Age:
-      - '1'
+      - '2'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -326,15 +326,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - b4470479be14d3b673537c77488d72b98c31643c
+      - 1f7e56b9faebfc24a61a892d2db68cd674658a92
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - DE22:5461F:13BA26:1824C1:68C2EEC2
+      - 1F1B:2036C0:A67D8:D4AEF:68CC1D8A
       X-Served-By:
-      - cache-bos4671-BOS
+      - cache-bos4661-BOS
       X-Timer:
-      - S1757605912.388354,VS0,VE4
+      - S1758207373.970795,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -344,7 +344,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/licensing.json
   response:
@@ -371,13 +371,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:52 GMT
+      - Thu, 18 Sep 2025 14:56:13 GMT
       ETag:
       - '"d2cd4998f5154410f2dc79b42af5baaf118454186cee8d12066a5f42d3e821fc"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:52 GMT
+      - Thu, 18 Sep 2025 15:01:13 GMT
       Source-Age:
-      - '1'
+      - '2'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -391,15 +391,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 9f56fad1c1eaa5e91320dab128a7fe31a2feaab6
+      - 98af2eb62a5f3e14043f9ebe3a1216801732ca2d
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 2635:21E1E:F47BCB:132FF57:68C2EEC1
+      - 5403:383255:115583:14CF3E:68CC1D8B
       X-Served-By:
-      - cache-bos4641-BOS
+      - cache-bos4663-BOS
       X-Timer:
-      - S1757605912.463913,VS0,VE1
+      - S1758207373.042908,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -409,7 +409,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/metadata.json
   response:
@@ -438,11 +438,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:52 GMT
+      - Thu, 18 Sep 2025 14:56:13 GMT
       ETag:
       - '"a99228769e5d0400f7b006fa153262053fb7a6ffdb3b8bbf51c4df37a82098f6"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:52 GMT
+      - Thu, 18 Sep 2025 15:01:13 GMT
       Source-Age:
       - '1'
       Strict-Transport-Security:
@@ -458,15 +458,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 5596fe100870bd1478883dad1f0abdb5c649571f
+      - 112f7e913c274490e57902298dce82cb9bd4a888
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F45D:12459A:14DF05:195A37:68C2EEC2
+      - F21B:2AFB8F:119511:151B54:68CC1D8B
       X-Served-By:
-      - cache-bos4634-BOS
+      - cache-bos4686-BOS
       X-Timer:
-      - S1757605913.533728,VS0,VE1
+      - S1758207373.111291,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -476,7 +476,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/provider.json
   response:
@@ -513,11 +513,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:52 GMT
+      - Thu, 18 Sep 2025 14:56:13 GMT
       ETag:
       - '"a92eac8e15643dce5b9165724ce350d2ee5edad5f8baca7140c79ce8ce0da8c6"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:52 GMT
+      - Thu, 18 Sep 2025 15:01:13 GMT
       Source-Age:
       - '1'
       Strict-Transport-Security:
@@ -533,15 +533,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 789e80b760ac8a3b50cdf4e17665773453231464
+      - 995fdcb2d9436fc381766abe92e49b3c5d6ded20
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 13D9:87AC7:1335CB:17A9EB:68C2EEC3
+      - B078:1485D6:12232B:15A44A:68CC1D8B
       X-Served-By:
       - cache-bos4666-BOS
       X-Timer:
-      - S1757605913.601877,VS0,VE1
+      - S1758207373.180083,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -551,7 +551,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/extensions/checksum/json-schema/schema.json
   response:
@@ -589,11 +589,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:52 GMT
+      - Thu, 18 Sep 2025 14:56:13 GMT
       ETag:
       - '"9bde8b6875408a186b283e6e3dd3edb01bc2b938e55a0491b0b7f4e06f0faccb"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:52 GMT
+      - Thu, 18 Sep 2025 15:01:13 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -603,21 +603,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - dd1b01014bb868c9e11bf78a3d62302c66c9baf5
+      - bb53fe7ff161e21d478db0bbdfe3d015457f8c32
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 2EEA:2ACBC:14A59B:191DF0:68C2EEC4
+      - 8D48:3FA7F8:124D47:15D3ED:68CC1D8C
       X-Served-By:
-      - cache-bos4635-BOS
+      - cache-bos4676-BOS
       X-Timer:
-      - S1757605913.672515,VS0,VE57
+      - S1758207373.247202,VS0,VE78
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example38].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example38].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/collection-spec/json-schema/collection.json
   response:
@@ -96,13 +96,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:52 GMT
+      - Thu, 18 Sep 2025 14:56:13 GMT
       ETag:
       - '"efa6309742b904ab7b06bab4c30c3ea2e1ce78163892365a7f4ee461716396b3"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:52 GMT
+      - Thu, 18 Sep 2025 15:01:13 GMT
       Source-Age:
-      - '2'
+      - '3'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -116,15 +116,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 58813c62cc44769d61bd6da4268269939a65725b
+      - ef53039dabb06ae0b591a210ddba564d012ee882
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - ED3E:151D18:158C55:1A0484:68C2EEC0
+      - E19D:388807:C6F9A:F2341:68CC1D89
       X-Served-By:
-      - cache-bos4633-BOS
+      - cache-bos4651-BOS
       X-Timer:
-      - S1757605913.815958,VS0,VE1
+      - S1758207373.395304,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -134,7 +134,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/catalog-spec/json-schema/catalog.json
   response:
@@ -183,13 +183,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:52 GMT
+      - Thu, 18 Sep 2025 14:56:13 GMT
       ETag:
       - '"c76fd44b22619705d40fb03a5b1d875e2e786f9ac7a85244758d15cc7cc947a9"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:52 GMT
+      - Thu, 18 Sep 2025 15:01:13 GMT
       Source-Age:
-      - '2'
+      - '3'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -199,19 +199,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '4'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 9041d653c3b276c1863219e20015bebea5476ddf
+      - c43a6ae74e711955913d97581f8a22f88ac58644
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F35F:176261:68C2EEC0
+      - DF64:33F2BE:BEF40:EA092:68CC1D88
       X-Served-By:
-      - cache-bos4640-BOS
+      - cache-bos4678-BOS
       X-Timer:
-      - S1757605913.889834,VS0,VE1
+      - S1758207373.461577,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example39].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example39].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/item.json
   response:
@@ -96,13 +96,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:52 GMT
+      - Thu, 18 Sep 2025 14:56:13 GMT
       ETag:
       - '"eb4ef35f5071c45c7b53e7fe6ef92a682455a0de207fcbe27507488c4bfcc9ca"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:52 GMT
+      - Thu, 18 Sep 2025 15:01:13 GMT
       Source-Age:
-      - '2'
+      - '3'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -116,15 +116,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - c3916f4fc986c02ba5e15f2eaaa244f32eeca8bc
+      - 6fd665860af8df8bc10ab0d16500d5e78d560eaa
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F39D:1762AB:68C2EEC2
+      - DF64:33F2BE:BEF70:EA0D4:68CC1D8A
       X-Served-By:
-      - cache-bos4688-BOS
+      - cache-bos4666-BOS
       X-Timer:
-      - S1757605913.951942,VS0,VE1
+      - S1758207374.521266,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -134,7 +134,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/basics.json
   response:
@@ -164,13 +164,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:53 GMT
+      - Thu, 18 Sep 2025 14:56:13 GMT
       ETag:
       - '"2436fa8ce8356cb57ec6581098dc3ea04f5395558aaca6e4008e09eb43f0a9db"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:53 GMT
+      - Thu, 18 Sep 2025 15:01:13 GMT
       Source-Age:
-      - '2'
+      - '3'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -184,15 +184,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - cbd89a465fe1986ce5b8dabbba9fc2defa91e6fa
+      - b7c80c024c6ede0155a860e1e16e65f30fa562ab
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F42A:3A83F:147263:18E1C9:68C2EEC1
+      - F7BE:14958F:C3456:EE728:68CC1D89
       X-Served-By:
-      - cache-bos4652-BOS
+      - cache-bos4627-BOS
       X-Timer:
-      - S1757605913.019817,VS0,VE2
+      - S1758207374.586735,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -202,7 +202,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/datetimerange.json
   response:
@@ -237,13 +237,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:53 GMT
+      - Thu, 18 Sep 2025 14:56:13 GMT
       ETag:
       - '"e1248a7fa9f6feeddb9c683a0fcfcab1b8ea66ae5db2d9a36f0602d44879a0f8"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:53 GMT
+      - Thu, 18 Sep 2025 15:01:13 GMT
       Source-Age:
-      - '2'
+      - '3'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -257,15 +257,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 60795cffd2a2dce96eb110eb905cea29a79fa2fb
+      - f43d48209a4ebb438ad2fc5d221662df378b04d6
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 7F51:114F63:12D433:1743BA:68C2EEBE
+      - 9DD1:E9BED:A09F7:CECE4:68CC1D8A
       X-Served-By:
-      - cache-bos4654-BOS
+      - cache-bos4665-BOS
       X-Timer:
-      - S1757605913.081342,VS0,VE1
+      - S1758207374.647545,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -275,7 +275,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/instrument.json
   response:
@@ -306,13 +306,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:53 GMT
+      - Thu, 18 Sep 2025 14:56:13 GMT
       ETag:
       - '"84c39a084fe100d85a10cdeef11399cb06ceed2c623ee37cfbdb03f85d39477c"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:53 GMT
+      - Thu, 18 Sep 2025 15:01:13 GMT
       Source-Age:
-      - '2'
+      - '3'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -326,15 +326,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - a52ab97645d252b74870d832cace6e8910365407
+      - f993853bf0a59e5d3a925964d24877ce200e6fb4
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - DE22:5461F:13BA26:1824C1:68C2EEC2
+      - 1F1B:2036C0:A67D8:D4AEF:68CC1D8A
       X-Served-By:
-      - cache-bos4681-BOS
+      - cache-bos4692-BOS
       X-Timer:
-      - S1757605913.147619,VS0,VE1
+      - S1758207374.711051,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -344,7 +344,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/licensing.json
   response:
@@ -371,11 +371,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:53 GMT
+      - Thu, 18 Sep 2025 14:56:13 GMT
       ETag:
       - '"d2cd4998f5154410f2dc79b42af5baaf118454186cee8d12066a5f42d3e821fc"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:53 GMT
+      - Thu, 18 Sep 2025 15:01:13 GMT
       Source-Age:
       - '2'
       Strict-Transport-Security:
@@ -391,15 +391,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 6d8860c0fd60e7c3e94497e7a9288d105565f0a2
+      - e5e42ea59647faec8364e593ba34c5b21d5a255c
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 2635:21E1E:F47BCB:132FF57:68C2EEC1
+      - 5403:383255:115583:14CF3E:68CC1D8B
       X-Served-By:
-      - cache-bos4675-BOS
+      - cache-bos4665-BOS
       X-Timer:
-      - S1757605913.212433,VS0,VE1
+      - S1758207374.775323,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -409,7 +409,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/metadata.json
   response:
@@ -438,11 +438,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:53 GMT
+      - Thu, 18 Sep 2025 14:56:13 GMT
       ETag:
       - '"a99228769e5d0400f7b006fa153262053fb7a6ffdb3b8bbf51c4df37a82098f6"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:53 GMT
+      - Thu, 18 Sep 2025 15:01:13 GMT
       Source-Age:
       - '2'
       Strict-Transport-Security:
@@ -458,15 +458,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 36abbbe0ced437ec06ac10604df346f179b15c22
+      - fea22b7a82de8f980f4b2b2aaa008f7c9beef4f0
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F45D:12459A:14DF05:195A37:68C2EEC2
+      - F21B:2AFB8F:119511:151B54:68CC1D8B
       X-Served-By:
-      - cache-bos4676-BOS
+      - cache-bos4679-BOS
       X-Timer:
-      - S1757605913.271523,VS0,VE1
+      - S1758207374.835216,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -476,7 +476,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/provider.json
   response:
@@ -513,11 +513,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:53 GMT
+      - Thu, 18 Sep 2025 14:56:13 GMT
       ETag:
       - '"a92eac8e15643dce5b9165724ce350d2ee5edad5f8baca7140c79ce8ce0da8c6"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:53 GMT
+      - Thu, 18 Sep 2025 15:01:13 GMT
       Source-Age:
       - '2'
       Strict-Transport-Security:
@@ -533,15 +533,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - d2eb9ccd8da896a1da634275cd3dd1c22556b103
+      - 6e9bbfa22cea22fd24288f07c0ba18c3e400ede0
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 13D9:87AC7:1335CB:17A9EB:68C2EEC3
+      - B078:1485D6:12232B:15A44A:68CC1D8B
       X-Served-By:
-      - cache-bos4620-BOS
+      - cache-bos4646-BOS
       X-Timer:
-      - S1757605913.333095,VS0,VE1
+      - S1758207374.903901,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -551,7 +551,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/extensions/eo/json-schema/schema.json
   response:
@@ -604,11 +604,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:53 GMT
+      - Thu, 18 Sep 2025 14:56:13 GMT
       ETag:
       - '"4ce0628a6b4d2c8e80ff67d116b60196c8f9d0a017a63b3557ebd6b46f42dfef"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:53 GMT
+      - Thu, 18 Sep 2025 15:01:13 GMT
       Source-Age:
       - '2'
       Strict-Transport-Security:
@@ -624,15 +624,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 938a52f2c0d975678025fce883ee898e04e01b02
+      - 5fcf45cacf97a2dc92f38d5c594fa729c7610fe8
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 5020:6F752:15D8B0:1A5E45:68C2EEC3
+      - 7FC8:E9BED:A0AA0:CEDB6:68CC1D8B
       X-Served-By:
-      - cache-bos4651-BOS
+      - cache-bos4660-BOS
       X-Timer:
-      - S1757605913.396917,VS0,VE1
+      - S1758207374.965180,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -642,7 +642,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/extensions/sat/json-schema/schema.json
   response:
@@ -678,11 +678,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:53 GMT
+      - Thu, 18 Sep 2025 14:56:14 GMT
       ETag:
       - '"90408dbc0c6ce835205fcdbeeab881774f06517052d7c3dbcf6ba7c3ccced7eb"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:53 GMT
+      - Thu, 18 Sep 2025 15:01:14 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -692,21 +692,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 8a983fa186d99a1943d3b0871d2e5c4731e97b4b
+      - 3d4c38fae1e849e911340832214c555605ac1800
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3186:12459A:14E01C:195B91:68C2EEC4
+      - 55BA:BACE2:EB046:122BB8:68CC1D8E
       X-Served-By:
-      - cache-bos4621-BOS
+      - cache-bos4624-BOS
       X-Timer:
-      - S1757605913.457765,VS0,VE45
+      - S1758207374.029108,VS0,VE162
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example3].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example3].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/item-spec/json-schema/item.json
   response:
@@ -108,11 +108,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:42 GMT
+      - Thu, 18 Sep 2025 14:56:01 GMT
       ETag:
       - '"4e24763d74f0d463b0cb6c63fc099e0b59447c7a049b93ffda4c6eb9eb54ae95"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:42 GMT
+      - Thu, 18 Sep 2025 15:01:01 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -122,21 +122,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - f7bea26f09502898b07962a81ce9b1a2ef213a10
+      - ec57a3541bd578242d601f752e5fdf213c9a45cf
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 688A:1E0DA2:13B02E:181CCC:68C2EEB5
+      - DDD5:286E0:D0F1D:FC0CF:68CC1D7C
       X-Served-By:
-      - cache-bos4665-BOS
+      - cache-bos4671-BOS
       X-Timer:
-      - S1757605902.458130,VS0,VE46
+      - S1758207361.405040,VS0,VE59
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -146,7 +146,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/extensions/eo/json-schema/schema.json
   response:
@@ -212,11 +212,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:42 GMT
+      - Thu, 18 Sep 2025 14:56:01 GMT
       ETag:
       - '"c8576d5ea3fcee4039dcddbdcf9e59fed3f3086419a33aa96f18f4617203b76d"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:42 GMT
+      - Thu, 18 Sep 2025 15:01:01 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -226,21 +226,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - f273ba2684643ade943f2bb6ac057d32d0cabae9
+      - a33a5222814baec2bd580c8565aa3d024faf6e92
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 10B8:1C3F94:144BD8:18BB04:68C2EEB7
+      - 46FA:175DD:C2790:ED92C:68CC1D80
       X-Served-By:
-      - cache-bos4652-BOS
+      - cache-bos4678-BOS
       X-Timer:
-      - S1757605903.577928,VS0,VE54
+      - S1758207362.540614,VS0,VE84
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example40].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example40].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/collection-spec/json-schema/collection.json
   response:
@@ -96,13 +96,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:53 GMT
+      - Thu, 18 Sep 2025 14:56:14 GMT
       ETag:
       - '"efa6309742b904ab7b06bab4c30c3ea2e1ce78163892365a7f4ee461716396b3"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:53 GMT
+      - Thu, 18 Sep 2025 15:01:14 GMT
       Source-Age:
-      - '3'
+      - '4'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -116,15 +116,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 0bf4ddbe48981d28c04a3dc7d92469db015d8341
+      - fba7fc26b15dcf5f618dd3bca0c5da957a1c5f6d
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - ED3E:151D18:158C55:1A0484:68C2EEC0
+      - E19D:388807:C6F9A:F2341:68CC1D89
       X-Served-By:
-      - cache-bos4689-BOS
+      - cache-bos4643-BOS
       X-Timer:
-      - S1757605914.565890,VS0,VE1
+      - S1758207374.333462,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -134,7 +134,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/catalog-spec/json-schema/catalog.json
   response:
@@ -183,13 +183,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:53 GMT
+      - Thu, 18 Sep 2025 14:56:14 GMT
       ETag:
       - '"c76fd44b22619705d40fb03a5b1d875e2e786f9ac7a85244758d15cc7cc947a9"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:53 GMT
+      - Thu, 18 Sep 2025 15:01:14 GMT
       Source-Age:
-      - '3'
+      - '4'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -203,15 +203,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - f341851fd3799ee75a680017c0c67544869a4668
+      - 02a1f71134cf7514b576f3f44ecfe4c1e78ce0a4
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F35F:176261:68C2EEC0
+      - DF64:33F2BE:BEF40:EA092:68CC1D88
       X-Served-By:
-      - cache-bos4623-BOS
+      - cache-bos4625-BOS
       X-Timer:
-      - S1757605914.638425,VS0,VE1
+      - S1758207374.411821,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example41].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example41].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/item.json
   response:
@@ -96,13 +96,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:53 GMT
+      - Thu, 18 Sep 2025 14:56:14 GMT
       ETag:
       - '"eb4ef35f5071c45c7b53e7fe6ef92a682455a0de207fcbe27507488c4bfcc9ca"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:53 GMT
+      - Thu, 18 Sep 2025 15:01:14 GMT
       Source-Age:
-      - '3'
+      - '4'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -112,19 +112,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '26'
+      - '1'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - a3b888107a06559e021b683a75ffad17f68e777c
+      - 18f5f7efeea19e27fb990ef4ff8d8796cbabb0be
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F39D:1762AB:68C2EEC2
+      - DF64:33F2BE:BEF70:EA0D4:68CC1D8A
       X-Served-By:
-      - cache-bos4678-BOS
+      - cache-bos4691-BOS
       X-Timer:
-      - S1757605914.711627,VS0,VE0
+      - S1758207374.494770,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -134,7 +134,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/basics.json
   response:
@@ -164,13 +164,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:53 GMT
+      - Thu, 18 Sep 2025 14:56:14 GMT
       ETag:
       - '"2436fa8ce8356cb57ec6581098dc3ea04f5395558aaca6e4008e09eb43f0a9db"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:53 GMT
+      - Thu, 18 Sep 2025 15:01:14 GMT
       Source-Age:
-      - '3'
+      - '4'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -184,15 +184,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - fcf7c625224607a00ff9ce9ed6d91abfc64e8853
+      - 03229638d6d4a8c57b993eee6311736fab146320
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F42A:3A83F:147263:18E1C9:68C2EEC1
+      - F7BE:14958F:C3456:EE728:68CC1D89
       X-Served-By:
-      - cache-bos4655-BOS
+      - cache-bos4674-BOS
       X-Timer:
-      - S1757605914.788219,VS0,VE1
+      - S1758207375.573407,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -202,7 +202,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/datetimerange.json
   response:
@@ -237,13 +237,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:53 GMT
+      - Thu, 18 Sep 2025 14:56:14 GMT
       ETag:
       - '"e1248a7fa9f6feeddb9c683a0fcfcab1b8ea66ae5db2d9a36f0602d44879a0f8"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:53 GMT
+      - Thu, 18 Sep 2025 15:01:14 GMT
       Source-Age:
-      - '3'
+      - '4'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -257,15 +257,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 0a1f3b80c147ae9aa57297fcff444747e9194d06
+      - efacb68d025c4747e742d5a3636516f3b898e33d
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 7F51:114F63:12D433:1743BA:68C2EEBE
+      - 9DD1:E9BED:A09F7:CECE4:68CC1D8A
       X-Served-By:
-      - cache-bos4636-BOS
+      - cache-bos4670-BOS
       X-Timer:
-      - S1757605914.852412,VS0,VE1
+      - S1758207375.649104,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -275,7 +275,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/instrument.json
   response:
@@ -306,13 +306,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:53 GMT
+      - Thu, 18 Sep 2025 14:56:14 GMT
       ETag:
       - '"84c39a084fe100d85a10cdeef11399cb06ceed2c623ee37cfbdb03f85d39477c"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:53 GMT
+      - Thu, 18 Sep 2025 15:01:14 GMT
       Source-Age:
-      - '3'
+      - '4'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -326,15 +326,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - f5d43920f49dbca4e1ddabcc749f4dd94b355f41
+      - c8652f8c331448cb54dda8162a6a8ba03511c6fc
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - DE22:5461F:13BA26:1824C1:68C2EEC2
+      - 1F1B:2036C0:A67D8:D4AEF:68CC1D8A
       X-Served-By:
-      - cache-bos4691-BOS
+      - cache-bos4634-BOS
       X-Timer:
-      - S1757605914.914136,VS0,VE8
+      - S1758207375.725231,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -344,7 +344,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/licensing.json
   response:
@@ -371,11 +371,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:53 GMT
+      - Thu, 18 Sep 2025 14:56:14 GMT
       ETag:
       - '"d2cd4998f5154410f2dc79b42af5baaf118454186cee8d12066a5f42d3e821fc"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:53 GMT
+      - Thu, 18 Sep 2025 15:01:14 GMT
       Source-Age:
       - '3'
       Strict-Transport-Security:
@@ -391,15 +391,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 698883f1148ec6f324ad9c3c58d22f7ac46656e7
+      - 0d959c3c8da41d71c458cedd8f6dd8367754b061
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 2635:21E1E:F47BCB:132FF57:68C2EEC1
+      - 5403:383255:115583:14CF3E:68CC1D8B
       X-Served-By:
-      - cache-bos4667-BOS
+      - cache-bos4664-BOS
       X-Timer:
-      - S1757605914.983958,VS0,VE1
+      - S1758207375.795380,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -409,7 +409,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/metadata.json
   response:
@@ -438,11 +438,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:54 GMT
+      - Thu, 18 Sep 2025 14:56:14 GMT
       ETag:
       - '"a99228769e5d0400f7b006fa153262053fb7a6ffdb3b8bbf51c4df37a82098f6"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:54 GMT
+      - Thu, 18 Sep 2025 15:01:14 GMT
       Source-Age:
       - '3'
       Strict-Transport-Security:
@@ -454,19 +454,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - a605ebfb900f6093a504ede3f3ed5716c6a3f231
+      - 00447ead7bbc174423a5a976ef4f8c9f363f51a8
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F45D:12459A:14DF05:195A37:68C2EEC2
+      - F21B:2AFB8F:119511:151B54:68CC1D8B
       X-Served-By:
-      - cache-bos4676-BOS
+      - cache-bos4650-BOS
       X-Timer:
-      - S1757605914.043669,VS0,VE0
+      - S1758207375.865535,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -476,7 +476,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/provider.json
   response:
@@ -513,11 +513,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:54 GMT
+      - Thu, 18 Sep 2025 14:56:14 GMT
       ETag:
       - '"a92eac8e15643dce5b9165724ce350d2ee5edad5f8baca7140c79ce8ce0da8c6"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:54 GMT
+      - Thu, 18 Sep 2025 15:01:14 GMT
       Source-Age:
       - '3'
       Strict-Transport-Security:
@@ -533,15 +533,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - a52ca67f3ac3d9b1d1f98758186fa28858ef85da
+      - d7cfd5cba43635c848fbd1c4bcd67801bc399f51
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 13D9:87AC7:1335CB:17A9EB:68C2EEC3
+      - B078:1485D6:12232B:15A44A:68CC1D8B
       X-Served-By:
-      - cache-bos4680-BOS
+      - cache-bos4637-BOS
       X-Timer:
-      - S1757605914.104733,VS0,VE1
+      - S1758207375.933232,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example42].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example42].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/item.json
   response:
@@ -96,13 +96,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:54 GMT
+      - Thu, 18 Sep 2025 14:56:15 GMT
       ETag:
       - '"eb4ef35f5071c45c7b53e7fe6ef92a682455a0de207fcbe27507488c4bfcc9ca"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:54 GMT
+      - Thu, 18 Sep 2025 15:01:15 GMT
       Source-Age:
-      - '3'
+      - '5'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -116,15 +116,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - d3200f1e17b1af042a4f2e8e24d3ccd895abb5ad
+      - b67e8f6be1f1ee599a43ef9e90b71ae977fae0e1
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F39D:1762AB:68C2EEC2
+      - DF64:33F2BE:BEF70:EA0D4:68CC1D8A
       X-Served-By:
-      - cache-bos4650-BOS
+      - cache-bos4643-BOS
       X-Timer:
-      - S1757605914.170366,VS0,VE1
+      - S1758207375.007238,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -134,7 +134,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/basics.json
   response:
@@ -164,13 +164,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:54 GMT
+      - Thu, 18 Sep 2025 14:56:15 GMT
       ETag:
       - '"2436fa8ce8356cb57ec6581098dc3ea04f5395558aaca6e4008e09eb43f0a9db"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:54 GMT
+      - Thu, 18 Sep 2025 15:01:15 GMT
       Source-Age:
-      - '3'
+      - '4'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -184,15 +184,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - a5ea2564a2c91c80686aa5f304023f7067ed8f50
+      - c0daf4f9670682a8eab17c85e0aaf5328f345019
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F42A:3A83F:147263:18E1C9:68C2EEC1
+      - F7BE:14958F:C3456:EE728:68CC1D89
       X-Served-By:
-      - cache-bos4690-BOS
+      - cache-bos4649-BOS
       X-Timer:
-      - S1757605914.233865,VS0,VE7
+      - S1758207375.080922,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -202,7 +202,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/datetimerange.json
   response:
@@ -237,13 +237,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:54 GMT
+      - Thu, 18 Sep 2025 14:56:15 GMT
       ETag:
       - '"e1248a7fa9f6feeddb9c683a0fcfcab1b8ea66ae5db2d9a36f0602d44879a0f8"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:54 GMT
+      - Thu, 18 Sep 2025 15:01:15 GMT
       Source-Age:
-      - '3'
+      - '4'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -257,15 +257,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 9af1c76337acdd9137ac31dd8e2380f76a045630
+      - a299529fe462b8bdf012ae4c8a4bc0c4be99532e
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 7F51:114F63:12D433:1743BA:68C2EEBE
+      - 9DD1:E9BED:A09F7:CECE4:68CC1D8A
       X-Served-By:
-      - cache-bos4690-BOS
+      - cache-bos4660-BOS
       X-Timer:
-      - S1757605914.305670,VS0,VE1
+      - S1758207375.143410,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -275,7 +275,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/instrument.json
   response:
@@ -306,13 +306,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:54 GMT
+      - Thu, 18 Sep 2025 14:56:15 GMT
       ETag:
       - '"84c39a084fe100d85a10cdeef11399cb06ceed2c623ee37cfbdb03f85d39477c"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:54 GMT
+      - Thu, 18 Sep 2025 15:01:15 GMT
       Source-Age:
-      - '3'
+      - '4'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -322,19 +322,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - eb92c3488ef76cb7e8ba5f88f0e9ca7d27f49439
+      - 227523f345d50ea01ba110abe9c1fe11cfceb222
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - DE22:5461F:13BA26:1824C1:68C2EEC2
+      - 1F1B:2036C0:A67D8:D4AEF:68CC1D8A
       X-Served-By:
-      - cache-bos4679-BOS
+      - cache-bos4692-BOS
       X-Timer:
-      - S1757605914.366242,VS0,VE1
+      - S1758207375.207694,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -344,7 +344,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/licensing.json
   response:
@@ -371,13 +371,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:54 GMT
+      - Thu, 18 Sep 2025 14:56:15 GMT
       ETag:
       - '"d2cd4998f5154410f2dc79b42af5baaf118454186cee8d12066a5f42d3e821fc"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:54 GMT
+      - Thu, 18 Sep 2025 15:01:15 GMT
       Source-Age:
-      - '3'
+      - '4'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -391,15 +391,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - cb09749c890fa5636189690cf30fb63f8412fc94
+      - e2a003e080daaaea1ea70f374157e81583f345a8
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 2635:21E1E:F47BCB:132FF57:68C2EEC1
+      - 5403:383255:115583:14CF3E:68CC1D8B
       X-Served-By:
-      - cache-bos4677-BOS
+      - cache-bos4646-BOS
       X-Timer:
-      - S1757605914.427900,VS0,VE48
+      - S1758207375.269296,VS0,VE2
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -409,7 +409,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/metadata.json
   response:
@@ -438,13 +438,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:54 GMT
+      - Thu, 18 Sep 2025 14:56:15 GMT
       ETag:
       - '"a99228769e5d0400f7b006fa153262053fb7a6ffdb3b8bbf51c4df37a82098f6"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:54 GMT
+      - Thu, 18 Sep 2025 15:01:15 GMT
       Source-Age:
-      - '3'
+      - '4'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -458,15 +458,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - da934ef4494c97f8011bdad149699136c20f039a
+      - c328eb1560c5dbb7b50bca08d9cb3ced972ac170
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F45D:12459A:14DF05:195A37:68C2EEC2
+      - F21B:2AFB8F:119511:151B54:68CC1D8B
       X-Served-By:
-      - cache-bos4643-BOS
+      - cache-bos4641-BOS
       X-Timer:
-      - S1757605915.541074,VS0,VE1
+      - S1758207375.333866,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -476,7 +476,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/provider.json
   response:
@@ -513,13 +513,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:54 GMT
+      - Thu, 18 Sep 2025 14:56:15 GMT
       ETag:
       - '"a92eac8e15643dce5b9165724ce350d2ee5edad5f8baca7140c79ce8ce0da8c6"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:54 GMT
+      - Thu, 18 Sep 2025 15:01:15 GMT
       Source-Age:
-      - '3'
+      - '4'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -533,15 +533,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - fe4f6f1dd382d51740d90b9e7045b41a4679930f
+      - f4a50a72cb652da4fbda5d7a3a0a1c9141e5af3a
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 13D9:87AC7:1335CB:17A9EB:68C2EEC3
+      - B078:1485D6:12232B:15A44A:68CC1D8B
       X-Served-By:
-      - cache-bos4679-BOS
+      - cache-bos4655-BOS
       X-Timer:
-      - S1757605915.610054,VS0,VE1
+      - S1758207375.395184,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -551,7 +551,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/extensions/eo/json-schema/schema.json
   response:
@@ -604,11 +604,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:54 GMT
+      - Thu, 18 Sep 2025 14:56:15 GMT
       ETag:
       - '"4ce0628a6b4d2c8e80ff67d116b60196c8f9d0a017a63b3557ebd6b46f42dfef"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:54 GMT
+      - Thu, 18 Sep 2025 15:01:15 GMT
       Source-Age:
       - '3'
       Strict-Transport-Security:
@@ -620,19 +620,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '9'
+      - '1'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - ff9198af7c93bd67061c1924e98775b1b354b1e0
+      - 0cf0c8803ca674f2299af68741efdb0d3b903393
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 5020:6F752:15D8B0:1A5E45:68C2EEC3
+      - 7FC8:E9BED:A0AA0:CEDB6:68CC1D8B
       X-Served-By:
-      - cache-bos4671-BOS
+      - cache-bos4679-BOS
       X-Timer:
-      - S1757605915.671359,VS0,VE0
+      - S1758207375.459418,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -642,7 +642,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/extensions/view/json-schema/schema.json
   response:
@@ -686,11 +686,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:54 GMT
+      - Thu, 18 Sep 2025 14:56:15 GMT
       ETag:
       - '"e3e45b623ffe7f49713a2595b631681ba13de3813a1f297508e46360b2becd71"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:54 GMT
+      - Thu, 18 Sep 2025 15:01:15 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -700,21 +700,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - f6c9755b0e3a43b9a3af3806041781d6d5d310f1
+      - e4e288be4011606d2f46b02dff6932c4349414b7
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 7F99:1C3F94:14550C:18C5EE:68C2EEC5
+      - 2E67:2A363F:A6B3E:D5185:68CC1D8E
       X-Served-By:
-      - cache-bos4658-BOS
+      - cache-bos4634-BOS
       X-Timer:
-      - S1757605915.746388,VS0,VE48
+      - S1758207376.523618,VS0,VE67
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example43].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example43].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/catalog-spec/json-schema/catalog.json
   response:
@@ -52,13 +52,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:54 GMT
+      - Thu, 18 Sep 2025 14:56:15 GMT
       ETag:
       - '"c76fd44b22619705d40fb03a5b1d875e2e786f9ac7a85244758d15cc7cc947a9"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:54 GMT
+      - Thu, 18 Sep 2025 15:01:15 GMT
       Source-Age:
-      - '4'
+      - '6'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -72,15 +72,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 50ac406fca8be24b6c201ed2b253ee93ad4083d1
+      - 8a59d83a9566cf7dbe8f83f34a353164da0f2f6b
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F35F:176261:68C2EEC0
+      - DF64:33F2BE:BEF40:EA092:68CC1D88
       X-Served-By:
-      - cache-bos4687-BOS
+      - cache-bos4652-BOS
       X-Timer:
-      - S1757605915.877986,VS0,VE1
+      - S1758207376.668831,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example44].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example44].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/item.json
   response:
@@ -96,13 +96,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:54 GMT
+      - Thu, 18 Sep 2025 14:56:15 GMT
       ETag:
       - '"eb4ef35f5071c45c7b53e7fe6ef92a682455a0de207fcbe27507488c4bfcc9ca"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:54 GMT
+      - Thu, 18 Sep 2025 15:01:15 GMT
       Source-Age:
-      - '4'
+      - '5'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -116,15 +116,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - d1547d08a7a313173ebb6849b274ef8b05ac09ec
+      - 5674c0762c1e890c2e7b7b88c02a4bfd28d4aa77
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F39D:1762AB:68C2EEC2
+      - DF64:33F2BE:BEF70:EA0D4:68CC1D8A
       X-Served-By:
-      - cache-bos4655-BOS
+      - cache-bos4649-BOS
       X-Timer:
-      - S1757605915.957880,VS0,VE1
+      - S1758207376.739424,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -134,7 +134,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/basics.json
   response:
@@ -164,13 +164,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:55 GMT
+      - Thu, 18 Sep 2025 14:56:15 GMT
       ETag:
       - '"2436fa8ce8356cb57ec6581098dc3ea04f5395558aaca6e4008e09eb43f0a9db"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:55 GMT
+      - Thu, 18 Sep 2025 15:01:15 GMT
       Source-Age:
-      - '4'
+      - '5'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -184,15 +184,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - eac2dc3794ea2a9b1779cb5cc0779bb0a589f4fd
+      - 6e2cd86af9b7765a94ca0a3e50ff68433d7bf786
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F42A:3A83F:147263:18E1C9:68C2EEC1
+      - F7BE:14958F:C3456:EE728:68CC1D89
       X-Served-By:
-      - cache-bos4653-BOS
+      - cache-bos4636-BOS
       X-Timer:
-      - S1757605915.029652,VS0,VE1
+      - S1758207376.801331,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -202,7 +202,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/datetimerange.json
   response:
@@ -237,13 +237,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:55 GMT
+      - Thu, 18 Sep 2025 14:56:15 GMT
       ETag:
       - '"e1248a7fa9f6feeddb9c683a0fcfcab1b8ea66ae5db2d9a36f0602d44879a0f8"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:55 GMT
+      - Thu, 18 Sep 2025 15:01:15 GMT
       Source-Age:
-      - '4'
+      - '5'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -257,15 +257,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 7241cafa316ec56df1fbd85ef9facbe53d84fbe2
+      - d91dd5f74eb8227a56acbb335581e293ddc38f0d
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 7F51:114F63:12D433:1743BA:68C2EEBE
+      - 9DD1:E9BED:A09F7:CECE4:68CC1D8A
       X-Served-By:
-      - cache-bos4627-BOS
+      - cache-bos4624-BOS
       X-Timer:
-      - S1757605915.104284,VS0,VE1
+      - S1758207376.869516,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -275,7 +275,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/instrument.json
   response:
@@ -306,13 +306,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:55 GMT
+      - Thu, 18 Sep 2025 14:56:15 GMT
       ETag:
       - '"84c39a084fe100d85a10cdeef11399cb06ceed2c623ee37cfbdb03f85d39477c"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:55 GMT
+      - Thu, 18 Sep 2025 15:01:15 GMT
       Source-Age:
-      - '4'
+      - '5'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -326,15 +326,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 64ce6d6b8c8b19e512722872a9a429c85d54e7c9
+      - 7703e58925d3b8eb2cd92ebe883c3a13b00778fe
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - DE22:5461F:13BA26:1824C1:68C2EEC2
+      - 1F1B:2036C0:A67D8:D4AEF:68CC1D8A
       X-Served-By:
-      - cache-bos4668-BOS
+      - cache-bos4688-BOS
       X-Timer:
-      - S1757605915.178258,VS0,VE2
+      - S1758207376.939487,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -344,7 +344,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/licensing.json
   response:
@@ -371,13 +371,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:55 GMT
+      - Thu, 18 Sep 2025 14:56:16 GMT
       ETag:
       - '"d2cd4998f5154410f2dc79b42af5baaf118454186cee8d12066a5f42d3e821fc"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:55 GMT
+      - Thu, 18 Sep 2025 15:01:16 GMT
       Source-Age:
-      - '4'
+      - '5'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -391,15 +391,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - af872f27a8ef0d9dde0db57537d765894d5a623a
+      - 7dce5b6e94701f7f48d93a3096a6b3a5d7c33918
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 2635:21E1E:F47BCB:132FF57:68C2EEC1
+      - 5403:383255:115583:14CF3E:68CC1D8B
       X-Served-By:
-      - cache-bos4664-BOS
+      - cache-bos4629-BOS
       X-Timer:
-      - S1757605915.250220,VS0,VE1
+      - S1758207376.005021,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -409,7 +409,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/metadata.json
   response:
@@ -438,11 +438,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:55 GMT
+      - Thu, 18 Sep 2025 14:56:16 GMT
       ETag:
       - '"a99228769e5d0400f7b006fa153262053fb7a6ffdb3b8bbf51c4df37a82098f6"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:55 GMT
+      - Thu, 18 Sep 2025 15:01:16 GMT
       Source-Age:
       - '4'
       Strict-Transport-Security:
@@ -458,15 +458,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 58ca66cc353fa023bee67214da174a4ac563be3d
+      - 9328aa37f55ba0693d3090c10810c65f38df882f
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F45D:12459A:14DF05:195A37:68C2EEC2
+      - F21B:2AFB8F:119511:151B54:68CC1D8B
       X-Served-By:
       - cache-bos4688-BOS
       X-Timer:
-      - S1757605915.323992,VS0,VE1
+      - S1758207376.067464,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -476,7 +476,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/provider.json
   response:
@@ -513,11 +513,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:55 GMT
+      - Thu, 18 Sep 2025 14:56:16 GMT
       ETag:
       - '"a92eac8e15643dce5b9165724ce350d2ee5edad5f8baca7140c79ce8ce0da8c6"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:55 GMT
+      - Thu, 18 Sep 2025 15:01:16 GMT
       Source-Age:
       - '4'
       Strict-Transport-Security:
@@ -533,15 +533,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - a822d9826ec43f99b6e78abb7265852da7669ea5
+      - 1276603cf1c8e4aeb24da5be089d19db80366b83
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 13D9:87AC7:1335CB:17A9EB:68C2EEC3
+      - B078:1485D6:12232B:15A44A:68CC1D8B
       X-Served-By:
-      - cache-bos4643-BOS
+      - cache-bos4620-BOS
       X-Timer:
-      - S1757605915.397812,VS0,VE1
+      - S1758207376.126950,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example45].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example45].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/item.json
   response:
@@ -96,13 +96,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:55 GMT
+      - Thu, 18 Sep 2025 14:56:16 GMT
       ETag:
       - '"eb4ef35f5071c45c7b53e7fe6ef92a682455a0de207fcbe27507488c4bfcc9ca"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:55 GMT
+      - Thu, 18 Sep 2025 15:01:16 GMT
       Source-Age:
-      - '5'
+      - '6'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -116,15 +116,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - e62b24d1a9f2c1f425779f89e274fa352cb9d463
+      - b241811c4a76d4d5d73e34669f6c2014b6e0778c
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F39D:1762AB:68C2EEC2
+      - DF64:33F2BE:BEF70:EA0D4:68CC1D8A
       X-Served-By:
-      - cache-bos4633-BOS
+      - cache-bos4637-BOS
       X-Timer:
-      - S1757605915.486361,VS0,VE6
+      - S1758207376.189458,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -134,7 +134,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/basics.json
   response:
@@ -164,13 +164,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:55 GMT
+      - Thu, 18 Sep 2025 14:56:16 GMT
       ETag:
       - '"2436fa8ce8356cb57ec6581098dc3ea04f5395558aaca6e4008e09eb43f0a9db"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:55 GMT
+      - Thu, 18 Sep 2025 15:01:16 GMT
       Source-Age:
-      - '5'
+      - '6'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -184,15 +184,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - ba139151e455e71ec9e6f7498d3956b2813bcd64
+      - bc7af2bd3a5c0397c1a91d139465209f033bc594
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F42A:3A83F:147263:18E1C9:68C2EEC1
+      - F7BE:14958F:C3456:EE728:68CC1D89
       X-Served-By:
-      - cache-bos4654-BOS
+      - cache-bos4634-BOS
       X-Timer:
-      - S1757605916.573781,VS0,VE1
+      - S1758207376.253607,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -202,7 +202,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/datetimerange.json
   response:
@@ -237,11 +237,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:55 GMT
+      - Thu, 18 Sep 2025 14:56:16 GMT
       ETag:
       - '"e1248a7fa9f6feeddb9c683a0fcfcab1b8ea66ae5db2d9a36f0602d44879a0f8"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:55 GMT
+      - Thu, 18 Sep 2025 15:01:16 GMT
       Source-Age:
       - '5'
       Strict-Transport-Security:
@@ -257,15 +257,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 172fbd1a42c4468108b36764c53ae62fa48e40f3
+      - 0c445a80325c3190be664cf0a08b37fa7a8601bc
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 7F51:114F63:12D433:1743BA:68C2EEBE
+      - 9DD1:E9BED:A09F7:CECE4:68CC1D8A
       X-Served-By:
-      - cache-bos4686-BOS
+      - cache-bos4626-BOS
       X-Timer:
-      - S1757605916.643956,VS0,VE1
+      - S1758207376.315225,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -275,7 +275,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/instrument.json
   response:
@@ -306,11 +306,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:55 GMT
+      - Thu, 18 Sep 2025 14:56:16 GMT
       ETag:
       - '"84c39a084fe100d85a10cdeef11399cb06ceed2c623ee37cfbdb03f85d39477c"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:55 GMT
+      - Thu, 18 Sep 2025 15:01:16 GMT
       Source-Age:
       - '5'
       Strict-Transport-Security:
@@ -326,15 +326,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 51b0fc5d42c723adac365ae358b340c3f75a5608
+      - cec0f3c18fc5970a36c6e618c41d8be13f2c4b25
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - DE22:5461F:13BA26:1824C1:68C2EEC2
+      - 1F1B:2036C0:A67D8:D4AEF:68CC1D8A
       X-Served-By:
       - cache-bos4666-BOS
       X-Timer:
-      - S1757605916.711990,VS0,VE1
+      - S1758207376.375459,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -344,7 +344,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/licensing.json
   response:
@@ -371,13 +371,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:55 GMT
+      - Thu, 18 Sep 2025 14:56:16 GMT
       ETag:
       - '"d2cd4998f5154410f2dc79b42af5baaf118454186cee8d12066a5f42d3e821fc"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:55 GMT
+      - Thu, 18 Sep 2025 15:01:16 GMT
       Source-Age:
-      - '4'
+      - '5'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -391,15 +391,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 9a5984c1ac72af7a26becbf7b94d1f4796b6e569
+      - 969da298fa9377d818c8bfa76e0f0928e8c88699
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 2635:21E1E:F47BCB:132FF57:68C2EEC1
+      - 5403:383255:115583:14CF3E:68CC1D8B
       X-Served-By:
-      - cache-bos4645-BOS
+      - cache-bos4623-BOS
       X-Timer:
-      - S1757605916.784541,VS0,VE1
+      - S1758207376.443517,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -409,7 +409,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/metadata.json
   response:
@@ -438,13 +438,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:55 GMT
+      - Thu, 18 Sep 2025 14:56:16 GMT
       ETag:
       - '"a99228769e5d0400f7b006fa153262053fb7a6ffdb3b8bbf51c4df37a82098f6"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:55 GMT
+      - Thu, 18 Sep 2025 15:01:16 GMT
       Source-Age:
-      - '4'
+      - '5'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -458,15 +458,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 65ab0714b185f2eb28b97941fae80151542f5872
+      - d0d8064e7142afae0ef398d1e355a14d06dfbbb7
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F45D:12459A:14DF05:195A37:68C2EEC2
+      - F21B:2AFB8F:119511:151B54:68CC1D8B
       X-Served-By:
-      - cache-bos4675-BOS
+      - cache-bos4625-BOS
       X-Timer:
-      - S1757605916.852163,VS0,VE1
+      - S1758207377.505255,VS0,VE2
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -476,7 +476,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/provider.json
   response:
@@ -513,13 +513,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:55 GMT
+      - Thu, 18 Sep 2025 14:56:16 GMT
       ETag:
       - '"a92eac8e15643dce5b9165724ce350d2ee5edad5f8baca7140c79ce8ce0da8c6"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:55 GMT
+      - Thu, 18 Sep 2025 15:01:16 GMT
       Source-Age:
-      - '4'
+      - '5'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -533,15 +533,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 8c80ba18d0e678836a0a04e06ff27b0846df0384
+      - fb8162d259df4ba446478d012e170e3082df46bb
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 13D9:87AC7:1335CB:17A9EB:68C2EEC3
+      - B078:1485D6:12232B:15A44A:68CC1D8B
       X-Served-By:
-      - cache-bos4684-BOS
+      - cache-bos4634-BOS
       X-Timer:
-      - S1757605916.925655,VS0,VE1
+      - S1758207377.567223,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example46].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example46].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/item.json
   response:
@@ -96,13 +96,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:56 GMT
+      - Thu, 18 Sep 2025 14:56:16 GMT
       ETag:
       - '"eb4ef35f5071c45c7b53e7fe6ef92a682455a0de207fcbe27507488c4bfcc9ca"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:01:16 GMT
       Source-Age:
-      - '5'
+      - '6'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -116,15 +116,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - c3dc56c742dfce9d8447d3276a3d03917d949e9b
+      - 992f9167cc6f9dc822bf693dd22058914a5676ef
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F39D:1762AB:68C2EEC2
+      - DF64:33F2BE:BEF70:EA0D4:68CC1D8A
       X-Served-By:
-      - cache-bos4672-BOS
+      - cache-bos4648-BOS
       X-Timer:
-      - S1757605916.003836,VS0,VE8
+      - S1758207377.636883,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -134,7 +134,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/basics.json
   response:
@@ -164,13 +164,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:56 GMT
+      - Thu, 18 Sep 2025 14:56:16 GMT
       ETag:
       - '"2436fa8ce8356cb57ec6581098dc3ea04f5395558aaca6e4008e09eb43f0a9db"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:01:16 GMT
       Source-Age:
-      - '5'
+      - '6'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -184,15 +184,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - c2d3fc21b1fe727a7ea60849dfada0e9147bef33
+      - 54482e69d77eaec8ef30b7a824242fc11a0f440a
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F42A:3A83F:147263:18E1C9:68C2EEC1
+      - F7BE:14958F:C3456:EE728:68CC1D89
       X-Served-By:
-      - cache-bos4634-BOS
+      - cache-bos4620-BOS
       X-Timer:
-      - S1757605916.075689,VS0,VE1
+      - S1758207377.699271,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -202,7 +202,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/datetimerange.json
   response:
@@ -237,13 +237,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:56 GMT
+      - Thu, 18 Sep 2025 14:56:16 GMT
       ETag:
       - '"e1248a7fa9f6feeddb9c683a0fcfcab1b8ea66ae5db2d9a36f0602d44879a0f8"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:01:16 GMT
       Source-Age:
-      - '5'
+      - '6'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -257,15 +257,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - cce10c07333fd6d789aafc85f70e884264a0ae66
+      - c4b65758a209d04b1670676e9c0020305ff06039
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 7F51:114F63:12D433:1743BA:68C2EEBE
+      - 9DD1:E9BED:A09F7:CECE4:68CC1D8A
       X-Served-By:
-      - cache-bos4653-BOS
+      - cache-bos4667-BOS
       X-Timer:
-      - S1757605916.139787,VS0,VE1
+      - S1758207377.790504,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -275,7 +275,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/instrument.json
   response:
@@ -306,13 +306,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:56 GMT
+      - Thu, 18 Sep 2025 14:56:16 GMT
       ETag:
       - '"84c39a084fe100d85a10cdeef11399cb06ceed2c623ee37cfbdb03f85d39477c"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:01:16 GMT
       Source-Age:
-      - '5'
+      - '6'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -326,15 +326,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 04a1ab9d62f710696697d89429cf33db6acafead
+      - 2a448f8763b810fac1bb06aa340d35bd6795b1aa
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - DE22:5461F:13BA26:1824C1:68C2EEC2
+      - 1F1B:2036C0:A67D8:D4AEF:68CC1D8A
       X-Served-By:
-      - cache-bos4655-BOS
+      - cache-bos4642-BOS
       X-Timer:
-      - S1757605916.203139,VS0,VE1
+      - S1758207377.853279,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -344,7 +344,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/licensing.json
   response:
@@ -371,13 +371,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:56 GMT
+      - Thu, 18 Sep 2025 14:56:16 GMT
       ETag:
       - '"d2cd4998f5154410f2dc79b42af5baaf118454186cee8d12066a5f42d3e821fc"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:01:16 GMT
       Source-Age:
-      - '5'
+      - '6'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -391,15 +391,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - b2729c6aff161a12e55c6f518ad23584a46619a1
+      - 403fc1464a23f25acc361bb7977832f39b7f2383
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 2635:21E1E:F47BCB:132FF57:68C2EEC1
+      - 5403:383255:115583:14CF3E:68CC1D8B
       X-Served-By:
-      - cache-bos4670-BOS
+      - cache-bos4625-BOS
       X-Timer:
-      - S1757605916.265949,VS0,VE1
+      - S1758207377.920893,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -409,7 +409,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/metadata.json
   response:
@@ -438,11 +438,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:56 GMT
+      - Thu, 18 Sep 2025 14:56:16 GMT
       ETag:
       - '"a99228769e5d0400f7b006fa153262053fb7a6ffdb3b8bbf51c4df37a82098f6"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:01:16 GMT
       Source-Age:
       - '5'
       Strict-Transport-Security:
@@ -454,19 +454,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 1c76d8800576fb85f0aaa99af970d77d5b728dd8
+      - fb0a3284cb0832375017ece65cc0384b14500787
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F45D:12459A:14DF05:195A37:68C2EEC2
+      - F21B:2AFB8F:119511:151B54:68CC1D8B
       X-Served-By:
-      - cache-bos4620-BOS
+      - cache-bos4625-BOS
       X-Timer:
-      - S1757605916.332658,VS0,VE1
+      - S1758207377.996915,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -476,7 +476,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/provider.json
   response:
@@ -513,11 +513,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:56 GMT
+      - Thu, 18 Sep 2025 14:56:17 GMT
       ETag:
       - '"a92eac8e15643dce5b9165724ce350d2ee5edad5f8baca7140c79ce8ce0da8c6"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:01:17 GMT
       Source-Age:
       - '5'
       Strict-Transport-Security:
@@ -533,15 +533,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 08ba75c89d7229b04fd71df46ea7596721b810f8
+      - 9bd56d505a1a070469fc1b9ccbc852038fafda39
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 13D9:87AC7:1335CB:17A9EB:68C2EEC3
+      - B078:1485D6:12232B:15A44A:68CC1D8B
       X-Served-By:
-      - cache-bos4642-BOS
+      - cache-bos4636-BOS
       X-Timer:
-      - S1757605916.396691,VS0,VE1
+      - S1758207377.071191,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example47].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example47].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/collection-spec/json-schema/collection.json
   response:
@@ -96,13 +96,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:56 GMT
+      - Thu, 18 Sep 2025 14:56:17 GMT
       ETag:
       - '"efa6309742b904ab7b06bab4c30c3ea2e1ce78163892365a7f4ee461716396b3"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:01:17 GMT
       Source-Age:
-      - '6'
+      - '7'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -116,15 +116,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 7c7f7d4387bad51aea746c859c3384d44d892bec
+      - 7c607ce067abe08de8f8e97de356b5daba42c4c2
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - ED3E:151D18:158C55:1A0484:68C2EEC0
+      - E19D:388807:C6F9A:F2341:68CC1D89
       X-Served-By:
-      - cache-bos4664-BOS
+      - cache-bos4656-BOS
       X-Timer:
-      - S1757605916.466017,VS0,VE1
+      - S1758207377.158621,VS0,VE3
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -134,7 +134,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/catalog-spec/json-schema/catalog.json
   response:
@@ -183,13 +183,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:56 GMT
+      - Thu, 18 Sep 2025 14:56:17 GMT
       ETag:
       - '"c76fd44b22619705d40fb03a5b1d875e2e786f9ac7a85244758d15cc7cc947a9"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:01:17 GMT
       Source-Age:
-      - '6'
+      - '7'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -203,15 +203,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 731ba717133e451664b585bfc2f0fcd5fa40188c
+      - ce58c6bf5ab3cd6bf9aa114920e087e44ac21929
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F35F:176261:68C2EEC0
+      - DF64:33F2BE:BEF40:EA092:68CC1D88
       X-Served-By:
-      - cache-bos4651-BOS
+      - cache-bos4690-BOS
       X-Timer:
-      - S1757605917.530695,VS0,VE1
+      - S1758207377.245402,VS0,VE14
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example48].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example48].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/collection-spec/json-schema/collection.json
   response:
@@ -96,13 +96,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:56 GMT
+      - Thu, 18 Sep 2025 14:56:17 GMT
       ETag:
       - '"efa6309742b904ab7b06bab4c30c3ea2e1ce78163892365a7f4ee461716396b3"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:01:17 GMT
       Source-Age:
-      - '6'
+      - '7'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -116,15 +116,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - db83611e3e672238100a26c90dc1195b5cfde740
+      - 09848402faa072de5aef2146f55b636e394ff7fb
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - ED3E:151D18:158C55:1A0484:68C2EEC0
+      - E19D:388807:C6F9A:F2341:68CC1D89
       X-Served-By:
-      - cache-bos4677-BOS
+      - cache-bos4666-BOS
       X-Timer:
-      - S1757605917.592027,VS0,VE1
+      - S1758207377.337052,VS0,VE3
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -134,7 +134,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/catalog-spec/json-schema/catalog.json
   response:
@@ -183,13 +183,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:56 GMT
+      - Thu, 18 Sep 2025 14:56:17 GMT
       ETag:
       - '"c76fd44b22619705d40fb03a5b1d875e2e786f9ac7a85244758d15cc7cc947a9"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:01:17 GMT
       Source-Age:
-      - '6'
+      - '7'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -203,15 +203,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - f433d551cbe1ec471f479c80c6537ff07fd1a79c
+      - 39b58b3158bdc2c6f396c0c939cf3aa32e32564c
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F35F:176261:68C2EEC0
+      - DF64:33F2BE:BEF40:EA092:68CC1D88
       X-Served-By:
-      - cache-bos4680-BOS
+      - cache-bos4640-BOS
       X-Timer:
-      - S1757605917.660227,VS0,VE1
+      - S1758207377.419507,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example49].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example49].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/item.json
   response:
@@ -96,13 +96,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:56 GMT
+      - Thu, 18 Sep 2025 14:56:17 GMT
       ETag:
       - '"eb4ef35f5071c45c7b53e7fe6ef92a682455a0de207fcbe27507488c4bfcc9ca"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:01:17 GMT
       Source-Age:
-      - '6'
+      - '7'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -116,15 +116,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 642674739bd21fe7a6858cdcb579a47c7213aecf
+      - 3374ae8127adf7940319d1714a9bbae04ba25afe
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F39D:1762AB:68C2EEC2
+      - DF64:33F2BE:BEF70:EA0D4:68CC1D8A
       X-Served-By:
-      - cache-bos4684-BOS
+      - cache-bos4652-BOS
       X-Timer:
-      - S1757605917.737924,VS0,VE1
+      - S1758207378.506803,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -134,7 +134,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/basics.json
   response:
@@ -164,13 +164,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:56 GMT
+      - Thu, 18 Sep 2025 14:56:17 GMT
       ETag:
       - '"2436fa8ce8356cb57ec6581098dc3ea04f5395558aaca6e4008e09eb43f0a9db"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:01:17 GMT
       Source-Age:
-      - '6'
+      - '7'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -184,15 +184,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 4a18bb4f8fdeed2444190a17224e83ee0291bf22
+      - fa0d1135b21c68678524226757e86bcb49704bcd
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F42A:3A83F:147263:18E1C9:68C2EEC1
+      - F7BE:14958F:C3456:EE728:68CC1D89
       X-Served-By:
-      - cache-bos4631-BOS
+      - cache-bos4637-BOS
       X-Timer:
-      - S1757605917.812134,VS0,VE1
+      - S1758207378.591961,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -202,7 +202,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/datetimerange.json
   response:
@@ -237,11 +237,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:56 GMT
+      - Thu, 18 Sep 2025 14:56:17 GMT
       ETag:
       - '"e1248a7fa9f6feeddb9c683a0fcfcab1b8ea66ae5db2d9a36f0602d44879a0f8"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:01:17 GMT
       Source-Age:
       - '6'
       Strict-Transport-Security:
@@ -253,19 +253,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - a6872df4a64c5b35f2d10308cc6f99e8ba756859
+      - 95befa28ebd8b63be814dd5dcbd28515571321dd
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 7F51:114F63:12D433:1743BA:68C2EEBE
+      - 9DD1:E9BED:A09F7:CECE4:68CC1D8A
       X-Served-By:
-      - cache-bos4642-BOS
+      - cache-bos4626-BOS
       X-Timer:
-      - S1757605917.870840,VS0,VE1
+      - S1758207378.657145,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -275,7 +275,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/instrument.json
   response:
@@ -306,13 +306,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:56 GMT
+      - Thu, 18 Sep 2025 14:56:17 GMT
       ETag:
       - '"84c39a084fe100d85a10cdeef11399cb06ceed2c623ee37cfbdb03f85d39477c"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:56 GMT
+      - Thu, 18 Sep 2025 15:01:17 GMT
       Source-Age:
-      - '6'
+      - '7'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -322,19 +322,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - b855aa5c9cad462e74bcd85c6548bb051c3f0845
+      - a90c4289f03800bef5a9fec50816616712f88067
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - DE22:5461F:13BA26:1824C1:68C2EEC2
+      - 1F1B:2036C0:A67D8:D4AEF:68CC1D8A
       X-Served-By:
-      - cache-bos4671-BOS
+      - cache-bos4622-BOS
       X-Timer:
-      - S1757605917.936344,VS0,VE0
+      - S1758207378.727707,VS0,VE2
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -344,7 +344,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/licensing.json
   response:
@@ -371,11 +371,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:57 GMT
+      - Thu, 18 Sep 2025 14:56:17 GMT
       ETag:
       - '"d2cd4998f5154410f2dc79b42af5baaf118454186cee8d12066a5f42d3e821fc"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:57 GMT
+      - Thu, 18 Sep 2025 15:01:17 GMT
       Source-Age:
       - '6'
       Strict-Transport-Security:
@@ -391,15 +391,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 272a4bf0f180ad651975874a784d35100885b8c7
+      - c0612b4b46359a02b2cfe0225b52efcfdceed301
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 2635:21E1E:F47BCB:132FF57:68C2EEC1
+      - 5403:383255:115583:14CF3E:68CC1D8B
       X-Served-By:
-      - cache-bos4638-BOS
+      - cache-bos4675-BOS
       X-Timer:
-      - S1757605917.000804,VS0,VE1
+      - S1758207378.796839,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -409,7 +409,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/metadata.json
   response:
@@ -438,11 +438,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:57 GMT
+      - Thu, 18 Sep 2025 14:56:17 GMT
       ETag:
       - '"a99228769e5d0400f7b006fa153262053fb7a6ffdb3b8bbf51c4df37a82098f6"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:57 GMT
+      - Thu, 18 Sep 2025 15:01:17 GMT
       Source-Age:
       - '6'
       Strict-Transport-Security:
@@ -454,19 +454,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - cefa5396ded53251e65fbe90ccf1b6de0b9ffa4b
+      - cffb84ce4e6b954f8a41d3fcf85bb812fa079007
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F45D:12459A:14DF05:195A37:68C2EEC2
+      - F21B:2AFB8F:119511:151B54:68CC1D8B
       X-Served-By:
-      - cache-bos4657-BOS
+      - cache-bos4650-BOS
       X-Timer:
-      - S1757605917.058262,VS0,VE2
+      - S1758207378.877275,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -476,7 +476,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/provider.json
   response:
@@ -513,11 +513,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:57 GMT
+      - Thu, 18 Sep 2025 14:56:17 GMT
       ETag:
       - '"a92eac8e15643dce5b9165724ce350d2ee5edad5f8baca7140c79ce8ce0da8c6"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:57 GMT
+      - Thu, 18 Sep 2025 15:01:17 GMT
       Source-Age:
       - '6'
       Strict-Transport-Security:
@@ -533,15 +533,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 339144b86adb99e97d875f0ff29159076c57d557
+      - 699ecc0a0147735db922bf088ae7496ab7f6c3d3
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 13D9:87AC7:1335CB:17A9EB:68C2EEC3
+      - B078:1485D6:12232B:15A44A:68CC1D8B
       X-Served-By:
-      - cache-bos4675-BOS
+      - cache-bos4682-BOS
       X-Timer:
-      - S1757605917.122163,VS0,VE1
+      - S1758207378.949229,VS0,VE2
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example4].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example4].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/collection-spec/json-schema/collection.json
   response:
@@ -85,11 +85,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:42 GMT
+      - Thu, 18 Sep 2025 14:56:01 GMT
       ETag:
       - '"031974beaaaf6f0b5c6877dc97088d9e2aff3bc8962df33ff291dddded353f09"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:42 GMT
+      - Thu, 18 Sep 2025 15:01:01 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -105,15 +105,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 72856912b47f329b260115e4c39e68745ecf8ff9
+      - 5aefb31837c4e4d1d7f13e756b539441828fb55e
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 48D2:9DF63:14B8DC:192D3D:68C2EEB6
+      - EAA4:3C3312:A80AF:D3151:68CC1D7F
       X-Served-By:
-      - cache-bos4632-BOS
+      - cache-bos4630-BOS
       X-Timer:
-      - S1757605903.703860,VS0,VE6
+      - S1758207362.713425,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -123,7 +123,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/catalog-spec/json-schema/catalog.json
   response:
@@ -184,11 +184,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:42 GMT
+      - Thu, 18 Sep 2025 14:56:01 GMT
       ETag:
       - '"3b514933a3747f038125935624a13df108e30fe1cb8f9660a7f54ac6d4765ce9"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:42 GMT
+      - Thu, 18 Sep 2025 15:01:01 GMT
       Source-Age:
       - '1'
       Strict-Transport-Security:
@@ -204,15 +204,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 06ac09f664f3867de8f2bfdeead0d0b24107b4e4
+      - 0bf051c2446dc0ecabdf9877af720e2276ed10e4
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 4D53:1CB1E4:12EBE4:17599A:68C2EEB7
+      - BCE7:388807:C697B:F1BF7:68CC1D7C
       X-Served-By:
-      - cache-bos4687-BOS
+      - cache-bos4625-BOS
       X-Timer:
-      - S1757605903.780814,VS0,VE1
+      - S1758207362.793818,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example50].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example50].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/collection-spec/json-schema/collection.json
   response:
@@ -96,13 +96,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:57 GMT
+      - Thu, 18 Sep 2025 14:56:18 GMT
       ETag:
       - '"efa6309742b904ab7b06bab4c30c3ea2e1ce78163892365a7f4ee461716396b3"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:57 GMT
+      - Thu, 18 Sep 2025 15:01:18 GMT
       Source-Age:
-      - '7'
+      - '8'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -112,19 +112,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '7'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - f7e1557c085872e83c862447ec81e90b4f78bc45
+      - 86ea4dbe7adb71997ebd230f51509df8d980e853
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - ED3E:151D18:158C55:1A0484:68C2EEC0
+      - E19D:388807:C6F9A:F2341:68CC1D89
       X-Served-By:
-      - cache-bos4679-BOS
+      - cache-bos4635-BOS
       X-Timer:
-      - S1757605917.194353,VS0,VE1
+      - S1758207378.033402,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -134,7 +134,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/catalog-spec/json-schema/catalog.json
   response:
@@ -183,13 +183,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:57 GMT
+      - Thu, 18 Sep 2025 14:56:18 GMT
       ETag:
       - '"c76fd44b22619705d40fb03a5b1d875e2e786f9ac7a85244758d15cc7cc947a9"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:57 GMT
+      - Thu, 18 Sep 2025 15:01:18 GMT
       Source-Age:
-      - '7'
+      - '8'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -203,15 +203,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 6729aa9bf06d3775c6e7e7adc83e6eccfcddc5b6
+      - 8ba4029e08cd21e5719681e477af0be6d0b55cdd
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F35F:176261:68C2EEC0
+      - DF64:33F2BE:BEF40:EA092:68CC1D88
       X-Served-By:
-      - cache-bos4639-BOS
+      - cache-bos4687-BOS
       X-Timer:
-      - S1757605917.264636,VS0,VE1
+      - S1758207378.113314,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example51].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example51].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/item.json
   response:
@@ -96,13 +96,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:57 GMT
+      - Thu, 18 Sep 2025 14:56:18 GMT
       ETag:
       - '"eb4ef35f5071c45c7b53e7fe6ef92a682455a0de207fcbe27507488c4bfcc9ca"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:57 GMT
+      - Thu, 18 Sep 2025 15:01:18 GMT
       Source-Age:
-      - '6'
+      - '8'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -116,15 +116,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 3e1e1b154a5c8ac9d7bdeb9cf63b4a10ae9a7079
+      - 2e3f7b77d8b88cb58477fc074e670448e834b932
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F39D:1762AB:68C2EEC2
+      - DF64:33F2BE:BEF70:EA0D4:68CC1D8A
       X-Served-By:
       - cache-bos4687-BOS
       X-Timer:
-      - S1757605917.330214,VS0,VE1
+      - S1758207378.192901,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -134,7 +134,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/basics.json
   response:
@@ -164,13 +164,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:57 GMT
+      - Thu, 18 Sep 2025 14:56:18 GMT
       ETag:
       - '"2436fa8ce8356cb57ec6581098dc3ea04f5395558aaca6e4008e09eb43f0a9db"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:57 GMT
+      - Thu, 18 Sep 2025 15:01:18 GMT
       Source-Age:
-      - '6'
+      - '8'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -184,15 +184,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 0eeb7228196dc35e76f5ced98cf816834be5be91
+      - 47c221c769c36ec6d852a7f198bdccb9a25c9c74
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F42A:3A83F:147263:18E1C9:68C2EEC1
+      - F7BE:14958F:C3456:EE728:68CC1D89
       X-Served-By:
-      - cache-bos4686-BOS
+      - cache-bos4680-BOS
       X-Timer:
-      - S1757605917.389769,VS0,VE1
+      - S1758207378.263663,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -202,7 +202,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/datetimerange.json
   response:
@@ -237,13 +237,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:57 GMT
+      - Thu, 18 Sep 2025 14:56:18 GMT
       ETag:
       - '"e1248a7fa9f6feeddb9c683a0fcfcab1b8ea66ae5db2d9a36f0602d44879a0f8"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:57 GMT
+      - Thu, 18 Sep 2025 15:01:18 GMT
       Source-Age:
-      - '6'
+      - '7'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -257,15 +257,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 15d3e667beaaa3946037be99fa9f7a4316fb82b6
+      - b47e00c326d8ff42e3f8ce87c7a9b86e6c523298
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 7F51:114F63:12D433:1743BA:68C2EEBE
+      - 9DD1:E9BED:A09F7:CECE4:68CC1D8A
       X-Served-By:
-      - cache-bos4649-BOS
+      - cache-bos4657-BOS
       X-Timer:
-      - S1757605917.450365,VS0,VE1
+      - S1758207378.331106,VS0,VE6
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -275,7 +275,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/instrument.json
   response:
@@ -306,13 +306,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:57 GMT
+      - Thu, 18 Sep 2025 14:56:18 GMT
       ETag:
       - '"84c39a084fe100d85a10cdeef11399cb06ceed2c623ee37cfbdb03f85d39477c"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:57 GMT
+      - Thu, 18 Sep 2025 15:01:18 GMT
       Source-Age:
-      - '6'
+      - '7'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -326,15 +326,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - ce26469125bd241b846e8278ce3d82387eeb605a
+      - 47969897e7635b734f5691b99ef76155980aafbf
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - DE22:5461F:13BA26:1824C1:68C2EEC2
+      - 1F1B:2036C0:A67D8:D4AEF:68CC1D8A
       X-Served-By:
-      - cache-bos4677-BOS
+      - cache-bos4647-BOS
       X-Timer:
-      - S1757605918.516296,VS0,VE1
+      - S1758207378.410106,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -344,7 +344,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/licensing.json
   response:
@@ -371,13 +371,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:57 GMT
+      - Thu, 18 Sep 2025 14:56:18 GMT
       ETag:
       - '"d2cd4998f5154410f2dc79b42af5baaf118454186cee8d12066a5f42d3e821fc"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:57 GMT
+      - Thu, 18 Sep 2025 15:01:18 GMT
       Source-Age:
-      - '6'
+      - '7'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -391,15 +391,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - a390bab57be49bf5915a6233f48e95e5da163510
+      - 075892c856e352b639ff7c2e657c5ee891097c51
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 2635:21E1E:F47BCB:132FF57:68C2EEC1
+      - 5403:383255:115583:14CF3E:68CC1D8B
       X-Served-By:
-      - cache-bos4643-BOS
+      - cache-bos4649-BOS
       X-Timer:
-      - S1757605918.581909,VS0,VE1
+      - S1758207378.485506,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -409,7 +409,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/metadata.json
   response:
@@ -438,13 +438,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:57 GMT
+      - Thu, 18 Sep 2025 14:56:18 GMT
       ETag:
       - '"a99228769e5d0400f7b006fa153262053fb7a6ffdb3b8bbf51c4df37a82098f6"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:57 GMT
+      - Thu, 18 Sep 2025 15:01:18 GMT
       Source-Age:
-      - '6'
+      - '7'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -458,15 +458,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 82063d44aa96836cb2dd33cc027a9c99f2eb0aba
+      - 58335b4be2a67a086bfd4bbb58fae5abe20c92db
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F45D:12459A:14DF05:195A37:68C2EEC2
+      - F21B:2AFB8F:119511:151B54:68CC1D8B
       X-Served-By:
-      - cache-bos4628-BOS
+      - cache-bos4634-BOS
       X-Timer:
-      - S1757605918.654376,VS0,VE2
+      - S1758207379.554978,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -476,7 +476,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/provider.json
   response:
@@ -513,13 +513,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:57 GMT
+      - Thu, 18 Sep 2025 14:56:18 GMT
       ETag:
       - '"a92eac8e15643dce5b9165724ce350d2ee5edad5f8baca7140c79ce8ce0da8c6"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:57 GMT
+      - Thu, 18 Sep 2025 15:01:18 GMT
       Source-Age:
-      - '6'
+      - '7'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -533,15 +533,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 792510ddf7b3f0725d8b5e1ec7751dcf1252f07d
+      - 68d2318d619087b5dd9e2aaa7aefd3ecc7fa7ce1
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 13D9:87AC7:1335CB:17A9EB:68C2EEC3
+      - B078:1485D6:12232B:15A44A:68CC1D8B
       X-Served-By:
-      - cache-bos4671-BOS
+      - cache-bos4676-BOS
       X-Timer:
-      - S1757605918.726551,VS0,VE1
+      - S1758207379.628954,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -551,7 +551,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/extensions/label/json-schema/schema.json
   response:
@@ -620,11 +620,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:57 GMT
+      - Thu, 18 Sep 2025 14:56:18 GMT
       ETag:
       - '"46c09f290da4303780880924f1569b2cb0b979a2d363a4446e2b8b7cc494844b"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:57 GMT
+      - Thu, 18 Sep 2025 15:01:18 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -634,21 +634,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 239c10fbd8bf7583cbd4a236a45ffec25d8dc150
+      - 13ea1e08581ce2d1ce02c3150e4bafd1deab79d6
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3EC1:1E49D:14AF0C:19350F:68C2EEC9
+      - D2EB:37FA06:1251B9:15DE7E:68CC1D91
       X-Served-By:
-      - cache-bos4667-BOS
+      - cache-bos4623-BOS
       X-Timer:
-      - S1757605918.796344,VS0,VE76
+      - S1758207379.699695,VS0,VE108
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -658,7 +658,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/extensions/version/json-schema/schema.json
   response:
@@ -698,11 +698,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:57 GMT
+      - Thu, 18 Sep 2025 14:56:19 GMT
       ETag:
       - '"3ad87031bb638da9b48582cbf730c047e1075960364c8fc992381ddf5467f296"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:57 GMT
+      - Thu, 18 Sep 2025 15:01:19 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -712,21 +712,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - c40ca4264a81eaa8538165c8f0974aeb5c07ed8f
+      - 43c2b4e674df9513265bc2fc695360bfd1eae95e
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 2635:87AC7:13389E:17ADA5:68C2EEC7
+      - 50D5:35ED5B:F4953:12BF1F:68CC1D91
       X-Served-By:
-      - cache-bos4648-BOS
+      - cache-bos4638-BOS
       X-Timer:
-      - S1757605918.946667,VS0,VE46
+      - S1758207379.931129,VS0,VE74
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -736,7 +736,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/collection-spec/json-schema/collection.json
   response:
@@ -829,13 +829,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:58 GMT
+      - Thu, 18 Sep 2025 14:56:19 GMT
       ETag:
       - '"efa6309742b904ab7b06bab4c30c3ea2e1ce78163892365a7f4ee461716396b3"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:58 GMT
+      - Thu, 18 Sep 2025 15:01:19 GMT
       Source-Age:
-      - '7'
+      - '9'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -849,15 +849,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 833d9a2f470cf1ca6b58268ac444baf09a048bee
+      - 9cfbf2d42f82ea4081b9f350b75cada4a98a105a
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - ED3E:151D18:158C55:1A0484:68C2EEC0
+      - E19D:388807:C6F9A:F2341:68CC1D89
       X-Served-By:
-      - cache-bos4636-BOS
+      - cache-bos4679-BOS
       X-Timer:
-      - S1757605918.069963,VS0,VE1
+      - S1758207379.085388,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -867,7 +867,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/catalog-spec/json-schema/catalog.json
   response:
@@ -916,13 +916,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:58 GMT
+      - Thu, 18 Sep 2025 14:56:19 GMT
       ETag:
       - '"c76fd44b22619705d40fb03a5b1d875e2e786f9ac7a85244758d15cc7cc947a9"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:58 GMT
+      - Thu, 18 Sep 2025 15:01:19 GMT
       Source-Age:
-      - '8'
+      - '9'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -936,15 +936,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 76d104d7ad02cac013164cff9e3f1ef8348f38a2
+      - 31ca2270d9198934be8daf12f5e8db96a9f589bb
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F35F:176261:68C2EEC0
+      - DF64:33F2BE:BEF40:EA092:68CC1D88
       X-Served-By:
-      - cache-bos4676-BOS
+      - cache-bos4661-BOS
       X-Timer:
-      - S1757605918.141719,VS0,VE1
+      - S1758207379.155088,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example52].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example52].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/item.json
   response:
@@ -96,13 +96,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:58 GMT
+      - Thu, 18 Sep 2025 14:56:19 GMT
       ETag:
       - '"eb4ef35f5071c45c7b53e7fe6ef92a682455a0de207fcbe27507488c4bfcc9ca"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:58 GMT
+      - Thu, 18 Sep 2025 15:01:19 GMT
       Source-Age:
-      - '7'
+      - '9'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -116,15 +116,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 526591dc6a5dd140a5e23994ce5aa55bfe648efa
+      - e7d564f7775fb061e520b23f718d68f99eb37280
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F39D:1762AB:68C2EEC2
+      - DF64:33F2BE:BEF70:EA0D4:68CC1D8A
       X-Served-By:
-      - cache-bos4643-BOS
+      - cache-bos4647-BOS
       X-Timer:
-      - S1757605918.214380,VS0,VE1
+      - S1758207379.241102,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -134,7 +134,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/basics.json
   response:
@@ -164,13 +164,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:58 GMT
+      - Thu, 18 Sep 2025 14:56:19 GMT
       ETag:
       - '"2436fa8ce8356cb57ec6581098dc3ea04f5395558aaca6e4008e09eb43f0a9db"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:58 GMT
+      - Thu, 18 Sep 2025 15:01:19 GMT
       Source-Age:
-      - '7'
+      - '9'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -184,15 +184,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 68584de2b51c9d4d361d894eb33221aeaaabca0a
+      - 8cd0518d55461748fabd1e30607349aa0ff625ec
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F42A:3A83F:147263:18E1C9:68C2EEC1
+      - F7BE:14958F:C3456:EE728:68CC1D89
       X-Served-By:
-      - cache-bos4658-BOS
+      - cache-bos4666-BOS
       X-Timer:
-      - S1757605918.292557,VS0,VE1
+      - S1758207379.318914,VS0,VE2
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -202,7 +202,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/datetimerange.json
   response:
@@ -237,13 +237,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:58 GMT
+      - Thu, 18 Sep 2025 14:56:19 GMT
       ETag:
       - '"e1248a7fa9f6feeddb9c683a0fcfcab1b8ea66ae5db2d9a36f0602d44879a0f8"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:58 GMT
+      - Thu, 18 Sep 2025 15:01:19 GMT
       Source-Age:
-      - '7'
+      - '9'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -257,15 +257,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 9ec753e0c0e224595f84598fa828c352cdfe95b2
+      - 7c26699e4119f1d11595590f1f4e35f3cccf8d54
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 7F51:114F63:12D433:1743BA:68C2EEBE
+      - 9DD1:E9BED:A09F7:CECE4:68CC1D8A
       X-Served-By:
-      - cache-bos4675-BOS
+      - cache-bos4623-BOS
       X-Timer:
-      - S1757605918.361543,VS0,VE1
+      - S1758207379.397506,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -275,7 +275,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/instrument.json
   response:
@@ -306,13 +306,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:58 GMT
+      - Thu, 18 Sep 2025 14:56:19 GMT
       ETag:
       - '"84c39a084fe100d85a10cdeef11399cb06ceed2c623ee37cfbdb03f85d39477c"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:58 GMT
+      - Thu, 18 Sep 2025 15:01:19 GMT
       Source-Age:
-      - '7'
+      - '8'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -326,15 +326,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - edf332b7ff59aa65457aecab91cf9fcc82f0c9f5
+      - 1797428759d25e2ab58308274d355a8d2eda1b7c
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - DE22:5461F:13BA26:1824C1:68C2EEC2
+      - 1F1B:2036C0:A67D8:D4AEF:68CC1D8A
       X-Served-By:
-      - cache-bos4625-BOS
+      - cache-bos4626-BOS
       X-Timer:
-      - S1757605918.436420,VS0,VE1
+      - S1758207379.471410,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -344,7 +344,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/licensing.json
   response:
@@ -371,13 +371,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:58 GMT
+      - Thu, 18 Sep 2025 14:56:19 GMT
       ETag:
       - '"d2cd4998f5154410f2dc79b42af5baaf118454186cee8d12066a5f42d3e821fc"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:58 GMT
+      - Thu, 18 Sep 2025 15:01:19 GMT
       Source-Age:
-      - '7'
+      - '8'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -391,15 +391,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 44c0f55672484f7f351d9e980f2cd1922db6cef1
+      - 74a059f87a4d02360bb452b49cf5c5212c7642b7
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 2635:21E1E:F47BCB:132FF57:68C2EEC1
+      - 5403:383255:115583:14CF3E:68CC1D8B
       X-Served-By:
-      - cache-bos4632-BOS
+      - cache-bos4656-BOS
       X-Timer:
-      - S1757605919.513054,VS0,VE1
+      - S1758207380.544809,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -409,7 +409,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/metadata.json
   response:
@@ -438,13 +438,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:58 GMT
+      - Thu, 18 Sep 2025 14:56:19 GMT
       ETag:
       - '"a99228769e5d0400f7b006fa153262053fb7a6ffdb3b8bbf51c4df37a82098f6"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:58 GMT
+      - Thu, 18 Sep 2025 15:01:19 GMT
       Source-Age:
-      - '7'
+      - '8'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -458,15 +458,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - bf45ce337d0c6ecd21e1be0d833453fcdf780629
+      - 107696ba494da9249bdad806952a209557613f8b
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F45D:12459A:14DF05:195A37:68C2EEC2
+      - F21B:2AFB8F:119511:151B54:68CC1D8B
       X-Served-By:
-      - cache-bos4682-BOS
+      - cache-bos4685-BOS
       X-Timer:
-      - S1757605919.588048,VS0,VE1
+      - S1758207380.620796,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -476,7 +476,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/provider.json
   response:
@@ -513,13 +513,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:58 GMT
+      - Thu, 18 Sep 2025 14:56:19 GMT
       ETag:
       - '"a92eac8e15643dce5b9165724ce350d2ee5edad5f8baca7140c79ce8ce0da8c6"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:58 GMT
+      - Thu, 18 Sep 2025 15:01:19 GMT
       Source-Age:
-      - '7'
+      - '8'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -533,15 +533,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - e35bcab1b69258482d0575355e31edfa9b1f882d
+      - 84e7cac6a5f1e9b0777c7f4b3e59325a232f5e06
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 13D9:87AC7:1335CB:17A9EB:68C2EEC3
+      - B078:1485D6:12232B:15A44A:68CC1D8B
       X-Served-By:
-      - cache-bos4689-BOS
+      - cache-bos4661-BOS
       X-Timer:
-      - S1757605919.655733,VS0,VE1
+      - S1758207380.690996,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example53].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example53].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/item.json
   response:
@@ -96,13 +96,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:58 GMT
+      - Thu, 18 Sep 2025 14:56:19 GMT
       ETag:
       - '"eb4ef35f5071c45c7b53e7fe6ef92a682455a0de207fcbe27507488c4bfcc9ca"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:58 GMT
+      - Thu, 18 Sep 2025 15:01:19 GMT
       Source-Age:
-      - '8'
+      - '9'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -116,15 +116,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 3d6ac601b1472aa16a059ad9ae0e13abd9dfc723
+      - 807715f8d51c76222080a0e5a43ee3672afe03fa
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F39D:1762AB:68C2EEC2
+      - DF64:33F2BE:BEF70:EA0D4:68CC1D8A
       X-Served-By:
-      - cache-bos4651-BOS
+      - cache-bos4677-BOS
       X-Timer:
-      - S1757605919.738705,VS0,VE1
+      - S1758207380.768244,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -134,7 +134,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/basics.json
   response:
@@ -164,13 +164,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:58 GMT
+      - Thu, 18 Sep 2025 14:56:19 GMT
       ETag:
       - '"2436fa8ce8356cb57ec6581098dc3ea04f5395558aaca6e4008e09eb43f0a9db"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:58 GMT
+      - Thu, 18 Sep 2025 15:01:19 GMT
       Source-Age:
-      - '8'
+      - '9'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -184,15 +184,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - a76752373d796ee561013d9de8b8d47056996bb8
+      - fa49cc51ee047615740848d1542dde844c6ed2c8
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F42A:3A83F:147263:18E1C9:68C2EEC1
+      - F7BE:14958F:C3456:EE728:68CC1D89
       X-Served-By:
-      - cache-bos4677-BOS
+      - cache-bos4655-BOS
       X-Timer:
-      - S1757605919.824213,VS0,VE1
+      - S1758207380.841412,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -202,7 +202,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/datetimerange.json
   response:
@@ -237,13 +237,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:58 GMT
+      - Thu, 18 Sep 2025 14:56:19 GMT
       ETag:
       - '"e1248a7fa9f6feeddb9c683a0fcfcab1b8ea66ae5db2d9a36f0602d44879a0f8"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:58 GMT
+      - Thu, 18 Sep 2025 15:01:19 GMT
       Source-Age:
-      - '8'
+      - '9'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -257,15 +257,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 85517f30194479bb5f9e93754d2fa65e1efbeb06
+      - c510c2c0426a9c73f7acfc61ef2b18787fda61dc
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 7F51:114F63:12D433:1743BA:68C2EEBE
+      - 9DD1:E9BED:A09F7:CECE4:68CC1D8A
       X-Served-By:
-      - cache-bos4664-BOS
+      - cache-bos4627-BOS
       X-Timer:
-      - S1757605919.894359,VS0,VE1
+      - S1758207380.914593,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -275,7 +275,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/instrument.json
   response:
@@ -306,13 +306,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:58 GMT
+      - Thu, 18 Sep 2025 14:56:19 GMT
       ETag:
       - '"84c39a084fe100d85a10cdeef11399cb06ceed2c623ee37cfbdb03f85d39477c"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:58 GMT
+      - Thu, 18 Sep 2025 15:01:19 GMT
       Source-Age:
-      - '8'
+      - '9'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -326,15 +326,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 8ed663722ec3acf9f8487a94093ff4b150d656d0
+      - e83707a91e89c038f7b068514800d0d265ebd329
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - DE22:5461F:13BA26:1824C1:68C2EEC2
+      - 1F1B:2036C0:A67D8:D4AEF:68CC1D8A
       X-Served-By:
-      - cache-bos4637-BOS
+      - cache-bos4669-BOS
       X-Timer:
-      - S1757605919.968570,VS0,VE1
+      - S1758207380.983161,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -344,7 +344,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/licensing.json
   response:
@@ -371,13 +371,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:59 GMT
+      - Thu, 18 Sep 2025 14:56:20 GMT
       ETag:
       - '"d2cd4998f5154410f2dc79b42af5baaf118454186cee8d12066a5f42d3e821fc"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:59 GMT
+      - Thu, 18 Sep 2025 15:01:20 GMT
       Source-Age:
-      - '8'
+      - '9'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -387,19 +387,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 1dd19cc077b80bd4e72421a1d80f2c5188cfb2e6
+      - 7924b3f50f0cef5ad7227787d2b44be3b8643487
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 2635:21E1E:F47BCB:132FF57:68C2EEC1
+      - 5403:383255:115583:14CF3E:68CC1D8B
       X-Served-By:
-      - cache-bos4632-BOS
+      - cache-bos4651-BOS
       X-Timer:
-      - S1757605919.029992,VS0,VE0
+      - S1758207380.049209,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -409,7 +409,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/metadata.json
   response:
@@ -438,11 +438,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:59 GMT
+      - Thu, 18 Sep 2025 14:56:20 GMT
       ETag:
       - '"a99228769e5d0400f7b006fa153262053fb7a6ffdb3b8bbf51c4df37a82098f6"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:59 GMT
+      - Thu, 18 Sep 2025 15:01:20 GMT
       Source-Age:
       - '8'
       Strict-Transport-Security:
@@ -458,15 +458,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - a8ef719778f51fcf33420bf3ecfde5a85a7055ec
+      - f7440693f125c46d28e46397303daa11fbb6160c
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F45D:12459A:14DF05:195A37:68C2EEC2
+      - F21B:2AFB8F:119511:151B54:68CC1D8B
       X-Served-By:
-      - cache-bos4658-BOS
+      - cache-bos4680-BOS
       X-Timer:
-      - S1757605919.088532,VS0,VE1
+      - S1758207380.123584,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -476,7 +476,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/provider.json
   response:
@@ -513,13 +513,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:59 GMT
+      - Thu, 18 Sep 2025 14:56:20 GMT
       ETag:
       - '"a92eac8e15643dce5b9165724ce350d2ee5edad5f8baca7140c79ce8ce0da8c6"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:59 GMT
+      - Thu, 18 Sep 2025 15:01:20 GMT
       Source-Age:
-      - '7'
+      - '8'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -529,19 +529,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - cd9bb80b25ceb730ea76fa80d7b93d36e3fcd14d
+      - 54b92ee47e1959973edf74e18ac980f753881a52
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 13D9:87AC7:1335CB:17A9EB:68C2EEC3
+      - B078:1485D6:12232B:15A44A:68CC1D8B
       X-Served-By:
-      - cache-bos4689-BOS
+      - cache-bos4626-BOS
       X-Timer:
-      - S1757605919.147808,VS0,VE0
+      - S1758207380.195323,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example54].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example54].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/item.json
   response:
@@ -96,13 +96,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:59 GMT
+      - Thu, 18 Sep 2025 14:56:20 GMT
       ETag:
       - '"eb4ef35f5071c45c7b53e7fe6ef92a682455a0de207fcbe27507488c4bfcc9ca"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:59 GMT
+      - Thu, 18 Sep 2025 15:01:20 GMT
       Source-Age:
-      - '8'
+      - '10'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -116,15 +116,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - c371993458dedecbac10c98a6779379c5c6cc465
+      - 408e78f93c149f7a7ccd28ed82cb2313d66544e5
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F39D:1762AB:68C2EEC2
+      - DF64:33F2BE:BEF70:EA0D4:68CC1D8A
       X-Served-By:
-      - cache-bos4654-BOS
+      - cache-bos4693-BOS
       X-Timer:
-      - S1757605919.215565,VS0,VE1
+      - S1758207380.273783,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -134,7 +134,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/basics.json
   response:
@@ -164,13 +164,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:59 GMT
+      - Thu, 18 Sep 2025 14:56:20 GMT
       ETag:
       - '"2436fa8ce8356cb57ec6581098dc3ea04f5395558aaca6e4008e09eb43f0a9db"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:59 GMT
+      - Thu, 18 Sep 2025 15:01:20 GMT
       Source-Age:
-      - '8'
+      - '10'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -180,19 +180,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 55814f3f60534733ecbe26848045f5d80ba40b59
+      - 926e3213cb711b483f699779407ac17f40d6960d
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F42A:3A83F:147263:18E1C9:68C2EEC1
+      - F7BE:14958F:C3456:EE728:68CC1D89
       X-Served-By:
-      - cache-bos4621-BOS
+      - cache-bos4666-BOS
       X-Timer:
-      - S1757605919.280096,VS0,VE1
+      - S1758207380.351349,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -202,7 +202,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/datetimerange.json
   response:
@@ -237,13 +237,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:59 GMT
+      - Thu, 18 Sep 2025 14:56:20 GMT
       ETag:
       - '"e1248a7fa9f6feeddb9c683a0fcfcab1b8ea66ae5db2d9a36f0602d44879a0f8"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:59 GMT
+      - Thu, 18 Sep 2025 15:01:20 GMT
       Source-Age:
-      - '8'
+      - '10'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -253,19 +253,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 42e4581f940b109e52f25f8928acf6dbdc190226
+      - 6730117a46c21c381708c02bb3657af1dd87e332
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 7F51:114F63:12D433:1743BA:68C2EEBE
+      - 9DD1:E9BED:A09F7:CECE4:68CC1D8A
       X-Served-By:
-      - cache-bos4664-BOS
+      - cache-bos4682-BOS
       X-Timer:
-      - S1757605919.342095,VS0,VE0
+      - S1758207380.423471,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -275,7 +275,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/instrument.json
   response:
@@ -306,13 +306,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:59 GMT
+      - Thu, 18 Sep 2025 14:56:20 GMT
       ETag:
       - '"84c39a084fe100d85a10cdeef11399cb06ceed2c623ee37cfbdb03f85d39477c"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:59 GMT
+      - Thu, 18 Sep 2025 15:01:20 GMT
       Source-Age:
-      - '8'
+      - '9'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -322,19 +322,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 5dee64764e5e446c4490a932e76ba33f426ed893
+      - a8b510073f8d77fb4da102eb20f11e19ad0ecbb6
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - DE22:5461F:13BA26:1824C1:68C2EEC2
+      - 1F1B:2036C0:A67D8:D4AEF:68CC1D8A
       X-Served-By:
-      - cache-bos4679-BOS
+      - cache-bos4674-BOS
       X-Timer:
-      - S1757605919.405447,VS0,VE0
+      - S1758207380.487421,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -344,7 +344,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/licensing.json
   response:
@@ -371,13 +371,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:59 GMT
+      - Thu, 18 Sep 2025 14:56:20 GMT
       ETag:
       - '"d2cd4998f5154410f2dc79b42af5baaf118454186cee8d12066a5f42d3e821fc"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:59 GMT
+      - Thu, 18 Sep 2025 15:01:20 GMT
       Source-Age:
-      - '8'
+      - '10'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -387,19 +387,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 18befb32b71f04a69019bb8f1852a5d504419129
+      - 1585ac6a1e62537c462118789e089afc86ed631f
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 2635:21E1E:F47BCB:132FF57:68C2EEC1
+      - 5403:383255:115583:14CF3E:68CC1D8B
       X-Served-By:
-      - cache-bos4671-BOS
+      - cache-bos4663-BOS
       X-Timer:
-      - S1757605919.469922,VS0,VE2
+      - S1758207381.547718,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -409,7 +409,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/metadata.json
   response:
@@ -438,13 +438,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:59 GMT
+      - Thu, 18 Sep 2025 14:56:20 GMT
       ETag:
       - '"a99228769e5d0400f7b006fa153262053fb7a6ffdb3b8bbf51c4df37a82098f6"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:59 GMT
+      - Thu, 18 Sep 2025 15:01:20 GMT
       Source-Age:
-      - '8'
+      - '9'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -458,15 +458,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - a59fe60e0b0f5ca6bb8afa46d66204c46f2f009a
+      - 8636e06b3dd3060cf9b948420eda7a1ce070ce15
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F45D:12459A:14DF05:195A37:68C2EEC2
+      - F21B:2AFB8F:119511:151B54:68CC1D8B
       X-Served-By:
-      - cache-bos4641-BOS
+      - cache-bos4649-BOS
       X-Timer:
-      - S1757605920.532403,VS0,VE1
+      - S1758207381.617136,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -476,7 +476,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/provider.json
   response:
@@ -513,13 +513,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:59 GMT
+      - Thu, 18 Sep 2025 14:56:20 GMT
       ETag:
       - '"a92eac8e15643dce5b9165724ce350d2ee5edad5f8baca7140c79ce8ce0da8c6"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:59 GMT
+      - Thu, 18 Sep 2025 15:01:20 GMT
       Source-Age:
-      - '8'
+      - '9'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -533,15 +533,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 4a6ddf7f3e86129aef79f31784a4848bc2afa037
+      - 2996ba30feca0615e77243671e37a1806ae9024c
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 13D9:87AC7:1335CB:17A9EB:68C2EEC3
+      - B078:1485D6:12232B:15A44A:68CC1D8B
       X-Served-By:
-      - cache-bos4623-BOS
+      - cache-bos4691-BOS
       X-Timer:
-      - S1757605920.596167,VS0,VE1
+      - S1758207381.687176,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example55].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example55].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/item.json
   response:
@@ -96,13 +96,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:59 GMT
+      - Thu, 18 Sep 2025 14:56:20 GMT
       ETag:
       - '"eb4ef35f5071c45c7b53e7fe6ef92a682455a0de207fcbe27507488c4bfcc9ca"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:59 GMT
+      - Thu, 18 Sep 2025 15:01:20 GMT
       Source-Age:
-      - '9'
+      - '10'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -116,15 +116,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - d158ed4f609f8c387a8ada0352adaed21c9e6338
+      - 9faccbe8f497b659780d7ff0cf7034285fcb077c
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F39D:1762AB:68C2EEC2
+      - DF64:33F2BE:BEF70:EA0D4:68CC1D8A
       X-Served-By:
-      - cache-bos4684-BOS
+      - cache-bos4677-BOS
       X-Timer:
-      - S1757605920.661858,VS0,VE0
+      - S1758207381.767465,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -134,7 +134,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/basics.json
   response:
@@ -164,13 +164,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:59 GMT
+      - Thu, 18 Sep 2025 14:56:20 GMT
       ETag:
       - '"2436fa8ce8356cb57ec6581098dc3ea04f5395558aaca6e4008e09eb43f0a9db"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:59 GMT
+      - Thu, 18 Sep 2025 15:01:20 GMT
       Source-Age:
-      - '9'
+      - '10'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -184,15 +184,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 88584db017b5b996c9e879f0b8e6f8f01a70fab1
+      - 7c0284126ca8b4996cb5a010df119bed07045e24
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F42A:3A83F:147263:18E1C9:68C2EEC1
+      - F7BE:14958F:C3456:EE728:68CC1D89
       X-Served-By:
       - cache-bos4687-BOS
       X-Timer:
-      - S1757605920.729982,VS0,VE1
+      - S1758207381.839311,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -202,7 +202,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/datetimerange.json
   response:
@@ -237,13 +237,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:59 GMT
+      - Thu, 18 Sep 2025 14:56:20 GMT
       ETag:
       - '"e1248a7fa9f6feeddb9c683a0fcfcab1b8ea66ae5db2d9a36f0602d44879a0f8"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:59 GMT
+      - Thu, 18 Sep 2025 15:01:20 GMT
       Source-Age:
-      - '9'
+      - '10'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -257,15 +257,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 8c0d33ca50fa50b8e8f1125dc53c6f8dd3905f04
+      - 65bc693320833fb7770f213f7b9f33ece2bbcd9e
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 7F51:114F63:12D433:1743BA:68C2EEBE
+      - 9DD1:E9BED:A09F7:CECE4:68CC1D8A
       X-Served-By:
-      - cache-bos4637-BOS
+      - cache-bos4628-BOS
       X-Timer:
-      - S1757605920.803905,VS0,VE1
+      - S1758207381.912920,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -275,7 +275,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/instrument.json
   response:
@@ -306,13 +306,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:59 GMT
+      - Thu, 18 Sep 2025 14:56:20 GMT
       ETag:
       - '"84c39a084fe100d85a10cdeef11399cb06ceed2c623ee37cfbdb03f85d39477c"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:59 GMT
+      - Thu, 18 Sep 2025 15:01:20 GMT
       Source-Age:
-      - '9'
+      - '10'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -326,15 +326,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 415f530c13391ea51605e7958ab5ba246b4473ba
+      - a5c929df557f2e55244d0b09dff20259da2fcff6
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - DE22:5461F:13BA26:1824C1:68C2EEC2
+      - 1F1B:2036C0:A67D8:D4AEF:68CC1D8A
       X-Served-By:
-      - cache-bos4641-BOS
+      - cache-bos4680-BOS
       X-Timer:
-      - S1757605920.872204,VS0,VE1
+      - S1758207381.987491,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -344,7 +344,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/licensing.json
   response:
@@ -371,11 +371,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:59 GMT
+      - Thu, 18 Sep 2025 14:56:21 GMT
       ETag:
       - '"d2cd4998f5154410f2dc79b42af5baaf118454186cee8d12066a5f42d3e821fc"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:59 GMT
+      - Thu, 18 Sep 2025 15:01:21 GMT
       Source-Age:
       - '9'
       Strict-Transport-Security:
@@ -387,19 +387,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 2159a65c0849971f41b5a71ae4341d7310e07f05
+      - 63321e684847fee188e5f6cf5f8f3fd2a0894705
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 2635:21E1E:F47BCB:132FF57:68C2EEC1
+      - 5403:383255:115583:14CF3E:68CC1D8B
       X-Served-By:
-      - cache-bos4624-BOS
+      - cache-bos4664-BOS
       X-Timer:
-      - S1757605920.936452,VS0,VE1
+      - S1758207381.053145,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -409,7 +409,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/metadata.json
   response:
@@ -438,11 +438,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:59 GMT
+      - Thu, 18 Sep 2025 14:56:21 GMT
       ETag:
       - '"a99228769e5d0400f7b006fa153262053fb7a6ffdb3b8bbf51c4df37a82098f6"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:59 GMT
+      - Thu, 18 Sep 2025 15:01:21 GMT
       Source-Age:
       - '9'
       Strict-Transport-Security:
@@ -458,15 +458,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - fb6ea9e569a80c7f2bccfeca26879536884f4ee5
+      - da1077d44fbbcd67826ff76c9a81f13568bda802
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F45D:12459A:14DF05:195A37:68C2EEC2
+      - F21B:2AFB8F:119511:151B54:68CC1D8B
       X-Served-By:
-      - cache-bos4651-BOS
+      - cache-bos4652-BOS
       X-Timer:
-      - S1757605920.998920,VS0,VE1
+      - S1758207381.124931,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -476,7 +476,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/provider.json
   response:
@@ -513,11 +513,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:00 GMT
+      - Thu, 18 Sep 2025 14:56:21 GMT
       ETag:
       - '"a92eac8e15643dce5b9165724ce350d2ee5edad5f8baca7140c79ce8ce0da8c6"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:00 GMT
+      - Thu, 18 Sep 2025 15:01:21 GMT
       Source-Age:
       - '9'
       Strict-Transport-Security:
@@ -529,19 +529,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - b0fc943527531993a1a4240080f398f5a3d1b19f
+      - b953a2bb5c1b892aeda850c578fbe379aaededb1
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 13D9:87AC7:1335CB:17A9EB:68C2EEC3
+      - B078:1485D6:12232B:15A44A:68CC1D8B
       X-Served-By:
-      - cache-bos4656-BOS
+      - cache-bos4636-BOS
       X-Timer:
-      - S1757605920.058054,VS0,VE49
+      - S1758207381.203110,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -551,7 +551,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/extensions/sat/json-schema/schema.json
   response:
@@ -587,11 +587,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:00 GMT
+      - Thu, 18 Sep 2025 14:56:21 GMT
       ETag:
       - '"90408dbc0c6ce835205fcdbeeab881774f06517052d7c3dbcf6ba7c3ccced7eb"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:00 GMT
+      - Thu, 18 Sep 2025 15:01:21 GMT
       Source-Age:
       - '7'
       Strict-Transport-Security:
@@ -607,15 +607,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 174d3670a12320784f94f0e9463a569af9832061
+      - e1c5487a7aa87ec39ed32eaf2559301a31ae86bc
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3186:12459A:14E01C:195B91:68C2EEC4
+      - 55BA:BACE2:EB046:122BB8:68CC1D8E
       X-Served-By:
-      - cache-bos4656-BOS
+      - cache-bos4668-BOS
       X-Timer:
-      - S1757605920.168511,VS0,VE2
+      - S1758207381.266014,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -625,7 +625,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/extensions/sar/json-schema/schema.json
   response:
@@ -700,11 +700,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:00 GMT
+      - Thu, 18 Sep 2025 14:56:21 GMT
       ETag:
       - '"8546ced8239a833de59c3c153dab1ad77f34c598818da6695196e7449d680592"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:00 GMT
+      - Thu, 18 Sep 2025 15:01:21 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -714,21 +714,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 995cf7bef5e0f6858f1f57382eed6593be6212f6
+      - 93a9f5680f72cf4b11df1d8fb62a97e28335dcf6
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F884:343E9B:1587B0:1A0615:68C2EECB
+      - 3181:FC5F:10ACA9:1430FD:68CC1D95
       X-Served-By:
-      - cache-bos4638-BOS
+      - cache-bos4670-BOS
       X-Timer:
-      - S1757605920.232524,VS0,VE61
+      - S1758207381.333100,VS0,VE55
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example56].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example56].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/item.json
   response:
@@ -96,13 +96,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:00 GMT
+      - Thu, 18 Sep 2025 14:56:21 GMT
       ETag:
       - '"eb4ef35f5071c45c7b53e7fe6ef92a682455a0de207fcbe27507488c4bfcc9ca"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:00 GMT
+      - Thu, 18 Sep 2025 15:01:21 GMT
       Source-Age:
-      - '9'
+      - '11'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -116,15 +116,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 5c16c2d6fbe20847cf111b832e79d88eb959d63a
+      - 3a83a6e2a90ab74da0aaf1e53c03f90acba389ca
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F39D:1762AB:68C2EEC2
+      - DF64:33F2BE:BEF70:EA0D4:68CC1D8A
       X-Served-By:
-      - cache-bos4632-BOS
+      - cache-bos4685-BOS
       X-Timer:
-      - S1757605920.366298,VS0,VE1
+      - S1758207381.460960,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -134,7 +134,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/basics.json
   response:
@@ -164,13 +164,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:00 GMT
+      - Thu, 18 Sep 2025 14:56:21 GMT
       ETag:
       - '"2436fa8ce8356cb57ec6581098dc3ea04f5395558aaca6e4008e09eb43f0a9db"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:00 GMT
+      - Thu, 18 Sep 2025 15:01:21 GMT
       Source-Age:
-      - '9'
+      - '11'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -180,19 +180,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 0f6de61221882cf94f3c463432c15ed9e49dcf31
+      - 22c6f0ca3974331e3c0cdc4bb85a35a798094515
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F42A:3A83F:147263:18E1C9:68C2EEC1
+      - F7BE:14958F:C3456:EE728:68CC1D89
       X-Served-By:
-      - cache-bos4690-BOS
+      - cache-bos4653-BOS
       X-Timer:
-      - S1757605920.429863,VS0,VE0
+      - S1758207382.524344,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -202,7 +202,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/datetimerange.json
   response:
@@ -237,13 +237,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:00 GMT
+      - Thu, 18 Sep 2025 14:56:21 GMT
       ETag:
       - '"e1248a7fa9f6feeddb9c683a0fcfcab1b8ea66ae5db2d9a36f0602d44879a0f8"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:00 GMT
+      - Thu, 18 Sep 2025 15:01:21 GMT
       Source-Age:
-      - '10'
+      - '11'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -253,19 +253,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - b73d216eb02501aac324f2dcd55324fb33a88480
+      - 9a3d2b8237596f399e2c7502de2c5b85ed4da756
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 7F51:114F63:12D433:1743BA:68C2EEBE
+      - 9DD1:E9BED:A09F7:CECE4:68CC1D8A
       X-Served-By:
-      - cache-bos4686-BOS
+      - cache-bos4683-BOS
       X-Timer:
-      - S1757605920.487467,VS0,VE0
+      - S1758207382.587123,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -275,7 +275,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/instrument.json
   response:
@@ -306,13 +306,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:00 GMT
+      - Thu, 18 Sep 2025 14:56:21 GMT
       ETag:
       - '"84c39a084fe100d85a10cdeef11399cb06ceed2c623ee37cfbdb03f85d39477c"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:00 GMT
+      - Thu, 18 Sep 2025 15:01:21 GMT
       Source-Age:
-      - '9'
+      - '11'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -326,15 +326,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - e894e0e77296f21b4a39059619a332bb490e5887
+      - 8fbafc9419ec42d1ed2b98bb73ddf3ec3bdfd521
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - DE22:5461F:13BA26:1824C1:68C2EEC2
+      - 1F1B:2036C0:A67D8:D4AEF:68CC1D8A
       X-Served-By:
-      - cache-bos4658-BOS
+      - cache-bos4689-BOS
       X-Timer:
-      - S1757605921.552389,VS0,VE1
+      - S1758207382.648911,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -344,7 +344,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/licensing.json
   response:
@@ -371,13 +371,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:00 GMT
+      - Thu, 18 Sep 2025 14:56:21 GMT
       ETag:
       - '"d2cd4998f5154410f2dc79b42af5baaf118454186cee8d12066a5f42d3e821fc"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:00 GMT
+      - Thu, 18 Sep 2025 15:01:21 GMT
       Source-Age:
-      - '9'
+      - '10'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -391,15 +391,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 46c6f9207d193645f481b539a74a1d0495c8b2ff
+      - 0367056933850d60c68937269ffcb6b6e8cef993
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 2635:21E1E:F47BCB:132FF57:68C2EEC1
+      - 5403:383255:115583:14CF3E:68CC1D8B
       X-Served-By:
-      - cache-bos4627-BOS
+      - cache-bos4661-BOS
       X-Timer:
-      - S1757605921.620746,VS0,VE1
+      - S1758207382.708894,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -409,7 +409,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/metadata.json
   response:
@@ -438,13 +438,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:00 GMT
+      - Thu, 18 Sep 2025 14:56:21 GMT
       ETag:
       - '"a99228769e5d0400f7b006fa153262053fb7a6ffdb3b8bbf51c4df37a82098f6"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:00 GMT
+      - Thu, 18 Sep 2025 15:01:21 GMT
       Source-Age:
-      - '9'
+      - '10'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -454,19 +454,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - f014429b7085394d763e385a5895085008c968ee
+      - 3d6cd17bea16df103f14097a8bd5724420e7b17f
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F45D:12459A:14DF05:195A37:68C2EEC2
+      - F21B:2AFB8F:119511:151B54:68CC1D8B
       X-Served-By:
-      - cache-bos4634-BOS
+      - cache-bos4661-BOS
       X-Timer:
-      - S1757605921.690209,VS0,VE0
+      - S1758207382.846403,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -476,7 +476,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/provider.json
   response:
@@ -513,13 +513,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:00 GMT
+      - Thu, 18 Sep 2025 14:56:21 GMT
       ETag:
       - '"a92eac8e15643dce5b9165724ce350d2ee5edad5f8baca7140c79ce8ce0da8c6"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:00 GMT
+      - Thu, 18 Sep 2025 15:01:21 GMT
       Source-Age:
-      - '9'
+      - '10'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -533,15 +533,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 0ab53d562bc7f02d766a07312da15a6eba766650
+      - 599e59e1d14283c047e844e9100f193785dc8f51
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 13D9:87AC7:1335CB:17A9EB:68C2EEC3
+      - B078:1485D6:12232B:15A44A:68CC1D8B
       X-Served-By:
-      - cache-bos4652-BOS
+      - cache-bos4643-BOS
       X-Timer:
-      - S1757605921.764269,VS0,VE1
+      - S1758207382.907445,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -551,7 +551,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/extensions/checksum/json-schema/schema.json
   response:
@@ -589,13 +589,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:00 GMT
+      - Thu, 18 Sep 2025 14:56:21 GMT
       ETag:
       - '"9bde8b6875408a186b283e6e3dd3edb01bc2b938e55a0491b0b7f4e06f0faccb"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:00 GMT
+      - Thu, 18 Sep 2025 15:01:21 GMT
       Source-Age:
-      - '8'
+      - '9'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -609,15 +609,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 1285dc67c37c519698f1aba635beccbdb0ff6197
+      - 7fc6df06c33cdb950dc8bdbfce84ce0603a0849e
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 2EEA:2ACBC:14A59B:191DF0:68C2EEC4
+      - 8D48:3FA7F8:124D47:15D3ED:68CC1D8C
       X-Served-By:
-      - cache-bos4665-BOS
+      - cache-bos4669-BOS
       X-Timer:
-      - S1757605921.825923,VS0,VE1
+      - S1758207382.979272,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -627,7 +627,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/extensions/sar/json-schema/schema.json
   response:
@@ -702,11 +702,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:00 GMT
+      - Thu, 18 Sep 2025 14:56:22 GMT
       ETag:
       - '"8546ced8239a833de59c3c153dab1ad77f34c598818da6695196e7449d680592"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:00 GMT
+      - Thu, 18 Sep 2025 15:01:22 GMT
       Source-Age:
       - '1'
       Strict-Transport-Security:
@@ -722,15 +722,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - d412b22bd973707c4e9e176fd658db1b6d3610bb
+      - c5f582e189d4b04f7f611ed59e9d64bd0429bac4
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F884:343E9B:1587B0:1A0615:68C2EECB
+      - 3181:FC5F:10ACA9:1430FD:68CC1D95
       X-Served-By:
-      - cache-bos4692-BOS
+      - cache-bos4630-BOS
       X-Timer:
-      - S1757605921.897936,VS0,VE1
+      - S1758207382.047151,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -740,7 +740,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/extensions/sat/json-schema/schema.json
   response:
@@ -776,13 +776,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:00 GMT
+      - Thu, 18 Sep 2025 14:56:22 GMT
       ETag:
       - '"90408dbc0c6ce835205fcdbeeab881774f06517052d7c3dbcf6ba7c3ccced7eb"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:00 GMT
+      - Thu, 18 Sep 2025 15:01:22 GMT
       Source-Age:
-      - '7'
+      - '8'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -796,15 +796,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 3e0899b9f39e6598a6ab84fc0d2ff2c60a78fbb2
+      - 9d4e9c087fa11b8562c3ed3ace9bcb428e5f243d
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3186:12459A:14E01C:195B91:68C2EEC4
+      - 55BA:BACE2:EB046:122BB8:68CC1D8E
       X-Served-By:
-      - cache-bos4640-BOS
+      - cache-bos4641-BOS
       X-Timer:
-      - S1757605921.978958,VS0,VE1
+      - S1758207382.123965,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example57].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example57].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/item.json
   response:
@@ -96,13 +96,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:01 GMT
+      - Thu, 18 Sep 2025 14:56:22 GMT
       ETag:
       - '"eb4ef35f5071c45c7b53e7fe6ef92a682455a0de207fcbe27507488c4bfcc9ca"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:01 GMT
+      - Thu, 18 Sep 2025 15:01:22 GMT
       Source-Age:
-      - '10'
+      - '12'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -116,15 +116,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 778b477e823fe8f956d20193d37b4c055195dba9
+      - c1f50418fb047f7911cec83f3fcf547c1056f84c
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F39D:1762AB:68C2EEC2
+      - DF64:33F2BE:BEF70:EA0D4:68CC1D8A
       X-Served-By:
-      - cache-bos4690-BOS
+      - cache-bos4682-BOS
       X-Timer:
-      - S1757605921.063930,VS0,VE1
+      - S1758207382.189477,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -134,7 +134,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/basics.json
   response:
@@ -164,13 +164,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:01 GMT
+      - Thu, 18 Sep 2025 14:56:22 GMT
       ETag:
       - '"2436fa8ce8356cb57ec6581098dc3ea04f5395558aaca6e4008e09eb43f0a9db"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:01 GMT
+      - Thu, 18 Sep 2025 15:01:22 GMT
       Source-Age:
-      - '10'
+      - '12'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -184,15 +184,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 6f9235db4ee4d709732775ff7dce9a7799bc7f88
+      - 6e996d6ac07db2f0a4d7306d90f8518145aa5f66
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F42A:3A83F:147263:18E1C9:68C2EEC1
+      - F7BE:14958F:C3456:EE728:68CC1D89
       X-Served-By:
-      - cache-bos4643-BOS
+      - cache-bos4693-BOS
       X-Timer:
-      - S1757605921.146175,VS0,VE1
+      - S1758207382.253217,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -202,7 +202,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/datetimerange.json
   response:
@@ -237,13 +237,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:01 GMT
+      - Thu, 18 Sep 2025 14:56:22 GMT
       ETag:
       - '"e1248a7fa9f6feeddb9c683a0fcfcab1b8ea66ae5db2d9a36f0602d44879a0f8"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:01 GMT
+      - Thu, 18 Sep 2025 15:01:22 GMT
       Source-Age:
-      - '10'
+      - '11'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -257,15 +257,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - ff50b0381abba5c496a2e4d6fb15335f8c751e6d
+      - fdf950835804cb8d91a5d8869e428622f29d3aea
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 7F51:114F63:12D433:1743BA:68C2EEBE
+      - 9DD1:E9BED:A09F7:CECE4:68CC1D8A
       X-Served-By:
-      - cache-bos4680-BOS
+      - cache-bos4691-BOS
       X-Timer:
-      - S1757605921.214098,VS0,VE1
+      - S1758207382.315478,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -275,7 +275,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/instrument.json
   response:
@@ -306,13 +306,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:01 GMT
+      - Thu, 18 Sep 2025 14:56:22 GMT
       ETag:
       - '"84c39a084fe100d85a10cdeef11399cb06ceed2c623ee37cfbdb03f85d39477c"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:01 GMT
+      - Thu, 18 Sep 2025 15:01:22 GMT
       Source-Age:
-      - '10'
+      - '11'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -326,15 +326,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 2fd1e765b4f93882c056f42573de4b0052feaa17
+      - 605e7e73cbefd12ccf481e2cd0e35fe6e1b14c68
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - DE22:5461F:13BA26:1824C1:68C2EEC2
+      - 1F1B:2036C0:A67D8:D4AEF:68CC1D8A
       X-Served-By:
-      - cache-bos4667-BOS
+      - cache-bos4645-BOS
       X-Timer:
-      - S1757605921.285017,VS0,VE1
+      - S1758207382.377031,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -344,7 +344,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/licensing.json
   response:
@@ -371,13 +371,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:01 GMT
+      - Thu, 18 Sep 2025 14:56:22 GMT
       ETag:
       - '"d2cd4998f5154410f2dc79b42af5baaf118454186cee8d12066a5f42d3e821fc"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:01 GMT
+      - Thu, 18 Sep 2025 15:01:22 GMT
       Source-Age:
-      - '10'
+      - '11'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -391,15 +391,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 9c036d551d4fa1d6df05b30707bfaac2111f4030
+      - dfaba041b90a46331f01ba080424ff13af03d0bf
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 2635:21E1E:F47BCB:132FF57:68C2EEC1
+      - 5403:383255:115583:14CF3E:68CC1D8B
       X-Served-By:
-      - cache-bos4673-BOS
+      - cache-bos4688-BOS
       X-Timer:
-      - S1757605921.358015,VS0,VE1
+      - S1758207382.441494,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -409,7 +409,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/metadata.json
   response:
@@ -438,13 +438,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:01 GMT
+      - Thu, 18 Sep 2025 14:56:22 GMT
       ETag:
       - '"a99228769e5d0400f7b006fa153262053fb7a6ffdb3b8bbf51c4df37a82098f6"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:01 GMT
+      - Thu, 18 Sep 2025 15:01:22 GMT
       Source-Age:
-      - '10'
+      - '11'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -458,15 +458,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 94bf4e6a9420cbd12042faa44fa3e90958f6d6cf
+      - b9a368da08190496d9c7200c7849b81547dd852f
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F45D:12459A:14DF05:195A37:68C2EEC2
+      - F21B:2AFB8F:119511:151B54:68CC1D8B
       X-Served-By:
-      - cache-bos4679-BOS
+      - cache-bos4631-BOS
       X-Timer:
-      - S1757605921.435608,VS0,VE1
+      - S1758207383.506680,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -476,7 +476,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/provider.json
   response:
@@ -513,13 +513,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:01 GMT
+      - Thu, 18 Sep 2025 14:56:22 GMT
       ETag:
       - '"a92eac8e15643dce5b9165724ce350d2ee5edad5f8baca7140c79ce8ce0da8c6"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:01 GMT
+      - Thu, 18 Sep 2025 15:01:22 GMT
       Source-Age:
-      - '10'
+      - '11'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -533,15 +533,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 94e582578a93bf7176c968f58f9931ab4f8f745d
+      - ad56014d81947446c6d79cac463b798cff995aaf
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 13D9:87AC7:1335CB:17A9EB:68C2EEC3
+      - B078:1485D6:12232B:15A44A:68CC1D8B
       X-Served-By:
-      - cache-bos4670-BOS
+      - cache-bos4638-BOS
       X-Timer:
-      - S1757605922.511974,VS0,VE1
+      - S1758207383.567480,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -551,7 +551,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/extensions/sat/json-schema/schema.json
   response:
@@ -587,11 +587,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:01 GMT
+      - Thu, 18 Sep 2025 14:56:22 GMT
       ETag:
       - '"90408dbc0c6ce835205fcdbeeab881774f06517052d7c3dbcf6ba7c3ccced7eb"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:01 GMT
+      - Thu, 18 Sep 2025 15:01:22 GMT
       Source-Age:
       - '8'
       Strict-Transport-Security:
@@ -607,15 +607,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 108b1dbfc476a46fe33a120996127d79896c50e2
+      - 4fc0c91d13b34614453eae66e8e6e340d5c4b274
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3186:12459A:14E01C:195B91:68C2EEC4
+      - 55BA:BACE2:EB046:122BB8:68CC1D8E
       X-Served-By:
-      - cache-bos4671-BOS
+      - cache-bos4655-BOS
       X-Timer:
-      - S1757605922.582577,VS0,VE1
+      - S1758207383.627428,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -625,7 +625,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/extensions/view/json-schema/schema.json
   response:
@@ -669,11 +669,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:01 GMT
+      - Thu, 18 Sep 2025 14:56:22 GMT
       ETag:
       - '"e3e45b623ffe7f49713a2595b631681ba13de3813a1f297508e46360b2becd71"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:01 GMT
+      - Thu, 18 Sep 2025 15:01:22 GMT
       Source-Age:
       - '7'
       Strict-Transport-Security:
@@ -689,15 +689,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 8609a272cac39b835cf8b36a6618d34b22c1e307
+      - dae371525f75b049a16e333c851894ec9bec93f0
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 7F99:1C3F94:14550C:18C5EE:68C2EEC5
+      - 2E67:2A363F:A6B3E:D5185:68CC1D8E
       X-Served-By:
-      - cache-bos4651-BOS
+      - cache-bos4664-BOS
       X-Timer:
-      - S1757605922.656722,VS0,VE2
+      - S1758207383.691247,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example58].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example58].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/collection-spec/json-schema/collection.json
   response:
@@ -96,13 +96,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:01 GMT
+      - Thu, 18 Sep 2025 14:56:22 GMT
       ETag:
       - '"efa6309742b904ab7b06bab4c30c3ea2e1ce78163892365a7f4ee461716396b3"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:01 GMT
+      - Thu, 18 Sep 2025 15:01:22 GMT
       Source-Age:
-      - '11'
+      - '13'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -112,19 +112,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '9'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 64ae19bc2d6ecdaa76a2f43d421ce2c68332a70d
+      - 0eff926d349c103a8658200586132a4ddee25901
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - ED3E:151D18:158C55:1A0484:68C2EEC0
+      - E19D:388807:C6F9A:F2341:68CC1D89
       X-Served-By:
-      - cache-bos4682-BOS
+      - cache-bos4635-BOS
       X-Timer:
-      - S1757605922.732244,VS0,VE1
+      - S1758207383.762161,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -134,7 +134,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/catalog-spec/json-schema/catalog.json
   response:
@@ -183,13 +183,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:01 GMT
+      - Thu, 18 Sep 2025 14:56:22 GMT
       ETag:
       - '"c76fd44b22619705d40fb03a5b1d875e2e786f9ac7a85244758d15cc7cc947a9"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:01 GMT
+      - Thu, 18 Sep 2025 15:01:22 GMT
       Source-Age:
-      - '11'
+      - '13'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -203,15 +203,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 0d540797468267eff9ac380dc382749fdacc54ff
+      - cdf0e9b62d479abdcc0f2ec3ba615a5456fe7a2b
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F35F:176261:68C2EEC0
+      - DF64:33F2BE:BEF40:EA092:68CC1D88
       X-Served-By:
-      - cache-bos4638-BOS
+      - cache-bos4668-BOS
       X-Timer:
-      - S1757605922.803498,VS0,VE1
+      - S1758207383.825963,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -221,7 +221,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/extensions/scientific/json-schema/schema.json
   response:
@@ -267,11 +267,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:01 GMT
+      - Thu, 18 Sep 2025 14:56:22 GMT
       ETag:
       - '"13ff4323200a45e6acb12e649221282624758beb0a8f5b3a190160c2aa9d358a"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:01 GMT
+      - Thu, 18 Sep 2025 15:01:22 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -281,21 +281,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - fa58e8f03ae2c1cccf24edfd77abf25ae74ffd61
+      - d9a3b542f01f7de61cb16f9a8b8199c9d5c2b261
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 688E:6F752:15DE06:1A64F7:68C2EECC
+      - 861D:3A2285:11BE8C:154127:68CC1D94
       X-Served-By:
-      - cache-bos4691-BOS
+      - cache-bos4683-BOS
       X-Timer:
-      - S1757605922.867522,VS0,VE51
+      - S1758207383.891246,VS0,VE72
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -305,7 +305,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/item.json
   response:
@@ -398,13 +398,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:01 GMT
+      - Thu, 18 Sep 2025 14:56:23 GMT
       ETag:
       - '"eb4ef35f5071c45c7b53e7fe6ef92a682455a0de207fcbe27507488c4bfcc9ca"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:01 GMT
+      - Thu, 18 Sep 2025 15:01:23 GMT
       Source-Age:
-      - '11'
+      - '13'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -418,15 +418,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 4d13e3f3156eb0e51661ea9637d6f846f37cd3b6
+      - fd4b779b716da42be909f176ae6228bb3448d9db
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F39D:1762AB:68C2EEC2
+      - DF64:33F2BE:BEF70:EA0D4:68CC1D8A
       X-Served-By:
-      - cache-bos4647-BOS
+      - cache-bos4692-BOS
       X-Timer:
-      - S1757605922.982152,VS0,VE1
+      - S1758207383.025270,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example59].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example59].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/item.json
   response:
@@ -96,13 +96,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:02 GMT
+      - Thu, 18 Sep 2025 14:56:23 GMT
       ETag:
       - '"eb4ef35f5071c45c7b53e7fe6ef92a682455a0de207fcbe27507488c4bfcc9ca"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:01:23 GMT
       Source-Age:
-      - '11'
+      - '12'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -112,19 +112,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - e5aca8d9561f52b5f4fc9ef72ad400a413eaa43c
+      - 78f8a4f4e52f30aec05d874524ec050ec5df3385
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F39D:1762AB:68C2EEC2
+      - DF64:33F2BE:BEF70:EA0D4:68CC1D8A
       X-Served-By:
       - cache-bos4686-BOS
       X-Timer:
-      - S1757605922.049533,VS0,VE5
+      - S1758207383.105169,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -134,7 +134,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/basics.json
   response:
@@ -164,13 +164,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:02 GMT
+      - Thu, 18 Sep 2025 14:56:23 GMT
       ETag:
       - '"2436fa8ce8356cb57ec6581098dc3ea04f5395558aaca6e4008e09eb43f0a9db"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:01:23 GMT
       Source-Age:
-      - '11'
+      - '13'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -184,15 +184,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 4bf60c956689060101d2e73d1649c8cda88db410
+      - 2e12ba0e0697a2ae23f0bd0eb08d330fa8b69661
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F42A:3A83F:147263:18E1C9:68C2EEC1
+      - F7BE:14958F:C3456:EE728:68CC1D89
       X-Served-By:
-      - cache-bos4668-BOS
+      - cache-bos4677-BOS
       X-Timer:
-      - S1757605922.117820,VS0,VE1
+      - S1758207383.179476,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -202,7 +202,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/datetimerange.json
   response:
@@ -237,13 +237,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:02 GMT
+      - Thu, 18 Sep 2025 14:56:23 GMT
       ETag:
       - '"e1248a7fa9f6feeddb9c683a0fcfcab1b8ea66ae5db2d9a36f0602d44879a0f8"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:01:23 GMT
       Source-Age:
-      - '11'
+      - '12'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -257,15 +257,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 87ec29e373a87c223eaedfcf34e77bc09fd36c98
+      - 348e9c05ad9581f9cf9dbce3aca699ea886f721d
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 7F51:114F63:12D433:1743BA:68C2EEBE
+      - 9DD1:E9BED:A09F7:CECE4:68CC1D8A
       X-Served-By:
-      - cache-bos4647-BOS
+      - cache-bos4629-BOS
       X-Timer:
-      - S1757605922.178070,VS0,VE1
+      - S1758207383.253072,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -275,7 +275,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/instrument.json
   response:
@@ -306,13 +306,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:02 GMT
+      - Thu, 18 Sep 2025 14:56:23 GMT
       ETag:
       - '"84c39a084fe100d85a10cdeef11399cb06ceed2c623ee37cfbdb03f85d39477c"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:01:23 GMT
       Source-Age:
-      - '11'
+      - '12'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -322,19 +322,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 00a529cd5c26697abaf1874dd4cd2f03d22a1876
+      - 54710c7a00fa8c8988b7dda82df5c4982ca14a70
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - DE22:5461F:13BA26:1824C1:68C2EEC2
+      - 1F1B:2036C0:A67D8:D4AEF:68CC1D8A
       X-Served-By:
-      - cache-bos4681-BOS
+      - cache-bos4691-BOS
       X-Timer:
-      - S1757605922.234413,VS0,VE0
+      - S1758207383.322799,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -344,7 +344,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/licensing.json
   response:
@@ -371,13 +371,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:02 GMT
+      - Thu, 18 Sep 2025 14:56:23 GMT
       ETag:
       - '"d2cd4998f5154410f2dc79b42af5baaf118454186cee8d12066a5f42d3e821fc"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:01:23 GMT
       Source-Age:
-      - '11'
+      - '12'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -387,19 +387,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - d562600ede13d44fa28d8229410089396adcd521
+      - 6b4bddbb59fef8ddd1da2c6f793901e90b0823d4
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 2635:21E1E:F47BCB:132FF57:68C2EEC1
+      - 5403:383255:115583:14CF3E:68CC1D8B
       X-Served-By:
-      - cache-bos4645-BOS
+      - cache-bos4670-BOS
       X-Timer:
-      - S1757605922.298271,VS0,VE0
+      - S1758207383.395109,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -409,7 +409,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/metadata.json
   response:
@@ -438,13 +438,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:02 GMT
+      - Thu, 18 Sep 2025 14:56:23 GMT
       ETag:
       - '"a99228769e5d0400f7b006fa153262053fb7a6ffdb3b8bbf51c4df37a82098f6"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:01:23 GMT
       Source-Age:
-      - '11'
+      - '12'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -454,19 +454,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 6c1291517c6e355c6574238b8651a423b33cd746
+      - 0ec5d3364972ea7c08caed6a50c490719d6e002a
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F45D:12459A:14DF05:195A37:68C2EEC2
+      - F21B:2AFB8F:119511:151B54:68CC1D8B
       X-Served-By:
-      - cache-bos4675-BOS
+      - cache-bos4638-BOS
       X-Timer:
-      - S1757605922.358452,VS0,VE0
+      - S1758207383.467685,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -476,7 +476,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/provider.json
   response:
@@ -513,13 +513,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:02 GMT
+      - Thu, 18 Sep 2025 14:56:23 GMT
       ETag:
       - '"a92eac8e15643dce5b9165724ce350d2ee5edad5f8baca7140c79ce8ce0da8c6"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:01:23 GMT
       Source-Age:
-      - '11'
+      - '12'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -529,19 +529,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 0469c44704685bb1799dc588b009215da9220d10
+      - f91972db0ae4ef62a9801f7443492c88376a86c5
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 13D9:87AC7:1335CB:17A9EB:68C2EEC3
+      - B078:1485D6:12232B:15A44A:68CC1D8B
       X-Served-By:
-      - cache-bos4680-BOS
+      - cache-bos4631-BOS
       X-Timer:
-      - S1757605922.416324,VS0,VE0
+      - S1758207384.543252,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -551,7 +551,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/extensions/scientific/json-schema/schema.json
   response:
@@ -597,11 +597,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:02 GMT
+      - Thu, 18 Sep 2025 14:56:23 GMT
       ETag:
       - '"13ff4323200a45e6acb12e649221282624758beb0a8f5b3a190160c2aa9d358a"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:01:23 GMT
       Source-Age:
       - '1'
       Strict-Transport-Security:
@@ -617,15 +617,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - e622bc6906015b702c05bf911a544d5692f17c4c
+      - 010dd2e22a0b9e679fc01e495ea44ebd988d0aba
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 688E:6F752:15DE06:1A64F7:68C2EECC
+      - 861D:3A2285:11BE8C:154127:68CC1D94
       X-Served-By:
-      - cache-bos4677-BOS
+      - cache-bos4689-BOS
       X-Timer:
-      - S1757605922.477861,VS0,VE18
+      - S1758207384.611080,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -635,7 +635,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/collection-spec/json-schema/collection.json
   response:
@@ -728,13 +728,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:02 GMT
+      - Thu, 18 Sep 2025 14:56:23 GMT
       ETag:
       - '"efa6309742b904ab7b06bab4c30c3ea2e1ce78163892365a7f4ee461716396b3"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:01:23 GMT
       Source-Age:
-      - '12'
+      - '13'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -748,15 +748,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 948aea5aeced0e12c1c3a085f3ba6c40f0967c99
+      - 962f35ae4ba835b1aa6b17df8caf98ec9bfcf9fc
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - ED3E:151D18:158C55:1A0484:68C2EEC0
+      - E19D:388807:C6F9A:F2341:68CC1D89
       X-Served-By:
-      - cache-bos4676-BOS
+      - cache-bos4688-BOS
       X-Timer:
-      - S1757605923.576060,VS0,VE1
+      - S1758207384.689374,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -766,7 +766,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/catalog-spec/json-schema/catalog.json
   response:
@@ -815,13 +815,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:02 GMT
+      - Thu, 18 Sep 2025 14:56:23 GMT
       ETag:
       - '"c76fd44b22619705d40fb03a5b1d875e2e786f9ac7a85244758d15cc7cc947a9"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:01:23 GMT
       Source-Age:
-      - '12'
+      - '14'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -831,19 +831,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '12'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 739eaa777cf074f623a8123396886141f4b98ca7
+      - 9725154081deb120910f1f1e21d90afd0fe10741
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F35F:176261:68C2EEC0
+      - DF64:33F2BE:BEF40:EA092:68CC1D88
       X-Served-By:
-      - cache-bos4685-BOS
+      - cache-bos4678-BOS
       X-Timer:
-      - S1757605923.645947,VS0,VE1
+      - S1758207384.760804,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -853,7 +853,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/extensions/checksum/json-schema/schema.json
   response:
@@ -891,13 +891,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:02 GMT
+      - Thu, 18 Sep 2025 14:56:23 GMT
       ETag:
       - '"9bde8b6875408a186b283e6e3dd3edb01bc2b938e55a0491b0b7f4e06f0faccb"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:01:23 GMT
       Source-Age:
-      - '10'
+      - '11'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -911,15 +911,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 62fbdb0ce587ac61b24567f09e88dd432bfd785d
+      - 167cf6946cbb2a07fe9a3f1c350ba72c5aaf5638
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 2EEA:2ACBC:14A59B:191DF0:68C2EEC4
+      - 8D48:3FA7F8:124D47:15D3ED:68CC1D8C
       X-Served-By:
-      - cache-bos4658-BOS
+      - cache-bos4684-BOS
       X-Timer:
-      - S1757605923.706157,VS0,VE1
+      - S1758207384.830841,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example5].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example5].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/collection-spec/json-schema/collection.json
   response:
@@ -85,11 +85,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:42 GMT
+      - Thu, 18 Sep 2025 14:56:01 GMT
       ETag:
       - '"031974beaaaf6f0b5c6877dc97088d9e2aff3bc8962df33ff291dddded353f09"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:42 GMT
+      - Thu, 18 Sep 2025 15:01:01 GMT
       Source-Age:
       - '1'
       Strict-Transport-Security:
@@ -105,15 +105,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 0c055bed66898a15bfc05132ff8ce8ffcdb2f09e
+      - 2d3089bfeafad19e91c8ee917fb4cab004b5c578
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 48D2:9DF63:14B8DC:192D3D:68C2EEB6
+      - EAA4:3C3312:A80AF:D3151:68CC1D7F
       X-Served-By:
-      - cache-bos4678-BOS
+      - cache-bos4652-BOS
       X-Timer:
-      - S1757605903.853625,VS0,VE1
+      - S1758207362.881101,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -123,7 +123,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/catalog-spec/json-schema/catalog.json
   response:
@@ -184,11 +184,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:42 GMT
+      - Thu, 18 Sep 2025 14:56:01 GMT
       ETag:
       - '"3b514933a3747f038125935624a13df108e30fe1cb8f9660a7f54ac6d4765ce9"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:42 GMT
+      - Thu, 18 Sep 2025 15:01:01 GMT
       Source-Age:
       - '1'
       Strict-Transport-Security:
@@ -204,15 +204,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 9a958abe729718ac314f2e7c91bc05cfea073995
+      - dc0620d5783f609730b8c0c2f0345fde26e889bb
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 4D53:1CB1E4:12EBE4:17599A:68C2EEB7
+      - BCE7:388807:C697B:F1BF7:68CC1D7C
       X-Served-By:
-      - cache-bos4669-BOS
+      - cache-bos4663-BOS
       X-Timer:
-      - S1757605903.916458,VS0,VE1
+      - S1758207362.959228,VS0,VE2
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -222,7 +222,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/extensions/asset/json-schema/schema.json
   response:
@@ -259,11 +259,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:43 GMT
+      - Thu, 18 Sep 2025 14:56:02 GMT
       ETag:
       - '"cffbb0036f526b016f24477e0ad674e75b6fefb89708ca796686de9d2e2a67ed"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:43 GMT
+      - Thu, 18 Sep 2025 15:01:02 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -273,21 +273,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 8d2b9f02671027c9a6c28ce86d7192af156aea85
+      - 1a773d937744506e268df72f6e26318afa3468a4
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 635E:2ACBC:149CBC:1913A5:68C2EEB7
+      - 6FDB:372AF9:AF9FC:DABC2:68CC1D80
       X-Served-By:
-      - cache-bos4621-BOS
+      - cache-bos4670-BOS
       X-Timer:
-      - S1757605903.982024,VS0,VE53
+      - S1758207362.025274,VS0,VE67
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example60].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example60].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/collection-spec/json-schema/collection.json
   response:
@@ -96,13 +96,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:02 GMT
+      - Thu, 18 Sep 2025 14:56:23 GMT
       ETag:
       - '"efa6309742b904ab7b06bab4c30c3ea2e1ce78163892365a7f4ee461716396b3"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:01:23 GMT
       Source-Age:
-      - '12'
+      - '14'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -116,15 +116,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - d4a1a70be9057719b68a1e2bb30f79564aa193ef
+      - 4aed4a14504a9950433e6d4c881779178d7b30f5
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - ED3E:151D18:158C55:1A0484:68C2EEC0
+      - E19D:388807:C6F9A:F2341:68CC1D89
       X-Served-By:
-      - cache-bos4658-BOS
+      - cache-bos4665-BOS
       X-Timer:
-      - S1757605923.772664,VS0,VE1
+      - S1758207384.915166,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -134,7 +134,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/catalog-spec/json-schema/catalog.json
   response:
@@ -183,13 +183,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:02 GMT
+      - Thu, 18 Sep 2025 14:56:23 GMT
       ETag:
       - '"c76fd44b22619705d40fb03a5b1d875e2e786f9ac7a85244758d15cc7cc947a9"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:01:23 GMT
       Source-Age:
-      - '12'
+      - '14'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -203,15 +203,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - a61ee21cba6cfab937b0877de9bdd41b11359872
+      - 33c28db82f53ac2abc6b2d8233b75716f0f56fbf
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F35F:176261:68C2EEC0
+      - DF64:33F2BE:BEF40:EA092:68CC1D88
       X-Served-By:
-      - cache-bos4643-BOS
+      - cache-bos4624-BOS
       X-Timer:
-      - S1757605923.835695,VS0,VE1
+      - S1758207384.993189,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -221,7 +221,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/extensions/version/json-schema/schema.json
   response:
@@ -261,11 +261,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:02 GMT
+      - Thu, 18 Sep 2025 14:56:24 GMT
       ETag:
       - '"3ad87031bb638da9b48582cbf730c047e1075960364c8fc992381ddf5467f296"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:01:24 GMT
       Source-Age:
       - '5'
       Strict-Transport-Security:
@@ -281,15 +281,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - a45550117ed4ad7642613d3773753cf4b13cbc21
+      - b63ca3a6464835985e5d2d2d8c9342ce37625062
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 2635:87AC7:13389E:17ADA5:68C2EEC7
+      - 50D5:35ED5B:F4953:12BF1F:68CC1D91
       X-Served-By:
-      - cache-bos4636-BOS
+      - cache-bos4640-BOS
       X-Timer:
-      - S1757605923.906407,VS0,VE1
+      - S1758207384.063519,VS0,VE8
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -299,7 +299,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/item.json
   response:
@@ -392,13 +392,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:02 GMT
+      - Thu, 18 Sep 2025 14:56:24 GMT
       ETag:
       - '"eb4ef35f5071c45c7b53e7fe6ef92a682455a0de207fcbe27507488c4bfcc9ca"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:02 GMT
+      - Thu, 18 Sep 2025 15:01:24 GMT
       Source-Age:
-      - '12'
+      - '13'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -408,19 +408,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '3'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 90888a8ebebe2830d0cc86eeec6cf4cc7d927ee9
+      - 68d624c67101601124aa326dda7c65e843731676
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F39D:1762AB:68C2EEC2
+      - DF64:33F2BE:BEF70:EA0D4:68CC1D8A
       X-Served-By:
-      - cache-bos4628-BOS
+      - cache-bos4677-BOS
       X-Timer:
-      - S1757605923.969840,VS0,VE1
+      - S1758207384.143340,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example61].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example61].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/item.json
   response:
@@ -96,13 +96,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:03 GMT
+      - Thu, 18 Sep 2025 14:56:24 GMT
       ETag:
       - '"eb4ef35f5071c45c7b53e7fe6ef92a682455a0de207fcbe27507488c4bfcc9ca"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:03 GMT
+      - Thu, 18 Sep 2025 15:01:24 GMT
       Source-Age:
-      - '12'
+      - '14'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -112,19 +112,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 3782d9ecedab724ba9cd1d3273e6e137d1e1c878
+      - e4108aaec4a199af65a22d5967ac64ad60b49862
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F39D:1762AB:68C2EEC2
+      - DF64:33F2BE:BEF70:EA0D4:68CC1D8A
       X-Served-By:
-      - cache-bos4628-BOS
+      - cache-bos4631-BOS
       X-Timer:
-      - S1757605923.038183,VS0,VE0
+      - S1758207384.216715,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -134,7 +134,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/basics.json
   response:
@@ -164,13 +164,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:03 GMT
+      - Thu, 18 Sep 2025 14:56:24 GMT
       ETag:
       - '"2436fa8ce8356cb57ec6581098dc3ea04f5395558aaca6e4008e09eb43f0a9db"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:03 GMT
+      - Thu, 18 Sep 2025 15:01:24 GMT
       Source-Age:
-      - '12'
+      - '14'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -184,15 +184,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - a7890be19392688b32b76be0e1c6422f2f254ba0
+      - 1d06cede77f598f7f42e67ab8bdf38c8324c23e5
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F42A:3A83F:147263:18E1C9:68C2EEC1
+      - F7BE:14958F:C3456:EE728:68CC1D89
       X-Served-By:
-      - cache-bos4630-BOS
+      - cache-bos4645-BOS
       X-Timer:
-      - S1757605923.099598,VS0,VE1
+      - S1758207384.295275,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -202,7 +202,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/datetimerange.json
   response:
@@ -237,13 +237,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:03 GMT
+      - Thu, 18 Sep 2025 14:56:24 GMT
       ETag:
       - '"e1248a7fa9f6feeddb9c683a0fcfcab1b8ea66ae5db2d9a36f0602d44879a0f8"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:03 GMT
+      - Thu, 18 Sep 2025 15:01:24 GMT
       Source-Age:
-      - '12'
+      - '14'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -257,15 +257,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - d65a60d3a208478cb9eb8aed57e95da4ff60fba1
+      - 8975e3ec85f4061ed00924cdf2fba030118b65dc
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 7F51:114F63:12D433:1743BA:68C2EEBE
+      - 9DD1:E9BED:A09F7:CECE4:68CC1D8A
       X-Served-By:
-      - cache-bos4655-BOS
+      - cache-bos4692-BOS
       X-Timer:
-      - S1757605923.169933,VS0,VE2
+      - S1758207384.357586,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -275,7 +275,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/instrument.json
   response:
@@ -306,13 +306,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:03 GMT
+      - Thu, 18 Sep 2025 14:56:24 GMT
       ETag:
       - '"84c39a084fe100d85a10cdeef11399cb06ceed2c623ee37cfbdb03f85d39477c"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:03 GMT
+      - Thu, 18 Sep 2025 15:01:24 GMT
       Source-Age:
-      - '12'
+      - '13'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -326,15 +326,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - e85f7eac8887f6a3ad3aac2f112535da90324377
+      - 03405cd04d3fd160a03f5f49e5ad2d60e25bfa61
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - DE22:5461F:13BA26:1824C1:68C2EEC2
+      - 1F1B:2036C0:A67D8:D4AEF:68CC1D8A
       X-Served-By:
-      - cache-bos4661-BOS
+      - cache-bos4643-BOS
       X-Timer:
-      - S1757605923.232192,VS0,VE1
+      - S1758207384.420136,VS0,VE2
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -344,7 +344,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/licensing.json
   response:
@@ -371,13 +371,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:03 GMT
+      - Thu, 18 Sep 2025 14:56:24 GMT
       ETag:
       - '"d2cd4998f5154410f2dc79b42af5baaf118454186cee8d12066a5f42d3e821fc"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:03 GMT
+      - Thu, 18 Sep 2025 15:01:24 GMT
       Source-Age:
-      - '12'
+      - '13'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -387,19 +387,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '37'
+      - '2'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - dfade8748dbf6e7bb83d2b5d0b75c2841500733a
+      - 95b938a87df83829f861311cee0e645874bd5399
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 2635:21E1E:F47BCB:132FF57:68C2EEC1
+      - 5403:383255:115583:14CF3E:68CC1D8B
       X-Served-By:
-      - cache-bos4650-BOS
+      - cache-bos4649-BOS
       X-Timer:
-      - S1757605923.297453,VS0,VE0
+      - S1758207384.487376,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -409,7 +409,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/metadata.json
   response:
@@ -438,13 +438,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:03 GMT
+      - Thu, 18 Sep 2025 14:56:24 GMT
       ETag:
       - '"a99228769e5d0400f7b006fa153262053fb7a6ffdb3b8bbf51c4df37a82098f6"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:03 GMT
+      - Thu, 18 Sep 2025 15:01:24 GMT
       Source-Age:
-      - '12'
+      - '13'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -458,15 +458,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - be6831b53656d060969510953b81c08bd2a26d43
+      - ddb0db5f06e1af6c0d9233aa5baadda51c35b63a
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F45D:12459A:14DF05:195A37:68C2EEC2
+      - F21B:2AFB8F:119511:151B54:68CC1D8B
       X-Served-By:
-      - cache-bos4680-BOS
+      - cache-bos4628-BOS
       X-Timer:
-      - S1757605923.360231,VS0,VE1
+      - S1758207385.548737,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -476,7 +476,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/provider.json
   response:
@@ -513,13 +513,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:03 GMT
+      - Thu, 18 Sep 2025 14:56:24 GMT
       ETag:
       - '"a92eac8e15643dce5b9165724ce350d2ee5edad5f8baca7140c79ce8ce0da8c6"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:03 GMT
+      - Thu, 18 Sep 2025 15:01:24 GMT
       Source-Age:
-      - '12'
+      - '13'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -533,15 +533,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - f36136286446643c97b9d922b05ac04b0011588c
+      - b3fe48558bafa9ea981446914b07284449369731
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 13D9:87AC7:1335CB:17A9EB:68C2EEC3
+      - B078:1485D6:12232B:15A44A:68CC1D8B
       X-Served-By:
-      - cache-bos4631-BOS
+      - cache-bos4635-BOS
       X-Timer:
-      - S1757605923.429952,VS0,VE1
+      - S1758207385.609183,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -551,7 +551,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/extensions/version/json-schema/schema.json
   response:
@@ -591,11 +591,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:03 GMT
+      - Thu, 18 Sep 2025 14:56:24 GMT
       ETag:
       - '"3ad87031bb638da9b48582cbf730c047e1075960364c8fc992381ddf5467f296"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:03 GMT
+      - Thu, 18 Sep 2025 15:01:24 GMT
       Source-Age:
       - '6'
       Strict-Transport-Security:
@@ -611,15 +611,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 0bcb08d3a4d75e89329af1524ac520533579f85f
+      - 9b827e026c78831e7b0370ac0aa7e6ebe5791735
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 2635:87AC7:13389E:17ADA5:68C2EEC7
+      - 50D5:35ED5B:F4953:12BF1F:68CC1D91
       X-Served-By:
-      - cache-bos4642-BOS
+      - cache-bos4664-BOS
       X-Timer:
-      - S1757605923.492865,VS0,VE1
+      - S1758207385.673208,VS0,VE2
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -629,7 +629,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/collection-spec/json-schema/collection.json
   response:
@@ -722,13 +722,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:03 GMT
+      - Thu, 18 Sep 2025 14:56:24 GMT
       ETag:
       - '"efa6309742b904ab7b06bab4c30c3ea2e1ce78163892365a7f4ee461716396b3"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:03 GMT
+      - Thu, 18 Sep 2025 15:01:24 GMT
       Source-Age:
-      - '13'
+      - '15'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -742,15 +742,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - fde74a16049bb3122bf50645bf02fa4a7239b9e1
+      - d4826e8773b5c3ea2e2dc9467fd42af49732facc
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - ED3E:151D18:158C55:1A0484:68C2EEC0
+      - E19D:388807:C6F9A:F2341:68CC1D89
       X-Served-By:
-      - cache-bos4627-BOS
+      - cache-bos4677-BOS
       X-Timer:
-      - S1757605924.566335,VS0,VE1
+      - S1758207385.741391,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -760,7 +760,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/catalog-spec/json-schema/catalog.json
   response:
@@ -809,13 +809,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:03 GMT
+      - Thu, 18 Sep 2025 14:56:24 GMT
       ETag:
       - '"c76fd44b22619705d40fb03a5b1d875e2e786f9ac7a85244758d15cc7cc947a9"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:03 GMT
+      - Thu, 18 Sep 2025 15:01:24 GMT
       Source-Age:
-      - '13'
+      - '15'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -825,19 +825,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 164e2cd74cc6b6b7222505a726c7c0decb35870d
+      - 6f77da0c9c7ce873b8960763733ad96547a70974
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F35F:176261:68C2EEC0
+      - DF64:33F2BE:BEF40:EA092:68CC1D88
       X-Served-By:
-      - cache-bos4686-BOS
+      - cache-bos4624-BOS
       X-Timer:
-      - S1757605924.635744,VS0,VE1
+      - S1758207385.803035,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example62].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example62].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/item.json
   response:
@@ -96,13 +96,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:03 GMT
+      - Thu, 18 Sep 2025 14:56:24 GMT
       ETag:
       - '"eb4ef35f5071c45c7b53e7fe6ef92a682455a0de207fcbe27507488c4bfcc9ca"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:03 GMT
+      - Thu, 18 Sep 2025 15:01:24 GMT
       Source-Age:
-      - '13'
+      - '14'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -116,15 +116,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 7831e4f5c7aee18f964dc9ded53c4db63f6c6626
+      - 6af3ad0833a6f6baa081ae15bae1758d07d1d0fd
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F39D:1762AB:68C2EEC2
+      - DF64:33F2BE:BEF70:EA0D4:68CC1D8A
       X-Served-By:
-      - cache-bos4659-BOS
+      - cache-bos4672-BOS
       X-Timer:
-      - S1757605924.717922,VS0,VE2
+      - S1758207385.863213,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -134,7 +134,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/basics.json
   response:
@@ -164,13 +164,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:03 GMT
+      - Thu, 18 Sep 2025 14:56:24 GMT
       ETag:
       - '"2436fa8ce8356cb57ec6581098dc3ea04f5395558aaca6e4008e09eb43f0a9db"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:03 GMT
+      - Thu, 18 Sep 2025 15:01:24 GMT
       Source-Age:
-      - '13'
+      - '14'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -184,15 +184,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - fd9ee52e3f90a704b36e74f7b1d8e61cb160fe6a
+      - 2fdd1f9c042bd17ec95845e2f58bc6d2694e43ee
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F42A:3A83F:147263:18E1C9:68C2EEC1
+      - F7BE:14958F:C3456:EE728:68CC1D89
       X-Served-By:
-      - cache-bos4657-BOS
+      - cache-bos4665-BOS
       X-Timer:
-      - S1757605924.800425,VS0,VE1
+      - S1758207385.933040,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -202,7 +202,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/datetimerange.json
   response:
@@ -237,13 +237,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:03 GMT
+      - Thu, 18 Sep 2025 14:56:24 GMT
       ETag:
       - '"e1248a7fa9f6feeddb9c683a0fcfcab1b8ea66ae5db2d9a36f0602d44879a0f8"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:03 GMT
+      - Thu, 18 Sep 2025 15:01:24 GMT
       Source-Age:
-      - '13'
+      - '14'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -257,15 +257,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 71b044e0aad845dd6a42c647ed92872b8804881b
+      - 793161540f8b3c6353324a649750cd318fa75d0e
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 7F51:114F63:12D433:1743BA:68C2EEBE
+      - 9DD1:E9BED:A09F7:CECE4:68CC1D8A
       X-Served-By:
-      - cache-bos4693-BOS
+      - cache-bos4680-BOS
       X-Timer:
-      - S1757605924.870007,VS0,VE1
+      - S1758207385.991762,VS0,VE8
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -275,7 +275,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/instrument.json
   response:
@@ -306,13 +306,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:03 GMT
+      - Thu, 18 Sep 2025 14:56:25 GMT
       ETag:
       - '"84c39a084fe100d85a10cdeef11399cb06ceed2c623ee37cfbdb03f85d39477c"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:03 GMT
+      - Thu, 18 Sep 2025 15:01:25 GMT
       Source-Age:
-      - '13'
+      - '14'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -326,15 +326,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - e313e211cf224aa64cd0a4dc801a03dbf8ab7af0
+      - 2d98926e352ab34f216e337152f17756e953abaf
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - DE22:5461F:13BA26:1824C1:68C2EEC2
+      - 1F1B:2036C0:A67D8:D4AEF:68CC1D8A
       X-Served-By:
-      - cache-bos4644-BOS
+      - cache-bos4665-BOS
       X-Timer:
-      - S1757605924.942339,VS0,VE1
+      - S1758207385.063170,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -344,7 +344,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/licensing.json
   response:
@@ -371,13 +371,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:04 GMT
+      - Thu, 18 Sep 2025 14:56:25 GMT
       ETag:
       - '"d2cd4998f5154410f2dc79b42af5baaf118454186cee8d12066a5f42d3e821fc"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:04 GMT
+      - Thu, 18 Sep 2025 15:01:25 GMT
       Source-Age:
-      - '13'
+      - '14'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -391,15 +391,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - d81b8b3a797debb8c30f4387d69a85f36a00acd6
+      - ce84ba19587a07825313cae7eefc3795e8e4f621
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 2635:21E1E:F47BCB:132FF57:68C2EEC1
+      - 5403:383255:115583:14CF3E:68CC1D8B
       X-Served-By:
-      - cache-bos4685-BOS
+      - cache-bos4691-BOS
       X-Timer:
-      - S1757605924.017883,VS0,VE1
+      - S1758207385.130992,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -409,7 +409,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/metadata.json
   response:
@@ -438,13 +438,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:04 GMT
+      - Thu, 18 Sep 2025 14:56:25 GMT
       ETag:
       - '"a99228769e5d0400f7b006fa153262053fb7a6ffdb3b8bbf51c4df37a82098f6"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:04 GMT
+      - Thu, 18 Sep 2025 15:01:25 GMT
       Source-Age:
-      - '13'
+      - '14'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -458,15 +458,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 026d6b27e0c052500f63b2349512ce65c73ca871
+      - 1d4960668abe57328c85dde6c1e25518761d1ce2
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F45D:12459A:14DF05:195A37:68C2EEC2
+      - F21B:2AFB8F:119511:151B54:68CC1D8B
       X-Served-By:
-      - cache-bos4644-BOS
+      - cache-bos4687-BOS
       X-Timer:
-      - S1757605924.092055,VS0,VE1
+      - S1758207385.211007,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -476,7 +476,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/provider.json
   response:
@@ -513,11 +513,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:04 GMT
+      - Thu, 18 Sep 2025 14:56:25 GMT
       ETag:
       - '"a92eac8e15643dce5b9165724ce350d2ee5edad5f8baca7140c79ce8ce0da8c6"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:04 GMT
+      - Thu, 18 Sep 2025 15:01:25 GMT
       Source-Age:
       - '13'
       Strict-Transport-Security:
@@ -533,15 +533,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 569fbf823b54fd35a293d8d5c1bffe429072f498
+      - 5b5b59faaca2c91311b9d7b44338c7a880fdae1b
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 13D9:87AC7:1335CB:17A9EB:68C2EEC3
+      - B078:1485D6:12232B:15A44A:68CC1D8B
       X-Served-By:
-      - cache-bos4686-BOS
+      - cache-bos4673-BOS
       X-Timer:
-      - S1757605924.162477,VS0,VE1
+      - S1758207385.275544,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -551,7 +551,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/extensions/sat/json-schema/schema.json
   response:
@@ -587,11 +587,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:04 GMT
+      - Thu, 18 Sep 2025 14:56:25 GMT
       ETag:
       - '"90408dbc0c6ce835205fcdbeeab881774f06517052d7c3dbcf6ba7c3ccced7eb"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:04 GMT
+      - Thu, 18 Sep 2025 15:01:25 GMT
       Source-Age:
       - '11'
       Strict-Transport-Security:
@@ -607,15 +607,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 86d59e45cc878354437abf5f22027c7c9ed20b89
+      - 6453e82002807bf050a576140b06c7415ac15969
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3186:12459A:14E01C:195B91:68C2EEC4
+      - 55BA:BACE2:EB046:122BB8:68CC1D8E
       X-Served-By:
-      - cache-bos4649-BOS
+      - cache-bos4631-BOS
       X-Timer:
-      - S1757605924.230296,VS0,VE1
+      - S1758207385.329266,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -625,7 +625,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/extensions/view/json-schema/schema.json
   response:
@@ -669,11 +669,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:04 GMT
+      - Thu, 18 Sep 2025 14:56:25 GMT
       ETag:
       - '"e3e45b623ffe7f49713a2595b631681ba13de3813a1f297508e46360b2becd71"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:04 GMT
+      - Thu, 18 Sep 2025 15:01:25 GMT
       Source-Age:
       - '10'
       Strict-Transport-Security:
@@ -689,15 +689,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 8c4661b0817b25b7fa22bc4941f74b97ae511749
+      - 00e73d2e79ccac81c2b970e4af6200034b7b2ba3
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 7F99:1C3F94:14550C:18C5EE:68C2EEC5
+      - 2E67:2A363F:A6B3E:D5185:68CC1D8E
       X-Served-By:
-      - cache-bos4682-BOS
+      - cache-bos4644-BOS
       X-Timer:
-      - S1757605924.316578,VS0,VE1
+      - S1758207385.388990,VS0,VE12
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example63].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example63].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/item.json
   response:
@@ -96,13 +96,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:04 GMT
+      - Thu, 18 Sep 2025 14:56:25 GMT
       ETag:
       - '"eb4ef35f5071c45c7b53e7fe6ef92a682455a0de207fcbe27507488c4bfcc9ca"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:04 GMT
+      - Thu, 18 Sep 2025 15:01:25 GMT
       Source-Age:
-      - '14'
+      - '15'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -112,19 +112,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 7180949315aed5028f4ec277b2ead90e64e02b81
+      - 2df3c42a7c9695c077c7e6892ea53d2fe8658df8
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F39D:1762AB:68C2EEC2
+      - DF64:33F2BE:BEF70:EA0D4:68CC1D8A
       X-Served-By:
-      - cache-bos4638-BOS
+      - cache-bos4672-BOS
       X-Timer:
-      - S1757605924.408776,VS0,VE1
+      - S1758207385.467157,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -134,7 +134,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/basics.json
   response:
@@ -164,13 +164,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:04 GMT
+      - Thu, 18 Sep 2025 14:56:25 GMT
       ETag:
       - '"2436fa8ce8356cb57ec6581098dc3ea04f5395558aaca6e4008e09eb43f0a9db"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:04 GMT
+      - Thu, 18 Sep 2025 15:01:25 GMT
       Source-Age:
-      - '14'
+      - '15'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -184,15 +184,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 58b44e095dad236e6f1ffbdd70636da0a9104723
+      - 8b8ddf61dd04d48028cb499a045ad434e85f1e71
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F42A:3A83F:147263:18E1C9:68C2EEC1
+      - F7BE:14958F:C3456:EE728:68CC1D89
       X-Served-By:
-      - cache-bos4684-BOS
+      - cache-bos4691-BOS
       X-Timer:
-      - S1757605924.481868,VS0,VE1
+      - S1758207386.529236,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -202,7 +202,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/datetimerange.json
   response:
@@ -237,13 +237,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:04 GMT
+      - Thu, 18 Sep 2025 14:56:25 GMT
       ETag:
       - '"e1248a7fa9f6feeddb9c683a0fcfcab1b8ea66ae5db2d9a36f0602d44879a0f8"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:04 GMT
+      - Thu, 18 Sep 2025 15:01:25 GMT
       Source-Age:
-      - '13'
+      - '15'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -257,15 +257,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - e2b03cb82a14eaf9de53e6f2016ed75440f98ffe
+      - f5dcebbad038579f08ec08e8db0a66bf22cb863b
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 7F51:114F63:12D433:1743BA:68C2EEBE
+      - 9DD1:E9BED:A09F7:CECE4:68CC1D8A
       X-Served-By:
-      - cache-bos4690-BOS
+      - cache-bos4624-BOS
       X-Timer:
-      - S1757605925.553751,VS0,VE0
+      - S1758207386.589183,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -275,7 +275,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/instrument.json
   response:
@@ -306,13 +306,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:04 GMT
+      - Thu, 18 Sep 2025 14:56:25 GMT
       ETag:
       - '"84c39a084fe100d85a10cdeef11399cb06ceed2c623ee37cfbdb03f85d39477c"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:04 GMT
+      - Thu, 18 Sep 2025 15:01:25 GMT
       Source-Age:
-      - '13'
+      - '15'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -326,15 +326,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - d542ed56e49c7473cc87faa8922acc0ea6ebb789
+      - 9ad18f36099759025cf4c7acdeb2f8222b1b4f81
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - DE22:5461F:13BA26:1824C1:68C2EEC2
+      - 1F1B:2036C0:A67D8:D4AEF:68CC1D8A
       X-Served-By:
-      - cache-bos4639-BOS
+      - cache-bos4676-BOS
       X-Timer:
-      - S1757605925.628886,VS0,VE1
+      - S1758207386.651495,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -344,7 +344,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/licensing.json
   response:
@@ -371,13 +371,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:04 GMT
+      - Thu, 18 Sep 2025 14:56:25 GMT
       ETag:
       - '"d2cd4998f5154410f2dc79b42af5baaf118454186cee8d12066a5f42d3e821fc"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:04 GMT
+      - Thu, 18 Sep 2025 15:01:25 GMT
       Source-Age:
-      - '13'
+      - '14'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -391,15 +391,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 6c165e7331413fbdda086d63bdd76ad10e8ff584
+      - 42ec71cf2215391cd37aab24522819ef1efa7829
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 2635:21E1E:F47BCB:132FF57:68C2EEC1
+      - 5403:383255:115583:14CF3E:68CC1D8B
       X-Served-By:
-      - cache-bos4644-BOS
+      - cache-bos4645-BOS
       X-Timer:
-      - S1757605925.704334,VS0,VE1
+      - S1758207386.715144,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -409,7 +409,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/metadata.json
   response:
@@ -438,13 +438,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:04 GMT
+      - Thu, 18 Sep 2025 14:56:25 GMT
       ETag:
       - '"a99228769e5d0400f7b006fa153262053fb7a6ffdb3b8bbf51c4df37a82098f6"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:04 GMT
+      - Thu, 18 Sep 2025 15:01:25 GMT
       Source-Age:
-      - '13'
+      - '14'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -454,19 +454,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '17'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 13d06beac25218cb7c5364e83f69e1c824a010c9
+      - cb503e1dc69e9965cbd8ad1b51fa8c729c564a44
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F45D:12459A:14DF05:195A37:68C2EEC2
+      - F21B:2AFB8F:119511:151B54:68CC1D8B
       X-Served-By:
-      - cache-bos4686-BOS
+      - cache-bos4670-BOS
       X-Timer:
-      - S1757605925.773436,VS0,VE1
+      - S1758207386.775239,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -476,7 +476,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/provider.json
   response:
@@ -513,13 +513,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:04 GMT
+      - Thu, 18 Sep 2025 14:56:25 GMT
       ETag:
       - '"a92eac8e15643dce5b9165724ce350d2ee5edad5f8baca7140c79ce8ce0da8c6"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:04 GMT
+      - Thu, 18 Sep 2025 15:01:25 GMT
       Source-Age:
-      - '13'
+      - '14'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -529,19 +529,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - da391c4c3ac538cfcaefebafe4ea955bfa8bd3ad
+      - e9a62ab5181ef04772098d99ed6effbd8ef330ca
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 13D9:87AC7:1335CB:17A9EB:68C2EEC3
+      - B078:1485D6:12232B:15A44A:68CC1D8B
       X-Served-By:
-      - cache-bos4668-BOS
+      - cache-bos4643-BOS
       X-Timer:
-      - S1757605925.838198,VS0,VE2
+      - S1758207386.833458,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example64].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example64].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/item.json
   response:
@@ -96,13 +96,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:04 GMT
+      - Thu, 18 Sep 2025 14:56:25 GMT
       ETag:
       - '"eb4ef35f5071c45c7b53e7fe6ef92a682455a0de207fcbe27507488c4bfcc9ca"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:04 GMT
+      - Thu, 18 Sep 2025 15:01:25 GMT
       Source-Age:
-      - '14'
+      - '15'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -112,19 +112,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - aca52668b088f0a43a902546459dcf9b797b034f
+      - 0c17b857f9a1f786b8bf14a997f2ed95a53d3556
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F39D:1762AB:68C2EEC2
+      - DF64:33F2BE:BEF70:EA0D4:68CC1D8A
       X-Served-By:
-      - cache-bos4638-BOS
+      - cache-bos4681-BOS
       X-Timer:
-      - S1757605925.909097,VS0,VE0
+      - S1758207386.895073,VS0,VE2
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -134,7 +134,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/basics.json
   response:
@@ -164,13 +164,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:04 GMT
+      - Thu, 18 Sep 2025 14:56:25 GMT
       ETag:
       - '"2436fa8ce8356cb57ec6581098dc3ea04f5395558aaca6e4008e09eb43f0a9db"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:04 GMT
+      - Thu, 18 Sep 2025 15:01:25 GMT
       Source-Age:
-      - '14'
+      - '16'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -184,15 +184,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 45f7dd0afcb9efb10f76a4a5d162b4f910c08ccb
+      - a63898c0ba49e183ab19d7e6f79eb1c0fa5335fc
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F42A:3A83F:147263:18E1C9:68C2EEC1
+      - F7BE:14958F:C3456:EE728:68CC1D89
       X-Served-By:
-      - cache-bos4621-BOS
+      - cache-bos4645-BOS
       X-Timer:
-      - S1757605925.968328,VS0,VE0
+      - S1758207386.961997,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -202,7 +202,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/datetimerange.json
   response:
@@ -237,13 +237,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:05 GMT
+      - Thu, 18 Sep 2025 14:56:26 GMT
       ETag:
       - '"e1248a7fa9f6feeddb9c683a0fcfcab1b8ea66ae5db2d9a36f0602d44879a0f8"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:05 GMT
+      - Thu, 18 Sep 2025 15:01:26 GMT
       Source-Age:
-      - '14'
+      - '15'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -257,15 +257,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 393cd49e3be8fb872007a942f50b73e14e2a6427
+      - 7a699b18496299031a61351c20638a0227fd9eaf
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 7F51:114F63:12D433:1743BA:68C2EEBE
+      - 9DD1:E9BED:A09F7:CECE4:68CC1D8A
       X-Served-By:
-      - cache-bos4689-BOS
+      - cache-bos4666-BOS
       X-Timer:
-      - S1757605925.028119,VS0,VE1
+      - S1758207386.026912,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -275,7 +275,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/instrument.json
   response:
@@ -306,13 +306,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:05 GMT
+      - Thu, 18 Sep 2025 14:56:26 GMT
       ETag:
       - '"84c39a084fe100d85a10cdeef11399cb06ceed2c623ee37cfbdb03f85d39477c"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:05 GMT
+      - Thu, 18 Sep 2025 15:01:26 GMT
       Source-Age:
-      - '14'
+      - '15'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -326,15 +326,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - e3a47c73667ee0bea03acb705cf39a8bc02296a7
+      - 74fc0e3793f6322e7d8d476257d457d2a4ae532d
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - DE22:5461F:13BA26:1824C1:68C2EEC2
+      - 1F1B:2036C0:A67D8:D4AEF:68CC1D8A
       X-Served-By:
-      - cache-bos4667-BOS
+      - cache-bos4647-BOS
       X-Timer:
-      - S1757605925.090025,VS0,VE0
+      - S1758207386.097348,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -344,7 +344,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/licensing.json
   response:
@@ -371,13 +371,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:05 GMT
+      - Thu, 18 Sep 2025 14:56:26 GMT
       ETag:
       - '"d2cd4998f5154410f2dc79b42af5baaf118454186cee8d12066a5f42d3e821fc"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:05 GMT
+      - Thu, 18 Sep 2025 15:01:26 GMT
       Source-Age:
-      - '14'
+      - '15'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -391,15 +391,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 58a43e9c12d2df89c29be5d7e78e21ce5819d467
+      - 3ce5d38a28a29fa7ab6b1aa3428d2257ff283819
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 2635:21E1E:F47BCB:132FF57:68C2EEC1
+      - 5403:383255:115583:14CF3E:68CC1D8B
       X-Served-By:
-      - cache-bos4654-BOS
+      - cache-bos4669-BOS
       X-Timer:
-      - S1757605925.145649,VS0,VE1
+      - S1758207386.161831,VS0,VE2
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -409,7 +409,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/metadata.json
   response:
@@ -438,13 +438,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:05 GMT
+      - Thu, 18 Sep 2025 14:56:26 GMT
       ETag:
       - '"a99228769e5d0400f7b006fa153262053fb7a6ffdb3b8bbf51c4df37a82098f6"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:05 GMT
+      - Thu, 18 Sep 2025 15:01:26 GMT
       Source-Age:
-      - '14'
+      - '15'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -458,15 +458,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - dc1a6534065e415043503322d0d23c592a861795
+      - fde2c9ee9ff93cf7d7a8f5758e33b371fa3f59ca
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F45D:12459A:14DF05:195A37:68C2EEC2
+      - F21B:2AFB8F:119511:151B54:68CC1D8B
       X-Served-By:
-      - cache-bos4624-BOS
+      - cache-bos4659-BOS
       X-Timer:
-      - S1757605925.207849,VS0,VE1
+      - S1758207386.228917,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -476,7 +476,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/provider.json
   response:
@@ -513,11 +513,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:05 GMT
+      - Thu, 18 Sep 2025 14:56:26 GMT
       ETag:
       - '"a92eac8e15643dce5b9165724ce350d2ee5edad5f8baca7140c79ce8ce0da8c6"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:05 GMT
+      - Thu, 18 Sep 2025 15:01:26 GMT
       Source-Age:
       - '14'
       Strict-Transport-Security:
@@ -533,15 +533,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 02997757a0ab3227d4a1982d1adfe141db0b22d2
+      - 7f0dd2ec65882f1eb83c59c61204cc737784aea1
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 13D9:87AC7:1335CB:17A9EB:68C2EEC3
+      - B078:1485D6:12232B:15A44A:68CC1D8B
       X-Served-By:
-      - cache-bos4673-BOS
+      - cache-bos4668-BOS
       X-Timer:
-      - S1757605925.266151,VS0,VE2
+      - S1758207386.302341,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -551,7 +551,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/extensions/eo/json-schema/schema.json
   response:
@@ -604,11 +604,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:05 GMT
+      - Thu, 18 Sep 2025 14:56:26 GMT
       ETag:
       - '"4ce0628a6b4d2c8e80ff67d116b60196c8f9d0a017a63b3557ebd6b46f42dfef"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:05 GMT
+      - Thu, 18 Sep 2025 15:01:26 GMT
       Source-Age:
       - '14'
       Strict-Transport-Security:
@@ -624,15 +624,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - c0af53aea2b79f7c808c6e90dc8a0844fa53ce6b
+      - 0af3adcd96b15a3a66f786120d79a94948c044b3
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 5020:6F752:15D8B0:1A5E45:68C2EEC3
+      - 7FC8:E9BED:A0AA0:CEDB6:68CC1D8B
       X-Served-By:
-      - cache-bos4658-BOS
+      - cache-bos4645-BOS
       X-Timer:
-      - S1757605925.330758,VS0,VE1
+      - S1758207386.371356,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -642,7 +642,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/extensions/view/json-schema/schema.json
   response:
@@ -686,11 +686,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:05 GMT
+      - Thu, 18 Sep 2025 14:56:26 GMT
       ETag:
       - '"e3e45b623ffe7f49713a2595b631681ba13de3813a1f297508e46360b2becd71"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:05 GMT
+      - Thu, 18 Sep 2025 15:01:26 GMT
       Source-Age:
       - '11'
       Strict-Transport-Security:
@@ -706,15 +706,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 842a910c0610dd332150868aa5b6de3e5469c1a6
+      - ec8d7a5b34f2b6c834fd1d25a20832d066a1037f
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 7F99:1C3F94:14550C:18C5EE:68C2EEC5
+      - 2E67:2A363F:A6B3E:D5185:68CC1D8E
       X-Served-By:
-      - cache-bos4633-BOS
+      - cache-bos4638-BOS
       X-Timer:
-      - S1757605925.392776,VS0,VE1
+      - S1758207386.447777,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example65].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example65].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/item.json
   response:
@@ -96,13 +96,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:05 GMT
+      - Thu, 18 Sep 2025 14:56:26 GMT
       ETag:
       - '"eb4ef35f5071c45c7b53e7fe6ef92a682455a0de207fcbe27507488c4bfcc9ca"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:05 GMT
+      - Thu, 18 Sep 2025 15:01:26 GMT
       Source-Age:
-      - '15'
+      - '16'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -116,15 +116,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 3f33023b8b0d514123a48d02c462f7b7719a825f
+      - a8d529e0872cfba95c0a341086365b33ead7987f
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F39D:1762AB:68C2EEC2
+      - DF64:33F2BE:BEF70:EA0D4:68CC1D8A
       X-Served-By:
-      - cache-bos4640-BOS
+      - cache-bos4690-BOS
       X-Timer:
-      - S1757605925.464135,VS0,VE1
+      - S1758207387.535156,VS0,VE2
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -134,7 +134,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/basics.json
   response:
@@ -164,13 +164,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:05 GMT
+      - Thu, 18 Sep 2025 14:56:26 GMT
       ETag:
       - '"2436fa8ce8356cb57ec6581098dc3ea04f5395558aaca6e4008e09eb43f0a9db"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:05 GMT
+      - Thu, 18 Sep 2025 15:01:26 GMT
       Source-Age:
-      - '15'
+      - '16'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -184,15 +184,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 2145721e6a63297a879afc8b25f6094b8ce51f76
+      - b7829a4c61fc9bc791fd76e69da4c97aebcf53cd
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F42A:3A83F:147263:18E1C9:68C2EEC1
+      - F7BE:14958F:C3456:EE728:68CC1D89
       X-Served-By:
-      - cache-bos4645-BOS
+      - cache-bos4629-BOS
       X-Timer:
-      - S1757605926.540154,VS0,VE1
+      - S1758207387.610958,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -202,7 +202,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/datetimerange.json
   response:
@@ -237,13 +237,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:05 GMT
+      - Thu, 18 Sep 2025 14:56:26 GMT
       ETag:
       - '"e1248a7fa9f6feeddb9c683a0fcfcab1b8ea66ae5db2d9a36f0602d44879a0f8"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:05 GMT
+      - Thu, 18 Sep 2025 15:01:26 GMT
       Source-Age:
-      - '15'
+      - '16'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -257,15 +257,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - addb8a0ba4cf0e38d684eb8432205cb2380556ee
+      - 4f4f71a1dd8103cc1b7a50240bb89b72d8f4359d
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 7F51:114F63:12D433:1743BA:68C2EEBE
+      - 9DD1:E9BED:A09F7:CECE4:68CC1D8A
       X-Served-By:
-      - cache-bos4634-BOS
+      - cache-bos4647-BOS
       X-Timer:
-      - S1757605926.608144,VS0,VE1
+      - S1758207387.681395,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -275,7 +275,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/instrument.json
   response:
@@ -306,13 +306,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:05 GMT
+      - Thu, 18 Sep 2025 14:56:26 GMT
       ETag:
       - '"84c39a084fe100d85a10cdeef11399cb06ceed2c623ee37cfbdb03f85d39477c"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:05 GMT
+      - Thu, 18 Sep 2025 15:01:26 GMT
       Source-Age:
-      - '14'
+      - '16'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -326,15 +326,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 7c0dfcea3eacc69956d66627e5f59f716de05b1b
+      - 7d752d082ca760649fed409a6506bab16c97ed8f
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - DE22:5461F:13BA26:1824C1:68C2EEC2
+      - 1F1B:2036C0:A67D8:D4AEF:68CC1D8A
       X-Served-By:
-      - cache-bos4635-BOS
+      - cache-bos4637-BOS
       X-Timer:
-      - S1757605926.673055,VS0,VE1
+      - S1758207387.751411,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -344,7 +344,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/licensing.json
   response:
@@ -371,13 +371,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:05 GMT
+      - Thu, 18 Sep 2025 14:56:26 GMT
       ETag:
       - '"d2cd4998f5154410f2dc79b42af5baaf118454186cee8d12066a5f42d3e821fc"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:05 GMT
+      - Thu, 18 Sep 2025 15:01:26 GMT
       Source-Age:
-      - '14'
+      - '15'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -391,15 +391,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - de166b61abf39c6a44d48824148bc6fdef530d88
+      - e47cf36e9023935b1f22af659e73c139372a71cc
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 2635:21E1E:F47BCB:132FF57:68C2EEC1
+      - 5403:383255:115583:14CF3E:68CC1D8B
       X-Served-By:
-      - cache-bos4631-BOS
+      - cache-bos4634-BOS
       X-Timer:
-      - S1757605926.734403,VS0,VE1
+      - S1758207387.823133,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -409,7 +409,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/metadata.json
   response:
@@ -438,13 +438,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:05 GMT
+      - Thu, 18 Sep 2025 14:56:26 GMT
       ETag:
       - '"a99228769e5d0400f7b006fa153262053fb7a6ffdb3b8bbf51c4df37a82098f6"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:05 GMT
+      - Thu, 18 Sep 2025 15:01:26 GMT
       Source-Age:
-      - '14'
+      - '15'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -458,15 +458,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 13d82ee06405b1e843e589d367d6ca95aca88209
+      - 18b064b6e05ee6728903a58dee5c2cde47fc82f3
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F45D:12459A:14DF05:195A37:68C2EEC2
+      - F21B:2AFB8F:119511:151B54:68CC1D8B
       X-Served-By:
-      - cache-bos4646-BOS
+      - cache-bos4629-BOS
       X-Timer:
-      - S1757605926.794874,VS0,VE1
+      - S1758207387.892751,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -476,7 +476,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/provider.json
   response:
@@ -513,13 +513,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:05 GMT
+      - Thu, 18 Sep 2025 14:56:26 GMT
       ETag:
       - '"a92eac8e15643dce5b9165724ce350d2ee5edad5f8baca7140c79ce8ce0da8c6"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:05 GMT
+      - Thu, 18 Sep 2025 15:01:26 GMT
       Source-Age:
-      - '14'
+      - '15'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -533,15 +533,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 343a8b5343d2be55133431852d17043e2bf3991c
+      - 06dfe95531865294f74b5264f332555693beea8d
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 13D9:87AC7:1335CB:17A9EB:68C2EEC3
+      - B078:1485D6:12232B:15A44A:68CC1D8B
       X-Served-By:
-      - cache-bos4647-BOS
+      - cache-bos4632-BOS
       X-Timer:
-      - S1757605926.860188,VS0,VE1
+      - S1758207387.959396,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -551,7 +551,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/extensions/eo/json-schema/schema.json
   response:
@@ -604,13 +604,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:05 GMT
+      - Thu, 18 Sep 2025 14:56:27 GMT
       ETag:
       - '"4ce0628a6b4d2c8e80ff67d116b60196c8f9d0a017a63b3557ebd6b46f42dfef"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:05 GMT
+      - Thu, 18 Sep 2025 15:01:27 GMT
       Source-Age:
-      - '14'
+      - '15'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -624,15 +624,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 5b09270e6b5c653c0e549de8eadf72abd30383be
+      - fd3ab355a022ff6f2192f548b993f9128d011b20
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 5020:6F752:15D8B0:1A5E45:68C2EEC3
+      - 7FC8:E9BED:A0AA0:CEDB6:68CC1D8B
       X-Served-By:
-      - cache-bos4659-BOS
+      - cache-bos4625-BOS
       X-Timer:
-      - S1757605926.924138,VS0,VE1
+      - S1758207387.028991,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -642,7 +642,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/extensions/view/json-schema/schema.json
   response:
@@ -686,13 +686,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:05 GMT
+      - Thu, 18 Sep 2025 14:56:27 GMT
       ETag:
       - '"e3e45b623ffe7f49713a2595b631681ba13de3813a1f297508e46360b2becd71"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:05 GMT
+      - Thu, 18 Sep 2025 15:01:27 GMT
       Source-Age:
-      - '11'
+      - '12'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -706,15 +706,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 75557b9609fad0f7b595dbee02d65959d16fa3c2
+      - 8f2dec9c507c9d4d2d38a5c170623caddc2cf534
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 7F99:1C3F94:14550C:18C5EE:68C2EEC5
+      - 2E67:2A363F:A6B3E:D5185:68CC1D8E
       X-Served-By:
-      - cache-bos4634-BOS
+      - cache-bos4648-BOS
       X-Timer:
-      - S1757605926.989231,VS0,VE1
+      - S1758207387.105109,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example66].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example66].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/item.json
   response:
@@ -96,13 +96,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:06 GMT
+      - Thu, 18 Sep 2025 14:56:27 GMT
       ETag:
       - '"eb4ef35f5071c45c7b53e7fe6ef92a682455a0de207fcbe27507488c4bfcc9ca"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:06 GMT
+      - Thu, 18 Sep 2025 15:01:27 GMT
       Source-Age:
-      - '15'
+      - '17'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -116,15 +116,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 6fea1462ff6730452041911833441f913d8f0c00
+      - b2e7eda78650c4e8f95c9840120d5c1f8f97ebb6
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F39D:1762AB:68C2EEC2
+      - DF64:33F2BE:BEF70:EA0D4:68CC1D8A
       X-Served-By:
-      - cache-bos4645-BOS
+      - cache-bos4623-BOS
       X-Timer:
-      - S1757605926.056758,VS0,VE1
+      - S1758207387.183597,VS0,VE2
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -134,7 +134,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/basics.json
   response:
@@ -164,13 +164,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:06 GMT
+      - Thu, 18 Sep 2025 14:56:27 GMT
       ETag:
       - '"2436fa8ce8356cb57ec6581098dc3ea04f5395558aaca6e4008e09eb43f0a9db"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:06 GMT
+      - Thu, 18 Sep 2025 15:01:27 GMT
       Source-Age:
-      - '15'
+      - '17'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -184,15 +184,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - c862a778b5559d62e763e888ce991fba37b2bdb2
+      - 48d2e3808bdbc218c8738fbee39452ec734cbc3f
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F42A:3A83F:147263:18E1C9:68C2EEC1
+      - F7BE:14958F:C3456:EE728:68CC1D89
       X-Served-By:
-      - cache-bos4673-BOS
+      - cache-bos4661-BOS
       X-Timer:
-      - S1757605926.125922,VS0,VE1
+      - S1758207387.267111,VS0,VE2
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -202,7 +202,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/datetimerange.json
   response:
@@ -237,13 +237,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:06 GMT
+      - Thu, 18 Sep 2025 14:56:27 GMT
       ETag:
       - '"e1248a7fa9f6feeddb9c683a0fcfcab1b8ea66ae5db2d9a36f0602d44879a0f8"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:06 GMT
+      - Thu, 18 Sep 2025 15:01:27 GMT
       Source-Age:
-      - '15'
+      - '16'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -257,15 +257,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 85465eb66a18418c3a97d2ffacf70b73c1ffb16e
+      - d2c2072eb0e4c2bdc934ef94bd40b5e2ea598792
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 7F51:114F63:12D433:1743BA:68C2EEBE
+      - 9DD1:E9BED:A09F7:CECE4:68CC1D8A
       X-Served-By:
-      - cache-bos4674-BOS
+      - cache-bos4637-BOS
       X-Timer:
-      - S1757605926.191990,VS0,VE1
+      - S1758207387.339375,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -275,7 +275,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/instrument.json
   response:
@@ -306,13 +306,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:06 GMT
+      - Thu, 18 Sep 2025 14:56:27 GMT
       ETag:
       - '"84c39a084fe100d85a10cdeef11399cb06ceed2c623ee37cfbdb03f85d39477c"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:06 GMT
+      - Thu, 18 Sep 2025 15:01:27 GMT
       Source-Age:
-      - '15'
+      - '16'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -326,15 +326,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 84eed00e2b2b3f31e37eb42d737c53530cc8c39e
+      - 8d6a17644539050e1249d0d843e6efc854f5b93e
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - DE22:5461F:13BA26:1824C1:68C2EEC2
+      - 1F1B:2036C0:A67D8:D4AEF:68CC1D8A
       X-Served-By:
-      - cache-bos4642-BOS
+      - cache-bos4646-BOS
       X-Timer:
-      - S1757605926.256207,VS0,VE2
+      - S1758207387.399071,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -344,7 +344,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/licensing.json
   response:
@@ -371,13 +371,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:06 GMT
+      - Thu, 18 Sep 2025 14:56:27 GMT
       ETag:
       - '"d2cd4998f5154410f2dc79b42af5baaf118454186cee8d12066a5f42d3e821fc"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:06 GMT
+      - Thu, 18 Sep 2025 15:01:27 GMT
       Source-Age:
-      - '15'
+      - '16'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -391,15 +391,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - d16232af18ebd2b015297c1e30141bc508a7cacd
+      - 12791a78a2cbd8b7d8d43f767a6cd58ee1e06c2d
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 2635:21E1E:F47BCB:132FF57:68C2EEC1
+      - 5403:383255:115583:14CF3E:68CC1D8B
       X-Served-By:
-      - cache-bos4669-BOS
+      - cache-bos4639-BOS
       X-Timer:
-      - S1757605926.323522,VS0,VE1
+      - S1758207387.461367,VS0,VE2
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -409,7 +409,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/metadata.json
   response:
@@ -438,13 +438,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:06 GMT
+      - Thu, 18 Sep 2025 14:56:27 GMT
       ETag:
       - '"a99228769e5d0400f7b006fa153262053fb7a6ffdb3b8bbf51c4df37a82098f6"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:06 GMT
+      - Thu, 18 Sep 2025 15:01:27 GMT
       Source-Age:
-      - '15'
+      - '16'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -458,15 +458,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 8ef27aa4abc3b8892ee417945e96a7df7abe6812
+      - 635ec6522ba5f1a1106459a4d0734681adc05608
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F45D:12459A:14DF05:195A37:68C2EEC2
+      - F21B:2AFB8F:119511:151B54:68CC1D8B
       X-Served-By:
-      - cache-bos4637-BOS
+      - cache-bos4651-BOS
       X-Timer:
-      - S1757605926.396137,VS0,VE1
+      - S1758207388.523601,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -476,7 +476,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/provider.json
   response:
@@ -513,13 +513,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:06 GMT
+      - Thu, 18 Sep 2025 14:56:27 GMT
       ETag:
       - '"a92eac8e15643dce5b9165724ce350d2ee5edad5f8baca7140c79ce8ce0da8c6"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:06 GMT
+      - Thu, 18 Sep 2025 15:01:27 GMT
       Source-Age:
-      - '15'
+      - '16'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -533,15 +533,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 34864ad8db8ac11e68e6eeab2d5d0bb7b7eed090
+      - d41e6373c065dc75f6a59001c9f5c5627258d84d
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 13D9:87AC7:1335CB:17A9EB:68C2EEC3
+      - B078:1485D6:12232B:15A44A:68CC1D8B
       X-Served-By:
-      - cache-bos4645-BOS
+      - cache-bos4630-BOS
       X-Timer:
-      - S1757605926.464531,VS0,VE1
+      - S1758207388.587145,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -551,7 +551,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/extensions/eo/json-schema/schema.json
   response:
@@ -604,13 +604,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:06 GMT
+      - Thu, 18 Sep 2025 14:56:27 GMT
       ETag:
       - '"4ce0628a6b4d2c8e80ff67d116b60196c8f9d0a017a63b3557ebd6b46f42dfef"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:06 GMT
+      - Thu, 18 Sep 2025 15:01:27 GMT
       Source-Age:
-      - '15'
+      - '16'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -624,15 +624,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - b58d23bb2ef1a9b99c9703639a6b7b0454a641ee
+      - 580d6f89fa07f9325554049545cdbc9d18a8b1cf
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 5020:6F752:15D8B0:1A5E45:68C2EEC3
+      - 7FC8:E9BED:A0AA0:CEDB6:68CC1D8B
       X-Served-By:
-      - cache-bos4674-BOS
+      - cache-bos4621-BOS
       X-Timer:
-      - S1757605927.531594,VS0,VE1
+      - S1758207388.652532,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -642,7 +642,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/extensions/view/json-schema/schema.json
   response:
@@ -686,11 +686,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:06 GMT
+      - Thu, 18 Sep 2025 14:56:27 GMT
       ETag:
       - '"e3e45b623ffe7f49713a2595b631681ba13de3813a1f297508e46360b2becd71"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:06 GMT
+      - Thu, 18 Sep 2025 15:01:27 GMT
       Source-Age:
       - '12'
       Strict-Transport-Security:
@@ -706,15 +706,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 4a8553e03713929eedf45a763f0f66f7d42dcc68
+      - ce1a1f29925b38e296996396b77a2189573d7e03
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 7F99:1C3F94:14550C:18C5EE:68C2EEC5
+      - 2E67:2A363F:A6B3E:D5185:68CC1D8E
       X-Served-By:
-      - cache-bos4667-BOS
+      - cache-bos4684-BOS
       X-Timer:
-      - S1757605927.607945,VS0,VE1
+      - S1758207388.715023,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example67].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example67].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/item.json
   response:
@@ -96,13 +96,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:06 GMT
+      - Thu, 18 Sep 2025 14:56:27 GMT
       ETag:
       - '"eb4ef35f5071c45c7b53e7fe6ef92a682455a0de207fcbe27507488c4bfcc9ca"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:06 GMT
+      - Thu, 18 Sep 2025 15:01:27 GMT
       Source-Age:
-      - '16'
+      - '17'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -116,15 +116,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - fd652d96f23eb9028d4856e794b3d3271da4a8bb
+      - 34ce95fd78c44438dda6e85328ac1f8d1ca869a0
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F39D:1762AB:68C2EEC2
+      - DF64:33F2BE:BEF70:EA0D4:68CC1D8A
       X-Served-By:
-      - cache-bos4623-BOS
+      - cache-bos4625-BOS
       X-Timer:
-      - S1757605927.694296,VS0,VE1
+      - S1758207388.790146,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -134,7 +134,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/basics.json
   response:
@@ -164,13 +164,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:06 GMT
+      - Thu, 18 Sep 2025 14:56:27 GMT
       ETag:
       - '"2436fa8ce8356cb57ec6581098dc3ea04f5395558aaca6e4008e09eb43f0a9db"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:06 GMT
+      - Thu, 18 Sep 2025 15:01:27 GMT
       Source-Age:
-      - '16'
+      - '17'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -180,19 +180,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 91127fb6c8d90dd4f411c6e97fc82172a7537e0c
+      - 99803c27c1bd6d44fb791a6814d829f91710c0f7
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F42A:3A83F:147263:18E1C9:68C2EEC1
+      - F7BE:14958F:C3456:EE728:68CC1D89
       X-Served-By:
-      - cache-bos4653-BOS
+      - cache-bos4621-BOS
       X-Timer:
-      - S1757605927.777497,VS0,VE0
+      - S1758207388.854707,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -202,7 +202,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/datetimerange.json
   response:
@@ -237,13 +237,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:06 GMT
+      - Thu, 18 Sep 2025 14:56:27 GMT
       ETag:
       - '"e1248a7fa9f6feeddb9c683a0fcfcab1b8ea66ae5db2d9a36f0602d44879a0f8"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:06 GMT
+      - Thu, 18 Sep 2025 15:01:27 GMT
       Source-Age:
-      - '16'
+      - '18'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -257,15 +257,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 98d3b8fffbd3f36dfd720271ca8160a4b7929716
+      - 7aef465c87ce9287f6ea58dac5b18a3d40518589
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 7F51:114F63:12D433:1743BA:68C2EEBE
+      - 9DD1:E9BED:A09F7:CECE4:68CC1D8A
       X-Served-By:
-      - cache-bos4634-BOS
+      - cache-bos4692-BOS
       X-Timer:
-      - S1757605927.856117,VS0,VE0
+      - S1758207388.919066,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -275,7 +275,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/instrument.json
   response:
@@ -306,13 +306,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:06 GMT
+      - Thu, 18 Sep 2025 14:56:27 GMT
       ETag:
       - '"84c39a084fe100d85a10cdeef11399cb06ceed2c623ee37cfbdb03f85d39477c"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:06 GMT
+      - Thu, 18 Sep 2025 15:01:27 GMT
       Source-Age:
-      - '16'
+      - '17'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -322,19 +322,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 0c1743675cf9a731565920609b66c8b853de6049
+      - e66997d5a28d9f1d2325305cc1729c54f913a350
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - DE22:5461F:13BA26:1824C1:68C2EEC2
+      - 1F1B:2036C0:A67D8:D4AEF:68CC1D8A
       X-Served-By:
-      - cache-bos4685-BOS
+      - cache-bos4642-BOS
       X-Timer:
-      - S1757605927.927928,VS0,VE1
+      - S1758207388.979681,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -344,7 +344,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/licensing.json
   response:
@@ -371,13 +371,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:07 GMT
+      - Thu, 18 Sep 2025 14:56:28 GMT
       ETag:
       - '"d2cd4998f5154410f2dc79b42af5baaf118454186cee8d12066a5f42d3e821fc"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:07 GMT
+      - Thu, 18 Sep 2025 15:01:28 GMT
       Source-Age:
-      - '16'
+      - '17'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -391,15 +391,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 5f15da364cec149f9cd269f513ee93f845d7eea8
+      - 10278f3024a7f5e2cd8f39ea5f50ce05bd68031f
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 2635:21E1E:F47BCB:132FF57:68C2EEC1
+      - 5403:383255:115583:14CF3E:68CC1D8B
       X-Served-By:
-      - cache-bos4635-BOS
+      - cache-bos4660-BOS
       X-Timer:
-      - S1757605927.002969,VS0,VE1
+      - S1758207388.041476,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -409,7 +409,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/metadata.json
   response:
@@ -438,13 +438,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:07 GMT
+      - Thu, 18 Sep 2025 14:56:28 GMT
       ETag:
       - '"a99228769e5d0400f7b006fa153262053fb7a6ffdb3b8bbf51c4df37a82098f6"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:07 GMT
+      - Thu, 18 Sep 2025 15:01:28 GMT
       Source-Age:
-      - '16'
+      - '17'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -454,19 +454,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '3'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 7714f8ffc9db00f345e2862804a14f2be2b2af1c
+      - b180e67ae2c8bed9e8f02f7d2293b59c9b2b02dc
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F45D:12459A:14DF05:195A37:68C2EEC2
+      - F21B:2AFB8F:119511:151B54:68CC1D8B
       X-Served-By:
-      - cache-bos4626-BOS
+      - cache-bos4625-BOS
       X-Timer:
-      - S1757605927.079575,VS0,VE1
+      - S1758207388.103156,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -476,7 +476,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/provider.json
   response:
@@ -513,11 +513,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:07 GMT
+      - Thu, 18 Sep 2025 14:56:28 GMT
       ETag:
       - '"a92eac8e15643dce5b9165724ce350d2ee5edad5f8baca7140c79ce8ce0da8c6"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:07 GMT
+      - Thu, 18 Sep 2025 15:01:28 GMT
       Source-Age:
       - '16'
       Strict-Transport-Security:
@@ -533,15 +533,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - d585f59e69e6e7d4ccddd5cc678cc4c91ead6829
+      - d859aa0119a699552739608eb12770ac2ba4b0c9
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 13D9:87AC7:1335CB:17A9EB:68C2EEC3
+      - B078:1485D6:12232B:15A44A:68CC1D8B
       X-Served-By:
-      - cache-bos4624-BOS
+      - cache-bos4627-BOS
       X-Timer:
-      - S1757605927.150401,VS0,VE1
+      - S1758207388.174544,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -551,7 +551,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/extensions/eo/json-schema/schema.json
   response:
@@ -604,11 +604,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:07 GMT
+      - Thu, 18 Sep 2025 14:56:28 GMT
       ETag:
       - '"4ce0628a6b4d2c8e80ff67d116b60196c8f9d0a017a63b3557ebd6b46f42dfef"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:07 GMT
+      - Thu, 18 Sep 2025 15:01:28 GMT
       Source-Age:
       - '16'
       Strict-Transport-Security:
@@ -624,15 +624,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 2b697c4deb8337bd541ae2fd97312c2b4e5e3282
+      - e44b57f1ccce62b658141126c31c0a5311fa1e88
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 5020:6F752:15D8B0:1A5E45:68C2EEC3
+      - 7FC8:E9BED:A0AA0:CEDB6:68CC1D8B
       X-Served-By:
-      - cache-bos4684-BOS
+      - cache-bos4688-BOS
       X-Timer:
-      - S1757605927.227723,VS0,VE1
+      - S1758207388.243218,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -642,7 +642,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/extensions/view/json-schema/schema.json
   response:
@@ -686,11 +686,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:07 GMT
+      - Thu, 18 Sep 2025 14:56:28 GMT
       ETag:
       - '"e3e45b623ffe7f49713a2595b631681ba13de3813a1f297508e46360b2becd71"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:07 GMT
+      - Thu, 18 Sep 2025 15:01:28 GMT
       Source-Age:
       - '13'
       Strict-Transport-Security:
@@ -706,15 +706,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 9e6e90f6539121d04e7385cb1fcbe11a4177582d
+      - 9ed2d3810edef81e934ebf03853ebac3236af759
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 7F99:1C3F94:14550C:18C5EE:68C2EEC5
+      - 2E67:2A363F:A6B3E:D5185:68CC1D8E
       X-Served-By:
-      - cache-bos4642-BOS
+      - cache-bos4628-BOS
       X-Timer:
-      - S1757605927.316956,VS0,VE1
+      - S1758207388.314573,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example68].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example68].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/item.json
   response:
@@ -96,13 +96,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:07 GMT
+      - Thu, 18 Sep 2025 14:56:28 GMT
       ETag:
       - '"eb4ef35f5071c45c7b53e7fe6ef92a682455a0de207fcbe27507488c4bfcc9ca"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:07 GMT
+      - Thu, 18 Sep 2025 15:01:28 GMT
       Source-Age:
-      - '17'
+      - '18'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -112,19 +112,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 7a7c7a2ba55fb501be3ef892581e064895e52d12
+      - b0cb840a7c896b2e019eb51bd2ee5e89967c9eeb
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F39D:1762AB:68C2EEC2
+      - DF64:33F2BE:BEF70:EA0D4:68CC1D8A
       X-Served-By:
-      - cache-bos4639-BOS
+      - cache-bos4693-BOS
       X-Timer:
-      - S1757605927.411097,VS0,VE1
+      - S1758207388.377213,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -134,7 +134,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/basics.json
   response:
@@ -164,13 +164,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:07 GMT
+      - Thu, 18 Sep 2025 14:56:28 GMT
       ETag:
       - '"2436fa8ce8356cb57ec6581098dc3ea04f5395558aaca6e4008e09eb43f0a9db"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:07 GMT
+      - Thu, 18 Sep 2025 15:01:28 GMT
       Source-Age:
-      - '17'
+      - '18'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -184,15 +184,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 6a1119f8e30ad161105848796003cbfa10f834a8
+      - 701b3fa8dbe20d43af925f8b04aec17188879f61
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F42A:3A83F:147263:18E1C9:68C2EEC1
+      - F7BE:14958F:C3456:EE728:68CC1D89
       X-Served-By:
-      - cache-bos4649-BOS
+      - cache-bos4669-BOS
       X-Timer:
-      - S1757605927.490857,VS0,VE1
+      - S1758207388.444185,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -202,7 +202,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/datetimerange.json
   response:
@@ -237,13 +237,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:07 GMT
+      - Thu, 18 Sep 2025 14:56:28 GMT
       ETag:
       - '"e1248a7fa9f6feeddb9c683a0fcfcab1b8ea66ae5db2d9a36f0602d44879a0f8"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:07 GMT
+      - Thu, 18 Sep 2025 15:01:28 GMT
       Source-Age:
-      - '16'
+      - '18'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -253,19 +253,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - dc36e47d07606dfce5b1858c56a19208fb08ff48
+      - cce990d9f38f6d61f140f8a7bcbbe953c142c319
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 7F51:114F63:12D433:1743BA:68C2EEBE
+      - 9DD1:E9BED:A09F7:CECE4:68CC1D8A
       X-Served-By:
-      - cache-bos4670-BOS
+      - cache-bos4682-BOS
       X-Timer:
-      - S1757605928.562638,VS0,VE2
+      - S1758207389.507341,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -275,7 +275,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/instrument.json
   response:
@@ -306,13 +306,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:07 GMT
+      - Thu, 18 Sep 2025 14:56:28 GMT
       ETag:
       - '"84c39a084fe100d85a10cdeef11399cb06ceed2c623ee37cfbdb03f85d39477c"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:07 GMT
+      - Thu, 18 Sep 2025 15:01:28 GMT
       Source-Age:
-      - '16'
+      - '17'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -326,15 +326,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - f392ab6103cbfd1eaaab3b567409afecf61dbfdb
+      - d66b562798eb4809e12822ff38646259db1c7f46
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - DE22:5461F:13BA26:1824C1:68C2EEC2
+      - 1F1B:2036C0:A67D8:D4AEF:68CC1D8A
       X-Served-By:
-      - cache-bos4660-BOS
+      - cache-bos4678-BOS
       X-Timer:
-      - S1757605928.638182,VS0,VE1
+      - S1758207389.571689,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -344,7 +344,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/licensing.json
   response:
@@ -371,13 +371,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:07 GMT
+      - Thu, 18 Sep 2025 14:56:28 GMT
       ETag:
       - '"d2cd4998f5154410f2dc79b42af5baaf118454186cee8d12066a5f42d3e821fc"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:07 GMT
+      - Thu, 18 Sep 2025 15:01:28 GMT
       Source-Age:
-      - '16'
+      - '17'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -387,19 +387,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - b632e370d9f9a8897e672d9b7105ea04ec6152c2
+      - b647d7aee82b348014c711ac3b764ea4f3b91475
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 2635:21E1E:F47BCB:132FF57:68C2EEC1
+      - 5403:383255:115583:14CF3E:68CC1D8B
       X-Served-By:
-      - cache-bos4693-BOS
+      - cache-bos4646-BOS
       X-Timer:
-      - S1757605928.702244,VS0,VE1
+      - S1758207389.635346,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -409,7 +409,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/metadata.json
   response:
@@ -438,13 +438,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:07 GMT
+      - Thu, 18 Sep 2025 14:56:28 GMT
       ETag:
       - '"a99228769e5d0400f7b006fa153262053fb7a6ffdb3b8bbf51c4df37a82098f6"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:07 GMT
+      - Thu, 18 Sep 2025 15:01:28 GMT
       Source-Age:
-      - '16'
+      - '17'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -454,19 +454,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 1355c7ad0f731dd74101e4cb4abe9944cb23af94
+      - 2b2bfa8e31b0e0cdeed9f334a16fcf55430457d8
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F45D:12459A:14DF05:195A37:68C2EEC2
+      - F21B:2AFB8F:119511:151B54:68CC1D8B
       X-Served-By:
-      - cache-bos4669-BOS
+      - cache-bos4651-BOS
       X-Timer:
-      - S1757605928.764902,VS0,VE1
+      - S1758207389.696813,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -476,7 +476,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/provider.json
   response:
@@ -513,13 +513,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:07 GMT
+      - Thu, 18 Sep 2025 14:56:28 GMT
       ETag:
       - '"a92eac8e15643dce5b9165724ce350d2ee5edad5f8baca7140c79ce8ce0da8c6"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:07 GMT
+      - Thu, 18 Sep 2025 15:01:28 GMT
       Source-Age:
-      - '16'
+      - '17'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -533,15 +533,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 3308e9587364ae2629f943dde0481def97fa00c0
+      - 722bd4af4ead6d8344139ae6c9b2e4bee320f19d
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 13D9:87AC7:1335CB:17A9EB:68C2EEC3
+      - B078:1485D6:12232B:15A44A:68CC1D8B
       X-Served-By:
-      - cache-bos4669-BOS
+      - cache-bos4683-BOS
       X-Timer:
-      - S1757605928.833485,VS0,VE1
+      - S1758207389.757150,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example69].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example69].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/item.json
   response:
@@ -96,13 +96,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:07 GMT
+      - Thu, 18 Sep 2025 14:56:28 GMT
       ETag:
       - '"eb4ef35f5071c45c7b53e7fe6ef92a682455a0de207fcbe27507488c4bfcc9ca"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:07 GMT
+      - Thu, 18 Sep 2025 15:01:28 GMT
       Source-Age:
-      - '17'
+      - '18'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -116,15 +116,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 87dc8f5f4346ebab82f74150e0a89a91f68929c5
+      - 0405f649ee2fc6b2b6218ef04cb5d5d73bd577c3
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3DDA:1CB1E4:12F39D:1762AB:68C2EEC2
+      - DF64:33F2BE:BEF70:EA0D4:68CC1D8A
       X-Served-By:
-      - cache-bos4660-BOS
+      - cache-bos4689-BOS
       X-Timer:
-      - S1757605928.897902,VS0,VE1
+      - S1758207389.821243,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -134,7 +134,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/basics.json
   response:
@@ -164,13 +164,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:07 GMT
+      - Thu, 18 Sep 2025 14:56:28 GMT
       ETag:
       - '"2436fa8ce8356cb57ec6581098dc3ea04f5395558aaca6e4008e09eb43f0a9db"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:07 GMT
+      - Thu, 18 Sep 2025 15:01:28 GMT
       Source-Age:
-      - '17'
+      - '18'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -184,15 +184,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - dc194a084e1f3350550a1a72083ef0e9fe234616
+      - 80448aed67c6df502b3c66d1b002296a2a3b78c1
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F42A:3A83F:147263:18E1C9:68C2EEC1
+      - F7BE:14958F:C3456:EE728:68CC1D89
       X-Served-By:
-      - cache-bos4659-BOS
+      - cache-bos4657-BOS
       X-Timer:
-      - S1757605928.963811,VS0,VE1
+      - S1758207389.889086,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -202,7 +202,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/datetimerange.json
   response:
@@ -237,13 +237,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:08 GMT
+      - Thu, 18 Sep 2025 14:56:28 GMT
       ETag:
       - '"e1248a7fa9f6feeddb9c683a0fcfcab1b8ea66ae5db2d9a36f0602d44879a0f8"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:08 GMT
+      - Thu, 18 Sep 2025 15:01:28 GMT
       Source-Age:
-      - '17'
+      - '18'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -253,19 +253,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 14ed88880f30e712572bcadf0bc2e9039a83789a
+      - d0b45d659e9181392e25f9e8a5fa9c8f7203fabb
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 7F51:114F63:12D433:1743BA:68C2EEBE
+      - 9DD1:E9BED:A09F7:CECE4:68CC1D8A
       X-Served-By:
-      - cache-bos4646-BOS
+      - cache-bos4667-BOS
       X-Timer:
-      - S1757605928.026505,VS0,VE1
+      - S1758207389.951624,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -275,7 +275,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/instrument.json
   response:
@@ -306,13 +306,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:08 GMT
+      - Thu, 18 Sep 2025 14:56:29 GMT
       ETag:
       - '"84c39a084fe100d85a10cdeef11399cb06ceed2c623ee37cfbdb03f85d39477c"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:08 GMT
+      - Thu, 18 Sep 2025 15:01:29 GMT
       Source-Age:
-      - '16'
+      - '18'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -322,19 +322,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 72a92daf2e4cfe4b06585aef7a47f62d242fe482
+      - 599836a089806a082c8bcb9e9fc0c94bbfd8cf4b
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - DE22:5461F:13BA26:1824C1:68C2EEC2
+      - 1F1B:2036C0:A67D8:D4AEF:68CC1D8A
       X-Served-By:
-      - cache-bos4660-BOS
+      - cache-bos4652-BOS
       X-Timer:
-      - S1757605928.088727,VS0,VE0
+      - S1758207389.013111,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -344,7 +344,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/licensing.json
   response:
@@ -371,13 +371,13 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:08 GMT
+      - Thu, 18 Sep 2025 14:56:29 GMT
       ETag:
       - '"d2cd4998f5154410f2dc79b42af5baaf118454186cee8d12066a5f42d3e821fc"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:08 GMT
+      - Thu, 18 Sep 2025 15:01:29 GMT
       Source-Age:
-      - '17'
+      - '18'
       Strict-Transport-Security:
       - max-age=31536000
       Vary:
@@ -387,19 +387,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 5593699684d4a818e714ec665b98d46d598327d2
+      - 69762b0f180508d817fe0268e4c1ff05a170bc94
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 2635:21E1E:F47BCB:132FF57:68C2EEC1
+      - 5403:383255:115583:14CF3E:68CC1D8B
       X-Served-By:
-      - cache-bos4624-BOS
+      - cache-bos4653-BOS
       X-Timer:
-      - S1757605928.152534,VS0,VE0
+      - S1758207389.082251,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -409,7 +409,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/metadata.json
   response:
@@ -438,11 +438,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:08 GMT
+      - Thu, 18 Sep 2025 14:56:29 GMT
       ETag:
       - '"a99228769e5d0400f7b006fa153262053fb7a6ffdb3b8bbf51c4df37a82098f6"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:08 GMT
+      - Thu, 18 Sep 2025 15:01:29 GMT
       Source-Age:
       - '17'
       Strict-Transport-Security:
@@ -458,15 +458,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 2b4776f1a9a7930a85c00c80fa48abf33ac829ee
+      - 858918129045a9753026de37836255f154190afb
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - F45D:12459A:14DF05:195A37:68C2EEC2
+      - F21B:2AFB8F:119511:151B54:68CC1D8B
       X-Served-By:
-      - cache-bos4644-BOS
+      - cache-bos4686-BOS
       X-Timer:
-      - S1757605928.218303,VS0,VE0
+      - S1758207389.151423,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -476,7 +476,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/item-spec/json-schema/provider.json
   response:
@@ -513,11 +513,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:08 GMT
+      - Thu, 18 Sep 2025 14:56:29 GMT
       ETag:
       - '"a92eac8e15643dce5b9165724ce350d2ee5edad5f8baca7140c79ce8ce0da8c6"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:08 GMT
+      - Thu, 18 Sep 2025 15:01:29 GMT
       Source-Age:
       - '17'
       Strict-Transport-Security:
@@ -533,15 +533,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 60e86ca15c11f28553f87568ffa499159c90b3b7
+      - cb3519e409bde888196b6b95d7da92bfa9c74d74
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 13D9:87AC7:1335CB:17A9EB:68C2EEC3
+      - B078:1485D6:12232B:15A44A:68CC1D8B
       X-Served-By:
-      - cache-bos4657-BOS
+      - cache-bos4649-BOS
       X-Timer:
-      - S1757605928.288374,VS0,VE1
+      - S1758207389.214533,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -551,7 +551,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/extensions/eo/json-schema/schema.json
   response:
@@ -604,11 +604,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:08 GMT
+      - Thu, 18 Sep 2025 14:56:29 GMT
       ETag:
       - '"4ce0628a6b4d2c8e80ff67d116b60196c8f9d0a017a63b3557ebd6b46f42dfef"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:08 GMT
+      - Thu, 18 Sep 2025 15:01:29 GMT
       Source-Age:
       - '17'
       Strict-Transport-Security:
@@ -624,15 +624,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 2fbd206b8a5643b478acefa3e19499121cc7c60c
+      - 5afb41e5a2aadf9d98efb46adfee023b3647cbd7
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 5020:6F752:15D8B0:1A5E45:68C2EEC3
+      - 7FC8:E9BED:A0AA0:CEDB6:68CC1D8B
       X-Served-By:
-      - cache-bos4688-BOS
+      - cache-bos4677-BOS
       X-Timer:
-      - S1757605928.352963,VS0,VE1
+      - S1758207389.287306,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -642,7 +642,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.9.0/extensions/view/json-schema/schema.json
   response:
@@ -686,11 +686,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:52:08 GMT
+      - Thu, 18 Sep 2025 14:56:29 GMT
       ETag:
       - '"e3e45b623ffe7f49713a2595b631681ba13de3813a1f297508e46360b2becd71"'
       Expires:
-      - Thu, 11 Sep 2025 15:57:08 GMT
+      - Thu, 18 Sep 2025 15:01:29 GMT
       Source-Age:
       - '14'
       Strict-Transport-Security:
@@ -702,19 +702,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 19aa899936b0c87dc046215a36fb2c6167d521ec
+      - d2787e6d56b5d0945e355eb4a6f3d714cdadea74
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 7F99:1C3F94:14550C:18C5EE:68C2EEC5
+      - 2E67:2A363F:A6B3E:D5185:68CC1D8E
       X-Served-By:
-      - cache-bos4639-BOS
+      - cache-bos4648-BOS
       X-Timer:
-      - S1757605928.420904,VS0,VE1
+      - S1758207389.372478,VS0,VE0
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example6].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example6].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/item-spec/json-schema/item.json
   response:
@@ -108,11 +108,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:43 GMT
+      - Thu, 18 Sep 2025 14:56:02 GMT
       ETag:
       - '"4e24763d74f0d463b0cb6c63fc099e0b59447c7a049b93ffda4c6eb9eb54ae95"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:43 GMT
+      - Thu, 18 Sep 2025 15:01:02 GMT
       Source-Age:
       - '1'
       Strict-Transport-Security:
@@ -128,15 +128,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - aa94bd681f0b5867df6a9f6afb7a9f8de67cb5a1
+      - 4fb23418e139dc18856d454393155d35bece245e
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 688A:1E0DA2:13B02E:181CCC:68C2EEB5
+      - DDD5:286E0:D0F1D:FC0CF:68CC1D7C
       X-Served-By:
-      - cache-bos4648-BOS
+      - cache-bos4693-BOS
       X-Timer:
-      - S1757605903.112114,VS0,VE1
+      - S1758207362.165377,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -146,7 +146,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/extensions/checksum/json-schema/schema.json
   response:
@@ -190,11 +190,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:43 GMT
+      - Thu, 18 Sep 2025 14:56:02 GMT
       ETag:
       - '"ceed674cee48a43076989957b8a4f96d8acba3f52df1d52a3745e28225923aac"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:43 GMT
+      - Thu, 18 Sep 2025 15:01:02 GMT
       Source-Age:
       - '0'
       Strict-Transport-Security:
@@ -204,21 +204,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - af8f2dafd7888bf0a534b68fe8adaea14c53bd15
+      - fb3c398d3b28c332c5248ccee0a62699818f247f
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 3EB7:6F752:15D306:1A5757:68C2EEB5
+      - A80D:3428C5:C3D9C:EEEC9:68CC1D81
       X-Served-By:
-      - cache-bos4630-BOS
+      - cache-bos4680-BOS
       X-Timer:
-      - S1757605903.177423,VS0,VE74
+      - S1758207362.239357,VS0,VE89
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example70].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example70].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/catalog-spec/json-schema/catalog.json
   response:
@@ -45,7 +45,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '341'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -55,7 +55,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:08 GMT
+      - Thu, 18 Sep 2025 14:56:29 GMT
       ETag:
       - '"66e1651c-84e"'
       Last-Modified:
@@ -67,19 +67,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 3fec157672e42ee03cc45d61ae6e1d7e225adb4d
+      - b80852503011006965cb3e4514a6bd7852360e8d
       X-GitHub-Request-Id:
-      - 6A55:180028:223E696:24A38DD:68C2EED2
+      - 3695:91567:105B1F4:125794D:68CC1D9D
       X-Served-By:
-      - cache-bos4655-BOS
+      - cache-bos4671-BOS
       X-Timer:
-      - S1757605928.493913,VS0,VE1
+      - S1758207389.475072,VS0,VE44
       expires:
-      - Thu, 11 Sep 2025 15:56:27 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example71].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example71].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/catalog-spec/json-schema/catalog.json
   response:
@@ -45,7 +45,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '341'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -55,7 +55,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:08 GMT
+      - Thu, 18 Sep 2025 14:56:29 GMT
       ETag:
       - '"66e1651c-84e"'
       Last-Modified:
@@ -71,15 +71,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 955981ce6060f1a7179f0e8f210785366ceeaf04
+      - c173c16588132f007cd39cbc01820ff554056993
       X-GitHub-Request-Id:
-      - 6A55:180028:223E696:24A38DD:68C2EED2
+      - 3695:91567:105B1F4:125794D:68CC1D9D
       X-Served-By:
-      - cache-bos4677-BOS
+      - cache-bos4678-BOS
       X-Timer:
-      - S1757605929.583112,VS0,VE2
+      - S1758207390.620792,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:27 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example72].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example72].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/collection-spec/json-schema/collection.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '340'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:08 GMT
+      - Thu, 18 Sep 2025 14:56:29 GMT
       ETag:
       - '"66e1651c-14e2"'
       Last-Modified:
@@ -107,19 +107,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 6e9e369e10903c61510f234a0bfa4a054cc0e672
+      - 2fed0438f44c569ce844d9ada528d1f6b75ab7b4
       X-GitHub-Request-Id:
-      - 3C0F:3556F2:2104189:236964E:68C2EED2
+      - DF8C:3D7940:20E828F:24A0D28:68CC1D9D
       X-Served-By:
-      - cache-bos4658-BOS
+      - cache-bos4672-BOS
       X-Timer:
-      - S1757605929.676622,VS0,VE1
+      - S1758207390.718909,VS0,VE30
       expires:
-      - Thu, 11 Sep 2025 15:56:28 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/catalog-spec/json-schema/catalog.json
   response:
@@ -171,7 +171,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '341'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -181,7 +181,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:08 GMT
+      - Thu, 18 Sep 2025 14:56:29 GMT
       ETag:
       - '"66e1651c-84e"'
       Last-Modified:
@@ -195,17 +195,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - ad5da1bee8b2277935d077bfb16771c510e46754
+      - 4a28b77bad0df04544f926e9f7b53c3e5988d1d3
       X-GitHub-Request-Id:
-      - 6A55:180028:223E696:24A38DD:68C2EED2
+      - 3695:91567:105B1F4:125794D:68CC1D9D
       X-Served-By:
-      - cache-bos4664-BOS
+      - cache-bos4627-BOS
       X-Timer:
-      - S1757605929.764057,VS0,VE1
+      - S1758207390.848635,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:27 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example73].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example73].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/collection-spec/json-schema/collection.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '340'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:08 GMT
+      - Thu, 18 Sep 2025 14:56:29 GMT
       ETag:
       - '"66e1651c-14e2"'
       Last-Modified:
@@ -111,15 +111,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 3ed8dffaf39e89ac42eb3839550aaeb0791725ac
+      - bd234c1829a7a21d1e87d479ac8543ebeb2514f5
       X-GitHub-Request-Id:
-      - 3C0F:3556F2:2104189:236964E:68C2EED2
+      - DF8C:3D7940:20E828F:24A0D28:68CC1D9D
       X-Served-By:
-      - cache-bos4630-BOS
+      - cache-bos4636-BOS
       X-Timer:
-      - S1757605929.848692,VS0,VE1
+      - S1758207390.935251,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:56:28 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/catalog-spec/json-schema/catalog.json
   response:
@@ -171,7 +171,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '341'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -181,7 +181,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:08 GMT
+      - Thu, 18 Sep 2025 14:56:30 GMT
       ETag:
       - '"66e1651c-84e"'
       Last-Modified:
@@ -195,17 +195,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 10ab74d5634905c9930cbd988d5634cd5e2bafda
+      - e13d5559dad167dbd212d97585f3793efc1cbb7b
       X-GitHub-Request-Id:
-      - 6A55:180028:223E696:24A38DD:68C2EED2
+      - 3695:91567:105B1F4:125794D:68CC1D9D
       X-Served-By:
-      - cache-bos4668-BOS
+      - cache-bos4643-BOS
       X-Timer:
-      - S1757605929.924535,VS0,VE0
+      - S1758207390.025084,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:56:27 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example74].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example74].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/item.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '387'
+      - '47'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:08 GMT
+      - Thu, 18 Sep 2025 14:56:30 GMT
       ETag:
       - '"66e1651c-147c"'
       Last-Modified:
@@ -111,15 +111,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 4b22403b8f641b43398dcd32888624381612fac8
+      - 54bafe18dbc18eeb4056731e7356cb579bf18c1d
       X-GitHub-Request-Id:
-      - 9540:197FBB:BCDCFE:D8897B:68C2EEA5
+      - A3C0:BAEAA:C84169:E2AD23:68CC1D6E
       X-Served-By:
-      - cache-bos4691-BOS
+      - cache-bos4666-BOS
       X-Timer:
-      - S1757605929.986651,VS0,VE1
+      - S1758207390.131013,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/basics.json
   response:
@@ -148,7 +148,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '388'
+      - '47'
       Cache-Control:
       - max-age=600
       Connection:
@@ -158,7 +158,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:09 GMT
+      - Thu, 18 Sep 2025 14:56:30 GMT
       ETag:
       - '"66e1651c-21c"'
       Last-Modified:
@@ -172,17 +172,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - d78f6a3835a4af5466552420997b99a1769a872e
+      - 9152e200a6c41ef73868948c87b0d38dcf54c018
       X-GitHub-Request-Id:
-      - E1F2:14AA27:C232A6:DDCD4A:68C2EEA4
+      - 2F53:A07A9:C8C99E:E32E77:68CC1D6E
       X-Served-By:
-      - cache-bos4676-BOS
+      - cache-bos4642-BOS
       X-Timer:
-      - S1757605929.067678,VS0,VE0
+      - S1758207390.206912,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -192,7 +192,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/datetime.json
   response:
@@ -241,7 +241,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '387'
+      - '47'
       Cache-Control:
       - max-age=600
       Connection:
@@ -251,7 +251,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:09 GMT
+      - Thu, 18 Sep 2025 14:56:30 GMT
       ETag:
       - '"66e1651c-a82"'
       Last-Modified:
@@ -265,17 +265,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 6bcd1d87a4bacab4c19d2ee987a2394dd3f43d6a
+      - 41d8ec9afb26824c9205223c930439491eef1ce5
       X-GitHub-Request-Id:
-      - 1865:153265:C4294F:DFCE98:68C2EEA5
+      - 3E81:0D6F:C30426:DD705D:68CC1D6F
       X-Served-By:
-      - cache-bos4647-BOS
+      - cache-bos4678-BOS
       X-Timer:
-      - S1757605929.142606,VS0,VE0
+      - S1758207390.280723,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -285,7 +287,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/instrument.json
   response:
@@ -306,7 +308,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '387'
+      - '47'
       Cache-Control:
       - max-age=600
       Connection:
@@ -316,7 +318,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:09 GMT
+      - Thu, 18 Sep 2025 14:56:30 GMT
       ETag:
       - '"66e1651c-2a2"'
       Last-Modified:
@@ -330,17 +332,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - c449c383d406ca4b56357dd469cdcbe81b516d37
+      - f38a0341bf9c32a19f0fc8a2399d9976bcc8330f
       X-GitHub-Request-Id:
-      - 4500:CA757:1EF5208:22C6B31:68C2EEA5
+      - 7C03:3CD2C3:DA5DDA:F4BC38:68CC1D6F
       X-Served-By:
-      - cache-bos4690-BOS
+      - cache-bos4641-BOS
       X-Timer:
-      - S1757605929.220289,VS0,VE0
+      - S1758207390.357202,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -350,7 +354,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/licensing.json
   response:
@@ -366,7 +370,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '387'
+      - '46'
       Cache-Control:
       - max-age=600
       Connection:
@@ -376,7 +380,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:09 GMT
+      - Thu, 18 Sep 2025 14:56:30 GMT
       ETag:
       - '"66e1651c-135"'
       Last-Modified:
@@ -392,15 +396,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - fa8219c10326e04001a0f7a4acbf904249901a6c
+      - 4a653c304863357839de188b429d928c04ca5042
       X-GitHub-Request-Id:
-      - ED10:15FE94:C5AB5F:E14C22:68C2EEA5
+      - C4E5:1D3617:CA3033:E4A206:68CC1D6F
       X-Served-By:
-      - cache-bos4640-BOS
+      - cache-bos4632-BOS
       X-Timer:
-      - S1757605929.293875,VS0,VE1
+      - S1758207390.435235,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -412,7 +416,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/provider.json
   response:
@@ -438,7 +442,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '387'
+      - '46'
       Cache-Control:
       - max-age=600
       Connection:
@@ -448,7 +452,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:09 GMT
+      - Thu, 18 Sep 2025 14:56:30 GMT
       ETag:
       - '"66e1651c-40e"'
       Last-Modified:
@@ -464,15 +468,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 3a5c6dfd01197f32f2248a14778b62d68e4cca9a
+      - 0207ce525c4fd9789f053cca16aa4de9b5a873da
       X-GitHub-Request-Id:
-      - F8AD:14A94E:C2C9FE:DE6C58:68C2EEA4
+      - 5805:B21BA:AD266F:C78835:68CC1D6F
       X-Served-By:
-      - cache-bos4678-BOS
+      - cache-bos4682-BOS
       X-Timer:
-      - S1757605929.370846,VS0,VE1
+      - S1758207391.513222,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:44 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -484,7 +488,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/checksum/json-schema/schema.json
   response:
@@ -527,7 +531,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '340'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -537,7 +541,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:09 GMT
+      - Thu, 18 Sep 2025 14:56:30 GMT
       ETag:
       - '"66e1651c-939"'
       Last-Modified:
@@ -549,21 +553,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 06309dafdfcc6623f9446951b5fb322c82d5b618
+      - 5c67c5c6648f26b47d90f4df6f4fd292efb6a515
       X-GitHub-Request-Id:
-      - 0EB2:39602E:21ACCE1:2413344:68C2EED5
+      - FDCC:1E445:218C2CF:25450D2:68CC1D9D
       X-Served-By:
-      - cache-bos4680-BOS
+      - cache-bos4632-BOS
       X-Timer:
-      - S1757605929.452167,VS0,VE1
+      - S1758207391.588902,VS0,VE56
       expires:
-      - Thu, 11 Sep 2025 15:56:29 GMT
-      x-origin-cache:
-      - HIT
+      - Thu, 18 Sep 2025 15:06:30 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -573,7 +575,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/catalog-spec/json-schema/catalog.json
   response:
@@ -615,7 +617,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '341'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -625,7 +627,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:09 GMT
+      - Thu, 18 Sep 2025 14:56:30 GMT
       ETag:
       - '"66e1651c-84e"'
       Last-Modified:
@@ -639,17 +641,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 53238796691b326c7164780536099e8505010799
+      - 3d9e215df367546e2ce17fc7fedd521882010a3f
       X-GitHub-Request-Id:
-      - 6A55:180028:223E696:24A38DD:68C2EED2
+      - 3695:91567:105B1F4:125794D:68CC1D9D
       X-Served-By:
-      - cache-bos4635-BOS
+      - cache-bos4677-BOS
       X-Timer:
-      - S1757605930.548976,VS0,VE0
+      - S1758207391.719270,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:27 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -659,7 +661,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/collection-spec/json-schema/collection.json
   response:
@@ -741,7 +743,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '341'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -751,7 +753,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:09 GMT
+      - Thu, 18 Sep 2025 14:56:30 GMT
       ETag:
       - '"66e1651c-14e2"'
       Last-Modified:
@@ -767,15 +769,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 18a7d79d2c53f62685856c7579e9fb0f3391fd3d
+      - 5c6430fd9285fc5019a8bfac3ac1dd0cadf928e1
       X-GitHub-Request-Id:
-      - 3C0F:3556F2:2104189:236964E:68C2EED2
+      - DF8C:3D7940:20E828F:24A0D28:68CC1D9D
       X-Served-By:
-      - cache-bos4637-BOS
+      - cache-bos4668-BOS
       X-Timer:
-      - S1757605930.614562,VS0,VE1
+      - S1758207391.795803,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:56:28 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example75].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example75].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/collection-spec/json-schema/collection.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '341'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:09 GMT
+      - Thu, 18 Sep 2025 14:56:30 GMT
       ETag:
       - '"66e1651c-14e2"'
       Last-Modified:
@@ -111,15 +111,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 2e27f9a578aa57d931c48eb3306eb90ab2a12c01
+      - bf86b4902f2744bff1055b0cbf10d00642a36e63
       X-GitHub-Request-Id:
-      - 3C0F:3556F2:2104189:236964E:68C2EED2
+      - DF8C:3D7940:20E828F:24A0D28:68CC1D9D
       X-Served-By:
-      - cache-bos4646-BOS
+      - cache-bos4680-BOS
       X-Timer:
-      - S1757605930.702329,VS0,VE4
+      - S1758207391.871565,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:28 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/catalog-spec/json-schema/catalog.json
   response:
@@ -171,7 +171,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '342'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -181,7 +181,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:09 GMT
+      - Thu, 18 Sep 2025 14:56:30 GMT
       ETag:
       - '"66e1651c-84e"'
       Last-Modified:
@@ -195,17 +195,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 91e420a0782ff6b10be0b9775b4e55ce57519d93
+      - 1f4fa670d9c43102152893384be1b00cfb1129ce
       X-GitHub-Request-Id:
-      - 6A55:180028:223E696:24A38DD:68C2EED2
+      - 3695:91567:105B1F4:125794D:68CC1D9D
       X-Served-By:
-      - cache-bos4681-BOS
+      - cache-bos4668-BOS
       X-Timer:
-      - S1757605930.802224,VS0,VE0
+      - S1758207391.964140,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:27 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -215,7 +215,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/collection-assets/json-schema/schema.json
   response:
@@ -238,7 +238,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '340'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -248,7 +248,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:09 GMT
+      - Thu, 18 Sep 2025 14:56:31 GMT
       ETag:
       - '"66e1651c-3ab"'
       Last-Modified:
@@ -260,19 +260,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - cb234e04ea35e366a52cef04044db251ffe7c750
+      - f1fbb168fd39606894d8fb31d6dc7df40301304b
       X-GitHub-Request-Id:
-      - 3D92:3ADB7:217C6F7:23E308E:68C2EED5
+      - A42A:91567:105B3B9:1257B3D:68CC1D9E
       X-Served-By:
-      - cache-bos4675-BOS
+      - cache-bos4691-BOS
       X-Timer:
-      - S1757605930.876177,VS0,VE1
+      - S1758207391.042657,VS0,VE56
       expires:
-      - Thu, 11 Sep 2025 15:56:29 GMT
+      - Thu, 18 Sep 2025 15:06:31 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -284,7 +284,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/item.json
   response:
@@ -366,7 +366,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '388'
+      - '48'
       Cache-Control:
       - max-age=600
       Connection:
@@ -376,7 +376,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:09 GMT
+      - Thu, 18 Sep 2025 14:56:31 GMT
       ETag:
       - '"66e1651c-147c"'
       Last-Modified:
@@ -392,15 +392,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 43307c679e58e0b9f6670aa4dff656b89e661820
+      - e6c28b28d7ceedb67f4f1ae78d1f860dac385fc1
       X-GitHub-Request-Id:
-      - 9540:197FBB:BCDCFE:D8897B:68C2EEA5
+      - A3C0:BAEAA:C84169:E2AD23:68CC1D6E
       X-Served-By:
-      - cache-bos4642-BOS
+      - cache-bos4620-BOS
       X-Timer:
-      - S1757605930.958626,VS0,VE1
+      - S1758207391.169477,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example76].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example76].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/collection-spec/json-schema/collection.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '342'
+      - '2'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:10 GMT
+      - Thu, 18 Sep 2025 14:56:31 GMT
       ETag:
       - '"66e1651c-14e2"'
       Last-Modified:
@@ -111,15 +111,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 7d55d56ace3be4d191bd160af659e13e1577885a
+      - 4e02d1e70d9deb34c21f22d1337c83f77ba02f2a
       X-GitHub-Request-Id:
-      - 3C0F:3556F2:2104189:236964E:68C2EED2
+      - DF8C:3D7940:20E828F:24A0D28:68CC1D9D
       X-Served-By:
-      - cache-bos4654-BOS
+      - cache-bos4691-BOS
       X-Timer:
-      - S1757605930.047963,VS0,VE35
+      - S1758207391.247313,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:28 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/catalog-spec/json-schema/catalog.json
   response:
@@ -171,7 +171,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '342'
+      - '2'
       Cache-Control:
       - max-age=600
       Connection:
@@ -181,7 +181,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:10 GMT
+      - Thu, 18 Sep 2025 14:56:31 GMT
       ETag:
       - '"66e1651c-84e"'
       Last-Modified:
@@ -195,17 +195,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '1'
       X-Fastly-Request-ID:
-      - 9612fdafa7e828dce79b4acc0d1d0bc68de63d7e
+      - 467648087c9a7bc6bfe008fe069248680ba00930
       X-GitHub-Request-Id:
-      - 6A55:180028:223E696:24A38DD:68C2EED2
+      - 3695:91567:105B1F4:125794D:68CC1D9D
       X-Served-By:
-      - cache-bos4668-BOS
+      - cache-bos4646-BOS
       X-Timer:
-      - S1757605930.173157,VS0,VE0
+      - S1758207391.321501,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:27 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -215,7 +215,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/datacube/json-schema/schema.json
   response:
@@ -326,7 +326,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '340'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -336,7 +336,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:10 GMT
+      - Thu, 18 Sep 2025 14:56:31 GMT
       ETag:
       - '"66e1651c-1d66"'
       Last-Modified:
@@ -348,19 +348,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - f0680836bbb59ebac84e8e54c5b98498b630f1ce
+      - 33ef669476431561b4e3525232967cc03d73a109
       X-GitHub-Request-Id:
-      - 7766:3FCBA6:20BD099:2323AF5:68C2EED5
+      - 499A:91567:105B412:1257BA3:68CC1D9E
       X-Served-By:
-      - cache-bos4641-BOS
+      - cache-bos4692-BOS
       X-Timer:
-      - S1757605930.259825,VS0,VE1
+      - S1758207391.395289,VS0,VE37
       expires:
-      - Thu, 11 Sep 2025 15:56:30 GMT
+      - Thu, 18 Sep 2025 15:06:31 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -372,7 +372,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/item.json
   response:
@@ -454,7 +454,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '389'
+      - '48'
       Cache-Control:
       - max-age=600
       Connection:
@@ -464,7 +464,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:10 GMT
+      - Thu, 18 Sep 2025 14:56:31 GMT
       ETag:
       - '"66e1651c-147c"'
       Last-Modified:
@@ -480,15 +480,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 5a250649f923b0dd9073af47f4befbe60fef8924
+      - 2d4f62cd28131ae55806511033c4021429360643
       X-GitHub-Request-Id:
-      - 9540:197FBB:BCDCFE:D8897B:68C2EEA5
+      - A3C0:BAEAA:C84169:E2AD23:68CC1D6E
       X-Served-By:
-      - cache-bos4666-BOS
+      - cache-bos4621-BOS
       X-Timer:
-      - S1757605930.355698,VS0,VE1
+      - S1758207392.509497,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example77].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example77].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/item.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '388'
+      - '48'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:10 GMT
+      - Thu, 18 Sep 2025 14:56:31 GMT
       ETag:
       - '"66e1651c-147c"'
       Last-Modified:
@@ -109,17 +109,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '2'
       X-Fastly-Request-ID:
-      - 1aee9704b9e2e81c6e80a7436ee8d96ab2c023a5
+      - 9d19a8251f77780c0f22edf7a18cc14ce13b2864
       X-GitHub-Request-Id:
-      - 9540:197FBB:BCDCFE:D8897B:68C2EEA5
+      - A3C0:BAEAA:C84169:E2AD23:68CC1D6E
       X-Served-By:
-      - cache-bos4624-BOS
+      - cache-bos4621-BOS
       X-Timer:
-      - S1757605930.454140,VS0,VE0
+      - S1758207392.593163,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/basics.json
   response:
@@ -148,7 +148,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '389'
+      - '49'
       Cache-Control:
       - max-age=600
       Connection:
@@ -158,7 +158,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:10 GMT
+      - Thu, 18 Sep 2025 14:56:31 GMT
       ETag:
       - '"66e1651c-21c"'
       Last-Modified:
@@ -174,15 +174,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - c7caf962f4b6ac9c9480ce4ed85423b416b95872
+      - 68443d83dd1bc58556fdae6f6a6fcf42b6eab41a
       X-GitHub-Request-Id:
-      - E1F2:14AA27:C232A6:DDCD4A:68C2EEA4
+      - 2F53:A07A9:C8C99E:E32E77:68CC1D6E
       X-Served-By:
-      - cache-bos4627-BOS
+      - cache-bos4624-BOS
       X-Timer:
-      - S1757605931.540453,VS0,VE2
+      - S1758207392.673217,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -192,7 +192,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/datetime.json
   response:
@@ -241,7 +241,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '389'
+      - '48'
       Cache-Control:
       - max-age=600
       Connection:
@@ -251,7 +251,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:10 GMT
+      - Thu, 18 Sep 2025 14:56:31 GMT
       ETag:
       - '"66e1651c-a82"'
       Last-Modified:
@@ -265,17 +265,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - edaba5b2ba865f982c4e5763c2e370519fbf8f96
+      - 7a9f55a7d48593e126f8c310ca3ac47a606f33f2
       X-GitHub-Request-Id:
-      - 1865:153265:C4294F:DFCE98:68C2EEA5
+      - 3E81:0D6F:C30426:DD705D:68CC1D6F
       X-Served-By:
-      - cache-bos4651-BOS
+      - cache-bos4683-BOS
       X-Timer:
-      - S1757605931.630790,VS0,VE0
+      - S1758207392.751310,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -285,7 +287,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/instrument.json
   response:
@@ -306,7 +308,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '388'
+      - '48'
       Cache-Control:
       - max-age=600
       Connection:
@@ -316,7 +318,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:10 GMT
+      - Thu, 18 Sep 2025 14:56:31 GMT
       ETag:
       - '"66e1651c-2a2"'
       Last-Modified:
@@ -330,17 +332,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 44fec6a43ef0ea04a0b81f0eb5a9702bb9fd3686
+      - 392c768e04a6b24755f3b3729e86e10570cb9f8a
       X-GitHub-Request-Id:
-      - 4500:CA757:1EF5208:22C6B31:68C2EEA5
+      - 7C03:3CD2C3:DA5DDA:F4BC38:68CC1D6F
       X-Served-By:
       - cache-bos4685-BOS
       X-Timer:
-      - S1757605931.714133,VS0,VE0
+      - S1758207392.831880,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -350,7 +354,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/licensing.json
   response:
@@ -366,7 +370,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '388'
+      - '48'
       Cache-Control:
       - max-age=600
       Connection:
@@ -376,7 +380,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:10 GMT
+      - Thu, 18 Sep 2025 14:56:31 GMT
       ETag:
       - '"66e1651c-135"'
       Last-Modified:
@@ -390,17 +394,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '27'
+      - '1'
       X-Fastly-Request-ID:
-      - 8c890a53adf319ef1326b33555162e12385a035f
+      - c70066bc26cabd8f28b4ae89825d3129f66d4726
       X-GitHub-Request-Id:
-      - ED10:15FE94:C5AB5F:E14C22:68C2EEA5
+      - C4E5:1D3617:CA3033:E4A206:68CC1D6F
       X-Served-By:
-      - cache-bos4650-BOS
+      - cache-bos4636-BOS
       X-Timer:
-      - S1757605931.801786,VS0,VE1
+      - S1758207392.913024,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -412,7 +416,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/provider.json
   response:
@@ -438,7 +442,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '388'
+      - '47'
       Cache-Control:
       - max-age=600
       Connection:
@@ -448,7 +452,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:10 GMT
+      - Thu, 18 Sep 2025 14:56:31 GMT
       ETag:
       - '"66e1651c-40e"'
       Last-Modified:
@@ -462,17 +466,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Fastly-Request-ID:
-      - ad6b1b12924e0a2f706d060636b00179480451e5
+      - 029d388db5a85c1505d46f9e63d402a77d4b8f16
       X-GitHub-Request-Id:
-      - F8AD:14A94E:C2C9FE:DE6C58:68C2EEA4
+      - 5805:B21BA:AD266F:C78835:68CC1D6F
       X-Served-By:
-      - cache-bos4659-BOS
+      - cache-bos4682-BOS
       X-Timer:
-      - S1757605931.888088,VS0,VE1
+      - S1758207392.985508,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:44 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -484,7 +488,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/datacube/json-schema/schema.json
   response:
@@ -595,7 +599,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '341'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -605,7 +609,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:10 GMT
+      - Thu, 18 Sep 2025 14:56:32 GMT
       ETag:
       - '"66e1651c-1d66"'
       Last-Modified:
@@ -621,15 +625,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 640cb0302671c29b0cf5bb3932f8af8bd9a526bb
+      - e854e4e0b0883e9a6fb0250dae2df60f53eaa6e6
       X-GitHub-Request-Id:
-      - 7766:3FCBA6:20BD099:2323AF5:68C2EED5
+      - 499A:91567:105B412:1257BA3:68CC1D9E
       X-Served-By:
-      - cache-bos4629-BOS
+      - cache-bos4628-BOS
       X-Timer:
-      - S1757605931.966714,VS0,VE1
+      - S1758207392.058855,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:30 GMT
+      - Thu, 18 Sep 2025 15:06:31 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -641,7 +645,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/collection-spec/json-schema/collection.json
   response:
@@ -723,7 +727,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '343'
+      - '2'
       Cache-Control:
       - max-age=600
       Connection:
@@ -733,7 +737,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:11 GMT
+      - Thu, 18 Sep 2025 14:56:32 GMT
       ETag:
       - '"66e1651c-14e2"'
       Last-Modified:
@@ -749,15 +753,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - cb121c0c433b5132c7c50cc9cee067ac961a12f4
+      - 724585e43dcb1e7fe42d0653e1fd90c6e9cd8806
       X-GitHub-Request-Id:
-      - 3C0F:3556F2:2104189:236964E:68C2EED2
+      - DF8C:3D7940:20E828F:24A0D28:68CC1D9D
       X-Served-By:
-      - cache-bos4647-BOS
+      - cache-bos4676-BOS
       X-Timer:
-      - S1757605931.045809,VS0,VE2
+      - S1758207392.155369,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:56:28 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -767,7 +771,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/catalog-spec/json-schema/catalog.json
   response:
@@ -809,7 +813,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '343'
+      - '3'
       Cache-Control:
       - max-age=600
       Connection:
@@ -819,7 +823,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:11 GMT
+      - Thu, 18 Sep 2025 14:56:32 GMT
       ETag:
       - '"66e1651c-84e"'
       Last-Modified:
@@ -833,17 +837,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - e9e6a5573246fdfdb640b09ed8ecae34a2c270c5
+      - 2f0e8b7efe8c1f61da3b7780fc4f42731547e68b
       X-GitHub-Request-Id:
-      - 6A55:180028:223E696:24A38DD:68C2EED2
+      - 3695:91567:105B1F4:125794D:68CC1D9D
       X-Served-By:
-      - cache-bos4626-BOS
+      - cache-bos4659-BOS
       X-Timer:
-      - S1757605931.119677,VS0,VE0
+      - S1758207392.242737,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:27 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example78].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example78].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/item.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '389'
+      - '49'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:11 GMT
+      - Thu, 18 Sep 2025 14:56:32 GMT
       ETag:
       - '"66e1651c-147c"'
       Last-Modified:
@@ -111,15 +111,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - c0f1f35171d100687ffd69c559f0c7be72cd293d
+      - 8e9ce065b05dddbc4241a876a8af7a37ec2fbec7
       X-GitHub-Request-Id:
-      - 9540:197FBB:BCDCFE:D8897B:68C2EEA5
+      - A3C0:BAEAA:C84169:E2AD23:68CC1D6E
       X-Served-By:
-      - cache-bos4678-BOS
+      - cache-bos4687-BOS
       X-Timer:
-      - S1757605931.196530,VS0,VE2
+      - S1758207392.343455,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/basics.json
   response:
@@ -148,7 +148,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '389'
+      - '49'
       Cache-Control:
       - max-age=600
       Connection:
@@ -158,7 +158,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:11 GMT
+      - Thu, 18 Sep 2025 14:56:32 GMT
       ETag:
       - '"66e1651c-21c"'
       Last-Modified:
@@ -174,15 +174,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 952869926caa9efe6481cec9afc0cdfdc6e14e4e
+      - 846c65a2df1ec4290d2e13439bce0060692adb62
       X-GitHub-Request-Id:
-      - E1F2:14AA27:C232A6:DDCD4A:68C2EEA4
+      - 2F53:A07A9:C8C99E:E32E77:68CC1D6E
       X-Served-By:
-      - cache-bos4640-BOS
+      - cache-bos4671-BOS
       X-Timer:
-      - S1757605931.274492,VS0,VE1
+      - S1758207392.437225,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -192,7 +192,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/datetime.json
   response:
@@ -241,7 +241,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '389'
+      - '49'
       Cache-Control:
       - max-age=600
       Connection:
@@ -251,7 +251,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:11 GMT
+      - Thu, 18 Sep 2025 14:56:32 GMT
       ETag:
       - '"66e1651c-a82"'
       Last-Modified:
@@ -265,17 +265,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '1'
       X-Fastly-Request-ID:
-      - df31aaa54ec2067c2e21af605d7cc0bd45499590
+      - bf9786c2d0f11a1f392853ecc84551edeb8144ba
       X-GitHub-Request-Id:
-      - 1865:153265:C4294F:DFCE98:68C2EEA5
+      - 3E81:0D6F:C30426:DD705D:68CC1D6F
       X-Served-By:
-      - cache-bos4676-BOS
+      - cache-bos4644-BOS
       X-Timer:
-      - S1757605931.349541,VS0,VE0
+      - S1758207393.517655,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -285,7 +287,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/instrument.json
   response:
@@ -306,7 +308,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '389'
+      - '49'
       Cache-Control:
       - max-age=600
       Connection:
@@ -316,7 +318,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:11 GMT
+      - Thu, 18 Sep 2025 14:56:32 GMT
       ETag:
       - '"66e1651c-2a2"'
       Last-Modified:
@@ -332,15 +334,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - bbd85887c412a23827c67c577ae27b64292281a7
+      - 84f054b73f302eca17a22cb368435f6393c4bf89
       X-GitHub-Request-Id:
-      - 4500:CA757:1EF5208:22C6B31:68C2EEA5
+      - 7C03:3CD2C3:DA5DDA:F4BC38:68CC1D6F
       X-Served-By:
-      - cache-bos4667-BOS
+      - cache-bos4628-BOS
       X-Timer:
-      - S1757605931.430093,VS0,VE2
+      - S1758207393.593454,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -350,7 +354,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/licensing.json
   response:
@@ -366,7 +370,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '389'
+      - '49'
       Cache-Control:
       - max-age=600
       Connection:
@@ -376,7 +380,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:11 GMT
+      - Thu, 18 Sep 2025 14:56:32 GMT
       ETag:
       - '"66e1651c-135"'
       Last-Modified:
@@ -390,17 +394,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 9d6a744dc17d94899a6e257c82d2d56b5043fd89
+      - 94835636af152f14a15e09ab04b869f5e7f82b66
       X-GitHub-Request-Id:
-      - ED10:15FE94:C5AB5F:E14C22:68C2EEA5
+      - C4E5:1D3617:CA3033:E4A206:68CC1D6F
       X-Served-By:
-      - cache-bos4689-BOS
+      - cache-bos4677-BOS
       X-Timer:
-      - S1757605932.506183,VS0,VE0
+      - S1758207393.669680,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -412,7 +416,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/provider.json
   response:
@@ -438,7 +442,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '389'
+      - '49'
       Cache-Control:
       - max-age=600
       Connection:
@@ -448,7 +452,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:11 GMT
+      - Thu, 18 Sep 2025 14:56:32 GMT
       ETag:
       - '"66e1651c-40e"'
       Last-Modified:
@@ -464,15 +468,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - a21c56eec51b8d03e50595fc52b8e46bd4b59fb1
+      - cbb392cdce6f7a633435e8b89e67dd91f953c3ee
       X-GitHub-Request-Id:
-      - F8AD:14A94E:C2C9FE:DE6C58:68C2EEA4
+      - 5805:B21BA:AD266F:C78835:68CC1D6F
       X-Served-By:
-      - cache-bos4673-BOS
+      - cache-bos4678-BOS
       X-Timer:
-      - S1757605932.580275,VS0,VE1
+      - S1758207393.743061,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:44 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -484,7 +488,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/eo/json-schema/schema.json
   response:
@@ -522,7 +526,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '340'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -532,7 +536,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:11 GMT
+      - Thu, 18 Sep 2025 14:56:32 GMT
       ETag:
       - '"66e1651c-805"'
       Last-Modified:
@@ -544,19 +548,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - a2294ddb96bd2e94e013885343023d3aa683ca8e
+      - e3440343d4ddf7b3be12b455ed5fbe1fb65a27ea
       X-GitHub-Request-Id:
-      - 61E0:85CEC:1F72DF5:22CFA7F:68C2EED7
+      - 2976:1A3C1:217E151:25362CA:68CC1DA0
       X-Served-By:
-      - cache-bos4645-BOS
+      - cache-bos4682-BOS
       X-Timer:
-      - S1757605932.659066,VS0,VE1
+      - S1758207393.817389,VS0,VE57
       expires:
-      - Thu, 11 Sep 2025 15:56:31 GMT
+      - Thu, 18 Sep 2025 15:06:32 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -566,7 +572,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/view/json-schema/schema.json
   response:
@@ -605,7 +611,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '340'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -615,7 +621,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:11 GMT
+      - Thu, 18 Sep 2025 14:56:33 GMT
       ETag:
       - '"66e1651c-829"'
       Last-Modified:
@@ -627,19 +633,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 2ec18b839f20a98e981eeb7d2be1a528bd326d58
+      - 442a4c10b3cee0455e35861ad1605e5b779deba9
       X-GitHub-Request-Id:
-      - 8BE4:15BCE:1E9511B:21F04EB:68C2EED7
+      - 2A0E:3A039E:FF2E25:11EE6ED:68CC1D9F
       X-Served-By:
-      - cache-bos4628-BOS
+      - cache-bos4674-BOS
       X-Timer:
-      - S1757605932.741894,VS0,VE1
+      - S1758207393.964147,VS0,VE42
       expires:
-      - Thu, 11 Sep 2025 15:56:31 GMT
+      - Thu, 18 Sep 2025 15:06:32 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example79].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example79].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/collection-spec/json-schema/collection.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '343'
+      - '3'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:11 GMT
+      - Thu, 18 Sep 2025 14:56:33 GMT
       ETag:
       - '"66e1651c-14e2"'
       Last-Modified:
@@ -111,15 +111,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - d17abb03ba9b116fa600aa7e147d2d253d576943
+      - b0a47671fee1934d5912b479c343e14b89ef5121
       X-GitHub-Request-Id:
-      - 3C0F:3556F2:2104189:236964E:68C2EED2
+      - DF8C:3D7940:20E828F:24A0D28:68CC1D9D
       X-Served-By:
-      - cache-bos4668-BOS
+      - cache-bos4639-BOS
       X-Timer:
-      - S1757605932.837811,VS0,VE1
+      - S1758207393.103724,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:28 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/catalog-spec/json-schema/catalog.json
   response:
@@ -171,7 +171,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '4'
       Cache-Control:
       - max-age=600
       Connection:
@@ -181,7 +181,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:11 GMT
+      - Thu, 18 Sep 2025 14:56:33 GMT
       ETag:
       - '"66e1651c-84e"'
       Last-Modified:
@@ -197,15 +197,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - f42f81f92c5249092671ca22ddd0c64cea7ffb22
+      - e5b14405fb2f276f819e666278e1299e422b0594
       X-GitHub-Request-Id:
-      - 6A55:180028:223E696:24A38DD:68C2EED2
+      - 3695:91567:105B1F4:125794D:68CC1D9D
       X-Served-By:
-      - cache-bos4666-BOS
+      - cache-bos4671-BOS
       X-Timer:
-      - S1757605932.907987,VS0,VE5
+      - S1758207393.195115,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:27 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -215,7 +215,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/item-assets/json-schema/schema.json
   response:
@@ -248,7 +248,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '340'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -258,7 +258,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:11 GMT
+      - Thu, 18 Sep 2025 14:56:33 GMT
       ETag:
       - '"66e1651c-65f"'
       Last-Modified:
@@ -270,19 +270,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - fa3805a61f52f1a5764f34eb7eea712370854992
+      - 14980f5be6c4b0027c366d537bdcc1dc80bb99b6
       X-GitHub-Request-Id:
-      - 61E0:85CEC:1F72E7B:22CFB19:68C2EED7
+      - 2976:1A3C1:217E1E7:253636A:68CC1DA1
       X-Served-By:
-      - cache-bos4650-BOS
+      - cache-bos4632-BOS
       X-Timer:
-      - S1757605932.986292,VS0,VE1
+      - S1758207393.279273,VS0,VE53
       expires:
-      - Thu, 11 Sep 2025 15:56:32 GMT
+      - Thu, 18 Sep 2025 15:06:33 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example7].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example7].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/item-spec/json-schema/item.json
   response:
@@ -108,11 +108,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:43 GMT
+      - Thu, 18 Sep 2025 14:56:02 GMT
       ETag:
       - '"4e24763d74f0d463b0cb6c63fc099e0b59447c7a049b93ffda4c6eb9eb54ae95"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:43 GMT
+      - Thu, 18 Sep 2025 15:01:02 GMT
       Source-Age:
       - '1'
       Strict-Transport-Security:
@@ -128,15 +128,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 9c441e1a2a2acef9c8b405336add42b19c8e9b87
+      - 3f25be99f36b50facd0675d40bb97d085bed16ab
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 688A:1E0DA2:13B02E:181CCC:68C2EEB5
+      - DDD5:286E0:D0F1D:FC0CF:68CC1D7C
       X-Served-By:
-      - cache-bos4674-BOS
+      - cache-bos4664-BOS
       X-Timer:
-      - S1757605903.317913,VS0,VE1
+      - S1758207362.417175,VS0,VE7
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example80].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example80].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/catalog-spec/json-schema/catalog.json
   response:
@@ -45,7 +45,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '4'
       Cache-Control:
       - max-age=600
       Connection:
@@ -55,7 +55,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:12 GMT
+      - Thu, 18 Sep 2025 14:56:33 GMT
       ETag:
       - '"66e1651c-84e"'
       Last-Modified:
@@ -69,17 +69,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 01efd8455596dfb67840d2853d2f8eae7a325d0e
+      - 195bfc907e884949f43fc26c23af89897f0d5045
       X-GitHub-Request-Id:
-      - 6A55:180028:223E696:24A38DD:68C2EED2
+      - 3695:91567:105B1F4:125794D:68CC1D9D
       X-Served-By:
-      - cache-bos4669-BOS
+      - cache-bos4630-BOS
       X-Timer:
-      - S1757605932.064044,VS0,VE0
+      - S1758207393.411303,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:27 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example81].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example81].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/item.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '390'
+      - '50'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:12 GMT
+      - Thu, 18 Sep 2025 14:56:33 GMT
       ETag:
       - '"66e1651c-147c"'
       Last-Modified:
@@ -111,15 +111,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 33e67912db3677daa2b6b247252bfd4b04a2ab48
+      - 5ed192026870134470b9d86a867f1b8f66c28bdf
       X-GitHub-Request-Id:
-      - 9540:197FBB:BCDCFE:D8897B:68C2EEA5
+      - A3C0:BAEAA:C84169:E2AD23:68CC1D6E
       X-Served-By:
-      - cache-bos4635-BOS
+      - cache-bos4680-BOS
       X-Timer:
-      - S1757605932.144515,VS0,VE1
+      - S1758207393.495403,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/basics.json
   response:
@@ -148,7 +148,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '391'
+      - '50'
       Cache-Control:
       - max-age=600
       Connection:
@@ -158,7 +158,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:12 GMT
+      - Thu, 18 Sep 2025 14:56:33 GMT
       ETag:
       - '"66e1651c-21c"'
       Last-Modified:
@@ -172,17 +172,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 99c0a344d199a9f024258af525e75af99d88acfd
+      - 9b52bbbcd3da32d22be6ea5694b93d22fbd86b75
       X-GitHub-Request-Id:
-      - E1F2:14AA27:C232A6:DDCD4A:68C2EEA4
+      - 2F53:A07A9:C8C99E:E32E77:68CC1D6E
       X-Served-By:
-      - cache-bos4672-BOS
+      - cache-bos4632-BOS
       X-Timer:
-      - S1757605932.219900,VS0,VE0
+      - S1758207394.571155,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -192,7 +192,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/datetime.json
   response:
@@ -241,7 +241,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '390'
+      - '50'
       Cache-Control:
       - max-age=600
       Connection:
@@ -251,7 +251,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:12 GMT
+      - Thu, 18 Sep 2025 14:56:33 GMT
       ETag:
       - '"66e1651c-a82"'
       Last-Modified:
@@ -267,15 +267,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 0613ed4d6a5ee474086cf38e037b71d8f3476899
+      - 876b6367fc612676bd99fb5040874d06c55743b6
       X-GitHub-Request-Id:
-      - 1865:153265:C4294F:DFCE98:68C2EEA5
+      - 3E81:0D6F:C30426:DD705D:68CC1D6F
       X-Served-By:
-      - cache-bos4659-BOS
+      - cache-bos4647-BOS
       X-Timer:
-      - S1757605932.294266,VS0,VE2
+      - S1758207394.645039,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -285,7 +287,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/instrument.json
   response:
@@ -306,7 +308,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '390'
+      - '50'
       Cache-Control:
       - max-age=600
       Connection:
@@ -316,7 +318,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:12 GMT
+      - Thu, 18 Sep 2025 14:56:33 GMT
       ETag:
       - '"66e1651c-2a2"'
       Last-Modified:
@@ -332,15 +334,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - d23895beac34e55eced8041b2cbf41b29b73208a
+      - 94045bc202c1edf17a96f931bb2c463974ed9a9b
       X-GitHub-Request-Id:
-      - 4500:CA757:1EF5208:22C6B31:68C2EEA5
+      - 7C03:3CD2C3:DA5DDA:F4BC38:68CC1D6F
       X-Served-By:
-      - cache-bos4686-BOS
+      - cache-bos4646-BOS
       X-Timer:
-      - S1757605932.373398,VS0,VE1
+      - S1758207394.725214,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -350,7 +354,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/licensing.json
   response:
@@ -366,7 +370,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '390'
+      - '50'
       Cache-Control:
       - max-age=600
       Connection:
@@ -376,7 +380,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:12 GMT
+      - Thu, 18 Sep 2025 14:56:33 GMT
       ETag:
       - '"66e1651c-135"'
       Last-Modified:
@@ -390,17 +394,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 8c400a4f9fdd3cad910a732e1e41621dc504306f
+      - 5e4556d064d385358b3c7e4e7c8c35998a1ff839
       X-GitHub-Request-Id:
-      - ED10:15FE94:C5AB5F:E14C22:68C2EEA5
+      - C4E5:1D3617:CA3033:E4A206:68CC1D6F
       X-Served-By:
-      - cache-bos4655-BOS
+      - cache-bos4690-BOS
       X-Timer:
-      - S1757605932.450353,VS0,VE0
+      - S1758207394.801692,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -412,7 +416,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/provider.json
   response:
@@ -438,7 +442,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '390'
+      - '50'
       Cache-Control:
       - max-age=600
       Connection:
@@ -448,7 +452,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:12 GMT
+      - Thu, 18 Sep 2025 14:56:33 GMT
       ETag:
       - '"66e1651c-40e"'
       Last-Modified:
@@ -462,17 +466,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 393a5f4544ffc2398d041a944b3657953abab244
+      - b3e8d202a3e1bb047a18495f4f8063bed62b97ab
       X-GitHub-Request-Id:
-      - F8AD:14A94E:C2C9FE:DE6C58:68C2EEA4
+      - 5805:B21BA:AD266F:C78835:68CC1D6F
       X-Served-By:
-      - cache-bos4663-BOS
+      - cache-bos4692-BOS
       X-Timer:
-      - S1757605933.522316,VS0,VE0
+      - S1758207394.877094,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:44 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -484,7 +488,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/label/json-schema/schema.json
   response:
@@ -554,7 +558,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '340'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -564,7 +568,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:12 GMT
+      - Thu, 18 Sep 2025 14:56:34 GMT
       ETag:
       - '"66e1651c-1226"'
       Last-Modified:
@@ -576,19 +580,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 23951edbfcd64279c719179b7848f77187a1f391
+      - d52e94f41215fe208934d84adff7cf9e98e547ed
       X-GitHub-Request-Id:
-      - 6464:2BF852:1E92683:21F0317:68C2EED8
+      - B1CB:826F9:2182542:2539701:68CC1DA1
       X-Served-By:
-      - cache-bos4678-BOS
+      - cache-bos4626-BOS
       X-Timer:
-      - S1757605933.603530,VS0,VE2
+      - S1758207394.953451,VS0,VE55
       expires:
-      - Thu, 11 Sep 2025 15:56:33 GMT
+      - Thu, 18 Sep 2025 15:06:33 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -600,7 +604,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/version/json-schema/schema.json
   response:
@@ -635,7 +639,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '340'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -645,7 +649,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:12 GMT
+      - Thu, 18 Sep 2025 14:56:34 GMT
       ETag:
       - '"66e1651c-70b"'
       Last-Modified:
@@ -657,21 +661,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 5f2148869c99e4b5faae07513828ae9126a892a8
+      - 3860638f67c6d78283700b2c8036402b216af831
       X-GitHub-Request-Id:
-      - 3270:18947A:1F21620:227ED15:68C2EED8
+      - A42A:91567:105B703:1257EE0:68CC1DA0
       X-Served-By:
-      - cache-bos4660-BOS
+      - cache-bos4622-BOS
       X-Timer:
-      - S1757605933.682032,VS0,VE1
+      - S1758207394.099573,VS0,VE59
       expires:
-      - Thu, 11 Sep 2025 15:56:33 GMT
-      x-origin-cache:
-      - HIT
+      - Thu, 18 Sep 2025 15:06:34 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -681,7 +683,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/collection-spec/json-schema/collection.json
   response:
@@ -763,7 +765,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '345'
+      - '4'
       Cache-Control:
       - max-age=600
       Connection:
@@ -773,7 +775,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:12 GMT
+      - Thu, 18 Sep 2025 14:56:34 GMT
       ETag:
       - '"66e1651c-14e2"'
       Last-Modified:
@@ -787,17 +789,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 98c048f1e6d1862cbb849bc1fcf3b64e060ca9fc
+      - f9e38e8d469daa0c45396113aed1251934d8403b
       X-GitHub-Request-Id:
-      - 3C0F:3556F2:2104189:236964E:68C2EED2
+      - DF8C:3D7940:20E828F:24A0D28:68CC1D9D
       X-Served-By:
-      - cache-bos4623-BOS
+      - cache-bos4685-BOS
       X-Timer:
-      - S1757605933.764188,VS0,VE0
+      - S1758207394.241178,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:28 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -807,7 +809,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/catalog-spec/json-schema/catalog.json
   response:
@@ -849,7 +851,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '345'
+      - '5'
       Cache-Control:
       - max-age=600
       Connection:
@@ -859,7 +861,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:12 GMT
+      - Thu, 18 Sep 2025 14:56:34 GMT
       ETag:
       - '"66e1651c-84e"'
       Last-Modified:
@@ -875,15 +877,15 @@ interactions:
       X-Cache-Hits:
       - '2'
       X-Fastly-Request-ID:
-      - 63d0377c5dbd850348fdf7881e0f8519772ee140
+      - 3d8a48ba48a162553934712f2407a22e75cbf2e7
       X-GitHub-Request-Id:
-      - 6A55:180028:223E696:24A38DD:68C2EED2
+      - 3695:91567:105B1F4:125794D:68CC1D9D
       X-Served-By:
       - cache-bos4659-BOS
       X-Timer:
-      - S1757605933.843992,VS0,VE0
+      - S1758207394.310904,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:56:27 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example82].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example82].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/item.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '391'
+      - '51'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:12 GMT
+      - Thu, 18 Sep 2025 14:56:34 GMT
       ETag:
       - '"66e1651c-147c"'
       Last-Modified:
@@ -111,15 +111,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 1174fb6824e5aaae852e8a808bae9910d4e647a5
+      - fa78e7008019cfe8122f9776d067714230195806
       X-GitHub-Request-Id:
-      - 9540:197FBB:BCDCFE:D8897B:68C2EEA5
+      - A3C0:BAEAA:C84169:E2AD23:68CC1D6E
       X-Served-By:
-      - cache-bos4645-BOS
+      - cache-bos4648-BOS
       X-Timer:
-      - S1757605933.934305,VS0,VE1
+      - S1758207394.391041,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/basics.json
   response:
@@ -148,7 +148,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '391'
+      - '51'
       Cache-Control:
       - max-age=600
       Connection:
@@ -158,7 +158,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:13 GMT
+      - Thu, 18 Sep 2025 14:56:34 GMT
       ETag:
       - '"66e1651c-21c"'
       Last-Modified:
@@ -174,15 +174,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - b2dbd24e25f8fbe52be144b915d714a9126e422a
+      - 53b1a26568032a64d975a60c9bd6025e0a5d4b08
       X-GitHub-Request-Id:
-      - E1F2:14AA27:C232A6:DDCD4A:68C2EEA4
+      - 2F53:A07A9:C8C99E:E32E77:68CC1D6E
       X-Served-By:
-      - cache-bos4645-BOS
+      - cache-bos4625-BOS
       X-Timer:
-      - S1757605933.040803,VS0,VE2
+      - S1758207394.475281,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -192,7 +192,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/datetime.json
   response:
@@ -241,7 +241,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '391'
+      - '51'
       Cache-Control:
       - max-age=600
       Connection:
@@ -251,7 +251,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:13 GMT
+      - Thu, 18 Sep 2025 14:56:34 GMT
       ETag:
       - '"66e1651c-a82"'
       Last-Modified:
@@ -265,17 +265,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - fb038bab8db49beccdc9140c4efe49ac328d88a2
+      - c8c52430aafa7d6d555dea81a7b1865928ef4fc0
       X-GitHub-Request-Id:
-      - 1865:153265:C4294F:DFCE98:68C2EEA5
+      - 3E81:0D6F:C30426:DD705D:68CC1D6F
       X-Served-By:
-      - cache-bos4664-BOS
+      - cache-bos4657-BOS
       X-Timer:
-      - S1757605933.132357,VS0,VE1
+      - S1758207395.553035,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -285,7 +287,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/instrument.json
   response:
@@ -306,7 +308,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '391'
+      - '51'
       Cache-Control:
       - max-age=600
       Connection:
@@ -316,7 +318,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:13 GMT
+      - Thu, 18 Sep 2025 14:56:34 GMT
       ETag:
       - '"66e1651c-2a2"'
       Last-Modified:
@@ -332,15 +334,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 892a9ac96e13e767439ca67897471e4176f91f8d
+      - ce42d56de8abf75f4dd0534af83a4563ae598e66
       X-GitHub-Request-Id:
-      - 4500:CA757:1EF5208:22C6B31:68C2EEA5
+      - 7C03:3CD2C3:DA5DDA:F4BC38:68CC1D6F
       X-Served-By:
-      - cache-bos4624-BOS
+      - cache-bos4637-BOS
       X-Timer:
-      - S1757605933.222038,VS0,VE1
+      - S1758207395.629381,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -350,7 +354,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/licensing.json
   response:
@@ -366,7 +370,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '391'
+      - '51'
       Cache-Control:
       - max-age=600
       Connection:
@@ -376,7 +380,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:13 GMT
+      - Thu, 18 Sep 2025 14:56:34 GMT
       ETag:
       - '"66e1651c-135"'
       Last-Modified:
@@ -392,15 +396,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 8beb60b47637d6c667f0bab3105ad01f1123ef5b
+      - c5d931e6307004e92cf15a748c837d60524487a2
       X-GitHub-Request-Id:
-      - ED10:15FE94:C5AB5F:E14C22:68C2EEA5
+      - C4E5:1D3617:CA3033:E4A206:68CC1D6F
       X-Served-By:
-      - cache-bos4667-BOS
+      - cache-bos4630-BOS
       X-Timer:
-      - S1757605933.308386,VS0,VE3
+      - S1758207395.702994,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -412,7 +416,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/provider.json
   response:
@@ -438,7 +442,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '391'
+      - '51'
       Cache-Control:
       - max-age=600
       Connection:
@@ -448,7 +452,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:13 GMT
+      - Thu, 18 Sep 2025 14:56:34 GMT
       ETag:
       - '"66e1651c-40e"'
       Last-Modified:
@@ -462,17 +466,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - e37c469c2e2347892068b070bc5f94aef6f7100d
+      - 7df4686f86d97323219260e45fd813b1ad4af250
       X-GitHub-Request-Id:
-      - F8AD:14A94E:C2C9FE:DE6C58:68C2EEA4
+      - 5805:B21BA:AD266F:C78835:68CC1D6F
       X-Served-By:
-      - cache-bos4676-BOS
+      - cache-bos4623-BOS
       X-Timer:
-      - S1757605933.392164,VS0,VE0
+      - S1758207395.783522,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:44 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -484,7 +488,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/label/json-schema/schema.json
   response:
@@ -554,7 +558,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '340'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -564,7 +568,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:13 GMT
+      - Thu, 18 Sep 2025 14:56:34 GMT
       ETag:
       - '"66e1651c-1226"'
       Last-Modified:
@@ -580,15 +584,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 3a60328e81ea8b64365e3f69a9f6dc2930fe2b1a
+      - 832e8a7af5e24170d72b37856082a18dd157ee0a
       X-GitHub-Request-Id:
-      - 6464:2BF852:1E92683:21F0317:68C2EED8
+      - B1CB:826F9:2182542:2539701:68CC1DA1
       X-Served-By:
-      - cache-bos4679-BOS
+      - cache-bos4659-BOS
       X-Timer:
-      - S1757605933.479930,VS0,VE1
+      - S1758207395.861036,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:33 GMT
+      - Thu, 18 Sep 2025 15:06:33 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -600,7 +604,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/version/json-schema/schema.json
   response:
@@ -635,7 +639,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '341'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -645,7 +649,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:13 GMT
+      - Thu, 18 Sep 2025 14:56:34 GMT
       ETag:
       - '"66e1651c-70b"'
       Last-Modified:
@@ -659,19 +663,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - d8e7224712a5af809201e237a5a1c8baa48b7b6b
+      - 77df1116c01b65c5c36d4b1a3227be660dacb72f
       X-GitHub-Request-Id:
-      - 3270:18947A:1F21620:227ED15:68C2EED8
+      - A42A:91567:105B703:1257EE0:68CC1DA0
       X-Served-By:
-      - cache-bos4633-BOS
+      - cache-bos4623-BOS
       X-Timer:
-      - S1757605934.569953,VS0,VE0
+      - S1758207395.937564,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:33 GMT
-      x-origin-cache:
-      - HIT
+      - Thu, 18 Sep 2025 15:06:34 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -681,7 +683,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/collection-spec/json-schema/collection.json
   response:
@@ -763,7 +765,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '346'
+      - '5'
       Cache-Control:
       - max-age=600
       Connection:
@@ -773,7 +775,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:13 GMT
+      - Thu, 18 Sep 2025 14:56:35 GMT
       ETag:
       - '"66e1651c-14e2"'
       Last-Modified:
@@ -787,17 +789,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - a6a988e8504d8524859a0eafc0e281213a88982c
+      - e4e945b7ddbae78218acda6a51e6116b98bad174
       X-GitHub-Request-Id:
-      - 3C0F:3556F2:2104189:236964E:68C2EED2
+      - DF8C:3D7940:20E828F:24A0D28:68CC1D9D
       X-Served-By:
-      - cache-bos4685-BOS
+      - cache-bos4620-BOS
       X-Timer:
-      - S1757605934.653859,VS0,VE0
+      - S1758207395.029553,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:28 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -807,7 +809,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/catalog-spec/json-schema/catalog.json
   response:
@@ -849,7 +851,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '346'
+      - '6'
       Cache-Control:
       - max-age=600
       Connection:
@@ -859,7 +861,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:13 GMT
+      - Thu, 18 Sep 2025 14:56:35 GMT
       ETag:
       - '"66e1651c-84e"'
       Last-Modified:
@@ -875,15 +877,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - d7907a1bb9cec3dc388bf0b26b4fcec79c8b0736
+      - ed40bcc0b77ed2fd16fdb61963b6af92b07f819a
       X-GitHub-Request-Id:
-      - 6A55:180028:223E696:24A38DD:68C2EED2
+      - 3695:91567:105B1F4:125794D:68CC1D9D
       X-Served-By:
-      - cache-bos4636-BOS
+      - cache-bos4691-BOS
       X-Timer:
-      - S1757605934.732022,VS0,VE1
+      - S1758207395.110990,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:27 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example83].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example83].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/item.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '392'
+      - '52'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:13 GMT
+      - Thu, 18 Sep 2025 14:56:35 GMT
       ETag:
       - '"66e1651c-147c"'
       Last-Modified:
@@ -109,17 +109,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 12c40d4069fab27e0d78e81cf2804216db39ddaa
+      - a0421f7c8e270f31b2f96fb5aa3989b1cdb26900
       X-GitHub-Request-Id:
-      - 9540:197FBB:BCDCFE:D8897B:68C2EEA5
+      - A3C0:BAEAA:C84169:E2AD23:68CC1D6E
       X-Served-By:
-      - cache-bos4670-BOS
+      - cache-bos4664-BOS
       X-Timer:
-      - S1757605934.812604,VS0,VE1
+      - S1758207395.213140,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/basics.json
   response:
@@ -148,7 +148,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '392'
+      - '53'
       Cache-Control:
       - max-age=600
       Connection:
@@ -158,7 +158,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:13 GMT
+      - Thu, 18 Sep 2025 14:56:35 GMT
       ETag:
       - '"66e1651c-21c"'
       Last-Modified:
@@ -172,17 +172,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Fastly-Request-ID:
-      - 095bd39fb8b20cac8c6f5c4f9fd301d4645991bd
+      - ae003cba20119de6d8f83e1583483f3a10b297ac
       X-GitHub-Request-Id:
-      - E1F2:14AA27:C232A6:DDCD4A:68C2EEA4
+      - 2F53:A07A9:C8C99E:E32E77:68CC1D6E
       X-Served-By:
-      - cache-bos4664-BOS
+      - cache-bos4624-BOS
       X-Timer:
-      - S1757605934.896279,VS0,VE1
+      - S1758207395.309255,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -192,7 +192,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/datetime.json
   response:
@@ -241,7 +241,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '392'
+      - '52'
       Cache-Control:
       - max-age=600
       Connection:
@@ -251,7 +251,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:13 GMT
+      - Thu, 18 Sep 2025 14:56:35 GMT
       ETag:
       - '"66e1651c-a82"'
       Last-Modified:
@@ -265,17 +265,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Fastly-Request-ID:
-      - 7d65baf0de561dc564049d973d3b85a071139d22
+      - a4d17cea592f5da84e97ea4c30e9a51f1128a467
       X-GitHub-Request-Id:
-      - 1865:153265:C4294F:DFCE98:68C2EEA5
+      - 3E81:0D6F:C30426:DD705D:68CC1D6F
       X-Served-By:
-      - cache-bos4620-BOS
+      - cache-bos4644-BOS
       X-Timer:
-      - S1757605934.970706,VS0,VE1
+      - S1758207395.395499,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -285,7 +287,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/instrument.json
   response:
@@ -306,7 +308,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '391'
+      - '52'
       Cache-Control:
       - max-age=600
       Connection:
@@ -316,7 +318,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:14 GMT
+      - Thu, 18 Sep 2025 14:56:35 GMT
       ETag:
       - '"66e1651c-2a2"'
       Last-Modified:
@@ -330,17 +332,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 252307b087e86dd76042ad4391c075236d2c09d6
+      - 367ff509320bd3b7f82a05f2c90ad1b48860bd63
       X-GitHub-Request-Id:
-      - 4500:CA757:1EF5208:22C6B31:68C2EEA5
+      - 7C03:3CD2C3:DA5DDA:F4BC38:68CC1D6F
       X-Served-By:
-      - cache-bos4647-BOS
+      - cache-bos4669-BOS
       X-Timer:
-      - S1757605934.041961,VS0,VE1
+      - S1758207395.483372,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -350,7 +354,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/licensing.json
   response:
@@ -366,7 +370,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '392'
+      - '52'
       Cache-Control:
       - max-age=600
       Connection:
@@ -376,7 +380,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:14 GMT
+      - Thu, 18 Sep 2025 14:56:35 GMT
       ETag:
       - '"66e1651c-135"'
       Last-Modified:
@@ -392,15 +396,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 3da644f40b05f61f06be59dbc5600546ceb9e33c
+      - 3e88e2fce5c64656a5466a1427acac6b2c37975e
       X-GitHub-Request-Id:
-      - ED10:15FE94:C5AB5F:E14C22:68C2EEA5
+      - C4E5:1D3617:CA3033:E4A206:68CC1D6F
       X-Served-By:
-      - cache-bos4648-BOS
+      - cache-bos4631-BOS
       X-Timer:
-      - S1757605934.118285,VS0,VE1
+      - S1758207396.570864,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -412,7 +416,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/provider.json
   response:
@@ -438,7 +442,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '392'
+      - '52'
       Cache-Control:
       - max-age=600
       Connection:
@@ -448,7 +452,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:14 GMT
+      - Thu, 18 Sep 2025 14:56:35 GMT
       ETag:
       - '"66e1651c-40e"'
       Last-Modified:
@@ -464,15 +468,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - ef0ecbca8adcb88119cb085f0a5116d67dce5b4b
+      - 07475f2fceb01619564452861125c2a4d4d9b573
       X-GitHub-Request-Id:
-      - F8AD:14A94E:C2C9FE:DE6C58:68C2EEA4
+      - 5805:B21BA:AD266F:C78835:68CC1D6F
       X-Served-By:
-      - cache-bos4690-BOS
+      - cache-bos4653-BOS
       X-Timer:
-      - S1757605934.191568,VS0,VE1
+      - S1758207396.659080,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:44 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -484,7 +488,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/label/json-schema/schema.json
   response:
@@ -554,7 +558,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '341'
+      - '2'
       Cache-Control:
       - max-age=600
       Connection:
@@ -564,7 +568,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:14 GMT
+      - Thu, 18 Sep 2025 14:56:35 GMT
       ETag:
       - '"66e1651c-1226"'
       Last-Modified:
@@ -580,15 +584,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 8b04c8782a6ad694345c080a4194d83706914d94
+      - 5c0a0ee670af1e4cd5e03f00454ad71ce0da0176
       X-GitHub-Request-Id:
-      - 6464:2BF852:1E92683:21F0317:68C2EED8
+      - B1CB:826F9:2182542:2539701:68CC1DA1
       X-Served-By:
-      - cache-bos4638-BOS
+      - cache-bos4680-BOS
       X-Timer:
-      - S1757605934.264810,VS0,VE1
+      - S1758207396.741413,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:56:33 GMT
+      - Thu, 18 Sep 2025 15:06:33 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -600,7 +604,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/version/json-schema/schema.json
   response:
@@ -635,7 +639,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '341'
+      - '2'
       Cache-Control:
       - max-age=600
       Connection:
@@ -645,7 +649,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:14 GMT
+      - Thu, 18 Sep 2025 14:56:35 GMT
       ETag:
       - '"66e1651c-70b"'
       Last-Modified:
@@ -659,19 +663,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 0e30ab9b61cbba227035674683f0200ddb5da741
+      - 06f563aff4f62993eee5f3e769fd8d597c59e4d2
       X-GitHub-Request-Id:
-      - 3270:18947A:1F21620:227ED15:68C2EED8
+      - A42A:91567:105B703:1257EE0:68CC1DA0
       X-Served-By:
-      - cache-bos4680-BOS
+      - cache-bos4628-BOS
       X-Timer:
-      - S1757605934.337919,VS0,VE1
+      - S1758207396.835195,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:56:33 GMT
-      x-origin-cache:
-      - HIT
+      - Thu, 18 Sep 2025 15:06:34 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -681,7 +683,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/collection-spec/json-schema/collection.json
   response:
@@ -763,7 +765,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '346'
+      - '6'
       Cache-Control:
       - max-age=600
       Connection:
@@ -773,7 +775,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:14 GMT
+      - Thu, 18 Sep 2025 14:56:35 GMT
       ETag:
       - '"66e1651c-14e2"'
       Last-Modified:
@@ -789,15 +791,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 18debc0b538ee99249679ef784b7bed17305cf09
+      - cb6962a2cf39ea91675163889576f40c585fe8ae
       X-GitHub-Request-Id:
-      - 3C0F:3556F2:2104189:236964E:68C2EED2
+      - DF8C:3D7940:20E828F:24A0D28:68CC1D9D
       X-Served-By:
-      - cache-bos4660-BOS
+      - cache-bos4681-BOS
       X-Timer:
-      - S1757605934.411300,VS0,VE1
+      - S1758207396.925650,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:28 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -807,7 +809,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/catalog-spec/json-schema/catalog.json
   response:
@@ -849,7 +851,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '347'
+      - '6'
       Cache-Control:
       - max-age=600
       Connection:
@@ -859,7 +861,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:14 GMT
+      - Thu, 18 Sep 2025 14:56:36 GMT
       ETag:
       - '"66e1651c-84e"'
       Last-Modified:
@@ -875,15 +877,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 79f3286afc302d90af8774cb8ea325079b9a8544
+      - d920b61c225335d50b117e2b7f81650082ab0dea
       X-GitHub-Request-Id:
-      - 6A55:180028:223E696:24A38DD:68C2EED2
+      - 3695:91567:105B1F4:125794D:68CC1D9D
       X-Served-By:
-      - cache-bos4686-BOS
+      - cache-bos4687-BOS
       X-Timer:
-      - S1757605934.493593,VS0,VE1
+      - S1758207396.007144,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:27 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example84].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example84].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/collection-spec/json-schema/collection.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '347'
+      - '6'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:14 GMT
+      - Thu, 18 Sep 2025 14:56:36 GMT
       ETag:
       - '"66e1651c-14e2"'
       Last-Modified:
@@ -109,17 +109,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - b7a2e73e89bb27ab0fdffbbad7b223d3ba642173
+      - fcc93b6b8df5aa4a788df1fcbd6107ee3cc996bd
       X-GitHub-Request-Id:
-      - 3C0F:3556F2:2104189:236964E:68C2EED2
+      - DF8C:3D7940:20E828F:24A0D28:68CC1D9D
       X-Served-By:
-      - cache-bos4672-BOS
+      - cache-bos4659-BOS
       X-Timer:
-      - S1757605935.569175,VS0,VE0
+      - S1758207396.096920,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:28 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/catalog-spec/json-schema/catalog.json
   response:
@@ -171,7 +171,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '347'
+      - '7'
       Cache-Control:
       - max-age=600
       Connection:
@@ -181,7 +181,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:14 GMT
+      - Thu, 18 Sep 2025 14:56:36 GMT
       ETag:
       - '"66e1651c-84e"'
       Last-Modified:
@@ -197,15 +197,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 48d703a60fc525e70356b1d37a06546416e3a307
+      - 4a388a17e598ea9024039c4deaab5411c30ebce4
       X-GitHub-Request-Id:
-      - 6A55:180028:223E696:24A38DD:68C2EED2
+      - 3695:91567:105B1F4:125794D:68CC1D9D
       X-Served-By:
-      - cache-bos4621-BOS
+      - cache-bos4645-BOS
       X-Timer:
-      - S1757605935.646411,VS0,VE2
+      - S1758207396.187158,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:56:27 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example85].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example85].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/collection-spec/json-schema/collection.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '346'
+      - '7'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:14 GMT
+      - Thu, 18 Sep 2025 14:56:36 GMT
       ETag:
       - '"66e1651c-14e2"'
       Last-Modified:
@@ -109,17 +109,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '1'
       X-Fastly-Request-ID:
-      - e949112de6156bde77a94005ea834606bca33b8d
+      - f72cff7c04d533468287ec96ebeb6c564405cf02
       X-GitHub-Request-Id:
-      - 3C0F:3556F2:2104189:236964E:68C2EED2
+      - DF8C:3D7940:20E828F:24A0D28:68CC1D9D
       X-Served-By:
-      - cache-bos4629-BOS
+      - cache-bos4671-BOS
       X-Timer:
-      - S1757605935.731081,VS0,VE0
+      - S1758207396.285427,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:28 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/catalog-spec/json-schema/catalog.json
   response:
@@ -171,7 +171,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '347'
+      - '7'
       Cache-Control:
       - max-age=600
       Connection:
@@ -181,7 +181,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:14 GMT
+      - Thu, 18 Sep 2025 14:56:36 GMT
       ETag:
       - '"66e1651c-84e"'
       Last-Modified:
@@ -195,17 +195,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - f389ecc079eabbc682c2282e51d03d496b21b9c4
+      - 6a4ce61a7cfe386f976deef6cbbe6fb55af8f7ef
       X-GitHub-Request-Id:
-      - 6A55:180028:223E696:24A38DD:68C2EED2
+      - 3695:91567:105B1F4:125794D:68CC1D9D
       X-Served-By:
-      - cache-bos4666-BOS
+      - cache-bos4685-BOS
       X-Timer:
-      - S1757605935.799574,VS0,VE0
+      - S1758207396.365103,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:27 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example86].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example86].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/item.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '393'
+      - '53'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:14 GMT
+      - Thu, 18 Sep 2025 14:56:36 GMT
       ETag:
       - '"66e1651c-147c"'
       Last-Modified:
@@ -111,15 +111,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - abcf5aab23b35a7aa9e26fa48c8b4c4bc583131e
+      - 022b185992f2e9a31653f8fd852c3bc07fb894bb
       X-GitHub-Request-Id:
-      - 9540:197FBB:BCDCFE:D8897B:68C2EEA5
+      - A3C0:BAEAA:C84169:E2AD23:68CC1D6E
       X-Served-By:
-      - cache-bos4623-BOS
+      - cache-bos4640-BOS
       X-Timer:
-      - S1757605935.882386,VS0,VE2
+      - S1758207396.446004,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/basics.json
   response:
@@ -148,7 +148,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '393'
+      - '53'
       Cache-Control:
       - max-age=600
       Connection:
@@ -158,7 +158,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:14 GMT
+      - Thu, 18 Sep 2025 14:56:36 GMT
       ETag:
       - '"66e1651c-21c"'
       Last-Modified:
@@ -174,15 +174,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 7c834a7f83bef0ac5043370865ae73690b363509
+      - dff382de336785f93d2a528ea2dbcdf524b2e3db
       X-GitHub-Request-Id:
-      - E1F2:14AA27:C232A6:DDCD4A:68C2EEA4
+      - 2F53:A07A9:C8C99E:E32E77:68CC1D6E
       X-Served-By:
-      - cache-bos4693-BOS
+      - cache-bos4678-BOS
       X-Timer:
-      - S1757605935.959937,VS0,VE1
+      - S1758207397.523131,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -192,7 +192,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/datetime.json
   response:
@@ -241,7 +241,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '393'
+      - '53'
       Cache-Control:
       - max-age=600
       Connection:
@@ -251,7 +251,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:15 GMT
+      - Thu, 18 Sep 2025 14:56:36 GMT
       ETag:
       - '"66e1651c-a82"'
       Last-Modified:
@@ -265,17 +265,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 1c4ae94efa794d3052345b0c0dcb3e36b985aad8
+      - 50893a4d55fac27fc999ce0d1153ee2a70b22200
       X-GitHub-Request-Id:
-      - 1865:153265:C4294F:DFCE98:68C2EEA5
+      - 3E81:0D6F:C30426:DD705D:68CC1D6F
       X-Served-By:
-      - cache-bos4633-BOS
+      - cache-bos4669-BOS
       X-Timer:
-      - S1757605935.031967,VS0,VE0
+      - S1758207397.597237,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -285,7 +287,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/instrument.json
   response:
@@ -306,7 +308,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '393'
+      - '53'
       Cache-Control:
       - max-age=600
       Connection:
@@ -316,7 +318,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:15 GMT
+      - Thu, 18 Sep 2025 14:56:36 GMT
       ETag:
       - '"66e1651c-2a2"'
       Last-Modified:
@@ -332,15 +334,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - dfe1478cc201b58c07ec55b6e50255fbc88a90e3
+      - 0a5bdaff795fbd1a8ae4cae8d10213f8337259c1
       X-GitHub-Request-Id:
-      - 4500:CA757:1EF5208:22C6B31:68C2EEA5
+      - 7C03:3CD2C3:DA5DDA:F4BC38:68CC1D6F
       X-Served-By:
-      - cache-bos4649-BOS
+      - cache-bos4673-BOS
       X-Timer:
-      - S1757605935.108353,VS0,VE1
+      - S1758207397.665490,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -350,7 +354,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/licensing.json
   response:
@@ -366,7 +370,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '393'
+      - '53'
       Cache-Control:
       - max-age=600
       Connection:
@@ -376,7 +380,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:15 GMT
+      - Thu, 18 Sep 2025 14:56:36 GMT
       ETag:
       - '"66e1651c-135"'
       Last-Modified:
@@ -392,15 +396,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 039c8b2a51e0d744eaebe9ea290e141035661ffb
+      - 9afcdbfb63128c34bce11f6db16c43e8aeb802b0
       X-GitHub-Request-Id:
-      - ED10:15FE94:C5AB5F:E14C22:68C2EEA5
+      - C4E5:1D3617:CA3033:E4A206:68CC1D6F
       X-Served-By:
-      - cache-bos4677-BOS
+      - cache-bos4656-BOS
       X-Timer:
-      - S1757605935.182066,VS0,VE1
+      - S1758207397.743229,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -412,7 +416,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/provider.json
   response:
@@ -438,7 +442,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '393'
+      - '53'
       Cache-Control:
       - max-age=600
       Connection:
@@ -448,7 +452,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:15 GMT
+      - Thu, 18 Sep 2025 14:56:36 GMT
       ETag:
       - '"66e1651c-40e"'
       Last-Modified:
@@ -464,15 +468,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 2bae9706971b9ee72ae12a3a56492efd95c2910f
+      - 4766c23f5dfdce80a3813a4e059a7ef2330e6fe6
       X-GitHub-Request-Id:
-      - F8AD:14A94E:C2C9FE:DE6C58:68C2EEA4
+      - 5805:B21BA:AD266F:C78835:68CC1D6F
       X-Served-By:
-      - cache-bos4632-BOS
+      - cache-bos4629-BOS
       X-Timer:
-      - S1757605935.257686,VS0,VE2
+      - S1758207397.810810,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:44 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -484,7 +488,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/label/json-schema/schema.json
   response:
@@ -554,7 +558,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '342'
+      - '3'
       Cache-Control:
       - max-age=600
       Connection:
@@ -564,7 +568,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:15 GMT
+      - Thu, 18 Sep 2025 14:56:36 GMT
       ETag:
       - '"66e1651c-1226"'
       Last-Modified:
@@ -580,15 +584,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 340f776666a03393d124e5cacbda00f32e284989
+      - 453959446734a35013cccb78fe6b0be86598ff9c
       X-GitHub-Request-Id:
-      - 6464:2BF852:1E92683:21F0317:68C2EED8
+      - B1CB:826F9:2182542:2539701:68CC1DA1
       X-Served-By:
-      - cache-bos4676-BOS
+      - cache-bos4632-BOS
       X-Timer:
-      - S1757605935.329522,VS0,VE2
+      - S1758207397.881600,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:33 GMT
+      - Thu, 18 Sep 2025 15:06:33 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -600,7 +604,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/version/json-schema/schema.json
   response:
@@ -635,7 +639,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '342'
+      - '3'
       Cache-Control:
       - max-age=600
       Connection:
@@ -645,7 +649,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:15 GMT
+      - Thu, 18 Sep 2025 14:56:36 GMT
       ETag:
       - '"66e1651c-70b"'
       Last-Modified:
@@ -661,17 +665,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - c6a1713d60524b10a7f27b347946bdd420beb1f4
+      - 42ff47073f3d46503a3caeb9238f420196844119
       X-GitHub-Request-Id:
-      - 3270:18947A:1F21620:227ED15:68C2EED8
+      - A42A:91567:105B703:1257EE0:68CC1DA0
       X-Served-By:
-      - cache-bos4681-BOS
+      - cache-bos4652-BOS
       X-Timer:
-      - S1757605935.416189,VS0,VE2
+      - S1758207397.962921,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:33 GMT
-      x-origin-cache:
-      - HIT
+      - Thu, 18 Sep 2025 15:06:34 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -681,7 +683,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/collection-spec/json-schema/collection.json
   response:
@@ -763,7 +765,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '347'
+      - '7'
       Cache-Control:
       - max-age=600
       Connection:
@@ -773,7 +775,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:15 GMT
+      - Thu, 18 Sep 2025 14:56:37 GMT
       ETag:
       - '"66e1651c-14e2"'
       Last-Modified:
@@ -789,15 +791,15 @@ interactions:
       X-Cache-Hits:
       - '2'
       X-Fastly-Request-ID:
-      - 4f9c92087d75ab6794e0418c6fae869bd36dc10a
+      - a91198619c117f2f08d3b824a69d4672986d4d58
       X-GitHub-Request-Id:
-      - 3C0F:3556F2:2104189:236964E:68C2EED2
+      - DF8C:3D7940:20E828F:24A0D28:68CC1D9D
       X-Served-By:
-      - cache-bos4626-BOS
+      - cache-bos4676-BOS
       X-Timer:
-      - S1757605935.499750,VS0,VE0
+      - S1758207397.034922,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:56:28 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -807,7 +809,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/catalog-spec/json-schema/catalog.json
   response:
@@ -849,7 +851,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '348'
+      - '8'
       Cache-Control:
       - max-age=600
       Connection:
@@ -859,7 +861,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:15 GMT
+      - Thu, 18 Sep 2025 14:56:37 GMT
       ETag:
       - '"66e1651c-84e"'
       Last-Modified:
@@ -875,15 +877,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 56c2b330ec67c42f15160133ad3c481439d54f54
+      - 3cd2c6da205fd7c9832fae9d20a339b43aa99789
       X-GitHub-Request-Id:
-      - 6A55:180028:223E696:24A38DD:68C2EED2
+      - 3695:91567:105B1F4:125794D:68CC1D9D
       X-Served-By:
-      - cache-bos4675-BOS
+      - cache-bos4680-BOS
       X-Timer:
-      - S1757605936.583941,VS0,VE1
+      - S1758207397.129527,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:27 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example87].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example87].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/item.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '394'
+      - '54'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:15 GMT
+      - Thu, 18 Sep 2025 14:56:37 GMT
       ETag:
       - '"66e1651c-147c"'
       Last-Modified:
@@ -111,15 +111,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 2bb797500d510c175b9867cc857462cd066a1531
+      - c916bb110d866eaff549f5bb21ac1c3f3def8bf1
       X-GitHub-Request-Id:
-      - 9540:197FBB:BCDCFE:D8897B:68C2EEA5
+      - A3C0:BAEAA:C84169:E2AD23:68CC1D6E
       X-Served-By:
-      - cache-bos4672-BOS
+      - cache-bos4623-BOS
       X-Timer:
-      - S1757605936.677539,VS0,VE3
+      - S1758207397.215815,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/basics.json
   response:
@@ -148,7 +148,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '394'
+      - '54'
       Cache-Control:
       - max-age=600
       Connection:
@@ -158,7 +158,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:15 GMT
+      - Thu, 18 Sep 2025 14:56:37 GMT
       ETag:
       - '"66e1651c-21c"'
       Last-Modified:
@@ -172,17 +172,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '1'
       X-Fastly-Request-ID:
-      - de4ce30e038a05366866e143b0a5d05b187db41a
+      - ace8b76de49d08f58eb352868d491e1ab6f7653c
       X-GitHub-Request-Id:
-      - E1F2:14AA27:C232A6:DDCD4A:68C2EEA4
+      - 2F53:A07A9:C8C99E:E32E77:68CC1D6E
       X-Served-By:
-      - cache-bos4672-BOS
+      - cache-bos4687-BOS
       X-Timer:
-      - S1757605936.771229,VS0,VE0
+      - S1758207397.281283,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -192,7 +192,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/datetime.json
   response:
@@ -241,7 +241,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '394'
+      - '54'
       Cache-Control:
       - max-age=600
       Connection:
@@ -251,7 +251,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:15 GMT
+      - Thu, 18 Sep 2025 14:56:37 GMT
       ETag:
       - '"66e1651c-a82"'
       Last-Modified:
@@ -267,15 +267,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 21465a97b18f977f9ce70202ad4c4fd629db67a3
+      - 7e2a045313e54a2e20b3ce0f46962fcfd0e060dd
       X-GitHub-Request-Id:
-      - 1865:153265:C4294F:DFCE98:68C2EEA5
+      - 3E81:0D6F:C30426:DD705D:68CC1D6F
       X-Served-By:
-      - cache-bos4641-BOS
+      - cache-bos4622-BOS
       X-Timer:
-      - S1757605936.857956,VS0,VE1
+      - S1758207397.363514,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -285,7 +287,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/instrument.json
   response:
@@ -306,7 +308,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '393'
+      - '54'
       Cache-Control:
       - max-age=600
       Connection:
@@ -316,7 +318,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:15 GMT
+      - Thu, 18 Sep 2025 14:56:37 GMT
       ETag:
       - '"66e1651c-2a2"'
       Last-Modified:
@@ -330,17 +332,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - d504bae56e1b634e66e19202b9d1ca57f281c6c4
+      - 9f750158ab31c2a9433a4dde29c6d6f66384ac6c
       X-GitHub-Request-Id:
-      - 4500:CA757:1EF5208:22C6B31:68C2EEA5
+      - 7C03:3CD2C3:DA5DDA:F4BC38:68CC1D6F
       X-Served-By:
-      - cache-bos4637-BOS
+      - cache-bos4649-BOS
       X-Timer:
-      - S1757605936.945829,VS0,VE0
+      - S1758207397.431047,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -350,7 +354,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/licensing.json
   response:
@@ -366,7 +370,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '394'
+      - '54'
       Cache-Control:
       - max-age=600
       Connection:
@@ -376,7 +380,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:16 GMT
+      - Thu, 18 Sep 2025 14:56:37 GMT
       ETag:
       - '"66e1651c-135"'
       Last-Modified:
@@ -390,17 +394,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 81175fc8bc3f98f1367767f933fc0e64d308873d
+      - b02f99d2f6b15697b274573e552f916361977997
       X-GitHub-Request-Id:
-      - ED10:15FE94:C5AB5F:E14C22:68C2EEA5
+      - C4E5:1D3617:CA3033:E4A206:68CC1D6F
       X-Served-By:
-      - cache-bos4640-BOS
+      - cache-bos4652-BOS
       X-Timer:
-      - S1757605936.028466,VS0,VE0
+      - S1758207398.515112,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -412,7 +416,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/provider.json
   response:
@@ -438,7 +442,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '393'
+      - '53'
       Cache-Control:
       - max-age=600
       Connection:
@@ -448,7 +452,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:16 GMT
+      - Thu, 18 Sep 2025 14:56:37 GMT
       ETag:
       - '"66e1651c-40e"'
       Last-Modified:
@@ -462,17 +466,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 7799fdcbe5d9c0e6147bbcc8cca867322699e43a
+      - de1e35a3e8fe94e396bef47d85280b41772566b9
       X-GitHub-Request-Id:
-      - F8AD:14A94E:C2C9FE:DE6C58:68C2EEA4
+      - 5805:B21BA:AD266F:C78835:68CC1D6F
       X-Served-By:
-      - cache-bos4670-BOS
+      - cache-bos4666-BOS
       X-Timer:
-      - S1757605936.110325,VS0,VE0
+      - S1758207398.591443,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:44 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -484,7 +488,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/label/json-schema/schema.json
   response:
@@ -554,7 +558,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '343'
+      - '4'
       Cache-Control:
       - max-age=600
       Connection:
@@ -564,7 +568,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:16 GMT
+      - Thu, 18 Sep 2025 14:56:37 GMT
       ETag:
       - '"66e1651c-1226"'
       Last-Modified:
@@ -580,15 +584,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 9dca36fb42db526cdca178e59325862ff42f6c2b
+      - 86c187fc423b8d72ac430b08ad913b16a136213f
       X-GitHub-Request-Id:
-      - 6464:2BF852:1E92683:21F0317:68C2EED8
+      - B1CB:826F9:2182542:2539701:68CC1DA1
       X-Served-By:
-      - cache-bos4650-BOS
+      - cache-bos4672-BOS
       X-Timer:
-      - S1757605936.196057,VS0,VE1
+      - S1758207398.659349,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:56:33 GMT
+      - Thu, 18 Sep 2025 15:06:33 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -600,7 +604,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/version/json-schema/schema.json
   response:
@@ -635,7 +639,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '343'
+      - '4'
       Cache-Control:
       - max-age=600
       Connection:
@@ -645,7 +649,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:16 GMT
+      - Thu, 18 Sep 2025 14:56:37 GMT
       ETag:
       - '"66e1651c-70b"'
       Last-Modified:
@@ -661,17 +665,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 7bb204362d3eefb48219145c6093c2679005c668
+      - 2fc8f4135859c4d4701ac18a754a3871d3d1cf39
       X-GitHub-Request-Id:
-      - 3270:18947A:1F21620:227ED15:68C2EED8
+      - A42A:91567:105B703:1257EE0:68CC1DA0
       X-Served-By:
-      - cache-bos4632-BOS
+      - cache-bos4620-BOS
       X-Timer:
-      - S1757605936.294112,VS0,VE1
+      - S1758207398.739171,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:33 GMT
-      x-origin-cache:
-      - HIT
+      - Thu, 18 Sep 2025 15:06:34 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -681,7 +683,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/collection-spec/json-schema/collection.json
   response:
@@ -763,7 +765,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '348'
+      - '8'
       Cache-Control:
       - max-age=600
       Connection:
@@ -773,7 +775,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:16 GMT
+      - Thu, 18 Sep 2025 14:56:37 GMT
       ETag:
       - '"66e1651c-14e2"'
       Last-Modified:
@@ -789,15 +791,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - daeaee2cbc15460e9b3a25f3047d559ecfb558ba
+      - 8ba19858fc24856962608c9d493a47ed4120354b
       X-GitHub-Request-Id:
-      - 3C0F:3556F2:2104189:236964E:68C2EED2
+      - DF8C:3D7940:20E828F:24A0D28:68CC1D9D
       X-Served-By:
-      - cache-bos4678-BOS
+      - cache-bos4667-BOS
       X-Timer:
-      - S1757605936.387823,VS0,VE1
+      - S1758207398.813156,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:28 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -807,7 +809,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/catalog-spec/json-schema/catalog.json
   response:
@@ -849,7 +851,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '349'
+      - '8'
       Cache-Control:
       - max-age=600
       Connection:
@@ -859,7 +861,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:16 GMT
+      - Thu, 18 Sep 2025 14:56:37 GMT
       ETag:
       - '"66e1651c-84e"'
       Last-Modified:
@@ -873,17 +875,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 01bbd7866fcc3aae5920357a4d120c7af55fd83c
+      - f85fbb6ad90953f4e2ecc54ccaf6f81479d32b1b
       X-GitHub-Request-Id:
-      - 6A55:180028:223E696:24A38DD:68C2EED2
+      - 3695:91567:105B1F4:125794D:68CC1D9D
       X-Served-By:
-      - cache-bos4630-BOS
+      - cache-bos4625-BOS
       X-Timer:
-      - S1757605936.479579,VS0,VE0
+      - S1758207398.884907,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:56:27 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example88].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example88].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/collection-spec/json-schema/collection.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '348'
+      - '8'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:16 GMT
+      - Thu, 18 Sep 2025 14:56:37 GMT
       ETag:
       - '"66e1651c-14e2"'
       Last-Modified:
@@ -111,15 +111,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 9ea490b4ddd366c7e03fb57f62dc57a3fa6edbb0
+      - d0d79ff292f4c38cb24265f60af9e27cf2ca8a86
       X-GitHub-Request-Id:
-      - 3C0F:3556F2:2104189:236964E:68C2EED2
+      - DF8C:3D7940:20E828F:24A0D28:68CC1D9D
       X-Served-By:
-      - cache-bos4658-BOS
+      - cache-bos4679-BOS
       X-Timer:
-      - S1757605937.572481,VS0,VE1
+      - S1758207398.965260,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:28 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/catalog-spec/json-schema/catalog.json
   response:
@@ -171,7 +171,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '349'
+      - '9'
       Cache-Control:
       - max-age=600
       Connection:
@@ -181,7 +181,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:16 GMT
+      - Thu, 18 Sep 2025 14:56:38 GMT
       ETag:
       - '"66e1651c-84e"'
       Last-Modified:
@@ -197,15 +197,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - a2d529a5a4438335e1b1ea6318fed1c6519e176e
+      - 02c03f056975ed4e25843f06b88cae78b4194897
       X-GitHub-Request-Id:
-      - 6A55:180028:223E696:24A38DD:68C2EED2
+      - 3695:91567:105B1F4:125794D:68CC1D9D
       X-Served-By:
-      - cache-bos4676-BOS
+      - cache-bos4664-BOS
       X-Timer:
-      - S1757605937.665896,VS0,VE1
+      - S1758207398.045359,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:56:27 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example89].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example89].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/item.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '395'
+      - '55'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:16 GMT
+      - Thu, 18 Sep 2025 14:56:38 GMT
       ETag:
       - '"66e1651c-147c"'
       Last-Modified:
@@ -111,15 +111,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 381c49804e2464cd6c828ea14712b51a07e7b396
+      - 5126113d72c56252cba069b6896fd0d73e87758c
       X-GitHub-Request-Id:
-      - 9540:197FBB:BCDCFE:D8897B:68C2EEA5
+      - A3C0:BAEAA:C84169:E2AD23:68CC1D6E
       X-Served-By:
-      - cache-bos4667-BOS
+      - cache-bos4677-BOS
       X-Timer:
-      - S1757605937.765817,VS0,VE1
+      - S1758207398.137184,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/basics.json
   response:
@@ -148,7 +148,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '395'
+      - '55'
       Cache-Control:
       - max-age=600
       Connection:
@@ -158,7 +158,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:16 GMT
+      - Thu, 18 Sep 2025 14:56:38 GMT
       ETag:
       - '"66e1651c-21c"'
       Last-Modified:
@@ -172,17 +172,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 5c0cfee830bbe570737e68510bd590510ef6cd0a
+      - f37806b5e31f69373a10a0a3446716807837b4a3
       X-GitHub-Request-Id:
-      - E1F2:14AA27:C232A6:DDCD4A:68C2EEA4
+      - 2F53:A07A9:C8C99E:E32E77:68CC1D6E
       X-Served-By:
-      - cache-bos4663-BOS
+      - cache-bos4693-BOS
       X-Timer:
-      - S1757605937.852373,VS0,VE0
+      - S1758207398.233528,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -192,7 +192,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/datetime.json
   response:
@@ -241,7 +241,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '395'
+      - '55'
       Cache-Control:
       - max-age=600
       Connection:
@@ -251,7 +251,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:16 GMT
+      - Thu, 18 Sep 2025 14:56:38 GMT
       ETag:
       - '"66e1651c-a82"'
       Last-Modified:
@@ -267,15 +267,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - ea0b5fae6a3033cce51b153ef81540b03e124e4c
+      - 0f4208e4f7193a16fd84ec1ed963425c8742cd58
       X-GitHub-Request-Id:
-      - 1865:153265:C4294F:DFCE98:68C2EEA5
+      - 3E81:0D6F:C30426:DD705D:68CC1D6F
       X-Served-By:
-      - cache-bos4645-BOS
+      - cache-bos4636-BOS
       X-Timer:
-      - S1757605937.930675,VS0,VE1
+      - S1758207398.323416,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -285,7 +287,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/instrument.json
   response:
@@ -306,7 +308,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '395'
+      - '55'
       Cache-Control:
       - max-age=600
       Connection:
@@ -316,7 +318,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:17 GMT
+      - Thu, 18 Sep 2025 14:56:38 GMT
       ETag:
       - '"66e1651c-2a2"'
       Last-Modified:
@@ -332,15 +334,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 8228ce0c0dc43533b55aeb3bc4359ed7f9abb087
+      - 7e75179af7a46f9dfaa7428c70fd479eafce95be
       X-GitHub-Request-Id:
-      - 4500:CA757:1EF5208:22C6B31:68C2EEA5
+      - 7C03:3CD2C3:DA5DDA:F4BC38:68CC1D6F
       X-Served-By:
       - cache-bos4671-BOS
       X-Timer:
-      - S1757605937.010899,VS0,VE1
+      - S1758207398.407052,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -350,7 +354,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/licensing.json
   response:
@@ -366,7 +370,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '395'
+      - '55'
       Cache-Control:
       - max-age=600
       Connection:
@@ -376,7 +380,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:17 GMT
+      - Thu, 18 Sep 2025 14:56:38 GMT
       ETag:
       - '"66e1651c-135"'
       Last-Modified:
@@ -392,15 +396,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 7efe4d414cc472e0fb1c736e6229c914abf310f3
+      - 31090c583c88216712dec1228c4718b97803ca3c
       X-GitHub-Request-Id:
-      - ED10:15FE94:C5AB5F:E14C22:68C2EEA5
+      - C4E5:1D3617:CA3033:E4A206:68CC1D6F
       X-Served-By:
-      - cache-bos4693-BOS
+      - cache-bos4644-BOS
       X-Timer:
-      - S1757605937.088092,VS0,VE1
+      - S1758207398.495102,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -412,7 +416,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/provider.json
   response:
@@ -438,7 +442,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '395'
+      - '54'
       Cache-Control:
       - max-age=600
       Connection:
@@ -448,7 +452,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:17 GMT
+      - Thu, 18 Sep 2025 14:56:38 GMT
       ETag:
       - '"66e1651c-40e"'
       Last-Modified:
@@ -462,17 +466,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - c76aa53b6dd386b0542e47a88379aa9e8bb8fe5b
+      - d1d328920795c83f5ad6a3c93e372f98ec37beaf
       X-GitHub-Request-Id:
-      - F8AD:14A94E:C2C9FE:DE6C58:68C2EEA4
+      - 5805:B21BA:AD266F:C78835:68CC1D6F
       X-Served-By:
-      - cache-bos4637-BOS
+      - cache-bos4689-BOS
       X-Timer:
-      - S1757605937.164246,VS0,VE0
+      - S1758207399.584990,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:44 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -484,7 +488,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/label/json-schema/schema.json
   response:
@@ -554,7 +558,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '5'
       Cache-Control:
       - max-age=600
       Connection:
@@ -564,7 +568,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:17 GMT
+      - Thu, 18 Sep 2025 14:56:38 GMT
       ETag:
       - '"66e1651c-1226"'
       Last-Modified:
@@ -580,15 +584,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 4937041af5205031d9ada69ace1263db89329c9a
+      - ae6726545fb450676371fa774871214ac0fe5e4f
       X-GitHub-Request-Id:
-      - 6464:2BF852:1E92683:21F0317:68C2EED8
+      - B1CB:826F9:2182542:2539701:68CC1DA1
       X-Served-By:
-      - cache-bos4633-BOS
+      - cache-bos4677-BOS
       X-Timer:
-      - S1757605937.249951,VS0,VE1
+      - S1758207399.667028,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:56:33 GMT
+      - Thu, 18 Sep 2025 15:06:33 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -600,7 +604,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/version/json-schema/schema.json
   response:
@@ -635,7 +639,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '344'
+      - '5'
       Cache-Control:
       - max-age=600
       Connection:
@@ -645,7 +649,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:17 GMT
+      - Thu, 18 Sep 2025 14:56:38 GMT
       ETag:
       - '"66e1651c-70b"'
       Last-Modified:
@@ -661,17 +665,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 924937186e2a3d636fbbe4f2bb1b8ff235fdf525
+      - c4f6a6c209e536a0b232f08642dbc4de3ea563cb
       X-GitHub-Request-Id:
-      - 3270:18947A:1F21620:227ED15:68C2EED8
+      - A42A:91567:105B703:1257EE0:68CC1DA0
       X-Served-By:
-      - cache-bos4631-BOS
+      - cache-bos4673-BOS
       X-Timer:
-      - S1757605937.326011,VS0,VE1
+      - S1758207399.759626,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:33 GMT
-      x-origin-cache:
-      - HIT
+      - Thu, 18 Sep 2025 15:06:34 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -681,7 +683,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/collection-spec/json-schema/collection.json
   response:
@@ -763,7 +765,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '349'
+      - '9'
       Cache-Control:
       - max-age=600
       Connection:
@@ -773,7 +775,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:17 GMT
+      - Thu, 18 Sep 2025 14:56:38 GMT
       ETag:
       - '"66e1651c-14e2"'
       Last-Modified:
@@ -787,17 +789,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 100a6376371238e647c07a7030648f07ab02eb6a
+      - 06326792c21efb47308ba96eaa42f18f7d6a615c
       X-GitHub-Request-Id:
-      - 3C0F:3556F2:2104189:236964E:68C2EED2
+      - DF8C:3D7940:20E828F:24A0D28:68CC1D9D
       X-Served-By:
-      - cache-bos4639-BOS
+      - cache-bos4674-BOS
       X-Timer:
-      - S1757605937.401775,VS0,VE1
+      - S1758207399.853421,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:28 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -807,7 +809,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/catalog-spec/json-schema/catalog.json
   response:
@@ -849,7 +851,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '350'
+      - '9'
       Cache-Control:
       - max-age=600
       Connection:
@@ -859,7 +861,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:17 GMT
+      - Thu, 18 Sep 2025 14:56:38 GMT
       ETag:
       - '"66e1651c-84e"'
       Last-Modified:
@@ -873,17 +875,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 06824ab7f5e444672f8b4bf6d617846e47d866cf
+      - 9db91fa4af96aa025973e101797ffa8f0d26409c
       X-GitHub-Request-Id:
-      - 6A55:180028:223E696:24A38DD:68C2EED2
+      - 3695:91567:105B1F4:125794D:68CC1D9D
       X-Served-By:
-      - cache-bos4676-BOS
+      - cache-bos4656-BOS
       X-Timer:
-      - S1757605937.485966,VS0,VE0
+      - S1758207399.939119,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:27 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example8].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example8].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/item-spec/json-schema/item.json
   response:
@@ -108,11 +108,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:43 GMT
+      - Thu, 18 Sep 2025 14:56:02 GMT
       ETag:
       - '"4e24763d74f0d463b0cb6c63fc099e0b59447c7a049b93ffda4c6eb9eb54ae95"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:43 GMT
+      - Thu, 18 Sep 2025 15:01:02 GMT
       Source-Age:
       - '1'
       Strict-Transport-Security:
@@ -128,15 +128,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - 91da22b5071a4a068428d2e224336618206e7d49
+      - 65722339577b74a860904175f452cd9f7b729dd0
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 688A:1E0DA2:13B02E:181CCC:68C2EEB5
+      - DDD5:286E0:D0F1D:FC0CF:68CC1D7C
       X-Served-By:
-      - cache-bos4692-BOS
+      - cache-bos4653-BOS
       X-Timer:
-      - S1757605903.407809,VS0,VE1
+      - S1758207363.507810,VS0,VE2
       X-XSS-Protection:
       - 1; mode=block
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example90].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example90].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/item.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '396'
+      - '56'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:17 GMT
+      - Thu, 18 Sep 2025 14:56:39 GMT
       ETag:
       - '"66e1651c-147c"'
       Last-Modified:
@@ -109,17 +109,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Fastly-Request-ID:
-      - 3cfa18697f1f5dafaef647cecd6284e46747c8d9
+      - 7d5b4cab79b677a392e7d949dc0f876bb5f2d5ea
       X-GitHub-Request-Id:
-      - 9540:197FBB:BCDCFE:D8897B:68C2EEA5
+      - A3C0:BAEAA:C84169:E2AD23:68CC1D6E
       X-Served-By:
-      - cache-bos4663-BOS
+      - cache-bos4680-BOS
       X-Timer:
-      - S1757605938.568181,VS0,VE3
+      - S1758207399.033334,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/basics.json
   response:
@@ -148,7 +148,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '396'
+      - '56'
       Cache-Control:
       - max-age=600
       Connection:
@@ -158,7 +158,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:17 GMT
+      - Thu, 18 Sep 2025 14:56:39 GMT
       ETag:
       - '"66e1651c-21c"'
       Last-Modified:
@@ -172,17 +172,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - f425e39086c57097ce5f61426a26706e6bd9ad0e
+      - b9c18ab1362538b83cc1da66215c68b6d63fac4b
       X-GitHub-Request-Id:
-      - E1F2:14AA27:C232A6:DDCD4A:68C2EEA4
+      - 2F53:A07A9:C8C99E:E32E77:68CC1D6E
       X-Served-By:
-      - cache-bos4692-BOS
+      - cache-bos4675-BOS
       X-Timer:
-      - S1757605938.672602,VS0,VE0
+      - S1758207399.119406,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -192,7 +192,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/datetime.json
   response:
@@ -241,7 +241,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '396'
+      - '56'
       Cache-Control:
       - max-age=600
       Connection:
@@ -251,7 +251,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:17 GMT
+      - Thu, 18 Sep 2025 14:56:39 GMT
       ETag:
       - '"66e1651c-a82"'
       Last-Modified:
@@ -267,15 +267,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 220e58e08bd7d0a98e8ee667dba1d59e837ab44f
+      - d207f57f9a618acce67cd61172251340ab34fa00
       X-GitHub-Request-Id:
-      - 1865:153265:C4294F:DFCE98:68C2EEA5
+      - 3E81:0D6F:C30426:DD705D:68CC1D6F
       X-Served-By:
-      - cache-bos4667-BOS
+      - cache-bos4681-BOS
       X-Timer:
-      - S1757605938.750280,VS0,VE1
+      - S1758207399.207026,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -285,7 +287,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/instrument.json
   response:
@@ -306,7 +308,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '396'
+      - '56'
       Cache-Control:
       - max-age=600
       Connection:
@@ -316,7 +318,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:17 GMT
+      - Thu, 18 Sep 2025 14:56:39 GMT
       ETag:
       - '"66e1651c-2a2"'
       Last-Modified:
@@ -332,15 +334,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - ff0a17ff2938ce7c49bf34176b91e8ef133387b9
+      - e606f456e3fd8a52f7e55bcef29cdcebc58b668e
       X-GitHub-Request-Id:
-      - 4500:CA757:1EF5208:22C6B31:68C2EEA5
+      - 7C03:3CD2C3:DA5DDA:F4BC38:68CC1D6F
       X-Served-By:
-      - cache-bos4688-BOS
+      - cache-bos4684-BOS
       X-Timer:
-      - S1757605938.826107,VS0,VE2
+      - S1758207399.304871,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -350,7 +354,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/licensing.json
   response:
@@ -366,7 +370,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '396'
+      - '55'
       Cache-Control:
       - max-age=600
       Connection:
@@ -376,7 +380,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:17 GMT
+      - Thu, 18 Sep 2025 14:56:39 GMT
       ETag:
       - '"66e1651c-135"'
       Last-Modified:
@@ -390,17 +394,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 6b80c6cdc2d33606f7a513c3c0f4ec690060bd3a
+      - 82342f4323182ee4a30990a053a2c4d5d0800529
       X-GitHub-Request-Id:
-      - ED10:15FE94:C5AB5F:E14C22:68C2EEA5
+      - C4E5:1D3617:CA3033:E4A206:68CC1D6F
       X-Served-By:
-      - cache-bos4648-BOS
+      - cache-bos4688-BOS
       X-Timer:
-      - S1757605938.902445,VS0,VE1
+      - S1758207399.389884,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -412,7 +416,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/provider.json
   response:
@@ -438,7 +442,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '396'
+      - '55'
       Cache-Control:
       - max-age=600
       Connection:
@@ -448,7 +452,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:17 GMT
+      - Thu, 18 Sep 2025 14:56:39 GMT
       ETag:
       - '"66e1651c-40e"'
       Last-Modified:
@@ -464,15 +468,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - ce593536c6c55b6a27ff32088ebf4b793e4ddc3b
+      - 7b5f68c6b41b807d71d0e8bc100cde64b3fa3599
       X-GitHub-Request-Id:
-      - F8AD:14A94E:C2C9FE:DE6C58:68C2EEA4
+      - 5805:B21BA:AD266F:C78835:68CC1D6F
       X-Served-By:
-      - cache-bos4643-BOS
+      - cache-bos4673-BOS
       X-Timer:
-      - S1757605938.976061,VS0,VE1
+      - S1758207399.477341,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:44 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example91].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example91].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/item.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '396'
+      - '57'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:18 GMT
+      - Thu, 18 Sep 2025 14:56:39 GMT
       ETag:
       - '"66e1651c-147c"'
       Last-Modified:
@@ -109,17 +109,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - f14ffcf61b271e0c4f0bfc896f9e3fa4bc565ed7
+      - 1226c5c614e76ab1b0cc4d9a077d70fb8df88754
       X-GitHub-Request-Id:
-      - 9540:197FBB:BCDCFE:D8897B:68C2EEA5
+      - A3C0:BAEAA:C84169:E2AD23:68CC1D6E
       X-Served-By:
-      - cache-bos4686-BOS
+      - cache-bos4688-BOS
       X-Timer:
-      - S1757605938.055397,VS0,VE0
+      - S1758207400.569334,VS0,VE33
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/basics.json
   response:
@@ -148,7 +148,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '396'
+      - '57'
       Cache-Control:
       - max-age=600
       Connection:
@@ -158,7 +158,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:18 GMT
+      - Thu, 18 Sep 2025 14:56:39 GMT
       ETag:
       - '"66e1651c-21c"'
       Last-Modified:
@@ -174,15 +174,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - a04da6f641bda93ed59b40abcc78124bbe0fffa8
+      - 3f6b3602f94e45f0c35e3ac0bbfdd2497071d3ac
       X-GitHub-Request-Id:
-      - E1F2:14AA27:C232A6:DDCD4A:68C2EEA4
+      - 2F53:A07A9:C8C99E:E32E77:68CC1D6E
       X-Served-By:
-      - cache-bos4655-BOS
+      - cache-bos4628-BOS
       X-Timer:
-      - S1757605938.126670,VS0,VE1
+      - S1758207400.692585,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -192,7 +192,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/datetime.json
   response:
@@ -241,7 +241,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '396'
+      - '56'
       Cache-Control:
       - max-age=600
       Connection:
@@ -251,7 +251,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:18 GMT
+      - Thu, 18 Sep 2025 14:56:39 GMT
       ETag:
       - '"66e1651c-a82"'
       Last-Modified:
@@ -265,17 +265,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 4c7e5e097650453241d6e0d5ed7a319e7a4d7d4a
+      - 44d28d31e9115abcdd55760734041c580e6e346c
       X-GitHub-Request-Id:
-      - 1865:153265:C4294F:DFCE98:68C2EEA5
+      - 3E81:0D6F:C30426:DD705D:68CC1D6F
       X-Served-By:
-      - cache-bos4666-BOS
+      - cache-bos4620-BOS
       X-Timer:
-      - S1757605938.199763,VS0,VE1
+      - S1758207400.779254,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -285,7 +287,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/instrument.json
   response:
@@ -306,7 +308,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '396'
+      - '56'
       Cache-Control:
       - max-age=600
       Connection:
@@ -316,7 +318,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:18 GMT
+      - Thu, 18 Sep 2025 14:56:39 GMT
       ETag:
       - '"66e1651c-2a2"'
       Last-Modified:
@@ -330,17 +332,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Fastly-Request-ID:
-      - 7cd1c2f43d7eae3e82f71a2532524169dc282a34
+      - 2445d2ddf0aca735d40dccf1eca1d7f42ce44abd
       X-GitHub-Request-Id:
-      - 4500:CA757:1EF5208:22C6B31:68C2EEA5
+      - 7C03:3CD2C3:DA5DDA:F4BC38:68CC1D6F
       X-Served-By:
-      - cache-bos4676-BOS
+      - cache-bos4671-BOS
       X-Timer:
-      - S1757605938.277024,VS0,VE8
+      - S1758207400.866810,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -350,7 +354,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/licensing.json
   response:
@@ -366,7 +370,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '396'
+      - '56'
       Cache-Control:
       - max-age=600
       Connection:
@@ -376,7 +380,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:18 GMT
+      - Thu, 18 Sep 2025 14:56:39 GMT
       ETag:
       - '"66e1651c-135"'
       Last-Modified:
@@ -392,15 +396,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - d85920efe31fb341d05d04883b82703cfc42aa2f
+      - a9f2a9cbd03f762c7fff72c9d4c3eb0816a99adb
       X-GitHub-Request-Id:
-      - ED10:15FE94:C5AB5F:E14C22:68C2EEA5
+      - C4E5:1D3617:CA3033:E4A206:68CC1D6F
       X-Served-By:
-      - cache-bos4656-BOS
+      - cache-bos4660-BOS
       X-Timer:
-      - S1757605938.361827,VS0,VE2
+      - S1758207400.943514,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -412,7 +416,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/provider.json
   response:
@@ -438,7 +442,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '396'
+      - '56'
       Cache-Control:
       - max-age=600
       Connection:
@@ -448,7 +452,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:18 GMT
+      - Thu, 18 Sep 2025 14:56:40 GMT
       ETag:
       - '"66e1651c-40e"'
       Last-Modified:
@@ -462,17 +466,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 65d7bf83bb08197760cda13ec31382494242b33c
+      - 341de7e6b5d3837414bd04215599f98cd0583f00
       X-GitHub-Request-Id:
-      - F8AD:14A94E:C2C9FE:DE6C58:68C2EEA4
+      - 5805:B21BA:AD266F:C78835:68CC1D6F
       X-Served-By:
-      - cache-bos4634-BOS
+      - cache-bos4647-BOS
       X-Timer:
-      - S1757605938.449891,VS0,VE0
+      - S1758207400.030979,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:44 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example92].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example92].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/item.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '397'
+      - '57'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:18 GMT
+      - Thu, 18 Sep 2025 14:56:40 GMT
       ETag:
       - '"66e1651c-147c"'
       Last-Modified:
@@ -109,17 +109,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Fastly-Request-ID:
-      - d4dfe7c03b3be91b5c95f95541a842efe5f4e576
+      - d2aaa0898b73a2fb076b07ea2d74305bd5f6f49e
       X-GitHub-Request-Id:
-      - 9540:197FBB:BCDCFE:D8897B:68C2EEA5
+      - A3C0:BAEAA:C84169:E2AD23:68CC1D6E
       X-Served-By:
-      - cache-bos4687-BOS
+      - cache-bos4664-BOS
       X-Timer:
-      - S1757605939.534329,VS0,VE1
+      - S1758207400.117366,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/basics.json
   response:
@@ -148,7 +148,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '397'
+      - '57'
       Cache-Control:
       - max-age=600
       Connection:
@@ -158,7 +158,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:18 GMT
+      - Thu, 18 Sep 2025 14:56:40 GMT
       ETag:
       - '"66e1651c-21c"'
       Last-Modified:
@@ -174,15 +174,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 7ea545b443495b39f1480ee9a42728358e212c61
+      - 9c38560f9f7c0321c649155d44f975d3a9ef82ec
       X-GitHub-Request-Id:
-      - E1F2:14AA27:C232A6:DDCD4A:68C2EEA4
+      - 2F53:A07A9:C8C99E:E32E77:68CC1D6E
       X-Served-By:
-      - cache-bos4647-BOS
+      - cache-bos4627-BOS
       X-Timer:
-      - S1757605939.630075,VS0,VE2
+      - S1758207400.198429,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -192,7 +192,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/datetime.json
   response:
@@ -241,7 +241,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '397'
+      - '57'
       Cache-Control:
       - max-age=600
       Connection:
@@ -251,7 +251,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:18 GMT
+      - Thu, 18 Sep 2025 14:56:40 GMT
       ETag:
       - '"66e1651c-a82"'
       Last-Modified:
@@ -267,15 +267,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - dfa015a8ed2f004fff14d991bfc6e6ccacb6183b
+      - c4001a9f02389f0b005173fa68e4c335d64dfc73
       X-GitHub-Request-Id:
-      - 1865:153265:C4294F:DFCE98:68C2EEA5
+      - 3E81:0D6F:C30426:DD705D:68CC1D6F
       X-Served-By:
-      - cache-bos4663-BOS
+      - cache-bos4664-BOS
       X-Timer:
-      - S1757605939.722851,VS0,VE5
+      - S1758207400.285280,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -285,7 +287,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/instrument.json
   response:
@@ -306,7 +308,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '397'
+      - '57'
       Cache-Control:
       - max-age=600
       Connection:
@@ -316,7 +318,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:18 GMT
+      - Thu, 18 Sep 2025 14:56:40 GMT
       ETag:
       - '"66e1651c-2a2"'
       Last-Modified:
@@ -330,17 +332,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 7077d0fc045dfa110789e85242d6fdd07367cf1b
+      - 051ad2fe3c0da5498a68d056041003ce0bebdd18
       X-GitHub-Request-Id:
-      - 4500:CA757:1EF5208:22C6B31:68C2EEA5
+      - 7C03:3CD2C3:DA5DDA:F4BC38:68CC1D6F
       X-Served-By:
-      - cache-bos4675-BOS
+      - cache-bos4624-BOS
       X-Timer:
-      - S1757605939.812373,VS0,VE0
+      - S1758207400.376957,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -350,7 +354,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/licensing.json
   response:
@@ -366,7 +370,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '397'
+      - '57'
       Cache-Control:
       - max-age=600
       Connection:
@@ -376,7 +380,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:18 GMT
+      - Thu, 18 Sep 2025 14:56:40 GMT
       ETag:
       - '"66e1651c-135"'
       Last-Modified:
@@ -390,17 +394,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Fastly-Request-ID:
-      - 0d7e9548c4eaa1869b5b1f774837e93c745884aa
+      - b737d0ec61d965a5ea182c0bbd3161cb106930ef
       X-GitHub-Request-Id:
-      - ED10:15FE94:C5AB5F:E14C22:68C2EEA5
+      - C4E5:1D3617:CA3033:E4A206:68CC1D6F
       X-Served-By:
-      - cache-bos4665-BOS
+      - cache-bos4636-BOS
       X-Timer:
-      - S1757605939.896028,VS0,VE1
+      - S1758207400.463181,VS0,VE3
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -412,7 +416,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/provider.json
   response:
@@ -438,7 +442,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '397'
+      - '56'
       Cache-Control:
       - max-age=600
       Connection:
@@ -448,7 +452,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:18 GMT
+      - Thu, 18 Sep 2025 14:56:40 GMT
       ETag:
       - '"66e1651c-40e"'
       Last-Modified:
@@ -464,15 +468,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 8562a34f1bc4e12076a72a8b9bd7812a485a7b3e
+      - 4804b0a8b3ce358e5ef3930e4c2bfcff0c14e962
       X-GitHub-Request-Id:
-      - F8AD:14A94E:C2C9FE:DE6C58:68C2EEA4
+      - 5805:B21BA:AD266F:C78835:68CC1D6F
       X-Served-By:
-      - cache-bos4625-BOS
+      - cache-bos4667-BOS
       X-Timer:
-      - S1757605939.984353,VS0,VE1
+      - S1758207401.550021,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:44 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -484,7 +488,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/eo/json-schema/schema.json
   response:
@@ -522,7 +526,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '347'
+      - '8'
       Cache-Control:
       - max-age=600
       Connection:
@@ -532,7 +536,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:19 GMT
+      - Thu, 18 Sep 2025 14:56:40 GMT
       ETag:
       - '"66e1651c-805"'
       Last-Modified:
@@ -548,15 +552,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 74aa5e9b34ab12f73d59af64873a2ee344044854
+      - e0ef84ac2664bbdc0458d4f230fb3d4c6a8d7769
       X-GitHub-Request-Id:
-      - 61E0:85CEC:1F72DF5:22CFA7F:68C2EED7
+      - 2976:1A3C1:217E151:25362CA:68CC1DA0
       X-Served-By:
-      - cache-bos4691-BOS
+      - cache-bos4643-BOS
       X-Timer:
-      - S1757605939.068309,VS0,VE1
+      - S1758207401.629760,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:56:31 GMT
+      - Thu, 18 Sep 2025 15:06:32 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -566,7 +572,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/projection/json-schema/schema.json
   response:
@@ -620,7 +626,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '339'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -630,7 +636,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:19 GMT
+      - Thu, 18 Sep 2025 14:56:40 GMT
       ETag:
       - '"66e1651c-dc7"'
       Last-Modified:
@@ -642,19 +648,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 37e79728730459880deac15b947ed96e62299869
+      - 90eb1ec4ed8ac08049c7c76e91cc3c6e36703688
       X-GitHub-Request-Id:
-      - A35A:108A1F:1F448D6:22A0F0C:68C2EEDF
+      - C94B:21FE6A:2283F11:263C621:68CC1DA8
       X-Served-By:
-      - cache-bos4667-BOS
+      - cache-bos4621-BOS
       X-Timer:
-      - S1757605939.159913,VS0,VE1
+      - S1758207401.725007,VS0,VE41
       expires:
-      - Thu, 11 Sep 2025 15:56:39 GMT
+      - Thu, 18 Sep 2025 15:06:40 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -664,7 +672,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://proj.org/schemas/v0.2/projjson.schema.json
   response:
@@ -673,12 +681,10 @@ interactions:
     headers:
       Access-Control-Allow-Origin:
       - '*'
-      Age:
-      - '1180'
       CF-Cache-Status:
-      - HIT
+      - EXPIRED
       CF-Ray:
-      - 97d854e07ecdf3ed-IAD
+      - 9811b0ff6a1c2d85-IAD
       Cache-Control:
       - max-age=1200
       Connection:
@@ -690,16 +696,16 @@ interactions:
       Content-Type:
       - text/html; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:19 GMT
+      - Thu, 18 Sep 2025 14:56:40 GMT
       Location:
       - https://proj.org/en/latest/schemas/v0.2/projjson.schema.json
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=bNSSdZLUU98tSDSaFiYFiKVMq_kmpWXbPel2tx3zp0A-1757605939-1.0.1.1-Rzm4hr6_Zx1NDTzQsHiMTQ_HfWB9NuEAOO4cAPfB0iqyszrM9VB9KwsI9Bj8qcoiDYOJGfs6MzF845gMk7lLHkq4lQymlhCvbRRXj9zAj8w;
-        path=/; expires=Thu, 11-Sep-25 16:22:19 GMT; domain=.proj.org; HttpOnly; Secure;
+      - __cf_bm=sNu2ITabpyJby_ExrOYl9uFiUjkmVase6EsmaXYtHL4-1758207400-1.0.1.1-qnmgHFgrYvbLN.768O.oY4On5iLqdfZjE6ZNvsByNMs6xwV9Sp__dv7qUOtwAAnKLYLj3RtC4EYSP_eyzJ1gkv1KIzVSbNCexj0DuSACkAc;
+        path=/; expires=Thu, 18-Sep-25 15:26:40 GMT; domain=.proj.org; HttpOnly; Secure;
         SameSite=None
-      - _cfuvid=u90C7GFfSkbCb0t8lbh76p_pNCng4y_p0FUFHrQaMUM-1757605939357-0.0.1.1-604800000;
+      - _cfuvid=vuJwFWssJXnplKL6Pmx2X6Pg8FzVLbCaACSHbzMinYA-1758207400995-0.0.1.1-604800000;
         path=/; domain=.proj.org; HttpOnly; Secure; SameSite=None
       Vary:
       - Accept-Language, Accept-Encoding
@@ -714,7 +720,7 @@ interactions:
       referrer-policy:
       - no-referrer-when-downgrade
       x-backend:
-      - web-i-08cdc39b7f37b37d5
+      - web-i-088faff751a7543b1
       x-content-type-options:
       - nosniff
       x-rtd-domain:
@@ -738,7 +744,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://proj.org/en/latest/schemas/v0.2/projjson.schema.json
   response:
@@ -1186,11 +1192,11 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '4744'
+      - '4725'
       CF-Cache-Status:
       - HIT
       CF-Ray:
-      - 97d854e198960841-IAD
+      - 9811b100dade0620-IAD
       Cache-Control:
       - max-age=1200
       Connection:
@@ -1198,7 +1204,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 11 Sep 2025 15:52:19 GMT
+      - Thu, 18 Sep 2025 14:56:41 GMT
       ETag:
       - W/"54be42a997d748d338984583b3f2c900"
       Last-Modified:
@@ -1206,10 +1212,10 @@ interactions:
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=QoTa7889oKLmp9oXzu7CuUWOWQzQm_FiG4wV8iQ2qe8-1757605939-1.0.1.1-68j4eLLR0bliO7r0ckP3I_8Zz_liXNJ7Tn7vCMcN1vfol6C83WGq.g1KuQqqbGMmfK4U6ON20Z0id2ZWZa7.iy9V4AazgFvajraBpJ3N1mo;
-        path=/; expires=Thu, 11-Sep-25 16:22:19 GMT; domain=.proj.org; HttpOnly; Secure;
+      - __cf_bm=ngxRI5W5lMTm1WLCbC2TQ7WhfXFmqL51qSs24Z5gKDs-1758207401-1.0.1.1-mxbEhNt_x7t6ALJ_s6szssUGtE7bYaxsnwri8rLHeG9Z38fSFNg4hMdkZ_6oE.HS8pExLOjtGlX8ONwlS6wKqam_cZW4LzkW4v.fBpoCOvU;
+        path=/; expires=Thu, 18-Sep-25 15:26:41 GMT; domain=.proj.org; HttpOnly; Secure;
         SameSite=None
-      - _cfuvid=pjBybs.IQtGHjs8fZ22aW1GSbUSsc4MG9XMk_YCg8Lw-1757605939534-0.0.1.1-604800000;
+      - _cfuvid=2uLt5qzAMWFWCJ.Mbf4N.3o2_ih1NoTV3rbUUc0zeoQ-1758207401130-0.0.1.1-604800000;
         path=/; domain=.proj.org; HttpOnly; Secure; SameSite=None
       Transfer-Encoding:
       - chunked
@@ -1224,15 +1230,15 @@ interactions:
       referrer-policy:
       - no-referrer-when-downgrade
       x-amz-id-2:
-      - u7n7KSoYu8w9cyLO4XLwBwTwYdQ3Wyml7J+C6woLMpHwu3whoWqiNnD9hKVSLIN5ghQElMaJ3Fo=
+      - AOYvBP/LpvTJOKVw+9O+zVM1dIoIgJlzOhPZaGe8UT/+DK52CrocE7/yPv9E1BQZHrqmD4BMboo=
       x-amz-meta-mtime:
       - '1714074779.458591481'
       x-amz-request-id:
-      - 8ARFMN6T2PBWDEG6
+      - VNA6573JK8SCMD2V
       x-amz-server-side-encryption:
       - AES256
       x-backend:
-      - web-i-0ff35b8ab69d931fc
+      - web-i-046a40256d6a3b46c
       x-content-type-options:
       - nosniff
       x-rtd-domain:
@@ -1260,7 +1266,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://geojson.org/schema/Polygon.json
   response:
@@ -1282,7 +1288,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '339'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -1292,7 +1298,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:19 GMT
+      - Thu, 18 Sep 2025 14:56:41 GMT
       ETag:
       - '"65f73090-2bf"'
       Last-Modified:
@@ -1304,19 +1310,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - b17cf94f5fc54ae552870437a711219edbad33c7
+      - a7ff2a8046e095a86f04fbd67993d43d01066a7f
       X-GitHub-Request-Id:
-      - A479:38B0E6:1F9EBC7:22FA0A3:68C2EEE0
+      - E10E:12B615:FDA9D5:11D7115:68CC1DA9
       X-Served-By:
-      - cache-bos4623-BOS
+      - cache-bos4664-BOS
       X-Timer:
-      - S1757605940.760172,VS0,VE2
+      - S1758207401.422976,VS0,VE47
       expires:
-      - Thu, 11 Sep 2025 15:56:40 GMT
+      - Thu, 18 Sep 2025 15:06:41 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example93].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example93].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/item.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '398'
+      - '59'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:19 GMT
+      - Thu, 18 Sep 2025 14:56:41 GMT
       ETag:
       - '"66e1651c-147c"'
       Last-Modified:
@@ -111,15 +111,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 5926db0da5453143ac98d5ccf1c263c779fa0766
+      - a3049823d4868186c9aaae592e90a0854fe40891
       X-GitHub-Request-Id:
-      - 9540:197FBB:BCDCFE:D8897B:68C2EEA5
+      - A3C0:BAEAA:C84169:E2AD23:68CC1D6E
       X-Served-By:
-      - cache-bos4620-BOS
+      - cache-bos4657-BOS
       X-Timer:
-      - S1757605940.850925,VS0,VE2
+      - S1758207402.563272,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/basics.json
   response:
@@ -148,7 +148,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '398'
+      - '59'
       Cache-Control:
       - max-age=600
       Connection:
@@ -158,7 +158,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:19 GMT
+      - Thu, 18 Sep 2025 14:56:41 GMT
       ETag:
       - '"66e1651c-21c"'
       Last-Modified:
@@ -174,15 +174,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - f4da9e22e4e3c3d1b035575154c00a43efc170da
+      - 84c00eeed56edb8cf2262124738450726f3727f2
       X-GitHub-Request-Id:
-      - E1F2:14AA27:C232A6:DDCD4A:68C2EEA4
+      - 2F53:A07A9:C8C99E:E32E77:68CC1D6E
       X-Served-By:
-      - cache-bos4660-BOS
+      - cache-bos4621-BOS
       X-Timer:
-      - S1757605940.929837,VS0,VE2
+      - S1758207402.658711,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -192,7 +192,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/datetime.json
   response:
@@ -241,7 +241,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '398'
+      - '58'
       Cache-Control:
       - max-age=600
       Connection:
@@ -251,7 +251,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:20 GMT
+      - Thu, 18 Sep 2025 14:56:41 GMT
       ETag:
       - '"66e1651c-a82"'
       Last-Modified:
@@ -267,15 +267,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 75b6a071d4e1377f39e170627ed134cf1acd5eef
+      - e32acbceef66cb072b7c2b8adb7d26a8dc9daa4c
       X-GitHub-Request-Id:
-      - 1865:153265:C4294F:DFCE98:68C2EEA5
+      - 3E81:0D6F:C30426:DD705D:68CC1D6F
       X-Served-By:
-      - cache-bos4635-BOS
+      - cache-bos4656-BOS
       X-Timer:
-      - S1757605940.008362,VS0,VE1
+      - S1758207402.747217,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -285,7 +287,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/instrument.json
   response:
@@ -306,7 +308,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '398'
+      - '58'
       Cache-Control:
       - max-age=600
       Connection:
@@ -316,7 +318,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:20 GMT
+      - Thu, 18 Sep 2025 14:56:41 GMT
       ETag:
       - '"66e1651c-2a2"'
       Last-Modified:
@@ -330,17 +332,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '1'
       X-Fastly-Request-ID:
-      - ede8cfbe2947751c3bcb132f6ac9517080ea2ec2
+      - 89fe6907c490b4bd21869e01a6361585c63d1023
       X-GitHub-Request-Id:
-      - 4500:CA757:1EF5208:22C6B31:68C2EEA5
+      - 7C03:3CD2C3:DA5DDA:F4BC38:68CC1D6F
       X-Served-By:
-      - cache-bos4675-BOS
+      - cache-bos4678-BOS
       X-Timer:
-      - S1757605940.093199,VS0,VE0
+      - S1758207402.830722,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -350,7 +354,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/licensing.json
   response:
@@ -366,7 +370,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '398'
+      - '58'
       Cache-Control:
       - max-age=600
       Connection:
@@ -376,7 +380,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:20 GMT
+      - Thu, 18 Sep 2025 14:56:41 GMT
       ETag:
       - '"66e1651c-135"'
       Last-Modified:
@@ -392,15 +396,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 3344073402043df5e86ef2c4ae0a958df7fda47b
+      - 56d842d79c7e30ae318fbe67dff0fd1ee2705510
       X-GitHub-Request-Id:
-      - ED10:15FE94:C5AB5F:E14C22:68C2EEA5
+      - C4E5:1D3617:CA3033:E4A206:68CC1D6F
       X-Served-By:
-      - cache-bos4632-BOS
+      - cache-bos4664-BOS
       X-Timer:
-      - S1757605940.172696,VS0,VE2
+      - S1758207402.908841,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -412,7 +416,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/provider.json
   response:
@@ -438,7 +442,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '397'
+      - '58'
       Cache-Control:
       - max-age=600
       Connection:
@@ -448,7 +452,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:20 GMT
+      - Thu, 18 Sep 2025 14:56:42 GMT
       ETag:
       - '"66e1651c-40e"'
       Last-Modified:
@@ -462,17 +466,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 647a84301ff20a440af318903eff0a5f1126b6fa
+      - daf455ba93422cbbd0b00070fabf76bd56a156f9
       X-GitHub-Request-Id:
-      - F8AD:14A94E:C2C9FE:DE6C58:68C2EEA4
+      - 5805:B21BA:AD266F:C78835:68CC1D6F
       X-Served-By:
-      - cache-bos4659-BOS
+      - cache-bos4648-BOS
       X-Timer:
-      - S1757605940.250473,VS0,VE1
+      - S1758207402.017848,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:44 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -484,7 +488,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/sat/json-schema/schema.json
   response:
@@ -514,7 +518,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '339'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -524,7 +528,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:20 GMT
+      - Thu, 18 Sep 2025 14:56:42 GMT
       ETag:
       - '"66e1651c-5bb"'
       Last-Modified:
@@ -536,19 +540,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 369c5f1a01280cf734615f9c26aadfd835031df0
+      - 6c494369b120e2d864875cb03c4ad46f42c20d89
       X-GitHub-Request-Id:
-      - 2BE1:2BF852:1E93090:21F0E03:68C2EEE0
+      - DF43:1629B2:212BCBC:24E37AE:68CC1DA9
       X-Served-By:
-      - cache-bos4677-BOS
+      - cache-bos4684-BOS
       X-Timer:
-      - S1757605940.327780,VS0,VE1
+      - S1758207402.100990,VS0,VE57
       expires:
-      - Thu, 11 Sep 2025 15:56:41 GMT
+      - Thu, 18 Sep 2025 15:06:42 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -560,7 +564,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/sar/json-schema/schema.json
   response:
@@ -627,7 +631,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '339'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -637,7 +641,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:20 GMT
+      - Thu, 18 Sep 2025 14:56:42 GMT
       ETag:
       - '"66e1651c-10cd"'
       Last-Modified:
@@ -649,19 +653,21 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 940c86a210fa73cb095b6648fb697022bba1408f
+      - 3428ecd2ba63635559296d8cc78f53bf5f62e8b7
       X-GitHub-Request-Id:
-      - F279:38B0E6:1F9ECA5:22FA18C:68C2EEE0
+      - A557:2C21AF:2107945:24BEC2F:68CC1DA9
       X-Served-By:
-      - cache-bos4682-BOS
+      - cache-bos4659-BOS
       X-Timer:
-      - S1757605940.404143,VS0,VE1
+      - S1758207402.235160,VS0,VE30
       expires:
-      - Thu, 11 Sep 2025 15:56:41 GMT
+      - Thu, 18 Sep 2025 15:06:42 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example94].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example94].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/item.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '399'
+      - '59'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:20 GMT
+      - Thu, 18 Sep 2025 14:56:42 GMT
       ETag:
       - '"66e1651c-147c"'
       Last-Modified:
@@ -111,15 +111,15 @@ interactions:
       X-Cache-Hits:
       - '2'
       X-Fastly-Request-ID:
-      - f1cc65a3f7b862826c3fbd56cbbb9b63ae5ebf3a
+      - cd908dca2c63bdd2a66efd128b8edb09fdd57caf
       X-GitHub-Request-Id:
-      - 9540:197FBB:BCDCFE:D8897B:68C2EEA5
+      - A3C0:BAEAA:C84169:E2AD23:68CC1D6E
       X-Served-By:
-      - cache-bos4625-BOS
+      - cache-bos4620-BOS
       X-Timer:
-      - S1757605940.488194,VS0,VE1
+      - S1758207402.340847,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/basics.json
   response:
@@ -148,7 +148,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '398'
+      - '59'
       Cache-Control:
       - max-age=600
       Connection:
@@ -158,7 +158,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:20 GMT
+      - Thu, 18 Sep 2025 14:56:42 GMT
       ETag:
       - '"66e1651c-21c"'
       Last-Modified:
@@ -172,17 +172,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 1e4c118aa0ab51fb0cfcf62372799b6e90bd62d8
+      - faaa50043989d1acbc1b5bbee124d5b02e541d98
       X-GitHub-Request-Id:
-      - E1F2:14AA27:C232A6:DDCD4A:68C2EEA4
+      - 2F53:A07A9:C8C99E:E32E77:68CC1D6E
       X-Served-By:
-      - cache-bos4679-BOS
+      - cache-bos4645-BOS
       X-Timer:
-      - S1757605941.564059,VS0,VE1
+      - S1758207402.423131,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -192,7 +192,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/datetime.json
   response:
@@ -241,7 +241,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '399'
+      - '59'
       Cache-Control:
       - max-age=600
       Connection:
@@ -251,7 +251,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:20 GMT
+      - Thu, 18 Sep 2025 14:56:42 GMT
       ETag:
       - '"66e1651c-a82"'
       Last-Modified:
@@ -267,15 +267,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 3fe6013e04b360cdae391e93673f40a569b28624
+      - adc34446047bee2a414a0872bee4b33d7ab79a59
       X-GitHub-Request-Id:
-      - 1865:153265:C4294F:DFCE98:68C2EEA5
+      - 3E81:0D6F:C30426:DD705D:68CC1D6F
       X-Served-By:
-      - cache-bos4670-BOS
+      - cache-bos4629-BOS
       X-Timer:
-      - S1757605941.650253,VS0,VE1
+      - S1758207403.500876,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -285,7 +287,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/instrument.json
   response:
@@ -306,7 +308,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '398'
+      - '59'
       Cache-Control:
       - max-age=600
       Connection:
@@ -316,7 +318,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:20 GMT
+      - Thu, 18 Sep 2025 14:56:42 GMT
       ETag:
       - '"66e1651c-2a2"'
       Last-Modified:
@@ -330,17 +332,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - acab226b44776a4c223b9d5ac88f5749fb242fbd
+      - 831a15a721be208ebad64adeed6a0e9d3d2fbb34
       X-GitHub-Request-Id:
-      - 4500:CA757:1EF5208:22C6B31:68C2EEA5
+      - 7C03:3CD2C3:DA5DDA:F4BC38:68CC1D6F
       X-Served-By:
-      - cache-bos4636-BOS
+      - cache-bos4665-BOS
       X-Timer:
-      - S1757605941.734435,VS0,VE0
+      - S1758207403.571386,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -350,7 +354,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/licensing.json
   response:
@@ -366,7 +370,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '398'
+      - '59'
       Cache-Control:
       - max-age=600
       Connection:
@@ -376,7 +380,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:20 GMT
+      - Thu, 18 Sep 2025 14:56:42 GMT
       ETag:
       - '"66e1651c-135"'
       Last-Modified:
@@ -390,17 +394,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Fastly-Request-ID:
-      - f5258f603744fd0e3cc20d753410ec2cee834f59
+      - f5a061d6c460c247f70e62813d0d3660fe5b8390
       X-GitHub-Request-Id:
-      - ED10:15FE94:C5AB5F:E14C22:68C2EEA5
+      - C4E5:1D3617:CA3033:E4A206:68CC1D6F
       X-Served-By:
-      - cache-bos4645-BOS
+      - cache-bos4644-BOS
       X-Timer:
-      - S1757605941.811926,VS0,VE2
+      - S1758207403.648041,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -412,7 +416,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/provider.json
   response:
@@ -438,7 +442,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '398'
+      - '59'
       Cache-Control:
       - max-age=600
       Connection:
@@ -448,7 +452,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:20 GMT
+      - Thu, 18 Sep 2025 14:56:42 GMT
       ETag:
       - '"66e1651c-40e"'
       Last-Modified:
@@ -462,17 +466,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Fastly-Request-ID:
-      - 00196546a78ac973127ce06684348bdeb122a910
+      - f663a2895d545f2b243a0f23c07bc3db0aaf5bc2
       X-GitHub-Request-Id:
-      - F8AD:14A94E:C2C9FE:DE6C58:68C2EEA4
+      - 5805:B21BA:AD266F:C78835:68CC1D6F
       X-Served-By:
-      - cache-bos4630-BOS
+      - cache-bos4692-BOS
       X-Timer:
-      - S1757605941.887413,VS0,VE2
+      - S1758207403.717423,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:44 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -484,7 +488,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/checksum/json-schema/schema.json
   response:
@@ -527,7 +531,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '352'
+      - '12'
       Cache-Control:
       - max-age=600
       Connection:
@@ -537,7 +541,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:20 GMT
+      - Thu, 18 Sep 2025 14:56:42 GMT
       ETag:
       - '"66e1651c-939"'
       Last-Modified:
@@ -553,17 +557,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - e62827405b143e0f5b6a87376847882c5299b130
+      - e619420326ed8bbdadbb599ea1d84b78ee541886
       X-GitHub-Request-Id:
-      - 0EB2:39602E:21ACCE1:2413344:68C2EED5
+      - FDCC:1E445:218C2CF:25450D2:68CC1D9D
       X-Served-By:
-      - cache-bos4641-BOS
+      - cache-bos4621-BOS
       X-Timer:
-      - S1757605941.963997,VS0,VE3
+      - S1758207403.792835,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:56:29 GMT
-      x-origin-cache:
-      - HIT
+      - Thu, 18 Sep 2025 15:06:30 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -573,7 +575,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/catalog-spec/json-schema/catalog.json
   response:
@@ -615,7 +617,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '353'
+      - '14'
       Cache-Control:
       - max-age=600
       Connection:
@@ -625,7 +627,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:21 GMT
+      - Thu, 18 Sep 2025 14:56:42 GMT
       ETag:
       - '"66e1651c-84e"'
       Last-Modified:
@@ -639,17 +641,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Fastly-Request-ID:
-      - 327a6da6b7db6187256c1bda05f5bdfa3ae63bcf
+      - 7791ca82f4096d7fc00b7ea1099dce97b4847f60
       X-GitHub-Request-Id:
-      - 6A55:180028:223E696:24A38DD:68C2EED2
+      - 3695:91567:105B1F4:125794D:68CC1D9D
       X-Served-By:
-      - cache-bos4690-BOS
+      - cache-bos4685-BOS
       X-Timer:
-      - S1757605941.043954,VS0,VE1
+      - S1758207403.871274,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:56:27 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -659,7 +661,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/collection-spec/json-schema/collection.json
   response:
@@ -741,7 +743,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '353'
+      - '13'
       Cache-Control:
       - max-age=600
       Connection:
@@ -751,7 +753,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:21 GMT
+      - Thu, 18 Sep 2025 14:56:42 GMT
       ETag:
       - '"66e1651c-14e2"'
       Last-Modified:
@@ -767,15 +769,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 21f4f549b13bf3cce0026b320814a48dcb4055c4
+      - e9cac738e204d8ba8a1038074b51a0fb345e7175
       X-GitHub-Request-Id:
-      - 3C0F:3556F2:2104189:236964E:68C2EED2
+      - DF8C:3D7940:20E828F:24A0D28:68CC1D9D
       X-Served-By:
-      - cache-bos4677-BOS
+      - cache-bos4651-BOS
       X-Timer:
-      - S1757605941.120086,VS0,VE1
+      - S1758207403.965255,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:28 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -785,7 +787,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/sar/json-schema/schema.json
   response:
@@ -852,7 +854,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '340'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -862,7 +864,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:21 GMT
+      - Thu, 18 Sep 2025 14:56:43 GMT
       ETag:
       - '"66e1651c-10cd"'
       Last-Modified:
@@ -878,15 +880,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - e9e56e47ca44a03328ed3e14239d549a3ae16fa2
+      - 11dcbd80787eb5489b11ca172b1347c15677d371
       X-GitHub-Request-Id:
-      - F279:38B0E6:1F9ECA5:22FA18C:68C2EEE0
+      - A557:2C21AF:2107945:24BEC2F:68CC1DA9
       X-Served-By:
-      - cache-bos4672-BOS
+      - cache-bos4659-BOS
       X-Timer:
-      - S1757605941.205519,VS0,VE2
+      - S1758207403.043132,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:41 GMT
+      - Thu, 18 Sep 2025 15:06:42 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -896,7 +900,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/sat/json-schema/schema.json
   response:
@@ -926,7 +930,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '340'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -936,7 +940,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:21 GMT
+      - Thu, 18 Sep 2025 14:56:43 GMT
       ETag:
       - '"66e1651c-5bb"'
       Last-Modified:
@@ -952,15 +956,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - eb236464bfc5ed7b93faff91bd8021df8b3058e2
+      - 5ce4ce61447dd068c1d9034dd228e15dc9b85565
       X-GitHub-Request-Id:
-      - 2BE1:2BF852:1E93090:21F0E03:68C2EEE0
+      - DF43:1629B2:212BCBC:24E37AE:68CC1DA9
       X-Served-By:
-      - cache-bos4646-BOS
+      - cache-bos4630-BOS
       X-Timer:
-      - S1757605941.286290,VS0,VE2
+      - S1758207403.119187,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:41 GMT
+      - Thu, 18 Sep 2025 15:06:42 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example95].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example95].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/item.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '400'
+      - '60'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:21 GMT
+      - Thu, 18 Sep 2025 14:56:43 GMT
       ETag:
       - '"66e1651c-147c"'
       Last-Modified:
@@ -109,17 +109,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '1'
       X-Fastly-Request-ID:
-      - 2b58f2594dc389ab097b95f6c281868691a2a968
+      - 1c4b367e7da519d8b163856b14c787eb4ec46bdb
       X-GitHub-Request-Id:
-      - 9540:197FBB:BCDCFE:D8897B:68C2EEA5
+      - A3C0:BAEAA:C84169:E2AD23:68CC1D6E
       X-Served-By:
-      - cache-bos4670-BOS
+      - cache-bos4632-BOS
       X-Timer:
-      - S1757605941.384109,VS0,VE0
+      - S1758207403.203663,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/basics.json
   response:
@@ -148,7 +148,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '400'
+      - '60'
       Cache-Control:
       - max-age=600
       Connection:
@@ -158,7 +158,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:21 GMT
+      - Thu, 18 Sep 2025 14:56:43 GMT
       ETag:
       - '"66e1651c-21c"'
       Last-Modified:
@@ -174,15 +174,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - b5905b9cfd4940325225d5d19fa8454c9bcc65b6
+      - f22038660c0e160577e13aa2bd01a346cf7ed633
       X-GitHub-Request-Id:
-      - E1F2:14AA27:C232A6:DDCD4A:68C2EEA4
+      - 2F53:A07A9:C8C99E:E32E77:68CC1D6E
       X-Served-By:
-      - cache-bos4673-BOS
+      - cache-bos4638-BOS
       X-Timer:
-      - S1757605941.466026,VS0,VE2
+      - S1758207403.279474,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -192,7 +192,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/datetime.json
   response:
@@ -241,7 +241,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '399'
+      - '60'
       Cache-Control:
       - max-age=600
       Connection:
@@ -251,7 +251,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:21 GMT
+      - Thu, 18 Sep 2025 14:56:43 GMT
       ETag:
       - '"66e1651c-a82"'
       Last-Modified:
@@ -267,15 +267,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - a8db7f80c1569ca6dd34710e2eb988ad281d8f21
+      - c78a56a83121cd2fef58bc4279cf7f9efff0b483
       X-GitHub-Request-Id:
-      - 1865:153265:C4294F:DFCE98:68C2EEA5
+      - 3E81:0D6F:C30426:DD705D:68CC1D6F
       X-Served-By:
-      - cache-bos4677-BOS
+      - cache-bos4645-BOS
       X-Timer:
-      - S1757605942.536015,VS0,VE2
+      - S1758207403.355515,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -285,7 +287,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/instrument.json
   response:
@@ -306,7 +308,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '399'
+      - '60'
       Cache-Control:
       - max-age=600
       Connection:
@@ -316,7 +318,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:21 GMT
+      - Thu, 18 Sep 2025 14:56:43 GMT
       ETag:
       - '"66e1651c-2a2"'
       Last-Modified:
@@ -330,17 +332,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 9b126a958b72f1f7b049bff041c2f7646ac5cc59
+      - a7d0a72a550b73b1bc5df3989e8fb801e1fa298a
       X-GitHub-Request-Id:
-      - 4500:CA757:1EF5208:22C6B31:68C2EEA5
+      - 7C03:3CD2C3:DA5DDA:F4BC38:68CC1D6F
       X-Served-By:
-      - cache-bos4628-BOS
+      - cache-bos4647-BOS
       X-Timer:
-      - S1757605942.613969,VS0,VE0
+      - S1758207403.433298,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -350,7 +354,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/licensing.json
   response:
@@ -366,7 +370,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '400'
+      - '60'
       Cache-Control:
       - max-age=600
       Connection:
@@ -376,7 +380,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:21 GMT
+      - Thu, 18 Sep 2025 14:56:43 GMT
       ETag:
       - '"66e1651c-135"'
       Last-Modified:
@@ -390,17 +394,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - f0d7ad9d493d9cabb2f9a69323a53aebac2f4a76
+      - 1b398c94b36377b54ebf4bfe7a5fdd911cac3dd2
       X-GitHub-Request-Id:
-      - ED10:15FE94:C5AB5F:E14C22:68C2EEA5
+      - C4E5:1D3617:CA3033:E4A206:68CC1D6F
       X-Served-By:
-      - cache-bos4677-BOS
+      - cache-bos4641-BOS
       X-Timer:
-      - S1757605942.686327,VS0,VE0
+      - S1758207404.507443,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -412,7 +416,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/provider.json
   response:
@@ -438,7 +442,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '399'
+      - '59'
       Cache-Control:
       - max-age=600
       Connection:
@@ -448,7 +452,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:21 GMT
+      - Thu, 18 Sep 2025 14:56:43 GMT
       ETag:
       - '"66e1651c-40e"'
       Last-Modified:
@@ -462,17 +466,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '1'
       X-Fastly-Request-ID:
-      - 1f9d442771a10e70d46282fea0ef6a40b26b36db
+      - de006bdf6e2c89fbfe0f7ab5e3346ded9c728c6a
       X-GitHub-Request-Id:
-      - F8AD:14A94E:C2C9FE:DE6C58:68C2EEA4
+      - 5805:B21BA:AD266F:C78835:68CC1D6F
       X-Served-By:
-      - cache-bos4676-BOS
+      - cache-bos4640-BOS
       X-Timer:
-      - S1757605942.763668,VS0,VE0
+      - S1758207404.585648,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:44 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -484,7 +488,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/sat/json-schema/schema.json
   response:
@@ -514,7 +518,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '341'
+      - '2'
       Cache-Control:
       - max-age=600
       Connection:
@@ -524,7 +528,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:21 GMT
+      - Thu, 18 Sep 2025 14:56:43 GMT
       ETag:
       - '"66e1651c-5bb"'
       Last-Modified:
@@ -540,15 +544,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - eea1b8938bcdb838c2271f63d206692e4998b691
+      - bef95c42ecff3912034797c6fb15ad4d5db66f2d
       X-GitHub-Request-Id:
-      - 2BE1:2BF852:1E93090:21F0E03:68C2EEE0
+      - DF43:1629B2:212BCBC:24E37AE:68CC1DA9
       X-Served-By:
-      - cache-bos4640-BOS
+      - cache-bos4677-BOS
       X-Timer:
-      - S1757605942.852129,VS0,VE1
+      - S1758207404.659553,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:56:41 GMT
+      - Thu, 18 Sep 2025 15:06:42 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -560,7 +564,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/view/json-schema/schema.json
   response:
@@ -599,7 +603,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '350'
+      - '11'
       Cache-Control:
       - max-age=600
       Connection:
@@ -609,7 +613,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:21 GMT
+      - Thu, 18 Sep 2025 14:56:43 GMT
       ETag:
       - '"66e1651c-829"'
       Last-Modified:
@@ -623,17 +627,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '9'
+      - '1'
       X-Fastly-Request-ID:
-      - 789fed5ebcb2b84f6eec73b63b3dc33c5d02f594
+      - 2781434e4a8fd5ba1e9a17745095326a7b650f3b
       X-GitHub-Request-Id:
-      - 8BE4:15BCE:1E9511B:21F04EB:68C2EED7
+      - 2A0E:3A039E:FF2E25:11EE6ED:68CC1D9F
       X-Served-By:
-      - cache-bos4663-BOS
+      - cache-bos4639-BOS
       X-Timer:
-      - S1757605942.936335,VS0,VE1
+      - S1758207404.739434,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:56:31 GMT
+      - Thu, 18 Sep 2025 15:06:32 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example96].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example96].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/collection-spec/json-schema/collection.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '354'
+      - '14'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:22 GMT
+      - Thu, 18 Sep 2025 14:56:43 GMT
       ETag:
       - '"66e1651c-14e2"'
       Last-Modified:
@@ -111,15 +111,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 1d49ad3a27a0e26b76fb667d5b2117fac719a392
+      - 2bd5966247393b11fa51b6a8846499d75c5ea9f2
       X-GitHub-Request-Id:
-      - 3C0F:3556F2:2104189:236964E:68C2EED2
+      - DF8C:3D7940:20E828F:24A0D28:68CC1D9D
       X-Served-By:
-      - cache-bos4692-BOS
+      - cache-bos4670-BOS
       X-Timer:
-      - S1757605942.030040,VS0,VE1
+      - S1758207404.829247,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:56:28 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/catalog-spec/json-schema/catalog.json
   response:
@@ -171,7 +171,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '354'
+      - '14'
       Cache-Control:
       - max-age=600
       Connection:
@@ -181,7 +181,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:22 GMT
+      - Thu, 18 Sep 2025 14:56:43 GMT
       ETag:
       - '"66e1651c-84e"'
       Last-Modified:
@@ -197,15 +197,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - b5c9fbc6a57ba0e197060cbda78333aa417924b5
+      - 60be58e728310736bf87b06f808479bdda49a850
       X-GitHub-Request-Id:
-      - 6A55:180028:223E696:24A38DD:68C2EED2
+      - 3695:91567:105B1F4:125794D:68CC1D9D
       X-Served-By:
-      - cache-bos4667-BOS
+      - cache-bos4642-BOS
       X-Timer:
-      - S1757605942.125860,VS0,VE2
+      - S1758207404.911913,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:27 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -215,7 +215,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/scientific/json-schema/schema.json
   response:
@@ -259,7 +259,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '339'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -269,7 +269,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:22 GMT
+      - Thu, 18 Sep 2025 14:56:44 GMT
       ETag:
       - '"66e1651c-9a3"'
       Last-Modified:
@@ -281,19 +281,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - 4a72ca56a8f30d0b77ea4f59c05be433c7782606
+      - 2df0873e891103c6fd59b502220445eb6a790616
       X-GitHub-Request-Id:
-      - A4D3:13E3A5:1E9712F:21F467E:68C2EEDE
+      - 3DC5:826F9:2183235:253A50C:68CC1DAA
       X-Served-By:
-      - cache-bos4687-BOS
+      - cache-bos4670-BOS
       X-Timer:
-      - S1757605942.208893,VS0,VE1
+      - S1758207404.995512,VS0,VE41
       expires:
-      - Thu, 11 Sep 2025 15:56:43 GMT
+      - Thu, 18 Sep 2025 15:06:44 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -305,7 +305,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/item.json
   response:
@@ -387,7 +387,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '401'
+      - '61'
       Cache-Control:
       - max-age=600
       Connection:
@@ -397,7 +397,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:22 GMT
+      - Thu, 18 Sep 2025 14:56:44 GMT
       ETag:
       - '"66e1651c-147c"'
       Last-Modified:
@@ -413,15 +413,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 4c7c41c223da0c43c6e88e0bde4ea774e623bb5e
+      - 1862069b51241fc7093d9f70e72c15d35c245e43
       X-GitHub-Request-Id:
-      - 9540:197FBB:BCDCFE:D8897B:68C2EEA5
+      - A3C0:BAEAA:C84169:E2AD23:68CC1D6E
       X-Served-By:
-      - cache-bos4688-BOS
+      - cache-bos4636-BOS
       X-Timer:
-      - S1757605942.287715,VS0,VE1
+      - S1758207404.119293,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example97].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example97].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/item.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '401'
+      - '61'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:22 GMT
+      - Thu, 18 Sep 2025 14:56:44 GMT
       ETag:
       - '"66e1651c-147c"'
       Last-Modified:
@@ -109,17 +109,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '4'
+      - '1'
       X-Fastly-Request-ID:
-      - 1d672ca68f1cb3ee320ea4525defaa66caa3b276
+      - f4a4d9914ed27458dbae678ed5d2053529187238
       X-GitHub-Request-Id:
-      - 9540:197FBB:BCDCFE:D8897B:68C2EEA5
+      - A3C0:BAEAA:C84169:E2AD23:68CC1D6E
       X-Served-By:
-      - cache-bos4676-BOS
+      - cache-bos4634-BOS
       X-Timer:
-      - S1757605942.369613,VS0,VE0
+      - S1758207404.215651,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/basics.json
   response:
@@ -148,7 +148,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '401'
+      - '61'
       Cache-Control:
       - max-age=600
       Connection:
@@ -158,7 +158,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:22 GMT
+      - Thu, 18 Sep 2025 14:56:44 GMT
       ETag:
       - '"66e1651c-21c"'
       Last-Modified:
@@ -172,17 +172,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 175724eed8d952e96440858b91015e5b2adf4918
+      - 6d89180ddc7c90f72b3391e2eb25b9d77bb02e0e
       X-GitHub-Request-Id:
-      - E1F2:14AA27:C232A6:DDCD4A:68C2EEA4
+      - 2F53:A07A9:C8C99E:E32E77:68CC1D6E
       X-Served-By:
-      - cache-bos4621-BOS
+      - cache-bos4660-BOS
       X-Timer:
-      - S1757605942.464034,VS0,VE0
+      - S1758207404.307277,VS0,VE8
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -192,7 +192,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/datetime.json
   response:
@@ -241,7 +241,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '400'
+      - '61'
       Cache-Control:
       - max-age=600
       Connection:
@@ -251,7 +251,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:22 GMT
+      - Thu, 18 Sep 2025 14:56:44 GMT
       ETag:
       - '"66e1651c-a82"'
       Last-Modified:
@@ -267,15 +267,17 @@ interactions:
       X-Cache-Hits:
       - '2'
       X-Fastly-Request-ID:
-      - 94682e6e81146c2c628b57719cfb698ff31e6ce6
+      - 3ea79b1a6f8d518736a246af9aca339002451656
       X-GitHub-Request-Id:
-      - 1865:153265:C4294F:DFCE98:68C2EEA5
+      - 3E81:0D6F:C30426:DD705D:68CC1D6F
       X-Served-By:
-      - cache-bos4632-BOS
+      - cache-bos4622-BOS
       X-Timer:
-      - S1757605943.553566,VS0,VE0
+      - S1758207404.401559,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -285,7 +287,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/instrument.json
   response:
@@ -306,7 +308,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '400'
+      - '61'
       Cache-Control:
       - max-age=600
       Connection:
@@ -316,7 +318,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:22 GMT
+      - Thu, 18 Sep 2025 14:56:44 GMT
       ETag:
       - '"66e1651c-2a2"'
       Last-Modified:
@@ -330,17 +332,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '1'
+      - '2'
       X-Fastly-Request-ID:
-      - eff5d996233c11e6b9f29c90101a009ef26a4c1c
+      - 347a3f2c48fc8b7953d1619ff7bebf98b80bceee
       X-GitHub-Request-Id:
-      - 4500:CA757:1EF5208:22C6B31:68C2EEA5
+      - 7C03:3CD2C3:DA5DDA:F4BC38:68CC1D6F
       X-Served-By:
-      - cache-bos4652-BOS
+      - cache-bos4628-BOS
       X-Timer:
-      - S1757605943.635838,VS0,VE1
+      - S1758207404.482509,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -350,7 +354,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/licensing.json
   response:
@@ -366,7 +370,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '400'
+      - '61'
       Cache-Control:
       - max-age=600
       Connection:
@@ -376,7 +380,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:22 GMT
+      - Thu, 18 Sep 2025 14:56:44 GMT
       ETag:
       - '"66e1651c-135"'
       Last-Modified:
@@ -390,17 +394,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - cbcb99a1a3c4ff6a2edbe85b8193f7831c39b450
+      - e20799c0d580a08b9c360127e9727867e232f632
       X-GitHub-Request-Id:
-      - ED10:15FE94:C5AB5F:E14C22:68C2EEA5
+      - C4E5:1D3617:CA3033:E4A206:68CC1D6F
       X-Served-By:
-      - cache-bos4656-BOS
+      - cache-bos4682-BOS
       X-Timer:
-      - S1757605943.722272,VS0,VE0
+      - S1758207405.567195,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -412,7 +416,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/provider.json
   response:
@@ -438,7 +442,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '401'
+      - '61'
       Cache-Control:
       - max-age=600
       Connection:
@@ -448,7 +452,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:22 GMT
+      - Thu, 18 Sep 2025 14:56:44 GMT
       ETag:
       - '"66e1651c-40e"'
       Last-Modified:
@@ -462,17 +466,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '1'
       X-Fastly-Request-ID:
-      - 6e2593faa0fea78a5f6e969b859facd2df6ff2aa
+      - 736847c32346eb194718a57da48b83677c10ef3d
       X-GitHub-Request-Id:
-      - F8AD:14A94E:C2C9FE:DE6C58:68C2EEA4
+      - 5805:B21BA:AD266F:C78835:68CC1D6F
       X-Served-By:
       - cache-bos4655-BOS
       X-Timer:
-      - S1757605943.808066,VS0,VE0
+      - S1758207405.653268,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:44 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -484,7 +488,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/scientific/json-schema/schema.json
   response:
@@ -528,7 +532,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '340'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -538,7 +542,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:22 GMT
+      - Thu, 18 Sep 2025 14:56:44 GMT
       ETag:
       - '"66e1651c-9a3"'
       Last-Modified:
@@ -552,17 +556,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 687d8978375dd770fd82ce8085b58f005d685ba5
+      - e9a0b62b15e6c98223f237b33ee0b16ec6b43a25
       X-GitHub-Request-Id:
-      - A4D3:13E3A5:1E9712F:21F467E:68C2EEDE
+      - 3DC5:826F9:2183235:253A50C:68CC1DAA
       X-Served-By:
-      - cache-bos4655-BOS
+      - cache-bos4652-BOS
       X-Timer:
-      - S1757605943.889940,VS0,VE0
+      - S1758207405.736868,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:43 GMT
+      - Thu, 18 Sep 2025 15:06:44 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -574,7 +578,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/collection-spec/json-schema/collection.json
   response:
@@ -656,7 +660,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '354'
+      - '15'
       Cache-Control:
       - max-age=600
       Connection:
@@ -666,7 +670,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:22 GMT
+      - Thu, 18 Sep 2025 14:56:44 GMT
       ETag:
       - '"66e1651c-14e2"'
       Last-Modified:
@@ -680,17 +684,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 51b484cc31c97911563ee7eda96b083b7bb53bad
+      - 95c69c93caf78b662c62f3af3ccb7fda59282367
       X-GitHub-Request-Id:
-      - 3C0F:3556F2:2104189:236964E:68C2EED2
+      - DF8C:3D7940:20E828F:24A0D28:68CC1D9D
       X-Served-By:
-      - cache-bos4658-BOS
+      - cache-bos4686-BOS
       X-Timer:
-      - S1757605943.966277,VS0,VE1
+      - S1758207405.833283,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:28 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -700,7 +704,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/catalog-spec/json-schema/catalog.json
   response:
@@ -742,7 +746,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '355'
+      - '15'
       Cache-Control:
       - max-age=600
       Connection:
@@ -752,7 +756,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:23 GMT
+      - Thu, 18 Sep 2025 14:56:44 GMT
       ETag:
       - '"66e1651c-84e"'
       Last-Modified:
@@ -768,15 +772,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 14836e192f25e14c4097657953533dbd537929c2
+      - 9f03c8c16cba71b09f659628d47a4fe5f6736462
       X-GitHub-Request-Id:
-      - 6A55:180028:223E696:24A38DD:68C2EED2
+      - 3695:91567:105B1F4:125794D:68CC1D9D
       X-Served-By:
-      - cache-bos4658-BOS
+      - cache-bos4621-BOS
       X-Timer:
-      - S1757605943.040205,VS0,VE1
+      - S1758207405.920784,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:27 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -786,7 +790,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/checksum/json-schema/schema.json
   response:
@@ -829,7 +833,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '354'
+      - '14'
       Cache-Control:
       - max-age=600
       Connection:
@@ -839,7 +843,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:23 GMT
+      - Thu, 18 Sep 2025 14:56:45 GMT
       ETag:
       - '"66e1651c-939"'
       Last-Modified:
@@ -855,17 +859,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - cf5d9b1691fcd9ea010a5be8e4fcb0c13b2173d0
+      - a21b8767f8d405ecb2815310b9ed0cddfe0e4fcf
       X-GitHub-Request-Id:
-      - 0EB2:39602E:21ACCE1:2413344:68C2EED5
+      - FDCC:1E445:218C2CF:25450D2:68CC1D9D
       X-Served-By:
-      - cache-bos4686-BOS
+      - cache-bos4693-BOS
       X-Timer:
-      - S1757605943.121698,VS0,VE1
+      - S1758207405.999261,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:29 GMT
-      x-origin-cache:
-      - HIT
+      - Thu, 18 Sep 2025 15:06:30 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example98].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example98].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/item.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '401'
+      - '62'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:23 GMT
+      - Thu, 18 Sep 2025 14:56:45 GMT
       ETag:
       - '"66e1651c-147c"'
       Last-Modified:
@@ -111,15 +111,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 6ef15543f4409565d412b896b7e8345ccdafde9a
+      - 75d79f337623fa31676a8669c132ffbed66058b2
       X-GitHub-Request-Id:
-      - 9540:197FBB:BCDCFE:D8897B:68C2EEA5
+      - A3C0:BAEAA:C84169:E2AD23:68CC1D6E
       X-Served-By:
-      - cache-bos4621-BOS
+      - cache-bos4646-BOS
       X-Timer:
-      - S1757605943.209753,VS0,VE1
+      - S1758207405.094930,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/basics.json
   response:
@@ -148,7 +148,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '401'
+      - '62'
       Cache-Control:
       - max-age=600
       Connection:
@@ -158,7 +158,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:23 GMT
+      - Thu, 18 Sep 2025 14:56:45 GMT
       ETag:
       - '"66e1651c-21c"'
       Last-Modified:
@@ -174,15 +174,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 29168415443a0fa41aabf45d419e366a2f53f339
+      - fd9711ac7c537b744f0f9fc0a1d95e50de795a45
       X-GitHub-Request-Id:
-      - E1F2:14AA27:C232A6:DDCD4A:68C2EEA4
+      - 2F53:A07A9:C8C99E:E32E77:68CC1D6E
       X-Served-By:
-      - cache-bos4688-BOS
+      - cache-bos4626-BOS
       X-Timer:
-      - S1757605943.280093,VS0,VE1
+      - S1758207405.189592,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -192,7 +192,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/datetime.json
   response:
@@ -241,7 +241,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '401'
+      - '62'
       Cache-Control:
       - max-age=600
       Connection:
@@ -251,7 +251,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:23 GMT
+      - Thu, 18 Sep 2025 14:56:45 GMT
       ETag:
       - '"66e1651c-a82"'
       Last-Modified:
@@ -265,17 +265,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '4'
+      - '1'
       X-Fastly-Request-ID:
-      - 258a8dda0bcd55dbd3c6c42996cf46673220cd5f
+      - 97e198cf6c6dd11a7eca241a2e6eee889eda8a36
       X-GitHub-Request-Id:
-      - 1865:153265:C4294F:DFCE98:68C2EEA5
+      - 3E81:0D6F:C30426:DD705D:68CC1D6F
       X-Served-By:
-      - cache-bos4676-BOS
+      - cache-bos4692-BOS
       X-Timer:
-      - S1757605943.355893,VS0,VE0
+      - S1758207405.263162,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -285,7 +287,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/instrument.json
   response:
@@ -306,7 +308,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '402'
+      - '62'
       Cache-Control:
       - max-age=600
       Connection:
@@ -316,7 +318,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:23 GMT
+      - Thu, 18 Sep 2025 14:56:45 GMT
       ETag:
       - '"66e1651c-2a2"'
       Last-Modified:
@@ -330,17 +332,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - c0b37d9e94c0ca5ca15eb8286604bda5e2b8c386
+      - 403f3b3ea445e41cde14792660f96073081cb167
       X-GitHub-Request-Id:
-      - 4500:CA757:1EF5208:22C6B31:68C2EEA5
+      - 7C03:3CD2C3:DA5DDA:F4BC38:68CC1D6F
       X-Served-By:
-      - cache-bos4688-BOS
+      - cache-bos4687-BOS
       X-Timer:
-      - S1757605943.428007,VS0,VE0
+      - S1758207405.343278,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -350,7 +354,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/licensing.json
   response:
@@ -366,7 +370,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '401'
+      - '61'
       Cache-Control:
       - max-age=600
       Connection:
@@ -376,7 +380,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:23 GMT
+      - Thu, 18 Sep 2025 14:56:45 GMT
       ETag:
       - '"66e1651c-135"'
       Last-Modified:
@@ -392,15 +396,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - eb76861e5b0c5c631c116f9ccc4aaf3b38c2163f
+      - df57ee0a25964fb6563e3d18e77edb7bb5ae4e70
       X-GitHub-Request-Id:
-      - ED10:15FE94:C5AB5F:E14C22:68C2EEA5
+      - C4E5:1D3617:CA3033:E4A206:68CC1D6F
       X-Served-By:
-      - cache-bos4674-BOS
+      - cache-bos4647-BOS
       X-Timer:
-      - S1757605944.503719,VS0,VE2
+      - S1758207405.417694,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -412,7 +416,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/provider.json
   response:
@@ -438,7 +442,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '402'
+      - '61'
       Cache-Control:
       - max-age=600
       Connection:
@@ -448,7 +452,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:23 GMT
+      - Thu, 18 Sep 2025 14:56:45 GMT
       ETag:
       - '"66e1651c-40e"'
       Last-Modified:
@@ -462,17 +466,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 3a5ad010ccab04babb4a0ab1ddcd530c8272aac6
+      - 0e5d0a1723e0e4bce01c3a68cfadf58c9ff08527
       X-GitHub-Request-Id:
-      - F8AD:14A94E:C2C9FE:DE6C58:68C2EEA4
+      - 5805:B21BA:AD266F:C78835:68CC1D6F
       X-Served-By:
-      - cache-bos4643-BOS
+      - cache-bos4669-BOS
       X-Timer:
-      - S1757605944.584195,VS0,VE0
+      - S1758207405.489189,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:44 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -484,7 +488,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/datacube/json-schema/schema.json
   response:
@@ -595,7 +599,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '354'
+      - '14'
       Cache-Control:
       - max-age=600
       Connection:
@@ -605,7 +609,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:23 GMT
+      - Thu, 18 Sep 2025 14:56:45 GMT
       ETag:
       - '"66e1651c-1d66"'
       Last-Modified:
@@ -621,15 +625,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - b61f99bbd1b4619e5b0a97fae0fdba53f83e2dce
+      - ff8e39aa203b4d359cfc1ea2b4032f11abac2a9f
       X-GitHub-Request-Id:
-      - 7766:3FCBA6:20BD099:2323AF5:68C2EED5
+      - 499A:91567:105B412:1257BA3:68CC1D9E
       X-Served-By:
-      - cache-bos4623-BOS
+      - cache-bos4647-BOS
       X-Timer:
-      - S1757605944.665980,VS0,VE2
+      - S1758207406.563276,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:30 GMT
+      - Thu, 18 Sep 2025 15:06:31 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -641,7 +645,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/collection-spec/json-schema/collection.json
   response:
@@ -723,7 +727,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '355'
+      - '16'
       Cache-Control:
       - max-age=600
       Connection:
@@ -733,7 +737,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:23 GMT
+      - Thu, 18 Sep 2025 14:56:45 GMT
       ETag:
       - '"66e1651c-14e2"'
       Last-Modified:
@@ -747,17 +751,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '34'
+      - '1'
       X-Fastly-Request-ID:
-      - 54423c6c33e9a6ca41b8f31f10cfc963736dc483
+      - 6ddf2b93ab50421d14533267eb641f4180e6c098
       X-GitHub-Request-Id:
-      - 3C0F:3556F2:2104189:236964E:68C2EED2
+      - DF8C:3D7940:20E828F:24A0D28:68CC1D9D
       X-Served-By:
-      - cache-bos4666-BOS
+      - cache-bos4657-BOS
       X-Timer:
-      - S1757605944.764791,VS0,VE0
+      - S1758207406.640995,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:28 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -767,7 +771,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/catalog-spec/json-schema/catalog.json
   response:
@@ -809,7 +813,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '356'
+      - '16'
       Cache-Control:
       - max-age=600
       Connection:
@@ -819,7 +823,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:23 GMT
+      - Thu, 18 Sep 2025 14:56:45 GMT
       ETag:
       - '"66e1651c-84e"'
       Last-Modified:
@@ -835,15 +839,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - beb5842eee6e47c2c5d7b26e5054a61cb4ac2d11
+      - 92ea0227de2b78b1714813852b0e63275d261935
       X-GitHub-Request-Id:
-      - 6A55:180028:223E696:24A38DD:68C2EED2
+      - 3695:91567:105B1F4:125794D:68CC1D9D
       X-Served-By:
-      - cache-bos4639-BOS
+      - cache-bos4681-BOS
       X-Timer:
-      - S1757605944.848158,VS0,VE1
+      - S1758207406.712872,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:27 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -853,7 +857,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/eo/json-schema/schema.json
   response:
@@ -891,7 +895,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '352'
+      - '13'
       Cache-Control:
       - max-age=600
       Connection:
@@ -901,7 +905,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:23 GMT
+      - Thu, 18 Sep 2025 14:56:45 GMT
       ETag:
       - '"66e1651c-805"'
       Last-Modified:
@@ -917,15 +921,17 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - b0c69832c835576db35af275d0f10de348ccf3e6
+      - ea72e65bd7e4b4b10a11c908cf671439a81d8553
       X-GitHub-Request-Id:
-      - 61E0:85CEC:1F72DF5:22CFA7F:68C2EED7
+      - 2976:1A3C1:217E151:25362CA:68CC1DA0
       X-Served-By:
-      - cache-bos4665-BOS
+      - cache-bos4630-BOS
       X-Timer:
-      - S1757605944.923766,VS0,VE1
+      - S1758207406.789090,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:31 GMT
+      - Thu, 18 Sep 2025 15:06:32 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -935,7 +941,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/tiled-assets/json-schema/schema.json
   response:
@@ -1042,7 +1048,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '339'
+      - '0'
       Cache-Control:
       - max-age=600
       Connection:
@@ -1052,7 +1058,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:24 GMT
+      - Thu, 18 Sep 2025 14:56:45 GMT
       ETag:
       - '"66e1651c-1c4b"'
       Last-Modified:
@@ -1064,19 +1070,19 @@ interactions:
       Via:
       - 1.1 varnish
       X-Cache:
-      - HIT
+      - MISS
       X-Cache-Hits:
       - '0'
       X-Fastly-Request-ID:
-      - c910c6899cc8366c09bb0bbb8105e786f70efd93
+      - b1cbf775726bfc364f215acdd885e06f8797ae13
       X-GitHub-Request-Id:
-      - C9D1:3A03AF:1DF955D:215772D:68C2EEE4
+      - 0BBC:35199E:2074AE2:242C75E:68CC1DAD
       X-Served-By:
-      - cache-bos4636-BOS
+      - cache-bos4680-BOS
       X-Timer:
-      - S1757605944.002213,VS0,VE2
+      - S1758207406.867377,VS0,VE54
       expires:
-      - Thu, 11 Sep 2025 15:56:45 GMT
+      - Thu, 18 Sep 2025 15:06:45 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example99].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example99].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/item.json
   response:
@@ -85,7 +85,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '402'
+      - '63'
       Cache-Control:
       - max-age=600
       Connection:
@@ -95,7 +95,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:24 GMT
+      - Thu, 18 Sep 2025 14:56:46 GMT
       ETag:
       - '"66e1651c-147c"'
       Last-Modified:
@@ -111,15 +111,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - e789f572681553a519b85c946db96702e0b521c2
+      - a73e3ac8162f3cb4c9b1407abc57b4f22b6838ca
       X-GitHub-Request-Id:
-      - 9540:197FBB:BCDCFE:D8897B:68C2EEA5
+      - A3C0:BAEAA:C84169:E2AD23:68CC1D6E
       X-Served-By:
-      - cache-bos4685-BOS
+      - cache-bos4656-BOS
       X-Timer:
-      - S1757605944.096078,VS0,VE1
+      - S1758207406.051204,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -129,7 +129,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/basics.json
   response:
@@ -148,7 +148,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '402'
+      - '63'
       Cache-Control:
       - max-age=600
       Connection:
@@ -158,7 +158,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:24 GMT
+      - Thu, 18 Sep 2025 14:56:46 GMT
       ETag:
       - '"66e1651c-21c"'
       Last-Modified:
@@ -174,15 +174,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 976d920de2d8284af130f6ca502230e2170458c2
+      - 15b45da564e3e07e8f4d3a98d2df18ed51c6ee68
       X-GitHub-Request-Id:
-      - E1F2:14AA27:C232A6:DDCD4A:68C2EEA4
+      - 2F53:A07A9:C8C99E:E32E77:68CC1D6E
       X-Served-By:
-      - cache-bos4635-BOS
+      - cache-bos4656-BOS
       X-Timer:
-      - S1757605944.182276,VS0,VE2
+      - S1758207406.146933,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:41 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -192,7 +192,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/datetime.json
   response:
@@ -241,7 +241,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '402'
+      - '63'
       Cache-Control:
       - max-age=600
       Connection:
@@ -251,7 +251,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:24 GMT
+      - Thu, 18 Sep 2025 14:56:46 GMT
       ETag:
       - '"66e1651c-a82"'
       Last-Modified:
@@ -265,17 +265,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 5877ad6fdbb1cb005432dbb002be429eae95d17e
+      - 105a109459358fa456d508623507d0ca1e102164
       X-GitHub-Request-Id:
-      - 1865:153265:C4294F:DFCE98:68C2EEA5
+      - 3E81:0D6F:C30426:DD705D:68CC1D6F
       X-Served-By:
-      - cache-bos4638-BOS
+      - cache-bos4684-BOS
       X-Timer:
-      - S1757605944.258610,VS0,VE1
+      - S1758207406.213308,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -285,7 +287,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/instrument.json
   response:
@@ -306,7 +308,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '402'
+      - '63'
       Cache-Control:
       - max-age=600
       Connection:
@@ -316,7 +318,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:24 GMT
+      - Thu, 18 Sep 2025 14:56:46 GMT
       ETag:
       - '"66e1651c-2a2"'
       Last-Modified:
@@ -330,17 +332,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 1da864f7ef42cefbe8c6f489a6f1a62acd9f6202
+      - 75a185dd706c159aa4b0e34853d5f6118578b125
       X-GitHub-Request-Id:
-      - 4500:CA757:1EF5208:22C6B31:68C2EEA5
+      - 7C03:3CD2C3:DA5DDA:F4BC38:68CC1D6F
       X-Served-By:
-      - cache-bos4650-BOS
+      - cache-bos4660-BOS
       X-Timer:
-      - S1757605944.337644,VS0,VE0
+      - S1758207406.295411,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -350,7 +354,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/licensing.json
   response:
@@ -366,7 +370,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '402'
+      - '63'
       Cache-Control:
       - max-age=600
       Connection:
@@ -376,7 +380,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:24 GMT
+      - Thu, 18 Sep 2025 14:56:46 GMT
       ETag:
       - '"66e1651c-135"'
       Last-Modified:
@@ -390,17 +394,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '3'
+      - '2'
       X-Fastly-Request-ID:
-      - baf5f8cdc1a432e37fb73edf2b3b65bf1ac3d1e3
+      - d366abcf86e76f6c94696aa2734e55556f03ec96
       X-GitHub-Request-Id:
-      - ED10:15FE94:C5AB5F:E14C22:68C2EEA5
+      - C4E5:1D3617:CA3033:E4A206:68CC1D6F
       X-Served-By:
-      - cache-bos4690-BOS
+      - cache-bos4677-BOS
       X-Timer:
-      - S1757605944.409505,VS0,VE1
+      - S1758207406.375186,VS0,VE0
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:43 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -412,7 +416,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/provider.json
   response:
@@ -438,7 +442,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '402'
+      - '62'
       Cache-Control:
       - max-age=600
       Connection:
@@ -448,7 +452,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:24 GMT
+      - Thu, 18 Sep 2025 14:56:46 GMT
       ETag:
       - '"66e1651c-40e"'
       Last-Modified:
@@ -462,17 +466,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 857cba329ffaaf74e3072381b6d731894609b0f7
+      - 87633ef995cae149b16f60e6eed0fb6c0db26ed7
       X-GitHub-Request-Id:
-      - F8AD:14A94E:C2C9FE:DE6C58:68C2EEA4
+      - 5805:B21BA:AD266F:C78835:68CC1D6F
       X-Served-By:
-      - cache-bos4677-BOS
+      - cache-bos4684-BOS
       X-Timer:
-      - S1757605944.483751,VS0,VE0
+      - S1758207406.446898,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:55:42 GMT
+      - Thu, 18 Sep 2025 15:05:44 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -484,7 +488,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/eo/json-schema/schema.json
   response:
@@ -522,7 +526,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '353'
+      - '14'
       Cache-Control:
       - max-age=600
       Connection:
@@ -532,7 +536,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:24 GMT
+      - Thu, 18 Sep 2025 14:56:46 GMT
       ETag:
       - '"66e1651c-805"'
       Last-Modified:
@@ -546,17 +550,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - 921af339333f7a16481575918774d0aa3d68208c
+      - 29805793e863e872b7866a3ff1bdbdd00a8571d8
       X-GitHub-Request-Id:
-      - 61E0:85CEC:1F72DF5:22CFA7F:68C2EED7
+      - 2976:1A3C1:217E151:25362CA:68CC1DA0
       X-Served-By:
-      - cache-bos4669-BOS
+      - cache-bos4639-BOS
       X-Timer:
-      - S1757605945.563498,VS0,VE0
+      - S1758207407.515306,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:31 GMT
+      - Thu, 18 Sep 2025 15:06:32 GMT
+      x-origin-cache:
+      - HIT
       x-proxy-cache:
       - MISS
     status:
@@ -566,7 +572,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/extensions/tiled-assets/json-schema/schema.json
   response:
@@ -673,7 +679,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '340'
+      - '1'
       Cache-Control:
       - max-age=600
       Connection:
@@ -683,7 +689,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:24 GMT
+      - Thu, 18 Sep 2025 14:56:46 GMT
       ETag:
       - '"66e1651c-1c4b"'
       Last-Modified:
@@ -699,15 +705,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 13135b6db3a4820853966718bc55cec2249afe71
+      - 423f4b68e2bacad5d66518aa745a59032051026c
       X-GitHub-Request-Id:
-      - C9D1:3A03AF:1DF955D:215772D:68C2EEE4
+      - 0BBC:35199E:2074AE2:242C75E:68CC1DAD
       X-Served-By:
-      - cache-bos4676-BOS
+      - cache-bos4623-BOS
       X-Timer:
-      - S1757605945.646005,VS0,VE2
+      - S1758207407.591559,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:56:45 GMT
+      - Thu, 18 Sep 2025 15:06:45 GMT
       x-origin-cache:
       - HIT
       x-proxy-cache:
@@ -719,7 +725,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/catalog-spec/json-schema/catalog.json
   response:
@@ -761,7 +767,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '357'
+      - '17'
       Cache-Control:
       - max-age=600
       Connection:
@@ -771,7 +777,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:24 GMT
+      - Thu, 18 Sep 2025 14:56:46 GMT
       ETag:
       - '"66e1651c-84e"'
       Last-Modified:
@@ -787,15 +793,15 @@ interactions:
       X-Cache-Hits:
       - '1'
       X-Fastly-Request-ID:
-      - 4f6c3e52dffd4bd7fb134d026911a254a3c849da
+      - 62450be797d3448caf6bfda50dc43591ea08b456
       X-GitHub-Request-Id:
-      - 6A55:180028:223E696:24A38DD:68C2EED2
+      - 3695:91567:105B1F4:125794D:68CC1D9D
       X-Served-By:
-      - cache-bos4642-BOS
+      - cache-bos4665-BOS
       X-Timer:
-      - S1757605945.726310,VS0,VE1
+      - S1758207407.673535,VS0,VE1
       expires:
-      - Thu, 11 Sep 2025 15:56:27 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:
@@ -805,7 +811,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://schemas.stacspec.org/v1.0.0-beta.2/collection-spec/json-schema/collection.json
   response:
@@ -887,7 +893,7 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '356'
+      - '17'
       Cache-Control:
       - max-age=600
       Connection:
@@ -897,7 +903,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 11 Sep 2025 15:52:24 GMT
+      - Thu, 18 Sep 2025 14:56:46 GMT
       ETag:
       - '"66e1651c-14e2"'
       Last-Modified:
@@ -911,17 +917,17 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Fastly-Request-ID:
-      - f89b0a865d40f14aef76fe9a2ae719a052705fa3
+      - deeeeadcb75905fbe47c4384b93bafbb9135a383
       X-GitHub-Request-Id:
-      - 3C0F:3556F2:2104189:236964E:68C2EED2
+      - DF8C:3D7940:20E828F:24A0D28:68CC1D9D
       X-Served-By:
-      - cache-bos4668-BOS
+      - cache-bos4690-BOS
       X-Timer:
-      - S1757605945.815875,VS0,VE1
+      - S1758207407.745405,VS0,VE2
       expires:
-      - Thu, 11 Sep 2025 15:56:28 GMT
+      - Thu, 18 Sep 2025 15:06:29 GMT
       x-proxy-cache:
       - MISS
     status:

--- a/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example9].yaml
+++ b/tests/validation/cassettes/test_validate/TestValidate.test_validate_examples[example9].yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/item-spec/json-schema/item.json
   response:
@@ -108,11 +108,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:43 GMT
+      - Thu, 18 Sep 2025 14:56:02 GMT
       ETag:
       - '"4e24763d74f0d463b0cb6c63fc099e0b59447c7a049b93ffda4c6eb9eb54ae95"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:43 GMT
+      - Thu, 18 Sep 2025 15:01:02 GMT
       Source-Age:
       - '1'
       Strict-Transport-Security:
@@ -124,19 +124,19 @@ interactions:
       X-Cache:
       - HIT
       X-Cache-Hits:
-      - '2'
+      - '1'
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - eba647cad55693523e59f7eda1f76c83cc941241
+      - 29027229156069804c1c3673fcd5a42e1161c210
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 688A:1E0DA2:13B02E:181CCC:68C2EEB5
+      - DDD5:286E0:D0F1D:FC0CF:68CC1D7C
       X-Served-By:
-      - cache-bos4692-BOS
+      - cache-bos4663-BOS
       X-Timer:
-      - S1757605903.496335,VS0,VE0
+      - S1758207363.590915,VS0,VE4
       X-XSS-Protection:
       - 1; mode=block
     status:
@@ -146,7 +146,7 @@ interactions:
     body: null
     headers:
       User-Agent:
-      - pystac/1.14.0
+      - pystac/1.14.1
     method: GET
     uri: https://raw.githubusercontent.com/radiantearth/stac-spec/v0.8.1/extensions/eo/json-schema/schema.json
   response:
@@ -212,11 +212,11 @@ interactions:
       Cross-Origin-Resource-Policy:
       - cross-origin
       Date:
-      - Thu, 11 Sep 2025 15:51:43 GMT
+      - Thu, 18 Sep 2025 14:56:02 GMT
       ETag:
       - '"c8576d5ea3fcee4039dcddbdcf9e59fed3f3086419a33aa96f18f4617203b76d"'
       Expires:
-      - Thu, 11 Sep 2025 15:56:43 GMT
+      - Thu, 18 Sep 2025 15:01:02 GMT
       Source-Age:
       - '1'
       Strict-Transport-Security:
@@ -232,15 +232,15 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       X-Fastly-Request-ID:
-      - da9a0222458be0a2e6823c7319c523f1a46d5224
+      - 7f7564a2dfac70ff11fcdcaf5e086d828bc1ae2b
       X-Frame-Options:
       - deny
       X-GitHub-Request-Id:
-      - 10B8:1C3F94:144BD8:18BB04:68C2EEB7
+      - 46FA:175DD:C2790:ED92C:68CC1D80
       X-Served-By:
-      - cache-bos4626-BOS
+      - cache-bos4674-BOS
       X-Timer:
-      - S1757605904.571527,VS0,VE1
+      - S1758207363.677559,VS0,VE1
       X-XSS-Protection:
       - 1; mode=block
     status:


### PR DESCRIPTION
To get #1580 into production

Basically all the cassettes will now be touched on every  release because of the version number being part of the "User-Agent" header.