### PR TITLE
chore: update to urllib3 2.6.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dynamic = ["version"]
 [project.optional-dependencies]
 jinja2 = ["jinja2<4.0"]
 orjson = ["orjson>=3.5"]
-urllib3 = ["urllib3>=2.6.0"]
+urllib3 = ["urllib3>=2.6.3"]
 validation = ["jsonschema~=4.18"]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -3164,14 +3164,14 @@ requires-dist = [
     { name = "jsonschema", marker = "extra == 'validation'", specifier = "~=4.18" },
     { name = "orjson", marker = "extra == 'orjson'", specifier = ">=3.5" },
     { name = "python-dateutil", specifier = ">=2.7.0" },
-    { name = "urllib3", marker = "extra == 'urllib3'", specifier = ">=2.6.0" },
+    { name = "urllib3", marker = "extra == 'urllib3'", specifier = ">=2.6.3" },
 ]
 provides-extras = ["jinja2", "orjson", "urllib3", "validation"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "asv", specifier = ">=0.6.4" },
-    { name = "codespell", specifier = "<2.3" },
+    { name = "codespell", specifier = "<2.5" },
     { name = "coverage", specifier = ">=7.6.2" },
     { name = "doc8", specifier = ">=1.1.2" },
     { name = "filelock", specifier = ">=3.20.1" },
@@ -4231,11 +4231,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.2"
+version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1e/24/a2a2ed9addd907787d7aa0355ba36a6cadf1768b934c652ea78acbd59dcd/urllib3-2.6.2.tar.gz", hash = "sha256:016f9c98bb7e98085cb2b4b17b87d2c702975664e4f060c6532e64d1c1a5e797", size = 432930, upload-time = "2025-12-11T15:56:40.252Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/b9/4095b668ea3678bf6a0af005527f39de12fb026516fb3df17495a733b7f8/urllib3-2.6.2-py3-none-any.whl", hash = "sha256:ec21cddfe7724fc7cb4ba4bea7aa8e2ef36f607a4bab81aa6ce42a13dc3f03dd", size = 131182, upload-time = "2025-12-11T15:56:38.584Z" },
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Related Issue(s):**

- #

**Description:**

This fixes GHSA-38jv-5279-wg99.

**PR Checklist:**

- [ ] Pre-commit hooks pass (run `pre-commit run --all-files`)
- [X] Tests pass (run `pytest`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [ ] This PR maintains or improves overall codebase code coverage
- [X] This PR's title is formatted per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
