### PR TITLE
fix: remove invalid version specifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "pystac-core==1.15.0-rc.1",  # x-release-please-version
+    "pystac-core==1.15.0",  # x-release-please-version
     "pystac-ext-classification",
     "pystac-ext-datacube",
     "pystac-ext-eo",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,8 @@
     ".": {
       "changelog-path": "CHANGELOG.md",
       "component": "pystac",
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "release-as": "1.15.0.post0"
     },
     "core": {
       "component": "pystac-core"

--- a/uv.lock
+++ b/uv.lock
@@ -3682,7 +3682,7 @@ wheels = [
 
 [[package]]
 name = "pystac"
-version = "1.15.0rc1"
+version = "1.15.0"
 source = { editable = "." }
 dependencies = [
     { name = "pystac-core" },
@@ -3888,7 +3888,7 @@ wheels = [
 
 [[package]]
 name = "pystac-core"
-version = "1.15.0rc1"
+version = "1.15.0"
 source = { editable = "core" }
 dependencies = [
     { name = "python-dateutil" },
@@ -3899,7 +3899,7 @@ requires-dist = [{ name = "python-dateutil", specifier = ">=2.7.0" }]
 
 [[package]]
 name = "pystac-ext-classification"
-version = "2.0.0rc0"
+version = "2.0.0"
 source = { editable = "extensions/classification" }
 dependencies = [
     { name = "pystac-core" },
@@ -3910,7 +3910,7 @@ requires-dist = [{ name = "pystac-core", editable = "core" }]
 
 [[package]]
 name = "pystac-ext-datacube"
-version = "2.2.0rc0"
+version = "2.2.0"
 source = { editable = "extensions/datacube" }
 dependencies = [
     { name = "pystac-core" },
@@ -3921,7 +3921,7 @@ requires-dist = [{ name = "pystac-core", editable = "core" }]
 
 [[package]]
 name = "pystac-ext-eo"
-version = "1.1.0rc0"
+version = "1.1.0"
 source = { editable = "extensions/eo" }
 dependencies = [
     { name = "pystac-core" },
@@ -3932,7 +3932,7 @@ requires-dist = [{ name = "pystac-core", editable = "core" }]
 
 [[package]]
 name = "pystac-ext-file"
-version = "2.1.0rc0"
+version = "2.1.0"
 source = { editable = "extensions/file" }
 dependencies = [
     { name = "pystac-core" },
@@ -3943,7 +3943,7 @@ requires-dist = [{ name = "pystac-core", editable = "core" }]
 
 [[package]]
 name = "pystac-ext-grid"
-version = "1.1.0rc0"
+version = "1.1.0"
 source = { editable = "extensions/grid" }
 dependencies = [
     { name = "pystac-core" },
@@ -3954,7 +3954,7 @@ requires-dist = [{ name = "pystac-core", editable = "core" }]
 
 [[package]]
 name = "pystac-ext-item-assets"
-version = "1.0.0rc0"
+version = "1.0.0"
 source = { editable = "extensions/item_assets" }
 dependencies = [
     { name = "pystac-core" },
@@ -3965,7 +3965,7 @@ requires-dist = [{ name = "pystac-core", editable = "core" }]
 
 [[package]]
 name = "pystac-ext-label"
-version = "1.0.1rc0"
+version = "1.0.1"
 source = { editable = "extensions/label" }
 dependencies = [
     { name = "pystac-core" },
@@ -3976,7 +3976,7 @@ requires-dist = [{ name = "pystac-core", editable = "core" }]
 
 [[package]]
 name = "pystac-ext-mgrs"
-version = "1.0.0rc0"
+version = "1.0.0"
 source = { editable = "extensions/mgrs" }
 dependencies = [
     { name = "pystac-core" },
@@ -3987,7 +3987,7 @@ requires-dist = [{ name = "pystac-core", editable = "core" }]
 
 [[package]]
 name = "pystac-ext-mlm"
-version = "1.4.0rc0"
+version = "1.4.0"
 source = { editable = "extensions/mlm" }
 dependencies = [
     { name = "pystac-core" },
@@ -3998,7 +3998,7 @@ requires-dist = [{ name = "pystac-core", editable = "core" }]
 
 [[package]]
 name = "pystac-ext-pointcloud"
-version = "1.0.0rc0"
+version = "1.0.0"
 source = { editable = "extensions/pointcloud" }
 dependencies = [
     { name = "pystac-core" },
@@ -4009,7 +4009,7 @@ requires-dist = [{ name = "pystac-core", editable = "core" }]
 
 [[package]]
 name = "pystac-ext-projection"
-version = "2.0.0rc0"
+version = "2.0.0"
 source = { editable = "extensions/projection" }
 dependencies = [
     { name = "pystac-core" },
@@ -4020,7 +4020,7 @@ requires-dist = [{ name = "pystac-core", editable = "core" }]
 
 [[package]]
 name = "pystac-ext-raster"
-version = "1.1.0rc0"
+version = "1.1.0"
 source = { editable = "extensions/raster" }
 dependencies = [
     { name = "pystac-core" },
@@ -4031,7 +4031,7 @@ requires-dist = [{ name = "pystac-core", editable = "core" }]
 
 [[package]]
 name = "pystac-ext-render"
-version = "2.0.0rc0"
+version = "2.0.0"
 source = { editable = "extensions/render" }
 dependencies = [
     { name = "pystac-core" },
@@ -4042,7 +4042,7 @@ requires-dist = [{ name = "pystac-core", editable = "core" }]
 
 [[package]]
 name = "pystac-ext-sar"
-version = "1.0.0rc0"
+version = "1.0.0"
 source = { editable = "extensions/sar" }
 dependencies = [
     { name = "pystac-core" },
@@ -4053,7 +4053,7 @@ requires-dist = [{ name = "pystac-core", editable = "core" }]
 
 [[package]]
 name = "pystac-ext-sat"
-version = "1.0.0rc0"
+version = "1.0.0"
 source = { editable = "extensions/sat" }
 dependencies = [
     { name = "pystac-core" },
@@ -4064,7 +4064,7 @@ requires-dist = [{ name = "pystac-core", editable = "core" }]
 
 [[package]]
 name = "pystac-ext-scientific"
-version = "1.0.0rc0"
+version = "1.0.0"
 source = { editable = "extensions/scientific" }
 dependencies = [
     { name = "pystac-core" },
@@ -4075,7 +4075,7 @@ requires-dist = [{ name = "pystac-core", editable = "core" }]
 
 [[package]]
 name = "pystac-ext-storage"
-version = "2.0.0rc0"
+version = "2.0.0"
 source = { editable = "extensions/storage" }
 dependencies = [
     { name = "pystac-core" },
@@ -4086,7 +4086,7 @@ requires-dist = [{ name = "pystac-core", editable = "core" }]
 
 [[package]]
 name = "pystac-ext-table"
-version = "1.2.0rc0"
+version = "1.2.0"
 source = { editable = "extensions/table" }
 dependencies = [
     { name = "pystac-core" },
@@ -4097,7 +4097,7 @@ requires-dist = [{ name = "pystac-core", editable = "core" }]
 
 [[package]]
 name = "pystac-ext-timestamps"
-version = "1.1.0rc0"
+version = "1.1.0"
 source = { editable = "extensions/timestamps" }
 dependencies = [
     { name = "pystac-core" },
@@ -4108,7 +4108,7 @@ requires-dist = [{ name = "pystac-core", editable = "core" }]
 
 [[package]]
 name = "pystac-ext-version"
-version = "1.2.0rc0"
+version = "1.2.0"
 source = { editable = "extensions/version" }
 dependencies = [
     { name = "pystac-core" },
@@ -4119,7 +4119,7 @@ requires-dist = [{ name = "pystac-core", editable = "core" }]
 
 [[package]]
 name = "pystac-ext-view"
-version = "1.0.0rc0"
+version = "1.0.0"
 source = { editable = "extensions/view" }
 dependencies = [
     { name = "pystac-core" },
@@ -4130,7 +4130,7 @@ requires-dist = [{ name = "pystac-core", editable = "core" }]
 
 [[package]]
 name = "pystac-ext-xarray-assets"
-version = "1.0.0rc0"
+version = "1.0.0"
 source = { editable = "extensions/xarray_assets" }
 dependencies = [
     { name = "pystac-core" },


### PR DESCRIPTION
Our v1.15.0 release was bad b/c we had a leftover invalid dependency specifier, very much my fault 🤦🏼 . I've yanked the bad release, and will do a post-release with this fix. I don't think we need to go to v1.15.1 but happy to be convinced otherwise.

**release-please** is being a bit awkward with this new layout, so I might have to rethink our releasing after the extension breakout.

Sorry for the churn @tylanderson 