### PR TITLE
chore: update dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 jinja2 = ["jinja2<4.0"]
 orjson = ["orjson>=3.5"]
-urllib3 = ["urllib3>=1.26"]
+urllib3 = ["urllib3>=2.6.0"]
 validation = ["jsonschema~=4.18"]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -3164,7 +3164,7 @@ requires-dist = [
     { name = "jsonschema", marker = "extra == 'validation'", specifier = "~=4.18" },
     { name = "orjson", marker = "extra == 'orjson'", specifier = ">=3.5" },
     { name = "python-dateutil", specifier = ">=2.7.0" },
-    { name = "urllib3", marker = "extra == 'urllib3'", specifier = ">=1.26" },
+    { name = "urllib3", marker = "extra == 'urllib3'", specifier = ">=2.6.0" },
 ]
 provides-extras = ["jinja2", "orjson", "urllib3", "validation"]
 
@@ -4231,11 +4231,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.5.0"
+version = "2.6.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185, upload-time = "2025-06-18T14:07:41.644Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/24/a2a2ed9addd907787d7aa0355ba36a6cadf1768b934c652ea78acbd59dcd/urllib3-2.6.2.tar.gz", hash = "sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797", size = 432930, upload-time = "2025-12-11T15:56:40.252Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795, upload-time = "2025-06-18T14:07:40.39Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b9/4095b668ea3678bf6a0af005527f39de12fb026516fb3df17495a733b7f8/urllib3-2.6.2-py3-none-any.whl", hash = "sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd", size = 131182, upload-time = "2025-12-11T15:56:38.584Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Related Issue(s):**

- #

**Description:**

The [OpenSSF scorecard](https://securityscorecards.dev/viewer/?uri=github.com/stac-utils/pystac) reports 6 vulnerabilities:
```
Details
Warn: Project is vulnerable to: https://osv.dev/GHSA-w853-jp5j-5j7f
Warn: Project is vulnerable to: https://osv.dev/GHSA-vvfj-2jqx-52jm
Warn: Project is vulnerable to: https://osv.dev/GHSA-xm59-rqc7-hhvf
Warn: Project is vulnerable to: https://osv.dev/GHSA-7f5h-v6xp-fcq8
Warn: Project is vulnerable to: https://osv.dev/GHSA-2xpw-w6gg-jr37
Warn: Project is vulnerable to: https://osv.dev/GHSA-gm62-xv2j-4w53
```
so update the dependencies to versions
that have fixed the CVEs.

**PR Checklist:**

- [ ] Pre-commit hooks pass (run `pre-commit run --all-files`)
- [X] Tests pass (run `pytest`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [ ] This PR maintains or improves overall codebase code coverage
- [X] This PR's title is formatted per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
