### PR TITLE
docs: reflect that PySTAC writes STAC v1.1.0 by default

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,8 +5,8 @@ PySTAC is a library for working with `SpatioTemporal Asset Catalogs (STAC)
 <https://stacspec.org/>`_ in `Python 3 <https://www.python.org/>`_. Some nice features
 of PySTAC are:
 
-* Reading and writing STAC version 1.0. Future versions will read older versions of
-  STAC, but always write the latest supported version. See :ref:`stac_version_support`
+* Reading and writing STAC version |stac_version|. PySTAC will read older versions of
+  STAC, but always writes the latest supported version. See :ref:`stac_version_support`
   for details.
 * In-memory manipulations of STAC catalogs.
 * Extend the I/O of STAC metadata to provide support for other platforms (e.g. cloud


### PR DESCRIPTION
**Related Issue(s):**

- #1513

**Description:**

## What
Update the docs landing-page intro bullet to say PySTAC reads and writes STAC
`|stac_version|` (currently 1.1.0) instead of the outdated "STAC version 1.0".

## Why / evidence
`docs/index.rst` line 8 still reads:

> Reading and writing STAC version 1.0. Future versions will read older versions of
> STAC, but always write the latest supported version.

Since v1.12.0 the default write version is 1.1.0
(`pystac.version.STACVersion.DEFAULT_STAC_VERSION == "1.1.0"`, and the 1.12.0
release notes state "STAC v1.1.0 is now the default"). Verified in a clean venv:

    $ python -c "import pystac; print(pystac.get_stac_version()); print(pystac.Catalog(id='x', description='d').to_dict()['stac_version'])"
    1.1.0
    1.1.0

## Change
Replace the hard-coded `1.0` with the `|stac_version|` substitution already
defined in `docs/conf.py` (`rst_epilog`) and already used in `docs/concepts.rst`,
so the bullet tracks `DEFAULT_STAC_VERSION` automatically. Also tightened the
next sentence ("Future versions will read..." -> "PySTAC will read...") since
older-version reading already works today. One file, docs only.

## Verified
- `STACVersion.DEFAULT_STAC_VERSION` -> `1.1.0`
- docutils render of the bullet with the `conf.py` epilog applied produces
  "Reading and writing STAC version 1.1.0."
- `|stac_version|` is an existing, working substitution (used in `concepts.rst`).

Fixes #1513
