### PR TITLE
ci: tweak Dependabot settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,13 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+    groups:
+      actions-deps:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 10
     commit-message:
       prefix: build(deps)
   - package-ecosystem: pip


### PR DESCRIPTION
**Related Issue(s):**

- #1618

**Description:**

Pinning actions by hash will cause
Dependabot to make more pull requests.
Reduce the interval to a weekly interval
and group all the action updates into
a single pull request to keep the amount
manageable.

Also add a cooldown of 10 days,
so the community has a chance to find
compromised releases before Dependabot
makes a pull request out of it.

**PR Checklist:**

- [ ] Pre-commit hooks pass (run `pre-commit run --all-files`)
- [ ] Tests pass (run `pytest`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [ ] This PR maintains or improves overall codebase code coverage
- [X] This PR's title is formatted per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
