### PR TITLE
refactor: while iterating, warn the user if a next link is present

### DIFF
--- a/pystac/stac_object.py
+++ b/pystac/stac_object.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable
 from html import escape
@@ -426,12 +427,21 @@ class STACObject(ABC):
         if modify_links:
             links = modify_links(links)
 
+        has_next_link = False
         for i in range(0, len(links)):
             link = links[i]
             if link.rel == rel:
                 link.resolve_stac_object(root=self.get_root())
                 if typ is None or isinstance(link.target, typ):
                     yield cast(STACObject, link.target)
+            if link.rel == "next":
+                has_next_link = True
+        if has_next_link:
+            warnings.warn(
+                "This STAC object has a 'next' link, but pystac does not support "
+                "pagination. If you need to paginate through responses from a STAC "
+                "API, use pystac-client: https://github.com/stac-utils/pystac-client"
+            )
 
     def save_object(
         self,

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -21,6 +21,7 @@ from pystac import (
     CatalogType,
     Collection,
     Item,
+    Link,
     MediaType,
 )
 from pystac.errors import STACError
@@ -2030,3 +2031,9 @@ def test_clone_extra_fields(catalog: Catalog) -> None:
     catalog.extra_fields["foo"] = "bar"
     cloned = catalog.clone()
     assert cloned.extra_fields["foo"] == "bar"
+
+
+def test_warn_if_next_link_present(catalog: Catalog) -> None:
+    catalog.links.append(Link(rel="next", target="./next.json"))
+    with pytest.warns(UserWarning):
+        _ = list(catalog.get_children())


### PR DESCRIPTION
**Related Issue(s):**

- Closes #1610 

**Description:**

Simple warning, I didn't pick a type so it's just a `UserWarning`, which feels appropriate? Here's what it looks like when running the script in the motivating issue:

```sh
$ python issue_1611.py
/Users/gadomski/Code/stac-utils/pystac/pystac/stac_object.py:440: UserWarning: This STAC object has a 'next' link, but pystac does not support pagination. If you need to paginate through responses from a STAC API, use pystac-client: https://github.com/stac-utils/pystac-client
  warnings.warn(
PySTAC: 100
Manual: 609
```

**PR Checklist:**

- [x] Pre-commit hooks pass (run `pre-commit run --all-files`)
- [x] Tests pass (run `pytest`)
- [x] This PR maintains or improves overall codebase code coverage
- [x] This PR's title is formatted per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
