### PR TITLE
Speed up importing pystac

### DIFF
--- a/pystac/__init__.py
+++ b/pystac/__init__.py
@@ -44,7 +44,6 @@ __all__ = [
     "set_stac_version",
 ]
 
-import os
 import warnings
 from typing import Any
 
@@ -198,6 +197,8 @@ def write_file(
     """
     if stac_io is None:
         stac_io = StacIO.default()
+    import os
+
     dest_href = None if dest_href is None else str(os.fspath(dest_href))
     obj.save_object(
         include_self_link=include_self_link, dest_href=dest_href, stac_io=stac_io

--- a/pystac/asset.py
+++ b/pystac/asset.py
@@ -1,13 +1,10 @@
 from __future__ import annotations
 
-import os
 import shutil
 from copy import copy, deepcopy
-from html import escape
 from typing import TYPE_CHECKING, Any, Protocol, TypeVar
 
 from pystac import MediaType, STACError, common_metadata, utils
-from pystac.html.jinja_env import get_jinja_env
 from pystac.utils import is_absolute_href, make_absolute_href, make_relative_href
 
 if TYPE_CHECKING:
@@ -181,6 +178,10 @@ class Asset:
         return f"<Asset href={self.href}>"
 
     def _repr_html_(self) -> str:
+        from html import escape
+
+        from pystac.html.jinja_env import get_jinja_env
+
         jinja_env = get_jinja_env()
         if jinja_env:
             template = jinja_env.get_template("JSON.jinja2")
@@ -258,6 +259,8 @@ class Asset:
 
         Does not modify the asset.
         """
+        import os
+
         href = _absolute_href(self.href, self.owner, "delete")
         os.remove(href)
 

--- a/pystac/catalog.py
+++ b/pystac/catalog.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
 import os
-import warnings
 from collections.abc import Callable, Iterable, Iterator
 from copy import deepcopy
-from itertools import chain
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -521,6 +519,8 @@ class Catalog(STACObject):
         Return:
             Item or None: The item with the given ID, or None if not found.
         """
+        import warnings
+
         warnings.warn(
             "get_item is deprecated and will be removed in v2. "
             "Use next(self.get_items(id), None) instead",
@@ -549,6 +549,8 @@ class Catalog(STACObject):
                 (if recursive) all catalogs or collections connected to this catalog
                 through child links.
         """
+        from itertools import chain
+
         items: Iterator[Item]
         if not recursive:
             items = map(
@@ -615,6 +617,9 @@ class Catalog(STACObject):
                 catalogs or collections connected to this catalog through
                 child links.
         """
+        import warnings
+        from itertools import chain
+
         warnings.warn(
             "get_all_items is deprecated and will be removed in v2",
             DeprecationWarning,

--- a/pystac/collection.py
+++ b/pystac/collection.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from collections.abc import Iterable, Sequence
 from copy import deepcopy
 from datetime import datetime, timezone
@@ -11,8 +10,6 @@ from typing import (
     TypeVar,
     cast,
 )
-
-from dateutil import tz
 
 import pystac
 from pystac import CatalogType, STACObjectType
@@ -257,6 +254,8 @@ class TemporalExtent:
         parsed_intervals: list[list[datetime | None]] = []
         for i in d["interval"]:
             if isinstance(i, str):
+                import warnings
+
                 # d["interval"] is a list of strings, so we correct the list and
                 # try again
                 # https://github.com/stac-utils/pystac/issues/1221
@@ -384,6 +383,8 @@ class Extent:
             Extent: An Extent that spatially and temporally covers all of the
             given items.
         """
+        from dateutil import tz
+
         bounds_values: list[list[float]] = [
             [float("inf")],
             [float("inf")],
@@ -635,6 +636,8 @@ class Collection(Catalog, Assets):
         migrate: bool = True,
         preserve_dict: bool = True,
     ) -> C:
+        import warnings
+
         from pystac.extensions.version import CollectionVersionExtension
 
         if migrate:

--- a/pystac/extensions/eo.py
+++ b/pystac/extensions/eo.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import warnings
 from collections.abc import Iterable
 from typing import (
     Any,
@@ -386,6 +385,8 @@ class EOExtension(
 
     @classmethod
     def get_schema_uris(cls) -> list[str]:
+        import warnings
+
         warnings.warn(
             "get_schema_uris is deprecated and will be removed in v2",
             DeprecationWarning,

--- a/pystac/extensions/file.py
+++ b/pystac/extensions/file.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import warnings
 from collections.abc import Iterable
 from typing import Any, Generic, Literal, TypeVar, cast
 
@@ -370,6 +369,8 @@ class FileExtensionHooks(ExtensionHooks):
                 found_fields[asset_key] = values
 
         if found_fields:
+            import warnings
+
             warnings.warn(
                 f"Assets {list(found_fields.keys())} contain fields: "
                 f"{list(set.union(*found_fields.values()))} which "

--- a/pystac/extensions/grid.py
+++ b/pystac/extensions/grid.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import re
-import warnings
 from re import Pattern
 from typing import Any, Literal
 
@@ -92,6 +91,8 @@ class GridExtension(
 
     @classmethod
     def get_schema_uris(cls) -> list[str]:
+        import warnings
+
         warnings.warn(
             "get_schema_uris is deprecated and will be removed in v2",
             DeprecationWarning,

--- a/pystac/extensions/item_assets.py
+++ b/pystac/extensions/item_assets.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import warnings
 from typing import Any, Literal
 
 import pystac
@@ -27,6 +26,8 @@ class AssetDefinition(ItemAssetDefinition):
     """
 
     def __init__(cls, *args: Any, **kwargs: Any) -> None:
+        import warnings
+
         warnings.warn(
             (
                 "``AssetDefinition`` is deprecated. "
@@ -49,6 +50,8 @@ class ItemAssetsExtension(ExtensionManagementMixin[pystac.Collection]):
     collection: pystac.Collection
 
     def __init__(self, collection: pystac.Collection) -> None:
+        import warnings
+
         warnings.warn(
             (
                 "The ``item_assets`` extension is deprecated. "

--- a/pystac/extensions/projection.py
+++ b/pystac/extensions/projection.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import json
-import warnings
 from collections.abc import Iterable
 from typing import (
     Any,
@@ -224,6 +222,8 @@ class ProjectionExtension(
         elif self.wkt2:
             return self.wkt2
         elif self.projjson:
+            import json
+
             return json.dumps(self.projjson)
         else:
             return None
@@ -322,6 +322,8 @@ class ProjectionExtension(
 
     @classmethod
     def get_schema_uris(cls) -> list[str]:
+        import warnings
+
         warnings.warn(
             "get_schema_uris is deprecated and will be removed in v2",
             DeprecationWarning,
@@ -477,6 +479,8 @@ class ProjectionExtensionHooks(ExtensionHooks):
     ) -> None:
         if not self.has_extension(obj):
             return
+
+        import warnings
 
         # proj:epsg moved to proj:code
         if epsg := obj["properties"].pop("proj:epsg", None):

--- a/pystac/extensions/raster.py
+++ b/pystac/extensions/raster.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import warnings
 from collections.abc import Iterable
 from typing import (
     Any,
@@ -716,6 +715,8 @@ class RasterExtension(
 
     @classmethod
     def get_schema_uris(cls) -> list[str]:
+        import warnings
+
         warnings.warn(
             "get_schema_uris is deprecated and will be removed in v2",
             DeprecationWarning,

--- a/pystac/extensions/scientific.py
+++ b/pystac/extensions/scientific.py
@@ -7,9 +7,7 @@ https://doi.org/10.1000/182
 
 from __future__ import annotations
 
-import copy
 from typing import Any, Generic, Literal, TypeVar, cast
-from urllib import parse
 
 import pystac
 from pystac.extensions.base import (
@@ -49,6 +47,8 @@ class ScientificRelType(StringEnum):
 
 def doi_to_url(doi: str) -> str:
     """Converts a DOI to the corresponding URL."""
+    from urllib import parse
+
     return DOI_URL_BASE + parse.quote(doi)
 
 
@@ -72,6 +72,8 @@ class Publication:
         return f"<Publication doi={self.doi} target={self.citation}>"
 
     def to_dict(self) -> dict[str, str | None]:
+        import copy
+
         return copy.deepcopy({"doi": self.doi, "citation": self.citation})
 
     @staticmethod

--- a/pystac/extensions/version.py
+++ b/pystac/extensions/version.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import warnings
 from collections.abc import Generator
 from contextlib import contextmanager
 from typing import (
@@ -437,6 +436,8 @@ def ignore_deprecated() -> Generator[None]:
     """Context manager for suppressing the :class:`pystac.DeprecatedWarning`
     when creating a deprecated :class:`~pystac.Item` or :class:`~pystac.Collection`
     from a dictionary."""
+    import warnings
+
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", category=DeprecatedWarning)
         yield

--- a/pystac/item.py
+++ b/pystac/item.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from copy import copy, deepcopy
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 
@@ -420,6 +419,8 @@ class Item(STACObject, Assets):
         migrate: bool = True,
         preserve_dict: bool = True,
     ) -> T:
+        import warnings
+
         from pystac.extensions.version import ItemVersionExtension
 
         if preserve_dict:

--- a/pystac/item_assets.py
+++ b/pystac/item_assets.py
@@ -6,7 +6,6 @@ for use as values in the :attr:`~pystac.Collection.item_assets` dict.
 
 from __future__ import annotations
 
-from copy import deepcopy
 from typing import TYPE_CHECKING, Any
 
 import pystac
@@ -179,6 +178,8 @@ class ItemAssetDefinition:
 
     def to_dict(self) -> dict[str, Any]:
         """Returns a dictionary representing this ``ItemAssetDefinition``."""
+        from copy import deepcopy
+
         return deepcopy(self.properties)
 
     def create_asset(self, href: str) -> pystac.Asset:

--- a/pystac/item_collection.py
+++ b/pystac/item_collection.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Collection, Iterable, Iterator
-from copy import deepcopy
-from html import escape
 from typing import (
     Any,
     TypeAlias,
@@ -11,7 +9,6 @@ from typing import (
 
 import pystac
 from pystac.errors import STACTypeError
-from pystac.html.jinja_env import get_jinja_env
 from pystac.serialization.identify import identify_stac_object_type
 from pystac.utils import HREF, is_absolute_href, make_absolute_href, make_posix_style
 
@@ -147,6 +144,10 @@ class ItemCollection(Collection[pystac.Item]):
         }
 
     def _repr_html_(self) -> str:
+        from html import escape
+
+        from pystac.html.jinja_env import get_jinja_env
+
         jinja_env = get_jinja_env()
         if jinja_env:
             template = jinja_env.get_template("JSON.jinja2")
@@ -158,6 +159,8 @@ class ItemCollection(Collection[pystac.Item]):
         """Creates a clone of this instance. This clone is a deep copy; all
         :class:`~pystac.Item` instances are cloned and all additional top-level fields
         are deep copied."""
+        from copy import deepcopy
+
         return self.__class__(
             items=[item.clone() for item in self.items],
             extra_fields=deepcopy(self.extra_fields),

--- a/pystac/layout.py
+++ b/pystac/layout.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-import os
 import posixpath
-import warnings
 from abc import ABC, abstractmethod
 from collections import OrderedDict
 from collections.abc import Callable
-from string import Formatter
 from typing import TYPE_CHECKING, Any
 
 import pystac
@@ -30,6 +27,8 @@ class TemplateError(Exception):
     """
 
     def __init__(self, *args, **kwargs) -> None:  # type: ignore
+        import warnings
+
         warnings.warn(
             message=(
                 "TemplateError in pystac.layout is deprecated and will be "
@@ -109,6 +108,8 @@ class LayoutTemplate:
     ITEM_TEMPLATE_VARS = ["date", "year", "month", "day", "collection"]
 
     def __init__(self, template: str, defaults: dict[str, str] | None = None) -> None:
+        from string import Formatter
+
         self.template = template
         self.defaults = defaults or {}
 
@@ -261,6 +262,8 @@ class HrefLayoutStrategy(ABC):
     def get_href(
         self, stac_object: STACObject, parent_dir: str, is_root: bool = False
     ) -> str:
+        import os
+
         if is_file_path(parent_dir):
             parent_dir = os.path.dirname(parent_dir)
 

--- a/pystac/link.py
+++ b/pystac/link.py
@@ -1,13 +1,10 @@
 from __future__ import annotations
 
 import os
-from copy import copy
-from html import escape
 from typing import TYPE_CHECKING, Any, TypeVar
 
 import pystac
 from pystac.errors import STACError
-from pystac.html.jinja_env import get_jinja_env
 from pystac.utils import (
     HREF as HREF,
 )
@@ -272,6 +269,10 @@ class Link(PathLike):
         return f"<Link rel={self.rel} target={self.target}>"
 
     def _repr_html_(self) -> str:
+        from html import escape
+
+        from pystac.html.jinja_env import get_jinja_env
+
         jinja_env = get_jinja_env()
         if jinja_env:
             template = jinja_env.get_template("JSON.jinja2")
@@ -435,6 +436,8 @@ class Link(PathLike):
         Returns:
             Link: Link instance constructed from the dict.
         """
+        from copy import copy
+
         d = copy(d)
         rel = d.pop("rel")
         href = d.pop("href")

--- a/pystac/provider.py
+++ b/pystac/provider.py
@@ -1,7 +1,5 @@
-from html import escape
 from typing import Any
 
-from pystac.html.jinja_env import get_jinja_env
 from pystac.utils import StringEnum
 
 
@@ -73,6 +71,10 @@ class Provider:
         return self.to_dict() == o.to_dict()
 
     def _repr_html_(self) -> str:
+        from html import escape
+
+        from pystac.html.jinja_env import get_jinja_env
+
         jinja_env = get_jinja_env()
         if jinja_env:
             template = jinja_env.get_template("JSON.jinja2")

--- a/pystac/serialization/migrate.py
+++ b/pystac/serialization/migrate.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from copy import deepcopy
 from typing import TYPE_CHECKING, Any
 
 import pystac
@@ -167,6 +166,8 @@ def migrate_to_latest(
         dict: A copy of the dict that is migrated to the latest version (the
         version that is pystac.version.STACVersion.DEFAULT_STAC_VERSION)
     """
+    from copy import deepcopy
+
     result = deepcopy(json_dict)
     version = info.version_range.latest_valid_version()
 

--- a/pystac/stac_io.py
+++ b/pystac/stac_io.py
@@ -1,13 +1,10 @@
 from __future__ import annotations
 
 import json
-import logging
 import os
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
-from urllib.error import HTTPError
-from urllib.request import Request, urlopen
 
 import pystac
 from pystac.serialization import (
@@ -35,9 +32,6 @@ else:
 if TYPE_CHECKING:
     from pystac.catalog import Catalog
     from pystac.stac_object import STACObject
-
-
-logger = logging.getLogger(__name__)
 
 
 class StacIO(ABC):
@@ -296,6 +290,11 @@ class DefaultStacIO(StacIO):
         """
         href_contents: str
         if _is_url(href):
+            import logging
+            from urllib.error import HTTPError
+            from urllib.request import Request, urlopen
+
+            logger = logging.getLogger(__name__)
             try:
                 logger.debug(f"GET {href} Headers: {self.headers}")
                 if HAS_URLLIB3:
@@ -451,6 +450,8 @@ if HAS_URLLIB3:
                 href : The URI of the file to open.
             """
             if _is_url(href):
+                from urllib.error import HTTPError
+
                 # TODO provide a pooled StacIO to enable more efficient network
                 # access (probably named `PooledStacIO`).
                 http = PoolManager()

--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -3,12 +3,10 @@ from __future__ import annotations
 import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable
-from html import escape
 from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar, cast
 
 import pystac
 from pystac import STACError
-from pystac.html.jinja_env import get_jinja_env
 from pystac.link import Link
 from pystac.utils import (
     HREF,
@@ -594,6 +592,10 @@ class STACObject(ABC):
         raise NotImplementedError
 
     def _repr_html_(self) -> str:
+        from html import escape
+
+        from pystac.html.jinja_env import get_jinja_env
+
         jinja_env = get_jinja_env()
         if jinja_env:
             template = jinja_env.get_template("JSON.jinja2")

--- a/pystac/summaries.py
+++ b/pystac/summaries.py
@@ -1,11 +1,7 @@
 from __future__ import annotations
 
-import importlib.resources
-import json
-import numbers
 from abc import abstractmethod
 from collections.abc import Iterable
-from copy import deepcopy
 from enum import Enum
 from functools import lru_cache
 from typing import (
@@ -100,6 +96,9 @@ class RangeSummary(Generic[T]):
 @lru_cache(maxsize=None)
 def _get_fields_json(url: str | None) -> dict[str, Any]:
     if url is None:
+        import importlib.resources
+        import json
+
         # Every time pystac is released this file gets pulled from
         # https://cdn.jsdelivr.net/npm/@radiantearth/stac-fields/fields-normalized.json
         jsonfields: dict[str, Any] = json.loads(
@@ -170,6 +169,8 @@ class Summarizer:
                 self.summaryfields[name] = strategy
 
     def _update_with_item(self, summaries: Summaries, item: Item) -> None:
+        import numbers
+
         for k, v in item.properties.items():
             if k in self.summaryfields:
                 strategy = self.summaryfields[k]
@@ -310,6 +311,8 @@ class Summaries:
         Returns:
             Summaries: The clone of this object
         """
+        from copy import deepcopy
+
         cls = self.__class__
         summaries = cls(summaries=deepcopy(self._summaries), maxcount=self.maxcount)
         summaries.lists = deepcopy(self.lists)

--- a/pystac/utils.py
+++ b/pystac/utils.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 import posixpath
-import warnings
 from collections.abc import Callable
 from datetime import datetime, timezone
 from enum import Enum
@@ -14,8 +13,6 @@ from typing import (
 )
 from urllib.parse import ParseResult as URLParseResult
 from urllib.parse import urljoin, urlparse, urlunparse
-
-import dateutil.parser
 
 from pystac.errors import RequiredPropertyMissing
 
@@ -132,6 +129,8 @@ class JoinType(StringEnum):
         Returns:
             JoinType : The join type for the URI.
         """
+        import warnings
+
         warnings.warn(
             message=(
                 "from_parsed_uri is deprecated and will be removed in pystac "
@@ -166,6 +165,8 @@ def join_path_or_url(join_type: JoinType, *args: str) -> str:
     Returns:
         str : The joined path
     """
+    import warnings
+
     warnings.warn(
         message=(
             "join_path_or_url is deprecated and will be removed in pystac "
@@ -440,6 +441,8 @@ def str_to_datetime(s: str) -> datetime:
     Returns:
         str: The :class:`datetime.datetime` represented the by the string.
     """
+    import dateutil.parser
+
     return dateutil.parser.isoparse(s)
 
 

--- a/pystac/validation/__init__.py
+++ b/pystac/validation/__init__.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from collections.abc import Iterable, Mapping
 from typing import TYPE_CHECKING, Any, cast
 
@@ -164,6 +163,8 @@ def validate_all(
         stac_io = pystac.StacIO.default()
 
     if isinstance(stac_object, dict):
+        import warnings
+
         warnings.warn(
             "validating a STAC object as a dict is deprecated;"
             " use validate_all_dict instead",

--- a/pystac/validation/local_validator.py
+++ b/pystac/validation/local_validator.py
@@ -1,10 +1,7 @@
-import importlib.resources
 import json
-import warnings
 from typing import Any, cast
 
 from jsonschema import Draft7Validator, ValidationError
-from referencing import Registry, Resource
 
 from pystac.errors import STACLocalValidationError
 from pystac.version import STACVersion
@@ -13,6 +10,8 @@ VERSION = STACVersion.DEFAULT_STAC_VERSION
 
 
 def _read_schema(file_name: str) -> dict[str, Any]:
+    import importlib.resources
+
     with (
         importlib.resources.files("pystac.validation.jsonschemas")
         .joinpath(file_name)
@@ -73,6 +72,8 @@ deprecated_names = ["ITEM_SCHEMA_URI", "COLLECTION_SCHEMA_URI", "CATALOG_SCHEMA_
 
 def __getattr__(name: str) -> Any:
     if name in deprecated_names:
+        import warnings
+
         warnings.warn(f"{name} is deprecated and will be removed in v2.", FutureWarning)
         return globals()[f"_deprecated_{name}"]
     raise AttributeError(f"module {__name__} has no attribute {name}")
@@ -81,6 +82,8 @@ def __getattr__(name: str) -> Any:
 class LocalValidator:
     def __init__(self) -> None:
         """DEPRECATED"""
+        import warnings
+
         warnings.warn(
             "``LocalValidator`` is deprecated and will be removed in v2.",
             DeprecationWarning,
@@ -88,6 +91,8 @@ class LocalValidator:
         self.schema_cache = get_local_schema_cache()
 
     def registry(self) -> Any:
+        from referencing import Registry, Resource
+
         return Registry().with_resources(
             [(k, Resource.from_contents(v)) for k, v in self.schema_cache.items()]
         )

--- a/pystac/version.py
+++ b/pystac/version.py
@@ -1,5 +1,3 @@
-import os
-
 __version__ = "1.14.2"  # x-release-please-version
 """Library version"""
 
@@ -20,6 +18,8 @@ class STACVersion:
     def get_stac_version(cls) -> str:
         if cls._override_version is not None:
             return cls._override_version
+
+        import os
 
         env_version = os.environ.get(cls.OVERRIDE_VERSION_ENV_VAR)
         if env_version is not None:


### PR DESCRIPTION
**Related Issue(s):**

- #

**Description:**

Python import times are noticeable during
interactive use of CLI applications, so
push the (near) single-use imports into
the functions where they are used so
the import cost is paid when calling
the functions instead of when starting
the CLI to print the help or do some
other unrelated action.

Timings on top of #1583 inside
a Python:3.10-bookworm container.

Before this change:

$ uv run hyperfine --warmup 3 "python3 -c 'import pystac'" Benchmark 1: python3 -c 'import pystac'
  Time (mean ± σ):      67.2 ms ±   1.6 ms    [User: 58.6 ms, System: 8.6 ms]
  Range (min … max):    62.5 ms …  69.9 ms    45 runs

After this change:

$ uv run hyperfine --warmup 3 "python3 -c 'import pystac'" Benchmark 1: python3 -c 'import pystac'
  Time (mean ± σ):      59.9 ms ±   1.5 ms    [User: 52.0 ms, System: 7.8 ms]
  Range (min … max):    56.9 ms …  64.2 ms    48 runs

**PR Checklist:**

- [X] Pre-commit hooks pass (run `pre-commit run --all-files`)
- [X] Tests pass (run `pytest`)
- [X] Documentation has been updated to reflect changes, if applicable
- [ ] This PR maintains or improves overall codebase code coverage.
- [X] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
