### PR TITLE
fix: V2 add .ext to stac objects

### DIFF
--- a/src/pystac/asset.py
+++ b/src/pystac/asset.py
@@ -18,6 +18,7 @@ from .utils import (
 from .writer import Writer
 
 if TYPE_CHECKING:
+    from .extensions.ext import AssetExt
     from .stac_object import STACObject
 
 
@@ -131,6 +132,18 @@ class Asset(ItemAsset):
     def to_dict(self) -> dict[str, Any]:
         data = super().to_dict()
         return {"href": self.href, **data}
+
+    @property
+    def ext(self) -> AssetExt:
+        """Accessor for extension classes on this asset
+
+        Example::
+
+            asset.ext.proj.code = "EPSG:4326"
+        """
+        from pystac.extensions.ext import AssetExt
+
+        return AssetExt(stac_object=self)
 
 
 class Assets(Protocol):

--- a/src/pystac/catalog.py
+++ b/src/pystac/catalog.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import copy
 import warnings
 from enum import StrEnum
-from typing import Any, ClassVar, override
+from typing import TYPE_CHECKING, Any, ClassVar, override
 
 from typing_extensions import deprecated
 
@@ -12,6 +12,9 @@ from .constants import DEFAULT_STAC_VERSION, STAC_OBJECT_TYPE
 from .container import Container
 from .link import Link
 from .rel_type import RelType
+
+if TYPE_CHECKING:
+    from .extensions.ext import CatalogExt
 
 
 class Catalog(Container):
@@ -82,6 +85,18 @@ class Catalog(Container):
         )
         data["description"] = self.description
         return data
+
+    @property
+    def ext(self) -> CatalogExt:
+        """Accessor for extension classes on this catalog
+
+        Example::
+
+            print(collection.ext.version)
+        """
+        from pystac.extensions.ext import CatalogExt
+
+        return CatalogExt(stac_object=self)
 
 
 @deprecated("CatalogType is deprecated")

--- a/src/pystac/collection.py
+++ b/src/pystac/collection.py
@@ -25,6 +25,7 @@ from .provider import Provider
 from .utils import to_datetime_str
 
 if TYPE_CHECKING:
+    from .extensions.ext import CollectionExt
     from .item import Item
     from .item_collection import ItemCollection
 
@@ -216,6 +217,18 @@ class Collection(Container, Assets):
         Update datetime and bbox based on all items to a single bbox and time window.
         """
         self.extent = Extent.from_items(self.get_items(recursive=True))
+
+    @property
+    def ext(self) -> CollectionExt:
+        """Accessor for extension classes on this collection
+
+        Example::
+
+            print(collection.ext.xarray)
+        """
+        from pystac.extensions.ext import CollectionExt
+
+        return CollectionExt(stac_object=self)
 
 
 class Extent:

--- a/src/pystac/item.py
+++ b/src/pystac/item.py
@@ -28,6 +28,7 @@ from .utils import make_posix_style
 
 if TYPE_CHECKING:
     from .collection import Collection
+    from .extensions.ext import ItemExt
 
 
 class Item(STACObject, Assets):
@@ -239,6 +240,18 @@ class Item(STACObject, Assets):
     @property
     def __geo_interface__(self) -> dict[str, Any]:
         return self.to_dict(include_self_link=False)
+
+    @property
+    def ext(self) -> ItemExt:
+        """Accessor for extension classes on this item
+
+        Example::
+
+            item.ext.proj.code = "EPSG:4326"
+        """
+        from pystac.extensions.ext import ItemExt
+
+        return ItemExt(stac_object=self)
 
 
 @final

--- a/src/pystac/link.py
+++ b/src/pystac/link.py
@@ -16,6 +16,7 @@ from .reader import Reader
 
 if TYPE_CHECKING:
     from . import Catalog, Collection, Item
+    from .extensions.ext import LinkExt
     from .stac_object import STACObject
 
 HIERARCHICAL_LINKS = [
@@ -318,3 +319,15 @@ class Link:
             title=title,
             media_type=MediaType.JSON,
         )
+
+    @property
+    def ext(self) -> LinkExt:
+        """Accessor for extension classes on this link
+
+        Example::
+
+            link.ext.file.size = 8675309
+        """
+        from pystac.extensions.ext import LinkExt
+
+        return LinkExt(stac_object=self)


### PR DESCRIPTION
This PR + #1710 brings the `uv run pytest tests/v1/extensions/ --v1` failures down to 109.