### PR TITLE
chore: fix release-please config for pystac-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "pystac-core==1.15.0",  # x-release-please-version
+    "pystac-core>=1.15.0,<2",
     "pystac-ext-classification",
     "pystac-ext-datacube",
     "pystac-ext-eo",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,8 @@
       "release-as": "1.15.0.post0"
     },
     "core": {
-      "component": "pystac-core"
+      "component": "pystac-core",
+      "extra-files": ["pystac/version.py"]
     },
     "extensions/classification": {
       "component": "pystac-ext-classification"
@@ -77,7 +78,7 @@
       "component": "pystac-ext-xarray-assets"
     }
   },
-  "extra-files": ["pyproject.toml", "core/pystac/version.py"],
+  "extra-files": ["pyproject.toml"],
   "plugins": [
     {
       "type": "linked-versions",


### PR DESCRIPTION
Once more, I think the extra-files fix will help **pystac** and **pystac-core** stay in sync.

BEGIN_COMMIT_OVERRIDE
fix: actually link pystac-core and pystac via release-please
BEGIN_COMMIT_OVERRIDE