### PR TITLE
fix: use supertype parameter name

### DIFF
--- a/pystac/extensions/label.py
+++ b/pystac/extensions/label.py
@@ -816,9 +816,9 @@ class LabelExtensionHooks(ExtensionHooks):
     stac_object_types = {pystac.STACObjectType.ITEM}
 
     def get_object_links(
-        self, so: pystac.STACObject
+        self, obj: pystac.STACObject
     ) -> list[str | pystac.RelType] | None:
-        if isinstance(so, pystac.Item):
+        if isinstance(obj, pystac.Item):
             return [LabelRelType.SOURCE]
         return None
 

--- a/pystac/extensions/version.py
+++ b/pystac/extensions/version.py
@@ -418,8 +418,8 @@ class VersionExtensionHooks(ExtensionHooks):
         STACObjectType.CATALOG,
     }
 
-    def get_object_links(self, so: STACObject) -> list[str] | None:
-        if isinstance(so, Collection) or isinstance(so, Item):
+    def get_object_links(self, obj: STACObject) -> list[str] | None:
+        if isinstance(obj, Collection) or isinstance(obj, Item):
             return [
                 VersionRelType.LATEST,
                 VersionRelType.PREDECESSOR,


### PR DESCRIPTION
**Related Issue(s):**

- #

**Description:**

Split out from #1614.

The parameter on the supertype is
named "obj", so use the same name
for the override.

**PR Checklist:**

- [ ] Pre-commit hooks pass (run `pre-commit run --all-files`)
- [ ] Tests pass (run `pytest`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [ ] This PR maintains or improves overall codebase code coverage
- [X] This PR's title is formatted per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
