### PR TITLE
fix: recursively convert values in PropertiesExtension._set_property

### DIFF
--- a/core/pystac/extensions/base.py
+++ b/core/pystac/extensions/base.py
@@ -45,6 +45,22 @@ class SummariesExtension:
 P = TypeVar("P")
 
 
+def _to_dict_recursive(v: Any) -> Any:
+    """Replaces any object that has a ``to_dict`` method with the result of calling
+    it, including objects nested at any depth inside lists, tuples and dicts."""
+    to_dict = getattr(v, "to_dict", None)
+    if callable(to_dict):
+        v = to_dict()
+    if isinstance(v, dict):
+        return {key: _to_dict_recursive(value) for key, value in v.items()}
+    elif isinstance(v, list):
+        return [_to_dict_recursive(x) for x in v]
+    elif isinstance(v, tuple):
+        return tuple(_to_dict_recursive(x) for x in v)
+    else:
+        return v
+
+
 class PropertiesExtension(ABC):
     """Abstract base class for extending the properties of an :class:`~pystac.Item`
     to include properties defined by a STAC Extension.
@@ -86,12 +102,8 @@ class PropertiesExtension(ABC):
     ) -> None:
         if v is None and pop_if_none:
             self.properties.pop(prop_name, None)
-        elif isinstance(v, list):
-            self.properties[prop_name] = [
-                x.to_dict() if hasattr(x, "to_dict") else x for x in v
-            ]
         else:
-            self.properties[prop_name] = v
+            self.properties[prop_name] = _to_dict_recursive(v)
 
 
 class ExtensionManagementMixin(Generic[S], ABC):

--- a/tests/extensions/test_custom.py
+++ b/tests/extensions/test_custom.py
@@ -1,5 +1,6 @@
 """Tests creating a custom extension"""
 
+import json
 from collections.abc import Generator
 from datetime import datetime
 from typing import Any, Generic, TypeVar, cast
@@ -201,3 +202,24 @@ def test_migrates(add_extension_hooks: None) -> None:
     item = Item.from_dict(item_as_dict, migrate=True)
     custom = CustomExtension.ext(item)
     assert custom.test_prop == "foo"
+
+
+class Nested:
+    def __init__(self, value: Any) -> None:
+        self.value = value
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"value": self.value}
+
+
+def test_set_property_converts_nested_objects(add_extension_hooks: None) -> None:
+    item = Item("an-id", None, None, datetime.now(), {})
+    custom = CustomExtension.ext(item, add_if_missing=True)
+    custom._set_property(
+        TEST_PROP, {"list": [Nested(1), (Nested(2),)], "obj": Nested(Nested(3))}
+    )
+    assert item.properties[TEST_PROP] == {
+        "list": [{"value": 1}, ({"value": 2},)],
+        "obj": {"value": {"value": 3}},
+    }
+    json.dumps(item.to_dict())


### PR DESCRIPTION
**Related Issue(s):**

- Closes #1802

**Description:**

`_set_property` only called `to_dict()` on the items of a top-level list, so an object nested any deeper (in a dict, in a tuple, or inside what another `to_dict()` returned) was stored as-is and the item could no longer be serialized to JSON.

This adds a small `_to_dict_recursive` helper in `pystac/extensions/base.py` and uses it for every value `_set_property` stores. It follows the approach suggested in the issue.

One behaviour change to be aware of: a dict passed to `_set_property` is now stored as a converted copy rather than the same object, the same way lists already were.

Added `test_set_property_converts_nested_objects` to `tests/extensions/test_custom.py`. It fails on `main` and passes here; the rest of the suite is unchanged (1542 passed, 5 skipped). The 20 errors I get locally are the Windows path-length `shutil` errors in the asset fixtures and happen on `main` too.

**PR Checklist:**

- [x] Pre-commit hooks pass (run `pre-commit run --all-files`)
- [x] Tests pass (run `pytest`)
- [x] Documentation has been updated to reflect changes, if applicable
- [x] This PR maintains or improves overall codebase code coverage
- [x] This PR's title is formatted per [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)

**AI tool usage:**

- [x] AI tools supported the development of this PR, per the [stac-utils AI tool policy](https://stac-utils.github.io/ai-contribution-policy/). I have reviewed the change and can answer questions about it.
