### PR TITLE
feat: V2 links updates

### DIFF
--- a/src/pystac/link.py
+++ b/src/pystac/link.py
@@ -159,6 +159,20 @@ class Link:
             if href := value.get_self_href():
                 self.set_href(href)
 
+    @deprecated("use .get_href()")
+    def get_target_str(self) -> str | None:
+        """Returns this link's target as a string.
+
+        If a string href was provided, returns that. If not, tries to resolve
+        the self link of the target object.
+        """
+        return self.get_href()
+
+    @deprecated("use bool(link.get_href())")
+    def has_target_href(self) -> bool:
+        """Returns true if this link has a string href in its target information."""
+        return bool(self.get_href())
+
     def get_target(self, start_href: str | None, reader: Reader) -> STACObject:
         from .stac_object import STACObject
 

--- a/src/pystac/link.py
+++ b/src/pystac/link.py
@@ -257,6 +257,16 @@ class Link:
 
     ##### Convenience methods for Link creation #####
     @classmethod
+    def root(cls: type[Self], c: Catalog) -> Self:
+        """Creates a link to a root Catalog or Collection."""
+        return cls(RelType.ROOT, c, media_type=MediaType.JSON)
+
+    @classmethod
+    def parent(cls: type[Self], c: Catalog, title: str | None = None) -> Self:
+        """Creates a link to a parent Catalog or Collection."""
+        return cls(RelType.PARENT, c, title=title, media_type=MediaType.JSON)
+
+    @classmethod
     def collection(cls: type[Self], c: Collection) -> Self:
         """Creates a link to a Collection."""
         return cls(RelType.COLLECTION, c, media_type=MediaType.JSON)

--- a/src/pystac/link.py
+++ b/src/pystac/link.py
@@ -48,7 +48,14 @@ class Link:
         self.method: str | None = method
         self.headers: dict[str, str | list[str]] | None = headers
         self.body: Any | None = body
+        extra_fields = kwargs.pop("extra_fields", None)
         self.extra_fields: dict[str, Any] = kwargs
+        if extra_fields:
+            warnings.warn(
+                "Pass extra_fields entries as kwargs "
+                "instead of extra_fields as keyword argument."
+            )
+            self.extra_fields.update(extra_fields)
 
         if isinstance(target, STACObject):
             self._href: str | None = href or target.get_self_href()

--- a/src/pystac/link.py
+++ b/src/pystac/link.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import copy
 import warnings
-from typing import TYPE_CHECKING, Any, override
+from typing import TYPE_CHECKING, Any, Self, override
 
 from typing_extensions import deprecated
 
@@ -14,6 +14,7 @@ from pystac.utils import make_absolute_href, make_posix_style
 from .reader import Reader
 
 if TYPE_CHECKING:
+    from . import Catalog, Collection, Item
     from .stac_object import STACObject
 
 HIERARCHICAL_LINKS = [
@@ -50,6 +51,7 @@ class Link:
 
         if isinstance(target, STACObject):
             self._href: str | None = href or target.get_self_href()
+            self.title = title or getattr(target, "title", None)
             self._target: STACObject | None = target
         elif href and target:
             raise ValueError("Both target and href were provided as strings")
@@ -81,6 +83,9 @@ class Link:
             return None
         else:
             return super().__getattribute__(name)
+
+    def clone(self: Self) -> Self:
+        return copy.deepcopy(self)
 
     @classmethod
     def try_from(cls, data: dict[str, Any] | Link) -> Link:
@@ -120,6 +125,12 @@ class Link:
     def get_href(self) -> str | None:
         return self._href or self._target and self._target.get_self_href()
 
+    def get_absolute_href(self, start_href: str = "") -> str | None:
+        href = self.get_href()
+        if href is None:
+            return href
+        return make_absolute_href(href, start_href, start_is_dir=False)
+
     def set_href(self, href: str) -> None:
         self._href = href
 
@@ -132,6 +143,20 @@ class Link:
     @deprecated("target is deprecated, either use .get_href() or .get_target()")
     def target(self) -> str | STACObject | None:
         return self._target or self._href
+
+    @target.setter
+    @deprecated("target is deprecated, either use .set_href() or .set_target()")
+    def target(self, value: str | STACObject) -> None:
+        if isinstance(value, str):
+            warnings.warn(
+                "Setting Link.target to href is no longer supported pystac v2.  "
+                "Assigning value to href instead."
+            )
+            self.set_href(value)
+        else:
+            self.set_target(value)
+            if href := value.get_self_href():
+                self.set_href(href)
 
     def get_target(self, start_href: str | None, reader: Reader) -> STACObject:
         from .stac_object import STACObject
@@ -186,3 +211,50 @@ class Link:
     @override
     def __repr__(self) -> str:
         return f"Link(rel={self.rel}, href={self._href})"
+
+    ##### Convenience methods for Link creation #####
+    @classmethod
+    def collection(cls: type[Self], c: Collection) -> Self:
+        """Creates a link to a Collection."""
+        return cls(RelType.COLLECTION, c, media_type=MediaType.JSON)
+
+    @classmethod
+    def self_href(cls: type[Self], href: str) -> Self:
+        """Creates a self link to a file's location."""
+        return cls(RelType.SELF, href, media_type=MediaType.JSON)
+
+    @classmethod
+    def child(cls: type[Self], c: Catalog, title: str | None = None) -> Self:
+        """Creates a link to a child Catalog or Collection."""
+        return cls(RelType.CHILD, c, title=title, media_type=MediaType.JSON)
+
+    @classmethod
+    def item(cls: type[Self], item: Item, title: str | None = None) -> Self:
+        """Creates a link to an Item."""
+        return cls(RelType.ITEM, item, title=title, media_type=MediaType.GEOJSON)
+
+    @classmethod
+    def derived_from(
+        cls: type[Self], item: Item | str, title: str | None = None
+    ) -> Self:
+        """Creates a link to a derived_from Item."""
+        return cls(
+            RelType.DERIVED_FROM,
+            item,
+            title=title,
+            media_type=MediaType.JSON,
+        )
+
+    @classmethod
+    def canonical(
+        cls: type[Self],
+        item_or_collection: Item | Collection,
+        title: str | None = None,
+    ) -> Self:
+        """Creates a canonical link to an Item or Collection."""
+        return cls(
+            RelType.CANONICAL,
+            item_or_collection,
+            title=title,
+            media_type=MediaType.JSON,
+        )

--- a/src/pystac/link.py
+++ b/src/pystac/link.py
@@ -6,10 +6,11 @@ from typing import TYPE_CHECKING, Any, Self, override
 
 from typing_extensions import deprecated
 
+import pystac
 from pystac.errors import STACError
 from pystac.media_type import MediaType
 from pystac.rel_type import RelType
-from pystac.utils import make_absolute_href, make_posix_style
+from pystac.utils import is_absolute_href, make_absolute_href, make_posix_style
 
 from .reader import Reader
 
@@ -207,6 +208,34 @@ class Link:
         if self.body is not None:
             data["body"] = self.body
         return data
+
+    def resolve_stac_object(self, start_href: str = "") -> Link:
+        """Resolves a STAC object from the HREF of this link, if the link is not
+        already resolved.
+
+        Args:
+            start_href : Optional string to put ahead of the href in this Link.
+
+        NOTE: This uses reader.DEFAULT_READER to read the HREF, if necessary.
+        """
+        if self._target:
+            return self
+        elif self._href:
+            # If it's a relative link, base it off the parent.
+            target_href = self._href
+            if not is_absolute_href(target_href):
+                target_href = make_absolute_href(self._href, start_href=start_href)
+            try:
+                obj = pystac.read_file(target_href)
+            except Exception as e:
+                raise STACError(
+                    f"HREF: '{target_href}' does not resolve to a STAC object"
+                ) from e
+            self._target = obj
+        else:
+            raise ValueError("Cannot resolve STAC object without a target")
+
+        return self
 
     @override
     def __repr__(self) -> str:

--- a/tests/v1/conftest.py
+++ b/tests/v1/conftest.py
@@ -37,6 +37,13 @@ def collection() -> Catalog:
 
 
 @pytest.fixture
+def self_link_collection() -> Catalog:
+    c = Collection("test-collection", "A test collection", ARBITRARY_EXTENT)
+    c.set_self_href("file:///a/real/url.json")
+    return c
+
+
+@pytest.fixture
 def multi_extent_collection() -> Collection:
     # TODO this code is repeated many times; refactor to use this fixture
     return Collection.from_file(

--- a/tests/v1/posix_paths/test_posix_paths.py
+++ b/tests/v1/posix_paths/test_posix_paths.py
@@ -71,6 +71,16 @@ def test_create_item_containing_posix_hrefs(tmp_path: Path) -> None:
     pystac.read_file(collection_href)
 
 
+def test_posix_self_link_added_from_file(tmp_path: Path) -> None:
+    href = get_data_file("item/sample-item.json")
+    item = pystac.Item.from_file(href)
+    item.links.append(pystac.Link(rel="self", href=href))
+    check_link(item.get_single_link(rel="self"))
+    item2 = pystac.read_file(href)
+    item2.links.append(pystac.Link(rel="self", href=href))
+    check_link(item2.get_single_link(rel="self"))
+
+
 @pytest.mark.skipif(os.name != "nt", reason="windows only test")
 def test_posix_self_link_from_absolute_href(tmp_path: Path) -> None:
     # Check that we convert to a windows style (\\) absolute href to posix style

--- a/tests/v1/test_link.py
+++ b/tests/v1/test_link.py
@@ -1,9 +1,10 @@
 import json
 import os
+import re
 from datetime import datetime
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, cast
+from typing import Any
 
 import pytest
 
@@ -128,9 +129,14 @@ def test_target_getter_setter(item: pystac.Item) -> None:
     link.set_href("./dead/d011.json")
     assert link.target == item  # target remains unchanged
     assert link.get_href() == "./dead/d011.json"  # href is updated
-    assert (
-        link.target.get_self_href() == "file:///bad/beef.json"
-    )  # set_href doesn't update target
+
+    expected_pattern_ltsh = r"file://([A-Z]:)?/bad/beef.json"
+    actual_ltsh = link.target.get_self_href()
+    # windows compatible absolute url regular expression.
+    # set_href doesn't update target, but self_href is mutated to be absolute.
+    assert actual_ltsh and re.match(expected_pattern_ltsh, actual_ltsh), (
+        f"{actual_ltsh} does not match {expected_pattern_ltsh}"
+    )
 
 
 def test_get_target_str_no_href(item: Item) -> None:

--- a/tests/v1/test_link.py
+++ b/tests/v1/test_link.py
@@ -9,7 +9,7 @@ from typing import Any
 import pytest
 
 import pystac
-from pystac import Catalog, Collection, Extent, Item, Link, MediaType, RelType
+from pystac import Collection, Item, Link
 from pystac.errors import STACError
 from pystac.link import HIERARCHICAL_LINKS
 from pystac.utils import make_posix_style
@@ -24,14 +24,14 @@ TEST_DATETIME: datetime = datetime(2020, 3, 14, 16, 32)
 def test_path_like() -> None:
     rel = "some-rel"
     target = os.path.abspath("../elsewhere")
-    link = Link(rel, target)
+    link = pystac.Link(rel, target)
     assert os.fspath(link) == make_posix_style(target)
 
 
 def test_minimal(item: pystac.Item) -> None:
     rel = "my rel"
     target = "https://example.com/a/b"
-    link = Link(rel, target)
+    link = pystac.Link(rel, target)
     assert target == link.get_href()
     assert target == link.get_absolute_href()
 
@@ -59,7 +59,7 @@ def test_relative() -> None:
     rel = "my rel"
     target = "../elsewhere"
     mime_type = "example/stac_thing"
-    link = Link(
+    link = pystac.Link(
         rel, target, media_type=mime_type, title="a title", extra_fields={"a": "b"}
     )
     expected_dict = {
@@ -76,7 +76,7 @@ def test_relative() -> None:
 
 def test_link_does_not_fail_if_href_is_none(item: pystac.Item) -> None:
     """Test to ensure get_href does not fail when the href is None."""
-    catalog = Catalog(id="test", description="test desc")
+    catalog = pystac.Catalog(id="test", description="test desc")
     catalog.add_item(item)
     catalog.set_self_href("/some/href")
 
@@ -86,13 +86,13 @@ def test_link_does_not_fail_if_href_is_none(item: pystac.Item) -> None:
 
 
 def test_resolve_stac_object_no_root_and_target_is_item(item: pystac.Item) -> None:
-    link = Link("my rel", target=item)
+    link = pystac.Link("my rel", target=item)
     link.resolve_stac_object()
 
 
 @pytest.mark.skipif(os.name == "nt", reason="Non-windows test")
 def test_resolve_stac_object_throws_informative_error() -> None:
-    link = Link("root", target="/a/b/foo.json")
+    link = pystac.Link("root", target="/a/b/foo.json")
     with pytest.raises(
         STACError, match="HREF: '/a/b/foo.json' does not resolve to a STAC object"
     ):
@@ -100,19 +100,19 @@ def test_resolve_stac_object_throws_informative_error() -> None:
 
 
 def test_resolved_self_href() -> None:
-    catalog = Catalog(id="test", description="test desc")
+    catalog = pystac.Catalog(id="test", description="test desc")
     with TemporaryDirectory() as temporary_directory:
         catalog.normalize_and_save(temporary_directory)
         path = os.path.join(temporary_directory, "catalog.json")
-        catalog = Catalog.from_file(path)
-        link = catalog.get_single_link(RelType.SELF)
+        catalog = pystac.Catalog.from_file(path)
+        link = catalog.get_single_link(pystac.RelType.SELF)
         assert link
         link.resolve_stac_object()
         assert link.get_absolute_href() == make_posix_style(path)
 
 
 def test_target_getter_setter(item: pystac.Item) -> None:
-    link = Link("my rel", target="./foo/bar.json")
+    link = pystac.Link("my rel", target="./foo/bar.json")
     assert link.target == "./foo/bar.json"
     assert link.get_href() == "./foo/bar.json"
 
@@ -136,9 +136,9 @@ def test_target_getter_setter(item: pystac.Item) -> None:
     )
 
 
-def test_get_target_str_no_href(item: Item) -> None:
+def test_get_target_str_no_href(item: pystac.Item) -> None:
     item.remove_links("self")
-    link = Link("self", target=item)
+    link = pystac.Link("self", target=item)
     item.add_link(link)
     assert link.get_href() is None
 
@@ -161,33 +161,33 @@ def test_relative_self_href(item: pystac.Item) -> None:
 
 
 def test_auto_title_when_resolved(item: pystac.Item) -> None:
-    extent = Extent.from_items([item])
-    collection = Collection(
+    extent = pystac.Extent.from_items([item])
+    collection = pystac.Collection(
         id="my_collection",
         description="Test Collection",
         extent=extent,
         title="Collection Title",
     )
-    link = Link("my rel", target=collection)
+    link = pystac.Link("my rel", target=collection)
 
     assert collection.title == link.title
 
 
 def test_auto_title_not_found(item: pystac.Item) -> None:
-    extent = Extent.from_items([item])
-    collection = Collection(
+    extent = pystac.Extent.from_items([item])
+    collection = pystac.Collection(
         id="my_collection",
         description="Test Collection",
         extent=extent,
     )
-    link = Link("my rel", target=collection)
+    link = pystac.Link("my rel", target=collection)
 
     assert link.title is None
 
 
 def test_auto_title_is_serialized(item: pystac.Item) -> None:
-    extent = Extent.from_items([item])
-    collection = Collection(
+    extent = pystac.Extent.from_items([item])
+    collection = pystac.Collection(
         id="my_collection",
         description="Test Collection",
         extent=extent,
@@ -195,28 +195,28 @@ def test_auto_title_is_serialized(item: pystac.Item) -> None:
     )
     collection.set_self_href("file:///dev/null")
 
-    link = Link("my rel", target=collection)
+    link = pystac.Link("my rel", target=collection)
 
     assert link.to_dict().get("title") == collection.title
 
 
 def test_no_auto_title_if_not_resolved() -> None:
-    link = Link("my rel", target="https://www.some-domain.com/path/to/thing.txt")
+    link = pystac.Link("my rel", target="https://www.some-domain.com/path/to/thing.txt")
 
     assert link.title is None
 
 
 def test_title_as_init_argument(item: pystac.Item) -> None:
     link_title = "Link title"
-    extent = Extent.from_items([item])
-    collection = Collection(
+    extent = pystac.Extent.from_items([item])
+    collection = pystac.Collection(
         id="my_collection",
         description="Test Collection",
         extent=extent,
         title="Collection Title",
     )
     collection.set_self_href("file:///dev/null")
-    link = Link("my rel", title=link_title, target=collection)
+    link = pystac.Link("my rel", title=link_title, target=collection)
 
     assert link.title == link_title
     assert link.to_dict().get("title") == link_title
@@ -227,10 +227,10 @@ def test_serialize_link() -> None:
     title = "A Test Link"
     # Positional is lame
     # link = Link(RelType.SELF, None, href, MediaType.JSON, title)
-    link = Link(
-        rel=RelType.SELF,
+    link = pystac.Link(
+        rel=pystac.RelType.SELF,
         href=href,
-        media_type=MediaType.JSON,
+        media_type=pystac.MediaType.JSON,
         title=title,
     )
     link_dict = link.to_dict()
@@ -248,7 +248,7 @@ def test_static_from_dict_round_trip() -> None:
         {"rel": "r", "href": "t", "type": "a/b", "title": "t", "c": "d", "1": 2},
     ]
     for d in test_cases:
-        d2 = Link.from_dict(d).to_dict()
+        d2 = pystac.Link.from_dict(d).to_dict()
         assert d == d2
     d = {"rel": "self", "href": "t"}
     d2 = {"rel": "self", "href": "t"}
@@ -262,10 +262,8 @@ def test_static_from_dict_failures() -> None:
             Link.from_dict(d)
 
 
-def test_static_collection(
-    self_link_collection: pystac.Collection,
-) -> None:
-    link = Link.collection(self_link_collection)
+def test_static_collection(self_link_collection: Collection) -> None:
+    link = pystac.Link.collection(self_link_collection)
     expected = {
         "rel": "collection",
         "href": self_link_collection.get_self_href(),
@@ -274,8 +272,8 @@ def test_static_collection(
     assert expected == link.to_dict()
 
 
-def test_static_child(self_link_collection: pystac.Collection) -> None:
-    link = Link.child(self_link_collection)
+def test_static_child(self_link_collection: Collection) -> None:
+    link = pystac.Link.child(self_link_collection)
     expected = {
         "rel": "child",
         "href": self_link_collection.get_self_href(),
@@ -286,7 +284,7 @@ def test_static_child(self_link_collection: pystac.Collection) -> None:
 
 def test_static_canonical_item(item: pystac.Item) -> None:
     item.set_self_href("file:///bad/beef.json")
-    link = Link.canonical(item)
+    link = pystac.Link.canonical(item)
     expected = {
         "rel": "canonical",
         "href": item.get_self_href(),
@@ -295,8 +293,8 @@ def test_static_canonical_item(item: pystac.Item) -> None:
     assert expected == link.to_dict()
 
 
-def test_static_canonical_collection(self_link_collection: pystac.Collection) -> None:
-    link = Link.canonical(self_link_collection)
+def test_static_canonical_collection(self_link_collection: Collection) -> None:
+    link = pystac.Link.canonical(self_link_collection)
     expected = {
         "rel": "canonical",
         "href": self_link_collection.get_self_href(),
@@ -316,22 +314,22 @@ def test_inheritance_from_dict() -> None:
     assert isinstance(link, CustomLink)
 
 
-def test_inheritance_collection(collection: pystac.Collection) -> None:
+def test_inheritance_collection(collection: Collection) -> None:
     link = CustomLink.collection(collection)
     assert isinstance(link, CustomLink)
 
 
-def test_inheritance_child(collection: pystac.Collection) -> None:
+def test_inheritance_child(collection: Collection) -> None:
     link = CustomLink.child(collection)
     assert isinstance(link, CustomLink)
 
 
-def test_inheritance_canonical_item(item: pystac.Item) -> None:
+def test_inheritance_canonical_item(item: Item) -> None:
     link = CustomLink.canonical(item)
     assert isinstance(link, CustomLink)
 
 
-def test_inheritance_canonical_collection(collection: pystac.Collection) -> None:
+def test_inheritance_canonical_collection(collection: Collection) -> None:
     link = CustomLink.canonical(collection)
     assert isinstance(link, CustomLink)
 

--- a/tests/v1/test_link.py
+++ b/tests/v1/test_link.py
@@ -85,13 +85,11 @@ def test_link_does_not_fail_if_href_is_none(item: pystac.Item) -> None:
     assert link.get_href() is None
 
 
-@pytest.mark.xfail(reason="STACObjects no longer have resolve_stac_object method")
 def test_resolve_stac_object_no_root_and_target_is_item(item: pystac.Item) -> None:
     link = Link("my rel", target=item)
     link.resolve_stac_object()
 
 
-@pytest.mark.xfail(reason="STACObjects no longer have resolve_stac_object method")
 @pytest.mark.skipif(os.name == "nt", reason="Non-windows test")
 def test_resolve_stac_object_throws_informative_error() -> None:
     link = Link("root", target="/a/b/foo.json")
@@ -101,7 +99,6 @@ def test_resolve_stac_object_throws_informative_error() -> None:
         link.resolve_stac_object()
 
 
-@pytest.mark.xfail(reason="STACObjects no longer have resolve_stac_object method")
 def test_resolved_self_href() -> None:
     catalog = Catalog(id="test", description="test desc")
     with TemporaryDirectory() as temporary_directory:

--- a/tests/v1/test_link.py
+++ b/tests/v1/test_link.py
@@ -146,7 +146,6 @@ def test_get_target_str_no_href(item: Item) -> None:
     assert link.get_href() is None
 
 
-@pytest.mark.xfail(reason="self links are no longer populated by read_file")
 def test_relative_self_href(item: pystac.Item) -> None:
     with TemporaryDirectory() as temporary_directory:
         item.save_object(

--- a/tests/v1/test_link.py
+++ b/tests/v1/test_link.py
@@ -379,7 +379,7 @@ def test_is_not_hierarchical(rel: str) -> None:
     assert not Link(rel, "a-target").is_hierarchical()
 
 
-def test_item_link_type(item: pystac.Item) -> None:
+def test_item_link_type(item: Item) -> None:
     # https://github.com/stac-utils/pystac/issues/1494
     link = Link.item(item)
     assert link.media_type == "application/geo+json"

--- a/tests/v1/test_link.py
+++ b/tests/v1/test_link.py
@@ -67,9 +67,7 @@ def test_relative() -> None:
         "href": target,
         "type": "example/stac_thing",
         "title": "a title",
-        "extra_fields": {
-            "a": "b",
-        },
+        "a": "b",
     }
     assert expected_dict == link.to_dict()
 

--- a/tests/v1/test_link.py
+++ b/tests/v1/test_link.py
@@ -194,9 +194,8 @@ def test_auto_title_is_serialized(item: pystac.Item) -> None:
         title="Collection Title",
     )
     collection.set_self_href("file:///dev/null")
-
+    ## link.to_dict needs to extract href from `target` or have it passed in
     link = pystac.Link("my rel", target=collection)
-
     assert link.to_dict().get("title") == collection.title
 
 
@@ -215,8 +214,14 @@ def test_title_as_init_argument(item: pystac.Item) -> None:
         extent=extent,
         title="Collection Title",
     )
-    collection.set_self_href("file:///dev/null")
-    link = pystac.Link("my rel", title=link_title, target=collection)
+
+    ## link.to_dict needs to extract href from `target` or have it passed in
+    link = pystac.Link(
+        "my rel",
+        title=link_title,
+        target=collection,
+        href="file:///dev/null",
+    )
 
     assert link.title == link_title
     assert link.to_dict().get("title") == link_title

--- a/tests/v1/test_link.py
+++ b/tests/v1/test_link.py
@@ -8,12 +8,14 @@ from typing import Any, cast
 import pytest
 
 import pystac
-from pystac import Collection, Item, Link
+from pystac import Catalog, Collection, Extent, Item, Link, MediaType, RelType
 from pystac.errors import STACError
 from pystac.link import HIERARCHICAL_LINKS
 from pystac.utils import make_posix_style
 
 from .utils.test_cases import ARBITRARY_EXTENT
+
+pytestmark = pytest.mark.passing_v2
 
 TEST_DATETIME: datetime = datetime(2020, 3, 14, 16, 32)
 
@@ -21,18 +23,18 @@ TEST_DATETIME: datetime = datetime(2020, 3, 14, 16, 32)
 def test_path_like() -> None:
     rel = "some-rel"
     target = os.path.abspath("../elsewhere")
-    link = pystac.Link(rel, target)
+    link = Link(rel, target)
     assert os.fspath(link) == make_posix_style(target)
 
 
 def test_minimal(item: pystac.Item) -> None:
     rel = "my rel"
     target = "https://example.com/a/b"
-    link = pystac.Link(rel, target)
+    link = Link(rel, target)
     assert target == link.get_href()
     assert target == link.get_absolute_href()
 
-    expected_repr = f"<Link rel={rel} target={target}>"
+    expected_repr = f"Link(rel={rel}, href={target})"
     assert expected_repr == link.__repr__()
 
     assert not link.is_resolved()
@@ -51,33 +53,29 @@ def test_minimal(item: pystac.Item) -> None:
 
     assert expected_dict == clone.to_dict()
 
-    # Try the modification methods.
-    assert link.owner is None
-    link.set_owner(None)
-    assert link.owner is None
-
-    link.set_owner(item)
-    assert item == link.owner
-
 
 def test_relative() -> None:
     rel = "my rel"
     target = "../elsewhere"
     mime_type = "example/stac_thing"
-    link = pystac.Link(rel, target, mime_type, "a title", extra_fields={"a": "b"})
+    link = Link(
+        rel, target, media_type=mime_type, title="a title", extra_fields={"a": "b"}
+    )
     expected_dict = {
         "rel": rel,
         "href": target,
         "type": "example/stac_thing",
         "title": "a title",
-        "a": "b",
+        "extra_fields": {
+            "a": "b",
+        },
     }
     assert expected_dict == link.to_dict()
 
 
 def test_link_does_not_fail_if_href_is_none(item: pystac.Item) -> None:
     """Test to ensure get_href does not fail when the href is None."""
-    catalog = pystac.Catalog(id="test", description="test desc")
+    catalog = Catalog(id="test", description="test desc")
     catalog.add_item(item)
     catalog.set_self_href("/some/href")
 
@@ -86,63 +84,73 @@ def test_link_does_not_fail_if_href_is_none(item: pystac.Item) -> None:
     assert link.get_href() is None
 
 
+@pytest.mark.xfail(reason="STACObjects no longer have resolve_stac_object method")
 def test_resolve_stac_object_no_root_and_target_is_item(item: pystac.Item) -> None:
-    link = pystac.Link("my rel", target=item)
+    link = Link("my rel", target=item)
     link.resolve_stac_object()
 
 
+@pytest.mark.xfail(reason="STACObjects no longer have resolve_stac_object method")
 @pytest.mark.skipif(os.name == "nt", reason="Non-windows test")
 def test_resolve_stac_object_throws_informative_error() -> None:
-    link = pystac.Link("root", target="/a/b/foo.json")
+    link = Link("root", target="/a/b/foo.json")
     with pytest.raises(
         STACError, match="HREF: '/a/b/foo.json' does not resolve to a STAC object"
     ):
         link.resolve_stac_object()
 
 
+@pytest.mark.xfail(reason="STACObjects no longer have resolve_stac_object method")
 def test_resolved_self_href() -> None:
-    catalog = pystac.Catalog(id="test", description="test desc")
+    catalog = Catalog(id="test", description="test desc")
     with TemporaryDirectory() as temporary_directory:
         catalog.normalize_and_save(temporary_directory)
         path = os.path.join(temporary_directory, "catalog.json")
-        catalog = pystac.Catalog.from_file(path)
-        link = catalog.get_single_link(pystac.RelType.SELF)
+        catalog = Catalog.from_file(path)
+        link = catalog.get_single_link(RelType.SELF)
         assert link
         link.resolve_stac_object()
         assert link.get_absolute_href() == make_posix_style(path)
 
 
 def test_target_getter_setter(item: pystac.Item) -> None:
-    link = pystac.Link("my rel", target="./foo/bar.json")
+    link = Link("my rel", target="./foo/bar.json")
     assert link.target == "./foo/bar.json"
-    assert link.get_target_str() == "./foo/bar.json"
+    assert link.get_href() == "./foo/bar.json"
 
+    item.set_self_href("file:///bad/beef.json")
     link.target = item
     assert link.target == item
-    assert link.get_target_str() == item.get_self_href()
+    # get_target_str is gone, so replaced with get_href
+    assert link.get_href() == item.get_self_href()
 
-    link.target = "./bar/foo.json"
-    assert link.target == "./bar/foo.json"
+    # target property
+    link.set_href("./dead/d011.json")
+    assert link.target == item  # target remains unchanged
+    assert link.get_href() == "./dead/d011.json"  # href is updated
+    assert (
+        link.target.get_self_href() == "file:///bad/beef.json"
+    )  # set_href doesn't update target
 
 
-def test_get_target_str_no_href(item: pystac.Item) -> None:
+def test_get_target_str_no_href(item: Item) -> None:
     item.remove_links("self")
-    link = pystac.Link("self", target=item)
+    link = Link("self", target=item)
     item.add_link(link)
-    assert link.get_target_str() is None
+    assert link.get_href() is None
 
 
+@pytest.mark.xfail(reason="self links are no longer populated by read_file")
 def test_relative_self_href(item: pystac.Item) -> None:
     with TemporaryDirectory() as temporary_directory:
-        pystac.write_file(
-            item,
+        item.save_object(
             include_self_link=False,
             dest_href=os.path.join(temporary_directory, "item.json"),
         )
         previous = os.getcwd()
         try:
             os.chdir(temporary_directory)
-            item = cast(pystac.Item, pystac.read_file("item.json"))
+            item = pystac.read_file("item.json")
             href = item.get_self_href()
             assert href
             assert os.path.isabs(href), f"Not an absolute path: {href}"
@@ -151,59 +159,62 @@ def test_relative_self_href(item: pystac.Item) -> None:
 
 
 def test_auto_title_when_resolved(item: pystac.Item) -> None:
-    extent = pystac.Extent.from_items([item])
-    collection = pystac.Collection(
+    extent = Extent.from_items([item])
+    collection = Collection(
         id="my_collection",
         description="Test Collection",
         extent=extent,
         title="Collection Title",
     )
-    link = pystac.Link("my rel", target=collection)
+    link = Link("my rel", target=collection)
 
     assert collection.title == link.title
 
 
 def test_auto_title_not_found(item: pystac.Item) -> None:
-    extent = pystac.Extent.from_items([item])
-    collection = pystac.Collection(
+    extent = Extent.from_items([item])
+    collection = Collection(
         id="my_collection",
         description="Test Collection",
         extent=extent,
     )
-    link = pystac.Link("my rel", target=collection)
+    link = Link("my rel", target=collection)
 
     assert link.title is None
 
 
 def test_auto_title_is_serialized(item: pystac.Item) -> None:
-    extent = pystac.Extent.from_items([item])
-    collection = pystac.Collection(
+    extent = Extent.from_items([item])
+    collection = Collection(
         id="my_collection",
         description="Test Collection",
         extent=extent,
         title="Collection Title",
     )
-    link = pystac.Link("my rel", target=collection)
+    collection.set_self_href("file:///dev/null")
+
+    link = Link("my rel", target=collection)
 
     assert link.to_dict().get("title") == collection.title
 
 
 def test_no_auto_title_if_not_resolved() -> None:
-    link = pystac.Link("my rel", target="https://www.some-domain.com/path/to/thing.txt")
+    link = Link("my rel", target="https://www.some-domain.com/path/to/thing.txt")
 
     assert link.title is None
 
 
 def test_title_as_init_argument(item: pystac.Item) -> None:
     link_title = "Link title"
-    extent = pystac.Extent.from_items([item])
-    collection = pystac.Collection(
+    extent = Extent.from_items([item])
+    collection = Collection(
         id="my_collection",
         description="Test Collection",
         extent=extent,
         title="Collection Title",
     )
-    link = pystac.Link("my rel", title=link_title, target=collection)
+    collection.set_self_href("file:///dev/null")
+    link = Link("my rel", title=link_title, target=collection)
 
     assert link.title == link_title
     assert link.to_dict().get("title") == link_title
@@ -212,7 +223,14 @@ def test_title_as_init_argument(item: pystac.Item) -> None:
 def test_serialize_link() -> None:
     href = "https://some-domain/path/to/item.json"
     title = "A Test Link"
-    link = pystac.Link(pystac.RelType.SELF, href, pystac.MediaType.JSON, title)
+    # Positional is lame
+    # link = Link(RelType.SELF, None, href, MediaType.JSON, title)
+    link = Link(
+        rel=RelType.SELF,
+        href=href,
+        media_type=MediaType.JSON,
+        title=title,
+    )
     link_dict = link.to_dict()
 
     assert link_dict["rel"] == "self"
@@ -223,47 +241,65 @@ def test_serialize_link() -> None:
 
 def test_static_from_dict_round_trip() -> None:
     test_cases: list[dict[str, Any]] = [
-        {"rel": "", "href": ""},  # Not valid, but works.
         {"rel": "r", "href": "t"},
         {"rel": "r", "href": "/t"},
         {"rel": "r", "href": "t", "type": "a/b", "title": "t", "c": "d", "1": 2},
     ]
     for d in test_cases:
-        d2 = pystac.Link.from_dict(d).to_dict()
+        d2 = Link.from_dict(d).to_dict()
         assert d == d2
     d = {"rel": "self", "href": "t"}
-    d2 = {"rel": "self", "href": make_posix_style(os.path.join(os.getcwd(), "t"))}
-    assert pystac.Link.from_dict(d).to_dict() == d2
+    d2 = {"rel": "self", "href": "t"}
+    assert Link.from_dict(d).to_dict() == d2
 
 
 def test_static_from_dict_failures() -> None:
     dicts: list[dict[str, Any]] = [{}, {"href": "t"}, {"rel": "r"}]
     for d in dicts:
-        with pytest.raises(KeyError):
-            pystac.Link.from_dict(d)
+        with pytest.raises((TypeError, ValueError)):
+            Link.from_dict(d)
 
 
-def test_static_collection(collection: pystac.Collection) -> None:
-    link = pystac.Link.collection(collection)
-    expected = {"rel": "collection", "href": None, "type": "application/json"}
+def test_static_collection(
+    self_link_collection: pystac.Collection,
+) -> None:
+    link = Link.collection(self_link_collection)
+    expected = {
+        "rel": "collection",
+        "href": self_link_collection.get_self_href(),
+        "type": "application/json",
+    }
     assert expected == link.to_dict()
 
 
-def test_static_child(collection: pystac.Collection) -> None:
-    link = pystac.Link.child(collection)
-    expected = {"rel": "child", "href": None, "type": "application/json"}
+def test_static_child(self_link_collection: pystac.Collection) -> None:
+    link = Link.child(self_link_collection)
+    expected = {
+        "rel": "child",
+        "href": self_link_collection.get_self_href(),
+        "type": "application/json",
+    }
     assert expected == link.to_dict()
 
 
 def test_static_canonical_item(item: pystac.Item) -> None:
-    link = pystac.Link.canonical(item)
-    expected = {"rel": "canonical", "href": None, "type": "application/json"}
+    item.set_self_href("file:///bad/beef.json")
+    link = Link.canonical(item)
+    expected = {
+        "rel": "canonical",
+        "href": item.get_self_href(),
+        "type": "application/json",
+    }
     assert expected == link.to_dict()
 
 
-def test_static_canonical_collection(collection: pystac.Collection) -> None:
-    link = pystac.Link.canonical(collection)
-    expected = {"rel": "canonical", "href": None, "type": "application/json"}
+def test_static_canonical_collection(self_link_collection: pystac.Collection) -> None:
+    link = Link.canonical(self_link_collection)
+    expected = {
+        "rel": "canonical",
+        "href": self_link_collection.get_self_href(),
+        "type": "application/json",
+    }
     assert expected == link.to_dict()
 
 
@@ -278,22 +314,22 @@ def test_inheritance_from_dict() -> None:
     assert isinstance(link, CustomLink)
 
 
-def test_inheritance_collection(collection: Collection) -> None:
+def test_inheritance_collection(collection: pystac.Collection) -> None:
     link = CustomLink.collection(collection)
     assert isinstance(link, CustomLink)
 
 
-def test_inheritance_child(collection: Collection) -> None:
+def test_inheritance_child(collection: pystac.Collection) -> None:
     link = CustomLink.child(collection)
     assert isinstance(link, CustomLink)
 
 
-def test_inheritance_canonical_item(item: Item) -> None:
+def test_inheritance_canonical_item(item: pystac.Item) -> None:
     link = CustomLink.canonical(item)
     assert isinstance(link, CustomLink)
 
 
-def test_inheritance_canonical_collection(collection: Collection) -> None:
+def test_inheritance_canonical_collection(collection: pystac.Collection) -> None:
     link = CustomLink.canonical(collection)
     assert isinstance(link, CustomLink)
 
@@ -340,7 +376,7 @@ def test_is_not_hierarchical(rel: str) -> None:
     assert not Link(rel, "a-target").is_hierarchical()
 
 
-def test_item_link_type(item: Item) -> None:
+def test_item_link_type(item: pystac.Item) -> None:
     # https://github.com/stac-utils/pystac/issues/1494
     link = Link.item(item)
     assert link.media_type == "application/geo+json"


### PR DESCRIPTION
**Related Issue(s):**

- #1657 
- adds `Container.get_item`
- adds `Link.clone` via `deepcopy`
- adds `Link.target` setter with deprecation notice
- adds `Link.get_absolute_href`, as it was needed for some v1 tests
- restores `Link.resolve_stac_object`
- restores convenience methods for common link types (`child, collection, item, derived_from`)

**Description:**

**PR Checklist:**

- [ ] Pre-commit hooks pass (run `pre-commit run --all-files`)
- [ ] Tests pass (run `pytest`)
- [ ] Documentation has been updated to reflect changes, if applicable
- [ ] This PR maintains or improves overall codebase code coverage
- [ ] This PR's title is formatted per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
