### PR TITLE
docs: tweak how we version extension packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ The core PySTAC API follows [Semantic Versioning](https://semver.org/).
 As of [Spring 2026](https://github.com/stac-utils/pystac/pull/1650), our [extension](https://stac-extensions.github.io/) implementations have moved to their own Python packages, so they can be versioned independently of the core PySTAC API.
 Breaking changes to the API of extension packages are _not_ considered breaking changes for the purposes of PySTAC versioning.
 
-The STAC extension packages' version will match the version extension itself, e.g. **pystac-ext-projection** v2.0.0 corresponds to the [v2.0.0](https://github.com/stac-extensions/projection/releases/tag/v2.0.0) release of the **projection** extension.
-Any changes to the software (not the extension) will be released via [post releases](https://packaging.python.org/en/latest/discussions/versioning/#valid-version-numbers).
+The STAC extension packages' MAJOR and MINOR versions will match the version extension itself, e.g. **pystac-ext-projection** v2.0.0 corresponds to the [v2.0.0](https://github.com/stac-extensions/projection/releases/tag/v2.0.0) release of the **projection** extension.
+Any changes to the software (not the extension) will be released via [PATCH releases](https://packaging.python.org/en/latest/discussions/versioning/#valid-version-numbers).
 
 ## Documentation
 


### PR DESCRIPTION
It was just going to be too much of a PITA to use post-release versions for extension packages with **release-please**. I'd like to relax our extension versioning to use PATCH releases for all PyPI updates that don't mirror a change in the extension specification itself.

This gives us the slightly awkward situation where a v1.2.3 **pystac** extension version could correspond to a v1.2.1 extension version, but in my experience most extensions don't do PATCH versions, so it doesn't feel like _that_ big a problem? Happy to get push-back, or feedback that I need to make more documentation — this new "extensions as their own packages" thing is pretty fresh.