### PR TITLE
ci: checkout with bot token

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -40,8 +40,6 @@ jobs:
       - name: Commit and push changes
         if: ${{ steps.release-please.outputs.prs_created }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
           git diff --staged --quiet || git commit -m "chore: update static files and test recordings"
           git push


### PR DESCRIPTION
It looks like **release-please** worked! https://github.com/stac-utils/pystac/pull/1603

One tweak is that the extra commit that we pushed used the Github token, which isn't allowed to trigger workflows. This PR tweaks that to use the app token, which _should_ allow the extra commit to start the workflow runs.