### PR TITLE
chore: fix release-please, yet again

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,7 +25,6 @@ jobs:
         id: release-please
         with:
           token: ${{ steps.generate-token.outputs.token }}
-          release-type: python
 
   update-static-files:
     runs-on: ubuntu-latest

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,8 @@
     ".": {
       "changelog-path": "CHANGELOG.md",
       "component": "pystac",
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "extra-files": ["pyproject.toml", "core/pystac/version.py"]
     },
     "extensions/classification": {
       "component": "pystac-ext-classification"
@@ -73,9 +74,5 @@
       "component": "pystac-ext-xarray-assets"
     }
   },
-  "extra-files": [
-    "pyproject.toml",
-    "core/pystac/version.py"
-  ],
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"
 }


### PR DESCRIPTION
I've really flailed to get **release-please** working with the new (more complex) extension setup — here's hoping this one is the fix we need 🤞🏼.

This closes https://github.com/stac-utils/pystac/issues/1792 because we've made the correct changes, we just didn't release the new extension versions to PyPI.