### PR TITLE
fix: typo nework --> network in test_summaries.py

### DIFF
--- a/tests/test_summaries.py
+++ b/tests/test_summaries.py
@@ -55,7 +55,7 @@ def test_summary_wrong_custom_fields_file() -> None:
     assert "No such file or directory" in str(context.value)
 
 
-def test_can_open_fields_file_even_with_no_nework() -> None:
+def test_can_open_fields_file_even_with_no_network() -> None:
     old_socket = socket.socket
     try:
 


### PR DESCRIPTION
**Description:**

This is a trivial typo fix in a test name.

**PR Checklist:**

- [ ] Pre-commit hooks pass (run `pre-commit run --all-files`)
- [ ] Tests pass (run `pytest`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [ ] This PR maintains or improves overall codebase code coverage
- [ ] This PR's title is formatted per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
