### PR TITLE
fix: dependent version for pystac-core

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,6 @@
 {
-  ".": "1.15.0-rc.0",
-  "core": "1.15.0-rc.0",
+  ".": "1.15.0-rc.1",
+  "core": "1.15.0-rc.1",
   "extensions/classification": "2.0.0-rc.0",
   "extensions/datacube": "2.2.0-rc.0",
   "extensions/eo": "1.1.0-rc.0",

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -2,7 +2,7 @@
 name = "pystac-core"
 description = "Core functionality for PySTAC without extensions. Most users will want to use pystac, not this package"
 readme = "README.md"
-version = "1.15.0-rc.0"
+version = "1.15.0-rc.1"
 authors = [
     { name = "Rob Emanuele", email = "rdemanuele@gmail.com" },
     { name = "Jon Duckworth", email = "duckontheweb@gmail.com" },

--- a/core/pystac/version.py
+++ b/core/pystac/version.py
@@ -1,4 +1,4 @@
-__version__ = "1.15.0-rc.0"  # x-release-please-version
+__version__ = "1.15.0-rc.1"  # x-release-please-version
 """Library version"""
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "pystac-core==1.14.3",
+    "pystac-core==1.15.0-rc.0",  # x-release-please-version
     "pystac-ext-classification",
     "pystac-ext-datacube",
     "pystac-ext-eo",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "pystac"
 description = "Python library for working with the SpatioTemporal Asset Catalog (STAC) specification"
 readme = "README.md"
-version = "1.15.0-rc.0"
+version = "1.15.0-rc.1"
 authors = [
     { name = "Rob Emanuele", email = "rdemanuele@gmail.com" },
     { name = "Jon Duckworth", email = "duckontheweb@gmail.com" },
@@ -23,7 +23,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "pystac-core==1.15.0-rc.0",  # x-release-please-version
+    "pystac-core==1.15.0-rc.1",  # x-release-please-version
     "pystac-ext-classification",
     "pystac-ext-datacube",
     "pystac-ext-eo",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -102,6 +102,7 @@
       "prerelease-type": "rc"
     }
   },
+  "extra-files": ["pyproject.toml", "core/pystac/version.py"],
   "plugins": [
     {
       "type": "linked-versions",

--- a/uv.lock
+++ b/uv.lock
@@ -3665,7 +3665,7 @@ wheels = [
 
 [[package]]
 name = "pystac"
-version = "1.15.0rc0"
+version = "1.15.0rc1"
 source = { editable = "." }
 dependencies = [
     { name = "pystac-core" },
@@ -3871,7 +3871,7 @@ wheels = [
 
 [[package]]
 name = "pystac-core"
-version = "1.15.0rc0"
+version = "1.15.0rc1"
 source = { editable = "core" }
 dependencies = [
     { name = "python-dateutil" },


### PR DESCRIPTION
I missed one spot where we need to link the **pystac** and **pystac-core** versions. Bump to rc.1 b/c https://pypi.org/project/pystac/1.15.0rc0/ is broken.