### PR TITLE
fix: remove python-version from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,6 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-        with:
-          python-version: "3.x"
       - name: Determine package path from tag
         id: package
         run: |


### PR DESCRIPTION
Broke in https://github.com/stac-utils/pystac/actions/runs/25698054392/job/75451270298. I don't feel like we need to set the Python version ... since we pin the github action version, it won't change underneath us.