### PR TITLE
fix: urllib3 raise on error status codes

### DIFF
--- a/core/pystac/stac_io.py
+++ b/core/pystac/stac_io.py
@@ -308,6 +308,8 @@ class DefaultStacIO(StacIO):
                         },
                         preload_content=False,  # type: ignore
                     ) as f:
+                        if f.status >= 400:
+                            raise HTTPError(href, f.status, f.reason, f.headers, None)
                         href_contents = f.read().decode("utf-8")
                 else:
                     req = Request(
@@ -465,6 +467,14 @@ if HAS_URLLIB3:
                         },
                         retries=self.retry,  # type: ignore
                     )
+                    if response.status >= 400:
+                        raise HTTPError(
+                            href,
+                            response.status,
+                            response.reason,
+                            response.headers,
+                            None,
+                        )
                     return cast(str, response.data.decode("utf-8"))
                 except HTTPError as e:
                     raise Exception(f"Could not read uri {href}") from e

--- a/tests/test_stac_io.py
+++ b/tests/test_stac_io.py
@@ -5,6 +5,7 @@ import unittest
 from pathlib import Path
 
 import pytest
+from pytest import MonkeyPatch
 
 import pystac
 import pystac.errors
@@ -124,6 +125,7 @@ def test_headers_stac_io(request_mock: unittest.mock.MagicMock) -> None:
     catalog = pystac.Catalog("an-id", "a description").to_dict()
     # required until https://github.com/stac-utils/pystac/pull/896 is merged
     catalog["links"] = []
+    request_mock.return_value.__enter__.return_value.status = 200
     request_mock.return_value.__enter__.return_value.read.return_value = json.dumps(
         catalog
     ).encode("utf-8")
@@ -157,6 +159,60 @@ def test_retry_stac_io_404() -> None:
             "https://planetarycomputer.microsoft.com"
             "/api/stac/v1/collections/not-a-collection-id"
         )
+
+
+def test_read_text_raises_on_429_with_urllib3(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    # https://github.com/stac-utils/pystac/issues/1738
+    urllib3 = pytest.importorskip("urllib3")
+
+    class FakeResponse:
+        status = 429
+
+        def read(self) -> bytes:
+            return b'{"error": "Nope!"}'
+
+        def __enter__(self) -> "FakeResponse":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            pass
+
+    class FakePoolManager:
+        def request(self, *args: object, **kwargs: object) -> FakeResponse:
+            return FakeResponse()
+
+    monkeypatch.setattr(urllib3, "PoolManager", FakePoolManager)
+
+    stac_io = DefaultStacIO()
+    with pytest.raises(Exception):
+        stac_io.read_text("http://localhost:5000")
+
+
+def test_retry_stac_io_raises_on_429(monkeypatch: MonkeyPatch) -> None:
+    # https://github.com/stac-utils/pystac/issues/1738
+    pytest.importorskip("urllib3")
+    from urllib3 import PoolManager
+
+    from pystac.stac_io import RetryStacIO
+
+    class FakeResponse:
+        status = 429
+        reason = "Too Many Requests"
+        headers: dict[str, str] = {}
+        data = b'{"error": "Nope!"}'
+
+    def fake_request(
+        self: PoolManager, *args: object, **kwargs: object
+    ) -> FakeResponse:
+        return FakeResponse()
+
+    monkeypatch.setattr(PoolManager, "request", fake_request)
+
+    stac_io = RetryStacIO()
+    with pytest.raises(Exception):
+        stac_io.read_text("http://localhost:5000")
 
 
 def test_save_http_href_errors(tmp_path: Path) -> None:


### PR DESCRIPTION
**Related Issue(s):**

- Closes #1738 

**Description:**

**urllib3** doesn't raise on error status codes, so things were getting swallowed.
