### PR TITLE
Add projection v1.2.0 to the list of schema URIs in projection.py

### DIFF
--- a/tests/data-files/projection/example-with-version-1.2.json
+++ b/tests/data-files/projection/example-with-version-1.2.json
@@ -1,0 +1,435 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0",
+    "id": "LC81530252014153LGN00",
+    "properties": {
+      "datetime": "2018-10-01T01:08:32.033000Z",
+      "proj:epsg": 32614,
+      "proj:code": "EPSG:32613",
+      "proj:wkt2": "PROJCS[\"WGS 84 / UTM zone 14N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-99],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],AUTHORITY[\"EPSG\",\"32614\"],AXIS[\"Easting\",EAST],AXIS[\"Northing\",NORTH]]",
+      "proj:projjson": {
+        "$schema": "https://proj.org/schemas/v0.2/projjson.schema.json",
+        "type": "ProjectedCRS",
+        "name": "WGS 84 / UTM zone 14N",
+        "base_crs": {
+          "name": "WGS 84",
+          "datum": {
+            "type": "GeodeticReferenceFrame",
+            "name": "World Geodetic System 1984",
+            "ellipsoid": {
+              "name": "WGS 84",
+              "semi_major_axis": 6378137,
+              "inverse_flattening": 298.257223563
+            }
+          },
+          "coordinate_system": {
+            "subtype": "ellipsoidal",
+            "axis": [
+              {
+                "name": "Geodetic latitude",
+                "abbreviation": "Lat",
+                "direction": "north",
+                "unit": "degree"
+              },
+              {
+                "name": "Geodetic longitude",
+                "abbreviation": "Lon",
+                "direction": "east",
+                "unit": "degree"
+              }
+            ]
+          },
+          "id": {
+            "authority": "EPSG",
+            "code": 4326
+          }
+        },
+        "conversion": {
+          "name": "UTM zone 14N",
+          "method": {
+            "name": "Transverse Mercator",
+            "id": {
+              "authority": "EPSG",
+              "code": 9807
+            }
+          },
+          "parameters": [
+            {
+              "name": "Latitude of natural origin",
+              "value": 0,
+              "unit": "degree",
+              "id": {
+                "authority": "EPSG",
+                "code": 8801
+              }
+            },
+            {
+              "name": "Longitude of natural origin",
+              "value": -99,
+              "unit": "degree",
+              "id": {
+                "authority": "EPSG",
+                "code": 8802
+              }
+            },
+            {
+              "name": "Scale factor at natural origin",
+              "value": 0.9996,
+              "unit": "unity",
+              "id": {
+                "authority": "EPSG",
+                "code": 8805
+              }
+            },
+            {
+              "name": "False easting",
+              "value": 500000,
+              "unit": "metre",
+              "id": {
+                "authority": "EPSG",
+                "code": 8806
+              }
+            },
+            {
+              "name": "False northing",
+              "value": 0,
+              "unit": "metre",
+              "id": {
+                "authority": "EPSG",
+                "code": 8807
+              }
+            }
+          ]
+        },
+        "coordinate_system": {
+          "subtype": "Cartesian",
+          "axis": [
+            {
+              "name": "Easting",
+              "abbreviation": "E",
+              "direction": "east",
+              "unit": "metre"
+            },
+            {
+              "name": "Northing",
+              "abbreviation": "N",
+              "direction": "north",
+              "unit": "metre"
+            }
+          ]
+        },
+        "area": "World - N hemisphere - 102\u00b0W to 96\u00b0W - by country",
+        "bbox": {
+          "south_latitude": 0,
+          "west_longitude": -102,
+          "north_latitude": 84,
+          "east_longitude": -96
+        },
+        "id": {
+          "authority": "EPSG",
+          "code": 32614
+        }
+      },
+      "proj:geometry": {
+        "coordinates": [
+          [
+            [
+              169200.0,
+              3712800.0
+            ],
+            [
+              403200.0,
+              3712800.0
+            ],
+            [
+              403200.0,
+              3951000.0
+            ],
+            [
+              169200.0,
+              3951000.0
+            ],
+            [
+              169200.0,
+              3712800.0
+            ]
+          ]
+        ],
+        "type": "Polygon"
+      },
+      "proj:bbox": [
+        169200.0,
+        3712800.0,
+        403200.0,
+        3951000.0
+      ],
+      "proj:centroid": {
+        "lat": 34.595302781575604,
+        "lon": -101.34448382627504
+      },
+      "proj:shape": [
+        8391,
+        8311
+      ],
+      "proj:transform": [
+        30.0,
+        0.0,
+        224985.0,
+        0.0,
+        -30.0,
+        6790215.0,
+        0.0,
+        0.0,
+        1.0
+      ]
+    },
+    "geometry": {
+      "type": "Polygon",
+      "coordinates": [
+        [
+          [
+            152.52758,
+            60.63437
+          ],
+          [
+            149.1755,
+            61.19016
+          ],
+          [
+            148.13933,
+            59.51584
+          ],
+          [
+            151.33786,
+            58.97792
+          ],
+          [
+            152.52758,
+            60.63437
+          ]
+        ]
+      ]
+    },
+    "links": [
+      {
+        "rel": "collection",
+        "href": "https://example.com/landsat/collection.json"
+      }
+    ],
+    "assets": {
+      "B1": {
+        "href": "https://landsat-pds.s3.amazonaws.com/c1/L8/107/018/LC08_L1TP_107018_20181001_20181001_01_RT/LC08_L1TP_107018_20181001_20181001_01_RT_B1.TIF",
+        "type": "image/tiff; application=geotiff",
+        "title": "Band 1 (coastal)",
+        "eo:bands": [
+          {
+            "name": "B1",
+            "common_name": "coastal",
+            "center_wavelength": 0.44,
+            "full_width_half_max": 0.02
+          }
+        ]
+      },
+      "B8": {
+        "href": "https://landsat-pds.s3.amazonaws.com/c1/L8/107/018/LC08_L1TP_107018_20181001_20181001_01_RT/LC08_L1TP_107018_20181001_20181001_01_RT_B8.TIF",
+        "type": "image/tiff; application=geotiff",
+        "title": "Band 8 (panchromatic)",
+        "eo:bands": [
+          {
+            "name": "B8",
+            "center_wavelength": 0.59,
+            "full_width_half_max": 0.18
+          }
+        ],
+        "proj:epsg": 9999,
+        "proj:code": "EPSG:9998",
+        "proj:wkt2": "PROJCS[\"WGS 84 / UTM zone 14N\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]],PROJECTION[\"Transverse_Mercator\"],PARAMETER[\"latitude_of_origin\",0],PARAMETER[\"central_meridian\",-99],PARAMETER[\"scale_factor\",0.9996],PARAMETER[\"false_easting\",500000],PARAMETER[\"false_northing\",0],AUTHORITY[\"EPSG\",\"32614\"],AXIS[\"Easting\",EAST],AXIS[\"Northing\",TEST_TEXT]]",
+        "proj:projjson": {
+          "$schema": "https://proj.org/schemas/v0.2/projjson.schema.json",
+          "type": "ProjectedCRS",
+          "name": "WGS 84 / UTM zone 14N",
+          "base_crs": {
+            "name": "WGS 84",
+            "datum": {
+              "type": "GeodeticReferenceFrame",
+              "name": "World Geodetic System 1984",
+              "ellipsoid": {
+                "name": "WGS 84",
+                "semi_major_axis": 6378137,
+                "inverse_flattening": 298.257223563
+              }
+            },
+            "coordinate_system": {
+              "subtype": "ellipsoidal",
+              "axis": [
+                {
+                  "name": "Geodetic latitude",
+                  "abbreviation": "Lat",
+                  "direction": "north",
+                  "unit": "degree"
+                },
+                {
+                  "name": "Geodetic longitude",
+                  "abbreviation": "Lon",
+                  "direction": "east",
+                  "unit": "degree"
+                }
+              ]
+            },
+            "id": {
+              "authority": "EPSG",
+              "code": 4326
+            }
+          },
+          "conversion": {
+            "name": "UTM zone 14N",
+            "method": {
+              "name": "Transverse Mercator",
+              "id": {
+                "authority": "EPSG",
+                "code": 9807
+              }
+            },
+            "parameters": [
+              {
+                "name": "Latitude of natural origin",
+                "value": 0,
+                "unit": "degree",
+                "id": {
+                  "authority": "EPSG",
+                  "code": 8801
+                }
+              },
+              {
+                "name": "Longitude of natural origin",
+                "value": -99,
+                "unit": "degree",
+                "id": {
+                  "authority": "EPSG",
+                  "code": 8802
+                }
+              },
+              {
+                "name": "Scale factor at natural origin",
+                "value": 0.9996,
+                "unit": "unity",
+                "id": {
+                  "authority": "EPSG",
+                  "code": 8805
+                }
+              },
+              {
+                "name": "False easting",
+                "value": 500000,
+                "unit": "metre",
+                "id": {
+                  "authority": "EPSG",
+                  "code": 8806
+                }
+              },
+              {
+                "name": "False northing",
+                "value": 0,
+                "unit": "metre",
+                "id": {
+                  "authority": "EPSG",
+                  "code": 8807
+                }
+              }
+            ]
+          },
+          "coordinate_system": {
+            "subtype": "Cartesian",
+            "axis": [
+              {
+                "name": "Easting",
+                "abbreviation": "E",
+                "direction": "east",
+                "unit": "metre"
+              },
+              {
+                "name": "Northing",
+                "abbreviation": "N",
+                "direction": "north",
+                "unit": "metre"
+              }
+            ]
+          },
+          "area": "World - N hemisphere - 102\u00b0W to 96\u00b0W - by country",
+          "bbox": {
+            "south_latitude": 0,
+            "west_longitude": -102,
+            "north_latitude": 84,
+            "east_longitude": -96
+          },
+          "id": {
+            "authority": "EPSG",
+            "code": 9999
+          }
+        },
+        "proj:geometry": {
+          "coordinates": [
+            [
+              [
+                0.0,
+                0.0
+              ],
+              [
+                1.0,
+                0.0
+              ],
+              [
+                1.0,
+                1.0
+              ],
+              [
+                1.0,
+                0.0
+              ],
+              [
+                0.0,
+                0.0
+              ]
+            ]
+          ],
+          "type": "Polygon"
+        },
+        "proj:bbox": [
+          1.0,
+          2.0,
+          3.0,
+          4.0
+        ],
+        "proj:centroid": {
+          "lat": 0.5,
+          "lon": 0.3
+        },
+        "proj:shape": [
+          16781,
+          16621
+        ],
+        "proj:transform": [
+          15.0,
+          0.0,
+          224992.5,
+          0.0,
+          -15.0,
+          6790207.5,
+          0.0,
+          0.0,
+          1.0
+        ]
+      }
+    },
+    "bbox": [
+      148.13933,
+      59.51584,
+      152.52758,
+      60.63437
+    ],
+    "stac_extensions": [
+      "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
+      "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
+    ],
+    "collection": "landsat-8-l1"
+  }

--- a/tests/extensions/test_projection.py
+++ b/tests/extensions/test_projection.py
@@ -574,7 +574,28 @@ def test_get_set_code(projection_landsat8_item: Item) -> None:
     assert proj_item.properties["proj:code"] == "IAU_2015:30100"
 
 
-def test_migrate_item() -> None:
+def test_migrate_item_on_1_2() -> None:
+    old = "https://stac-extensions.github.io/projection/v1.2.0/schema.json"
+    current = "https://stac-extensions.github.io/projection/v2.0.0/schema.json"
+
+    path = TestCases.get_path("data-files/projection/example-with-version-1.2.json")
+    with pytest.warns(UserWarning, match="surprising behavior"):
+        item = Item.from_file(path)
+
+    assert old not in item.stac_extensions
+    assert current in item.stac_extensions
+
+    assert item.ext.proj.epsg == 32613
+    assert item.ext.proj.code == "EPSG:32613"
+
+    assert item.assets["B1"].ext.proj.epsg == 32613
+    assert item.assets["B1"].ext.proj.code == "EPSG:32613"
+
+    assert item.assets["B8"].ext.proj.epsg == 9998
+    assert item.assets["B8"].ext.proj.code == "EPSG:9998"
+
+
+def test_migrate_item_on_1_1() -> None:
     old = "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
     current = "https://stac-extensions.github.io/projection/v2.0.0/schema.json"
 


### PR DESCRIPTION
**Description:**
The migration of projection to latest version systematically pops the field epsg. If extension URI is pointing to versions 1.0.0 or 1.1.0, it is also changed to point to version 2.0.0.  However, if schema URI is v1.2.0, the extension schema URI is not updated. Although it is not necessary to validate items as both properties `proj:code` and `proj:epsg` are authorized in that v1.2.0, I propose to update it as well to v2.0.0 when migrating so that the change is explicit for all versions < 2.0.0. That would help finding out that a change occurred without having to inspect all assets.

**PR Checklist:**

- [x] Pre-commit hooks pass (run `pre-commit run --all-files`)
- [x] Tests pass (run `pytest`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage.
- [ ] Changes are added to the [CHANGELOG](https://github.com/stac-utils/pystac/blob/main/CHANGELOG.md). See [the docs](https://pystac.readthedocs.io/en/latest/contributing.html#changelog) for information about adding to the changelog.
