### PR TITLE
fix: /vsi* paths are always absolute

### DIFF
--- a/pystac/utils.py
+++ b/pystac/utils.py
@@ -394,7 +394,8 @@ def is_absolute_href(href: str, start_href: str | None = None) -> bool:
         bool: ``True`` if the given HREF is absolute, ``False`` if it is relative.
     """
     parsed = safe_urlparse(href)
-    if parsed.scheme not in ["", "file"]:
+    # We treat /vsi paths, from GDAL, as absolute
+    if parsed.scheme not in ["", "file"] or parsed.path.startswith("/vsi"):
         return True
     else:
         parsed_start_scheme = (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -200,13 +200,15 @@ def test_make_absolute_href_windows(
 
 
 def test_is_absolute_href() -> None:
-    # Test cases of (href, expected)
+    # Test cases of (href, expected, start_href)
     test_cases = [
         ("item.json", False, None),
         ("./item.json", False, None),
         ("../item.json", False, None),
         ("http://stacspec.org/item.json", True, None),
         ("http://stacspec.org/item.json", True, "http://stacspec.org/"),
+        ("/vsigs/file.tiff", True, None),
+        ("/vsigs/file.tiff", True, "http://stacspec.org/"),
     ]
 
     for href, expected, start_href in test_cases:


### PR DESCRIPTION
**Related Issue(s):**

- Closes #1612

**Description:**

It's clunky.

**PR Checklist:**

- [x] Pre-commit hooks pass (run `pre-commit run --all-files`)
- [x] Tests pass (run `pytest`)
- [x] This PR maintains or improves overall codebase code coverage
- [x] This PR's title is formatted per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
