### PR TITLE
fix: persist stac_io when reading items

### DIFF
--- a/core/pystac/item.py
+++ b/core/pystac/item.py
@@ -108,6 +108,11 @@ class Item(STACObject, Assets):
     stac_extensions: list[str]
     """List of extensions the Item implements."""
 
+    _stac_io: pystac.StacIO | None = None
+    """Optional instance of StacIO that will be used by default for any IO
+    operations. This is set when an item is read by a StacIO instance.
+    """
+
     STAC_OBJECT_TYPE = STACObjectType.ITEM
 
     def __init__(

--- a/core/pystac/link.py
+++ b/core/pystac/link.py
@@ -321,6 +321,8 @@ class Link(PathLike):
             if root is not None:
                 obj = root._resolved_objects.get_by_href(target_href)
                 stac_io = root._stac_io
+            if stac_io is None and self.owner and hasattr(self.owner, "_stac_io"):
+                stac_io = self.owner._stac_io
 
             if obj is None:
                 if stac_io is None:

--- a/core/pystac/stac_io.py
+++ b/core/pystac/stac_io.py
@@ -162,21 +162,25 @@ class StacIO(ABC):
         d = migrate_to_latest(d, info)
 
         if info.object_type == pystac.STACObjectType.CATALOG:
-            result = pystac.Catalog.from_dict(
+            catalog = pystac.Catalog.from_dict(
                 d, href=href_str, root=root, migrate=True, preserve_dict=preserve_dict
             )
-            result._stac_io = self
-            return result
+            catalog._stac_io = self
+            return catalog
 
         if info.object_type == pystac.STACObjectType.COLLECTION:
-            return pystac.Collection.from_dict(
+            collection = pystac.Collection.from_dict(
                 d, href=href_str, root=root, migrate=True, preserve_dict=preserve_dict
             )
+            collection._stac_io = self
+            return collection
 
         if info.object_type == pystac.STACObjectType.ITEM:
-            return pystac.Item.from_dict(
+            item = pystac.Item.from_dict(
                 d, href=href_str, root=root, migrate=True, preserve_dict=preserve_dict
             )
+            item._stac_io = self
+            return item
 
         raise ValueError(f"Unknown STAC object type {info.object_type}")
 

--- a/tests/cassettes/test_stac_io/test_custom_stac_io.yaml
+++ b/tests/cassettes/test_stac_io/test_custom_stac_io.yaml
@@ -1,0 +1,90 @@
+interactions:
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://raw.githubusercontent.com/radiantearth/stac-spec/refs/heads/master/examples/simple-item.json
+  response:
+    body:
+      string: "{\n  \"stac_version\": \"1.1.0\",\n  \"stac_extensions\": [],\n  \"type\":
+        \"Feature\",\n  \"id\": \"20201211_223832_CS2\",\n  \"bbox\": [\n    172.91173669923782,\n
+        \   1.3438851951615003,\n    172.95469614953714,\n    1.3690476620161975\n
+        \ ],\n  \"geometry\": {\n    \"type\": \"Polygon\",\n    \"coordinates\":
+        [\n      [\n        [\n          172.91173669923782,\n          1.3438851951615003\n
+        \       ],\n        [\n          172.95469614953714,\n          1.3438851951615003\n
+        \       ],\n        [\n          172.95469614953714,\n          1.3690476620161975\n
+        \       ],\n        [\n          172.91173669923782,\n          1.3690476620161975\n
+        \       ],\n        [\n          172.91173669923782,\n          1.3438851951615003\n
+        \       ]\n      ]\n    ]\n  },\n  \"properties\": {\n    \"datetime\": \"2020-12-11T22:38:32.125000Z\"\n
+        \ },\n  \"collection\": \"simple-collection\",\n  \"links\": [\n    {\n      \"rel\":
+        \"collection\",\n      \"href\": \"./collection.json\",\n      \"type\": \"application/json\",\n
+        \     \"title\": \"Simple Example Collection\"\n    },\n    {\n      \"rel\":
+        \"root\",\n      \"href\": \"./collection.json\",\n      \"type\": \"application/json\",\n
+        \     \"title\": \"Simple Example Collection\"\n    },\n    {\n      \"rel\":
+        \"parent\",\n      \"href\": \"./collection.json\",\n      \"type\": \"application/json\",\n
+        \     \"title\": \"Simple Example Collection\"\n    }\n  ],\n  \"assets\":
+        {\n    \"visual\": {\n      \"href\": \"https://storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2.tif\",\n
+        \     \"type\": \"image/tiff; application=geotiff; profile=cloud-optimized\",\n
+        \     \"title\": \"3-Band Visual\",\n      \"roles\": [\n        \"visual\"\n
+        \     ]\n    },\n    \"thumbnail\": {\n      \"href\": \"https://storage.googleapis.com/open-cogs/stac-examples/20201211_223832_CS2.jpg\",\n
+        \     \"title\": \"Thumbnail\",\n      \"type\": \"image/jpeg\",\n      \"roles\":
+        [\n        \"thumbnail\"\n      ]\n    }\n  }\n}\n"
+    headers: {}
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers: {}
+    method: GET
+    uri: https://raw.githubusercontent.com/radiantearth/stac-spec/refs/heads/master/examples/collection.json
+  response:
+    body:
+      string: "{\n  \"id\": \"simple-collection\",\n  \"type\": \"Collection\",\n
+        \ \"stac_extensions\": [\n    \"https://stac-extensions.github.io/eo/v2.0.0/schema.json\",\n
+        \   \"https://stac-extensions.github.io/projection/v2.0.0/schema.json\",\n
+        \   \"https://stac-extensions.github.io/view/v1.0.0/schema.json\"\n  ],\n
+        \ \"stac_version\": \"1.1.0\",\n  \"description\": \"A simple collection demonstrating
+        core catalog fields with links to a couple of items\",\n  \"title\": \"Simple
+        Example Collection\",\n  \"keywords\": [\n    \"simple\",\n    \"example\",\n
+        \   \"collection\"\n  ],\n  \"providers\": [\n    {\n      \"name\": \"Remote
+        Data, Inc\",\n      \"description\": \"Producers of awesome spatiotemporal
+        assets\",\n      \"roles\": [\n        \"producer\",\n        \"processor\"\n
+        \     ],\n      \"url\": \"http://remotedata.io\"\n    }\n  ],\n  \"extent\":
+        {\n    \"spatial\": {\n      \"bbox\": [\n        [\n          172.91173669923782,\n
+        \         1.3438851951615003,\n          172.95469614953714,\n          1.3690476620161975\n
+        \       ]\n      ]\n    },\n    \"temporal\": {\n      \"interval\": [\n        [\n
+        \         \"2020-12-11T22:38:32.125Z\",\n          \"2020-12-14T18:02:31.437Z\"\n
+        \       ]\n      ]\n    }\n  },\n  \"license\": \"CC-BY-4.0\",\n  \"summaries\":
+        {\n    \"platform\": [\n      \"cool_sat1\",\n      \"cool_sat2\"\n    ],\n
+        \   \"constellation\": [\n      \"ion\"\n    ],\n    \"instruments\": [\n
+        \     \"cool_sensor_v1\",\n      \"cool_sensor_v2\"\n    ],\n    \"gsd\":
+        {\n      \"minimum\": 0.512,\n      \"maximum\": 0.66\n    },\n    \"eo:cloud_cover\":
+        {\n      \"minimum\": 1.2,\n      \"maximum\": 1.2\n    },\n    \"proj:cpde\":
+        [\n      \"EPSG:32659\"\n    ],\n    \"view:sun_elevation\": {\n      \"minimum\":
+        54.9,\n      \"maximum\": 54.9\n    },\n    \"view:off_nadir\": {\n      \"minimum\":
+        3.8,\n      \"maximum\": 3.8\n    },\n    \"view:sun_azimuth\": {\n      \"minimum\":
+        135.7,\n      \"maximum\": 135.7\n    },\n    \"statistics\": {\n      \"type\":
+        \"object\",\n      \"properties\": {\n        \"vegetation\": {\n          \"description\":
+        \"Percentage of pixels that are detected as vegetation, e.g. forests, grasslands,
+        etc.\",\n          \"minimum\": 0,\n          \"maximum\": 100\n        },\n
+        \       \"water\": {\n          \"description\": \"Percentage of pixels that
+        are detected as water, e.g. rivers, oceans and ponds.\",\n          \"minimum\":
+        0,\n          \"maximum\": 100\n        },\n        \"urban\": {\n          \"description\":
+        \"Percentage of pixels that detected as urban, e.g. roads and buildings.\",\n
+        \         \"minimum\": 0,\n          \"maximum\": 100\n        }\n      }\n
+        \   }\n  },\n  \"links\": [\n    {\n      \"rel\": \"root\",\n      \"href\":
+        \"./collection.json\",\n      \"type\": \"application/json\",\n      \"title\":
+        \"Simple Example Collection\"\n    },\n    {\n      \"rel\": \"item\",\n      \"href\":
+        \"./simple-item.json\",\n      \"type\": \"application/geo+json\",\n      \"title\":
+        \"Simple Item\"\n    },\n    {\n      \"rel\": \"item\",\n      \"href\":
+        \"./core-item.json\",\n      \"type\": \"application/geo+json\",\n      \"title\":
+        \"Core Item\"\n    },\n    {\n      \"rel\": \"item\",\n      \"href\": \"./extended-item.json\",\n
+        \     \"type\": \"application/geo+json\",\n      \"title\": \"Extended Item\"\n
+        \   },\n    {\n      \"rel\": \"self\",\n      \"href\": \"https://raw.githubusercontent.com/radiantearth/stac-spec/v1.1.0/examples/collection.json\",\n
+        \     \"type\": \"application/json\"\n    }\n  ]\n}\n"
+    headers: {}
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_stac_io.py
+++ b/tests/test_stac_io.py
@@ -8,7 +8,6 @@ import pytest
 from pytest import MonkeyPatch
 
 import pystac
-import pystac.errors
 from pystac.stac_io import DefaultStacIO, DuplicateKeyReportingMixin, StacIO
 from tests.utils import TestCases
 
@@ -243,3 +242,25 @@ def test_proj_json_schema_is_readable() -> None:
     _ = stac_io.read_text_from_href(
         "https://proj.org/schemas/v0.7/projjson.schema.json"
     )
+
+
+@pytest.mark.vcr()
+def test_custom_stac_io() -> None:
+    class CustomStacIO(DefaultStacIO):
+        def __init__(self, headers: dict[str, str] | None = None):
+            super().__init__(headers)
+            self.calls = 0
+
+        def read_text_from_href(self, href: str) -> str:
+            self.calls += 1
+            return super().read_text_from_href(href)
+
+    stac_io = CustomStacIO()
+    item = pystac.read_file(
+        "https://raw.githubusercontent.com/radiantearth/stac-spec/refs/heads/master/examples/simple-item.json",
+        stac_io=stac_io,
+    )
+    link = item.get_single_link(rel="self")
+    assert link
+    link.get_href()
+    assert stac_io.calls == 2


### PR DESCRIPTION
**Related Issue(s):**

- Closes #1743 

**Description:**

Previously, we only persisted StacIO when reading catalogs. _To me_, there's no reason to limit StacIO persistence to catalogs, so we add it to collections and items here. We also update links to check to see if their owner has a StacIO to use.

**PR Checklist:**

- [x] Pre-commit hooks pass (run `pre-commit run --all-files`)
- [x] Tests pass (run `pytest`)
- [x] This PR maintains or improves overall codebase code coverage
- [x] This PR's title is formatted per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
